### PR TITLE
chore(release): cut v0.1.1

### DIFF
--- a/.github/workflows/release-cortexctl.yml
+++ b/.github/workflows/release-cortexctl.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.1.0)"
+        description: "Tag to release (for example v0.1.1)"
         required: true
         type: string
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex-clickhouse"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "cortex-config"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "cortex-ingest"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cortex-config",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "cortex-ingest-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "cortex-mcp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cortex-config",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "cortex-mcp-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cortex-clickhouse",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "cortex-monitor"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cortex-config",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "cortex-monitor-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "cortexctl"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cortex-clickhouse",

--- a/apps/cortex-ingest/Cargo.toml
+++ b/apps/cortex-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex-ingest"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Cortex ingest service binary"
 

--- a/apps/cortex-mcp/Cargo.toml
+++ b/apps/cortex-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex-mcp"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Cortex MCP stdio server"
 

--- a/apps/cortex-monitor/Cargo.toml
+++ b/apps/cortex-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex-monitor"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Cortex monitor HTTP/UI service"
 

--- a/apps/cortexctl/Cargo.toml
+++ b/apps/cortexctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortexctl"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Unified runtime control plane for Cortex services"
 

--- a/crates/cortex-clickhouse/Cargo.toml
+++ b/crates/cortex-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex-clickhouse"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Shared Cortex ClickHouse client and query helpers"
 

--- a/crates/cortex-config/Cargo.toml
+++ b/crates/cortex-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex-config"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Shared Cortex configuration schema and loaders"
 

--- a/crates/cortex-ingest-core/Cargo.toml
+++ b/crates/cortex-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex-ingest-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Core ingestion pipeline internals for Cortex"
 

--- a/crates/cortex-mcp-core/Cargo.toml
+++ b/crates/cortex-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex-mcp-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "MCP protocol and tool routing core for Cortex"
 

--- a/crates/cortex-monitor-core/Cargo.toml
+++ b/crates/cortex-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex-monitor-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Analytics and query logic for Cortex monitor service"
 

--- a/docs/operations/build-and-operations.md
+++ b/docs/operations/build-and-operations.md
@@ -59,7 +59,7 @@ Install paths:
 
 Tag-driven GitHub Actions release workflow:
 
-1. Push a semantic tag (example: `v0.1.0`).
+1. Push a semantic tag (example: `v0.1.1`).
 2. Workflow `.github/workflows/release-cortexctl.yml` builds:
    - `x86_64-unknown-linux-gnu`
    - `aarch64-unknown-linux-gnu`

--- a/scripts/install-cortexctl.sh
+++ b/scripts/install-cortexctl.sh
@@ -19,7 +19,7 @@ options:
 
 examples:
   scripts/install-cortexctl.sh --repo eric-tramel/cortex
-  scripts/install-cortexctl.sh --repo eric-tramel/cortex --version v0.1.0
+  scripts/install-cortexctl.sh --repo eric-tramel/cortex --version v0.1.1
 EOF
 }
 


### PR DESCRIPTION
## Summary
- bump workspace crate/app versions from 0.1.0 to 0.1.1
- refresh release/tag examples in docs/workflow/install script
- update Cargo.lock workspace package versions

## Validation
- cargo test --workspace --offline
- cargo test --workspace --locked

## Release
- pushed tag: v0.1.1
- release workflow: https://github.com/eric-tramel/cortex/actions/runs/22049431797
- published release: https://github.com/eric-tramel/cortex/releases/tag/v0.1.1