### PR TITLE
feat(ci): isolate e2e stack state and drop macOS x86 release artifacts

### DIFF
--- a/.github/workflows/release-cortexctl.yml
+++ b/.github/workflows/release-cortexctl.yml
@@ -25,8 +25,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-          - os: macos-13
-            target: x86_64-apple-darwin
           - os: macos-14
             target: aarch64-apple-darwin
 

--- a/config/clickhouse.xml
+++ b/config/clickhouse.xml
@@ -15,9 +15,9 @@
   <pid>__CORTEX_HOME__/clickhouse/clickhouse.pid</pid>
 
   <listen_host>127.0.0.1</listen_host>
-  <http_port>8123</http_port>
-  <tcp_port>9000</tcp_port>
-  <interserver_http_port>9009</interserver_http_port>
+  <http_port>__CLICKHOUSE_HTTP_PORT__</http_port>
+  <tcp_port>__CLICKHOUSE_TCP_PORT__</tcp_port>
+  <interserver_http_port>__CLICKHOUSE_INTERSERVER_HTTP_PORT__</interserver_http_port>
 
   <max_connections>2048</max_connections>
   <max_concurrent_queries>500</max_concurrent_queries>

--- a/docs/operations/build-and-operations.md
+++ b/docs/operations/build-and-operations.md
@@ -63,7 +63,6 @@ Tag-driven GitHub Actions release workflow:
 2. Workflow `.github/workflows/release-cortexctl.yml` builds:
    - `x86_64-unknown-linux-gnu`
    - `aarch64-unknown-linux-gnu`
-   - `x86_64-apple-darwin`
    - `aarch64-apple-darwin`
 3. Uploads `cortex-bundle-<target>.tar.gz` plus `cortex-bundle-<target>.sha256` to the tag release.
 

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -10,6 +10,44 @@ need_cmd() {
   fi
 }
 
+pick_open_port() {
+  local python_bin="$1"
+  "$python_bin" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'
+}
+
+pick_clickhouse_http_port() {
+  local python_bin="$1"
+  "$python_bin" -c '
+import random
+import socket
+import sys
+
+TCP_OFFSET = 877
+INTERSERVER_OFFSET = 886
+
+for _ in range(500):
+    http_port = random.randint(20000, 60000 - INTERSERVER_OFFSET)
+    ports = [http_port, http_port + TCP_OFFSET, http_port + INTERSERVER_OFFSET]
+    sockets = []
+    try:
+        for port in ports:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.bind(("127.0.0.1", port))
+            sockets.append(sock)
+    except OSError:
+        for sock in sockets:
+            sock.close()
+        continue
+    for sock in sockets:
+        sock.close()
+    print(http_port)
+    sys.exit(0)
+
+print("failed to find available ClickHouse ports", file=sys.stderr)
+sys.exit(1)
+'
+}
+
 json_ok_true() {
   local python_bin="$1"
   "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sys.exit(0 if data.get("ok") is True else 1)'
@@ -42,8 +80,9 @@ wait_for_endpoint_ok() {
 }
 
 wait_for_clickhouse_count() {
-  local query="$1"
-  local timeout_seconds="${2:-120}"
+  local clickhouse_url="$1"
+  local query="$2"
+  local timeout_seconds="${3:-120}"
   local started
   started="$(date +%s)"
 
@@ -56,7 +95,7 @@ wait_for_clickhouse_count() {
     fi
 
     local count
-    count="$(curl -sS --max-time 3 "http://127.0.0.1:8123" --data-binary "$query" 2>/dev/null | tr -d '[:space:]' || true)"
+    count="$(curl -sS --max-time 3 "$clickhouse_url" --data-binary "$query" 2>/dev/null | tr -d '[:space:]' || true)"
     if [[ -n "$count" && "$count" =~ ^[0-9]+$ ]] && (( count > 0 )); then
       return 0
     fi
@@ -105,11 +144,37 @@ main() {
   repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
   local cortexctl_bin="${CORTEXCTL_BIN:-$repo_root/target/debug/cortexctl}"
   local python_bin="${PYTHON_BIN:-python3}"
-  local monitor_port="${MONITOR_PORT:-18080}"
-  local keyword="${CORTEX_TEST_KEYWORD:-portable_ci_keyword}"
+  local monitor_port="${MONITOR_PORT:-}"
+  local base_keyword="${CORTEX_TEST_KEYWORD:-portable_ci_keyword}"
+  base_keyword="${base_keyword//[^[:alnum:]_]/_}"
+  base_keyword="$(printf '%s' "$base_keyword" | tr '[:upper:]' '[:lower:]')"
+  if [[ -z "$base_keyword" ]]; then
+    base_keyword="portable_ci_keyword"
+  fi
+  local run_stamp
+  run_stamp="$(date +%s)_$$_$RANDOM"
+  local codex_keyword="${base_keyword}_codex_${run_stamp}"
+  local claude_keyword="${base_keyword}_claude_${run_stamp}"
+  local clickhouse_database="cortex"
+  local codex_session_suffix
+  codex_session_suffix="$(printf '%06x%06x' "$RANDOM" "$RANDOM")"
+  local codex_session_id="00000000-0000-4000-8000-${codex_session_suffix}"
+  local claude_session_suffix
+  claude_session_suffix="$(printf '%06x%06x' "$RANDOM" "$RANDOM")"
+  local claude_session_id="00000000-0000-4000-8000-${claude_session_suffix}"
+  local codex_trace_marker="mcp_codex_trace_marker_${run_stamp}"
+  local claude_trace_marker="mcp_claude_trace_marker_${run_stamp}"
 
   need_cmd curl
   need_cmd "$python_bin"
+
+  if [[ -z "$monitor_port" ]]; then
+    monitor_port="$(pick_open_port "$python_bin")"
+  fi
+
+  local clickhouse_http_port
+  clickhouse_http_port="$(pick_clickhouse_http_port "$python_bin")"
+  local clickhouse_url="http://127.0.0.1:${clickhouse_http_port}"
 
   if [[ ! -x "$cortexctl_bin" ]]; then
     echo "missing cortexctl binary: $cortexctl_bin" >&2
@@ -122,16 +187,30 @@ main() {
   local fixtures_root="$tmp_root/fixtures"
   local runtime_root="$tmp_root/runtime"
   local config_path="$tmp_root/cortex-ci.toml"
-  local fixture_file="$fixtures_root/codex/sessions/2026/02/16/session-ci.jsonl"
+  local codex_fixture_file="$fixtures_root/codex/sessions/2026/02/16/session-${codex_session_id}.jsonl"
+  local claude_fixture_file="$fixtures_root/claude/projects/e2e/session-${claude_session_id}.jsonl"
 
-  mkdir -p "$(dirname "$fixture_file")"
+  mkdir -p "$(dirname "$codex_fixture_file")"
+  mkdir -p "$(dirname "$claude_fixture_file")"
   mkdir -p "$runtime_root"
 
-  cat > "$fixture_file" <<EOF
-{"timestamp":"2026-02-16T12:00:00.000Z","type":"response_item","payload":{"type":"message","role":"assistant","id":"msg-ci-1","content":[{"type":"text","text":"${keyword} alpha beta gamma"}],"phase":"completed"}}
+  cat > "$codex_fixture_file" <<EOF
+{"timestamp":"2026-02-16T12:00:00.000Z","type":"session_meta","payload":{"id":"${codex_session_id}"}}
+{"timestamp":"2026-02-16T12:00:01.000Z","type":"turn_context","payload":{"turn_id":"1","model":"gpt-5.3-codex"}}
+{"timestamp":"2026-02-16T12:00:02.000Z","type":"response_item","payload":{"type":"message","role":"user","id":"msg-user-${run_stamp}","content":[{"type":"text","text":"local e2e codex user prompt ${codex_keyword}"}],"phase":"completed"}}
+{"timestamp":"2026-02-16T12:00:03.000Z","type":"response_item","payload":{"type":"message","role":"assistant","id":"msg-assistant-${run_stamp}","content":[{"type":"text","text":"local e2e codex assistant reply ${codex_keyword} ${codex_trace_marker}"}],"phase":"completed"}}
+EOF
+
+  cat > "$claude_fixture_file" <<EOF
+{"type":"user","sessionId":"${claude_session_id}","uuid":"claude-user-${run_stamp}","timestamp":"2026-02-16T12:00:04.000Z","message":{"role":"user","content":[{"type":"text","text":"local e2e claude user prompt ${claude_keyword}"}]}}
+{"type":"assistant","sessionId":"${claude_session_id}","uuid":"claude-assistant-${run_stamp}","parentUuid":"claude-user-${run_stamp}","requestId":"req-${run_stamp}","timestamp":"2026-02-16T12:00:05.000Z","message":{"model":"claude-opus-4-5-20251101","role":"assistant","usage":{"input_tokens":9,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"service_tier":"standard"},"content":[{"type":"text","text":"local e2e claude assistant reply ${claude_keyword} ${claude_trace_marker}"}]}}
 EOF
 
   cat > "$config_path" <<EOF
+[clickhouse]
+url = "${clickhouse_url}"
+database = "${clickhouse_database}"
+
 [monitor]
 host = "127.0.0.1"
 port = ${monitor_port}
@@ -141,6 +220,7 @@ backfill_on_start = true
 heartbeat_interval_seconds = 1.0
 flush_interval_seconds = 0.2
 reconcile_interval_seconds = 2.0
+state_dir = "${tmp_root}/ingest-state"
 
 [[ingest.sources]]
 name = "ci-codex"
@@ -148,6 +228,13 @@ provider = "codex"
 enabled = true
 glob = "${fixtures_root}/codex/sessions/**/*.jsonl"
 watch_root = "${fixtures_root}/codex/sessions"
+
+[[ingest.sources]]
+name = "ci-claude"
+provider = "claude"
+enabled = true
+glob = "${fixtures_root}/claude/projects/**/*.jsonl"
+watch_root = "${fixtures_root}/claude/projects"
 
 [runtime]
 root_dir = "${runtime_root}"
@@ -163,6 +250,12 @@ EOF
 
   trap "cleanup_e2e \"$cortexctl_bin\" \"$config_path\" \"$runtime_root\" \"$tmp_root\"" EXIT
 
+  echo "[e2e] run id: ${run_stamp}"
+  echo "[e2e] clickhouse url: ${clickhouse_url}"
+  echo "[e2e] clickhouse db: ${clickhouse_database}"
+  echo "[e2e] codex fixture: ${codex_fixture_file}"
+  echo "[e2e] claude fixture: ${claude_fixture_file}"
+
   echo "[e2e] installing managed ClickHouse"
   "$cortexctl_bin" clickhouse install --config "$config_path"
 
@@ -173,9 +266,11 @@ EOF
   wait_for_endpoint_ok "$python_bin" "http://127.0.0.1:${monitor_port}/api/health" 120
 
   echo "[e2e] waiting for ingest heartbeat + indexed content"
-  wait_for_clickhouse_count "SELECT count() FROM cortex.ingest_heartbeats" 120
-  wait_for_clickhouse_count "SELECT count() FROM cortex.search_documents WHERE positionCaseInsensitiveUTF8(text_content, '${keyword}') > 0" 120
-  wait_for_clickhouse_count "SELECT count() FROM cortex.search_postings WHERE term = '${keyword}'" 120
+  wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.ingest_heartbeats" 120
+  wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.search_documents WHERE positionCaseInsensitiveUTF8(text_content, '${codex_keyword}') > 0" 120
+  wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.search_postings WHERE term = '${codex_keyword}'" 120
+  wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.search_documents WHERE positionCaseInsensitiveUTF8(text_content, '${claude_keyword}') > 0" 120
+  wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.search_postings WHERE term = '${claude_keyword}'" 120
 
   echo "[e2e] checking monitor API routes"
   for path in /api/health /api/status /api/analytics /api/web-searches; do
@@ -184,11 +279,23 @@ EOF
     printf '%s' "$body" | json_ok_true "$python_bin"
   done
 
-  echo "[e2e] checking MCP initialize/tools/search/open"
+  echo "[e2e] checking MCP initialize/tools/search/open (codex)"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
     --cortexctl "$cortexctl_bin" \
     --config "$config_path" \
-    --query "$keyword"
+    --query "$codex_keyword" \
+    --expect-session-id "$codex_session_id" \
+    --expect-source-file "$codex_fixture_file" \
+    --expect-open-text "$codex_trace_marker"
+
+  echo "[e2e] checking MCP initialize/tools/search/open (claude)"
+  "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
+    --cortexctl "$cortexctl_bin" \
+    --config "$config_path" \
+    --query "$claude_keyword" \
+    --expect-session-id "$claude_session_id" \
+    --expect-source-file "$claude_fixture_file" \
+    --expect-open-text "$claude_trace_marker"
 
   echo "[e2e] final status"
   "$cortexctl_bin" status --config "$config_path"


### PR DESCRIPTION
## What changed
- made `scripts/ci/e2e-stack.sh` fully self-contained for DB/runtime state:
  - unique temp runtime root and ingest state dir per run
  - dynamic local monitor and ClickHouse ports per run
  - no dependency on pre-existing local Cortex DB state
- added deterministic dummy trace fixtures for both providers:
  - Codex fixture (`fixtures/codex/sessions/...`)
  - Claude fixture (`fixtures/claude/projects/...`)
- expanded MCP smoke assertions so e2e validates retrieval correctness, not only tool availability:
  - selects hits by expected session/source
  - verifies `open` returns expected source and marker text
- updated ClickHouse config rendering in `cortexctl`:
  - `config/clickhouse.xml` now templates ports
  - `apps/cortexctl/src/main.rs` derives ClickHouse ports from configured `clickhouse.url`
  - added unit tests for URL->port derivation
- removed unsupported macOS x86 release artifacts from CI:
  - dropped `x86_64-apple-darwin` from `.github/workflows/release-cortexctl.yml`
  - updated release target list in `docs/operations/build-and-operations.md`

## Why
- allows running e2e locally with strong isolation guarantees (port/path/db state), matching CI behavior
- ensures e2e verifies real ingest->index->MCP retrieval for both Codex and Claude data formats
- aligns published release artifacts with currently relevant platform support

## Operational impact
- CI release artifacts no longer include `x86_64-apple-darwin`
- e2e runs now start ClickHouse on a per-run local port derived from generated config
- e2e fixture data now includes both Codex and Claude traces, increasing functional coverage

## Validation
- `cargo test -p cortexctl --locked clickhouse_ports` (pass)
- `bash -n scripts/ci/e2e-stack.sh` (pass)
- `scripts/ci/e2e-stack.sh` (pass; verifies Codex and Claude MCP retrieval checks)

## Linked issues
- none
