### PR TITLE
fix(bench): prevent replay benchmark from re-selecting itself

### DIFF
--- a/bindings/python/moraine_conversations/src/lib.rs
+++ b/bindings/python/moraine_conversations/src/lib.rs
@@ -148,6 +148,7 @@ impl ConversationClient {
         min_should_match=None,
         include_tool_events=None,
         exclude_codex_mcp=None,
+        source=None,
     ))]
     fn search_events_json(
         &self,
@@ -158,11 +159,13 @@ impl ConversationClient {
         min_should_match: Option<u16>,
         include_tool_events: Option<bool>,
         exclude_codex_mcp: Option<bool>,
+        source: Option<String>,
     ) -> PyResult<String> {
         let results = self
             .rt
             .block_on(self.repo.search_events(SearchEventsQuery {
                 query,
+                source,
                 limit,
                 session_id,
                 min_score,

--- a/crates/moraine-conversations/src/clickhouse_repo.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo.rs
@@ -640,6 +640,7 @@ FORMAT JSONEachRow",
     async fn log_search_events(
         &self,
         query_id: &str,
+        source: &str,
         raw_query: &str,
         session_hint: &str,
         terms: &[String],
@@ -668,7 +669,7 @@ FORMAT JSONEachRow",
 
         let query_row = json!({
             "query_id": query_id,
-            "source": "moraine-conversations",
+            "source": source,
             "session_hint": session_hint,
             "raw_query": raw_query,
             "normalized_terms": terms,
@@ -1133,6 +1134,12 @@ FORMAT JSONEachRow",
         if query_text.is_empty() {
             return Err(RepoError::invalid_argument("query cannot be empty"));
         }
+        let source = query
+            .source
+            .as_deref()
+            .map(str::trim)
+            .filter(|raw| !raw.is_empty())
+            .unwrap_or("moraine-conversations");
 
         let query_id = Uuid::new_v4().to_string();
         let started = Instant::now();
@@ -1239,6 +1246,7 @@ FORMAT JSONEachRow",
 
         self.log_search_events(
             &query_id,
+            source,
             query_text,
             query.session_id.as_deref().unwrap_or(""),
             &terms,

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -175,6 +175,8 @@ pub struct OpenContext {
 pub struct SearchEventsQuery {
     pub query: String,
     #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
     pub limit: Option<u16>,
     #[serde(default)]
     pub session_id: Option<String>,

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -374,6 +374,7 @@ impl AppState {
             .repo
             .search_events(SearchEventsQuery {
                 query: args.query,
+                source: Some("moraine-mcp".to_string()),
                 limit: args.limit,
                 session_id: args.session_id,
                 min_score: args.min_score,

--- a/docs/operations/replay-search-latency-benchmark.md
+++ b/docs/operations/replay-search-latency-benchmark.md
@@ -9,8 +9,9 @@ The benchmark script is a self-declared `uv` script and replays through the loca
 The script:
 
 - selects top `N` rows from `moraine.search_query_log` by `response_ms` in a time window,
+- excludes prior benchmark replay rows (`source='benchmark-replay'`) by default,
 - runs `maturin develop` for `bindings/python/moraine_conversations` (unless skipped),
-- replays each query through `moraine_conversations.ConversationClient.search_events_json`,
+- replays each query through `moraine_conversations.ConversationClient.search_events_json` with `source='benchmark-replay'`,
 - runs warmup and measured repeats per query,
 - reports per-query and aggregate latency stats,
 - records timeout/error counts,
@@ -57,6 +58,7 @@ uv run --script scripts/bench/replay_search_latency.py \
 - `--repeats <int>`: measured runs per selected query.
 - `--timeout-seconds <int>`: timeout for each replayed search request.
 - `--skip-maturin-develop`: skip local binding rebuild before replay.
+- `--include-benchmark-replays`: include `source='benchmark-replay'` rows in selection.
 - `--output-json <path>`: write machine-readable benchmark output.
 - `--print-sql`: print generated ClickHouse selection SQL.
 - `--dry-run`: select and validate rows, but skip replay.
@@ -95,7 +97,8 @@ Exit code behavior:
 
 - No rows selected:
   - increase `--window` (for example `7d`),
-  - verify recent `search_query_log` writes are present.
+  - verify recent `search_query_log` writes are present,
+  - if you intentionally want replay-generated rows, pass `--include-benchmark-replays`.
 - Local binding build/import failure:
   - ensure `uv`, Python, Rust/Cargo, and a C toolchain are available,
   - run `uv run --script scripts/bench/replay_search_latency.py --config ...` so `maturin` is auto-installed,


### PR DESCRIPTION
## Summary
- Tag benchmark replay calls as `source=benchmark-replay`
- Exclude `benchmark-replay` rows from top-N selection by default
- Add `--include-benchmark-replays` override for explicit opt-in
- Plumb optional search source through moraine-conversations + Python binding and tag MCP calls as `moraine-mcp`

## Why
The benchmark was self-feeding from rows generated by prior replay runs, so top-N selection drifted away from live observed queries.

## Validation
- `cargo test -p moraine-conversations -p moraine-mcp-core --locked` (pass)
- `uv run --script scripts/bench/replay_search_latency.py --help` (shows new `--include-benchmark-replays` flag)
