### PR TITLE
chore(ci): validate installer via artifact-backed e2e

### DIFF
--- a/.github/workflows/ci-functional.yml
+++ b/.github/workflows/ci-functional.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Test workspace
         run: cargo test --workspace --locked
 
-      - name: Functional stack + MCP smoke
-        run: bash scripts/ci/e2e-stack.sh
+      - name: Functional install + stack + MCP smoke
+        run: bash scripts/ci/e2e-install-artifact.sh "${{ matrix.target }}"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ curl -fsSL https://raw.githubusercontent.com/eric-tramel/cortex/main/scripts/ins
 Then start and check the local stack:
 
 ```bash
+export PATH="$HOME/.local/bin:$PATH"
 cortexctl up
 cortexctl status
 ```

--- a/docs/operations/build-and-operations.md
+++ b/docs/operations/build-and-operations.md
@@ -42,6 +42,7 @@ cargo install --git https://github.com/eric-tramel/cortex.git \
 ```bash
 curl -fsSL https://raw.githubusercontent.com/eric-tramel/cortex/main/scripts/install-cortexctl.sh \
   | bash -s -- --repo eric-tramel/cortex
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 Default binary symlink location is `~/.local/bin`. Versioned bundles are installed under `~/.local/lib/cortex/<tag>/<target>` with `~/.local/lib/cortex/current` as active symlink.
@@ -67,6 +68,8 @@ Tag-driven GitHub Actions release workflow:
 3. Uploads `cortex-bundle-<target>.tar.gz` plus `cortex-bundle-<target>.sha256` to the tag release.
 
 Each bundle includes `manifest.json` with target/version metadata, per-binary checksums, and build metadata.
+
+Multiplatform functional CI (`.github/workflows/ci-functional.yml`) also packages per-target bundles and validates `scripts/install-cortexctl.sh` by installing from a local artifact server before running the stack + MCP smoke test.
 
 ## Config model
 

--- a/scripts/ci/e2e-install-artifact.sh
+++ b/scripts/ci/e2e-install-artifact.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+E2E_INSTALL_SUCCESS=0
+TMP_ROOT=""
+SERVER_PID=""
+SERVER_LOG=""
+
+usage() {
+  cat <<'EOF'
+usage: scripts/ci/e2e-install-artifact.sh <target-triple>
+
+example:
+  scripts/ci/e2e-install-artifact.sh aarch64-apple-darwin
+EOF
+}
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+pick_open_port() {
+  local python_bin="$1"
+  "$python_bin" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'
+}
+
+wait_for_local_server() {
+  local base_url="$1"
+  local timeout_seconds="${2:-30}"
+  local started
+  started="$(date +%s)"
+
+  while true; do
+    local now
+    now="$(date +%s)"
+    if (( now - started >= timeout_seconds )); then
+      echo "timed out waiting for local artifact server: $base_url" >&2
+      return 1
+    fi
+
+    if curl -fsS --max-time 2 "$base_url/" >/dev/null 2>&1; then
+      return 0
+    fi
+
+    sleep 1
+  done
+}
+
+cleanup_e2e_install() {
+  if [[ -n "$SERVER_PID" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+
+  if [[ -z "$TMP_ROOT" ]]; then
+    return
+  fi
+
+  if [[ "$E2E_INSTALL_SUCCESS" -ne 1 ]]; then
+    echo "[e2e-install] failure diagnostics (tmp root: $TMP_ROOT)" >&2
+    if [[ -n "$SERVER_LOG" && -f "$SERVER_LOG" ]]; then
+      echo "--- tail $SERVER_LOG ---" >&2
+      tail -n 120 "$SERVER_LOG" >&2 || true
+    fi
+  fi
+
+  if [[ "$E2E_INSTALL_SUCCESS" -eq 1 && "${KEEP_E2E_TMP:-0}" != "1" ]]; then
+    rm -rf "$TMP_ROOT"
+  else
+    echo "[e2e-install] keeping temp directory: $TMP_ROOT" >&2
+  fi
+}
+
+main() {
+  if [[ $# -ne 1 ]]; then
+    usage
+    exit 64
+  fi
+
+  local target="$1"
+  local repo_root
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  local package_script="$repo_root/scripts/package-cortexctl-release.sh"
+  local install_script="$repo_root/scripts/install-cortexctl.sh"
+  local e2e_script="$repo_root/scripts/ci/e2e-stack.sh"
+  local python_bin="${PYTHON_BIN:-python3}"
+  local run_stamp
+  run_stamp="$(date +%s)_$$_$RANDOM"
+  local bundle_version="ci-e2e-${run_stamp}"
+
+  need_cmd curl
+  need_cmd "$python_bin"
+  need_cmd tar
+  need_cmd bash
+
+  TMP_ROOT="$(mktemp -d)"
+  local dist_dir="$TMP_ROOT/dist"
+  local isolated_home="$TMP_ROOT/home"
+  SERVER_LOG="$TMP_ROOT/artifact-server.log"
+
+  echo "[e2e-install] packaging release bundle for target: $target"
+  "$package_script" "$target" "$dist_dir"
+
+  local artifact_port
+  artifact_port="$(pick_open_port "$python_bin")"
+  local asset_base_url="http://127.0.0.1:${artifact_port}"
+
+  echo "[e2e-install] starting local artifact server: $asset_base_url"
+  "$python_bin" -m http.server "$artifact_port" --bind 127.0.0.1 --directory "$dist_dir" >"$SERVER_LOG" 2>&1 &
+  SERVER_PID="$!"
+  wait_for_local_server "$asset_base_url" 30
+
+  echo "[e2e-install] installing via install script from local artifacts"
+  export HOME="$isolated_home"
+  mkdir -p "$HOME"
+  export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  "$install_script" \
+    --asset-base-url "$asset_base_url" \
+    --version "$bundle_version" \
+    --skip-clickhouse
+
+  export PATH="$HOME/.local/bin:$PATH"
+  local installed_cortexctl="$HOME/.local/bin/cortexctl"
+  if [[ ! -x "$installed_cortexctl" ]]; then
+    echo "missing installed cortexctl binary: $installed_cortexctl" >&2
+    exit 1
+  fi
+
+  echo "[e2e-install] running functional stack + MCP smoke with installed cortexctl"
+  unset CORTEX_SOURCE_TREE_MODE
+  CORTEXCTL_BIN="$installed_cortexctl" PYTHON_BIN="$python_bin" bash "$e2e_script"
+  E2E_INSTALL_SUCCESS=1
+}
+
+trap cleanup_e2e_install EXIT
+main "$@"


### PR DESCRIPTION
## Summary
This PR makes installer functionality part of multiplatform functional CI by validating the install script against locally produced release artifacts before running the existing stack+MCP e2e checks.

### What changed and why
- Added `--asset-base-url` to `scripts/install-cortexctl.sh`.
  - Why: allows CI to install from artifacts produced in the same job, instead of only from published GitHub Releases.
- Added `scripts/ci/e2e-install-artifact.sh`.
  - Why: packages target artifacts, serves them locally over HTTP, installs with the installer script, then runs `scripts/ci/e2e-stack.sh` using installed `cortexctl`.
- Updated `.github/workflows/ci-functional.yml` to run the new installer-backed e2e step across the matrix.
  - Why: catches installer regressions pre-release on Linux x86_64, Linux aarch64, and macOS aarch64.
- Kept quickstart docs functional by adding explicit PATH export after install in `README.md` and `docs/operations/build-and-operations.md`.

## Operational impact
- CI functional jobs now validate install-script behavior with packaged artifacts, increasing release-path confidence.
- Runtime/service behavior is unchanged; this affects installer input options and CI execution path only.
- Installer still defaults to GitHub Releases unless `--asset-base-url` is provided.

## Validation
- `bash -n scripts/install-cortexctl.sh scripts/ci/e2e-install-artifact.sh scripts/ci/e2e-stack.sh`
- `scripts/install-cortexctl.sh --asset-base-url http://127.0.0.1:18080` (expected exit 64: explicit `--version` required)
- `scripts/install-cortexctl.sh --repo eric-tramel/cortex --version v0.1.1 --skip-clickhouse`
- `scripts/install-cortexctl.sh --repo eric-tramel/cortex --skip-clickhouse`
- `bash scripts/ci/e2e-install-artifact.sh aarch64-apple-darwin`

## Linked issues
- None.
