### PR TITLE
fix(ci): remove Playwright from functional e2e stack

### DIFF
--- a/scripts/ci/e2e-install-artifact.sh
+++ b/scripts/ci/e2e-install-artifact.sh
@@ -87,7 +87,6 @@ main() {
   local install_script="$repo_root/scripts/install-cortexctl.sh"
   local e2e_script="$repo_root/scripts/ci/e2e-stack.sh"
   local python_bin="${PYTHON_BIN:-python3}"
-  local bun_bin=""
   local run_stamp
   run_stamp="$(date +%s)_$$_$RANDOM"
   local bundle_version="ci-e2e-${run_stamp}"
@@ -96,10 +95,6 @@ main() {
   need_cmd "$python_bin"
   need_cmd tar
   need_cmd bash
-
-  if command -v bun >/dev/null 2>&1; then
-    bun_bin="$(command -v bun)"
-  fi
 
   TMP_ROOT="$(mktemp -d)"
   local dist_dir="$TMP_ROOT/dist"
@@ -122,9 +117,6 @@ main() {
   export HOME="$isolated_home"
   mkdir -p "$HOME"
   local base_path="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  if [[ -n "$bun_bin" ]]; then
-    base_path="$(dirname "$bun_bin"):$base_path"
-  fi
   export PATH="$base_path"
   "$install_script" \
     --asset-base-url "$asset_base_url" \

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -104,40 +104,6 @@ wait_for_clickhouse_count() {
   done
 }
 
-ensure_monitor_frontend_assets() {
-  local repo_root="$1"
-  local playwright_browsers_path="$2"
-  local monitor_web_dir="$repo_root/web/monitor"
-
-  need_cmd bun
-
-  if [[ ! -d "$monitor_web_dir" ]]; then
-    echo "missing monitor frontend directory: $monitor_web_dir" >&2
-    exit 1
-  fi
-  if [[ ! -f "$monitor_web_dir/package.json" ]]; then
-    echo "missing monitor frontend package manifest: $monitor_web_dir/package.json" >&2
-    exit 1
-  fi
-
-  if [[ ! -d "$monitor_web_dir/node_modules" ]]; then
-    echo "[e2e] installing monitor frontend dependencies"
-    (cd "$monitor_web_dir" && bun install --frozen-lockfile)
-  else
-    echo "[e2e] reusing monitor frontend dependencies"
-  fi
-
-  echo "[e2e] building monitor frontend assets"
-  (cd "$monitor_web_dir" && bun run build)
-
-  mkdir -p "$playwright_browsers_path"
-  echo "[e2e] ensuring Playwright browser is installed"
-  (
-    cd "$monitor_web_dir"
-    PLAYWRIGHT_BROWSERS_PATH="$playwright_browsers_path" bunx playwright install chromium
-  )
-}
-
 cleanup_e2e() {
   local cortexctl_bin="$1"
   local config_path="$2"
@@ -218,7 +184,6 @@ main() {
 
   local tmp_root
   tmp_root="$(mktemp -d)"
-  local playwright_browsers_path="$tmp_root/playwright-browsers"
   local fixtures_root="$tmp_root/fixtures"
   local runtime_root="$tmp_root/runtime"
   local config_path="$tmp_root/cortex-ci.toml"
@@ -313,20 +278,6 @@ EOF
     body="$(curl -fsS "http://127.0.0.1:${monitor_port}${path}")"
     printf '%s' "$body" | json_ok_true "$python_bin"
   done
-
-  echo "[e2e] validating monitor frontend with Playwright (live backend)"
-  ensure_monitor_frontend_assets "$repo_root" "$playwright_browsers_path"
-  wait_for_endpoint_ok "$python_bin" "http://127.0.0.1:${monitor_port}/api/health" 120
-  (
-    cd "$repo_root/web/monitor"
-    PLAYWRIGHT_BROWSERS_PATH="$playwright_browsers_path" \
-      MONITOR_BASE_URL="http://127.0.0.1:${monitor_port}" \
-      CORTEX_E2E_CODEX_KEYWORD="$codex_keyword" \
-      CORTEX_E2E_CLAUDE_KEYWORD="$claude_keyword" \
-      CORTEX_E2E_CODEX_TRACE_MARKER="$codex_trace_marker" \
-      CORTEX_E2E_CLAUDE_TRACE_MARKER="$claude_trace_marker" \
-      bun run test:e2e -- e2e/monitor.live.spec.ts
-  )
 
   echo "[e2e] checking MCP initialize/tools/search/open (codex)"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \


### PR DESCRIPTION
## Summary
Remove Playwright from the functional e2e stack path so the post-install stack bring-up and smoke checks no longer depend on Bun/npm.

## What changed
- Removed monitor frontend Playwright validation from `scripts/ci/e2e-stack.sh`.
  - Deleted frontend dependency/bootstrap helper and browser install step.
  - Kept stack startup, monitor API checks, ingest verification, MCP smoke checks, and final status checks.
- Removed Bun PATH preservation in `scripts/ci/e2e-install-artifact.sh` for the runtime validation phase.
  - Bun is still required to build/package monitor assets in the earlier packaging step.

## Why
The functional e2e step validates installed binaries and service behavior. It should not require frontend test tooling to bring up monitor and validate API/MCP functionality.

## Operational impact
- No runtime binary behavior changes.
- No schema or config format changes.
- CI functional coverage shifts from API + Playwright UI + MCP to API + MCP for this path.

## Validation
- `bash -n scripts/ci/e2e-stack.sh`
- `bash -n scripts/ci/e2e-install-artifact.sh`
