### PR TITLE
chore(ci): deprecate x86 macOS from main CI matrix

### DIFF
--- a/.github/workflows/ci-functional.yml
+++ b/.github/workflows/ci-functional.yml
@@ -19,8 +19,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-          - os: macos-13
-            target: x86_64-apple-darwin
           - os: macos-14
             target: aarch64-apple-darwin
 


### PR DESCRIPTION
## Summary
- remove Intel macOS (`macos-13` / `x86_64-apple-darwin`) from the `ci-functional` matrix that runs on pushes to `main`
- keep Linux x86_64, Linux arm64, and Apple Silicon macOS coverage unchanged

## Why
- deprecates x86 macOS from the testing support matrix for `main` CI

## Operational Impact
- `main` CI no longer executes functional/build/test jobs on Intel macOS runners
- no runtime, migration, or service behavior changes

## Validation
- inspected workflow diff: `.github/workflows/ci-functional.yml`
- confirmed only matrix entry removal for `macos-13` + `x86_64-apple-darwin`

## Linked Issues
- none specified