### PR TITLE
feat(monitor): enforce bun in CI/release while keeping runtime bun-free

### DIFF
--- a/.github/workflows/ci-functional.yml
+++ b/.github/workflows/ci-functional.yml
@@ -31,6 +31,14 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Verify Bun
+        run: bun --version
+
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/release-cortexctl.yml
+++ b/.github/workflows/release-cortexctl.yml
@@ -39,6 +39,14 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Verify Bun
+        run: bun --version
+
       - name: Build release archive
         run: scripts/package-cortexctl-release.sh "${{ matrix.target }}" dist
 

--- a/README.md
+++ b/README.md
@@ -135,9 +135,10 @@ Legacy script commands (`bin/start-clickhouse`, `bin/init-db`, `bin/start-ingest
 
 Source-tree fallback mode is opt-in. Set `CORTEX_SOURCE_TREE_MODE=1` to allow `cortexctl run ...` to resolve `target/debug/*` binaries and repo `web/monitor/dist` assets.
 
-## Monitor Frontend (Bun + Svelte)
+## Monitor Frontend (Svelte)
 
-The monitor UI is a Bun-managed Svelte app under `web/monitor/`, built with Vite and served from `web/monitor/dist`.
+The monitor UI source lives under `web/monitor/` and is built with Vite.
+Release bundles include prebuilt `web/monitor/dist` assets, so installed binaries (`cortexctl`, `cortex-monitor`) do not require Bun at runtime.
 The legacy `cortex-monitor/web` directory has been removed.
 
 ```bash

--- a/cortex-monitor/README.md
+++ b/cortex-monitor/README.md
@@ -29,7 +29,8 @@ Environment helpers:
 
 ## Frontend build
 
-The monitor UI source lives under `web/monitor` and is built with Bun + Vite.
+The monitor UI source lives under `web/monitor` and is built with Vite.
+Release bundles include prebuilt web assets, so running installed binaries does not require Bun.
 The `cortex-monitor/web` directory has been removed.
 
 ```bash

--- a/scripts/package-cortexctl-release.sh
+++ b/scripts/package-cortexctl-release.sh
@@ -25,6 +25,16 @@ sha256_file() {
   exit 1
 }
 
+build_monitor_frontend() {
+  local monitor_dir="$PROJECT_ROOT/web/monitor"
+  echo "building monitor frontend with bun"
+  (
+    cd "$monitor_dir"
+    bun install --frozen-lockfile
+    bun run build
+  )
+}
+
 if [[ $# -lt 1 || $# -gt 2 ]]; then
   usage
   exit 64
@@ -46,12 +56,7 @@ OUTPUT_DIR="${2:-$PROJECT_ROOT/dist}"
 
 mkdir -p "$OUTPUT_DIR"
 
-echo "building monitor frontend (bun + vite)"
-(
-  cd "$PROJECT_ROOT/web/monitor"
-  bun install --frozen-lockfile
-  bun run build
-)
+build_monitor_frontend
 
 if [[ ! -d "$PROJECT_ROOT/web/monitor/dist" ]]; then
   echo "expected built frontend assets at $PROJECT_ROOT/web/monitor/dist"


### PR DESCRIPTION
## What changed and why
- Enforced Bun as the required frontend build tool in release packaging (`scripts/package-cortexctl-release.sh`) so release prep and CI do not silently vary by environment.
- Enforced Bun availability in CI by installing and verifying Bun in `ci-functional` and `release-cortexctl` workflows.
- Kept end-user runtime/install Bun-free by updating `cortex-monitor` static asset resolution to automatically use bundled `web/monitor/dist` assets when running installed binaries.
- Updated docs to clarify that Bun is required for frontend development/build, not for installed binary runtime.

## Operational impact
- CI/release now fail fast if Bun is unavailable.
- Installed bundles continue to work without Bun/npm on user machines.
- Source-tree monitor workflows still use `web/monitor/dist` under `CORTEX_SOURCE_TREE_MODE=1`.

## Validation
- `cargo test -p cortex-monitor --locked` (pass)
- `bash -n scripts/package-cortexctl-release.sh` (pass)

## Linked issue
- N/A
