### PR TITLE
docs: rewrite README for new-user clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # Moraine
 
-Moraine is a local-first system that ingests your Codex and Claude Code session logs into a local database (ClickHouse) so you can monitor them, inspect them, and use them for retrieval.
+Moraine indexes your Claude Code and Codex session logs into a local ClickHouse database — giving your agents searchable long-term memory and giving you a unified record of everything they've done.
 
-What you get:
+- **Agent memory via MCP**: agents search and retrieve context from past conversations using `search` and `open` tools
+- **Unified trace database**: every conversation turn, tool call, and token count in one place — query it however you want
+- **Monitor UI**: browse sessions, check ingestion health, inspect what your agents have been doing
+- **Fully local**: nothing leaves your machine
 
-- A local ingestion pipeline that watches your session logs and keeps ClickHouse up to date
-- A monitor UI to see health and browse the stored tables
-- An MCP server so agent runtimes can retrieve traces via `search` and `open`
+## Quickstart
 
-## Quickstart (5 minutes)
-
-Install `moraine` (prebuilt bundle, recommended):
+Install `moraine` (prebuilt bundle):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/eric-tramel/moraine/main/scripts/install-moraine.sh \
@@ -18,63 +17,115 @@ curl -fsSL https://raw.githubusercontent.com/eric-tramel/moraine/main/scripts/in
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-Start the local stack and confirm it is healthy:
+Start the stack and confirm it is healthy:
 
 ```bash
 moraine up
 moraine status
-moraine status --output rich --verbose
 ```
 
-Open the monitor UI:
+Open the monitor UI at `http://127.0.0.1:8080`.
 
-- `http://127.0.0.1:8080`
+Run a Claude Code or Codex session as you normally would, then check `moraine status` again — you'll see row counts and the ingest heartbeat move as your sessions are indexed.
 
-To see value quickly: run a Codex or Claude Code session as you normally would, then refresh the UI (or rerun `moraine status`) and watch row counts and heartbeat move.
+Use `moraine status --output rich --verbose` for a detailed breakdown.
 
-Notes:
+## Connect an Agent (MCP)
 
-- Moraine stores state under `~/.moraine`.
-- If ClickHouse is missing, `moraine up` auto-installs a managed ClickHouse build by default.
+This is where Moraine pays off: your agents can search past sessions to find relevant context.
 
-## Where Data Comes From
-
-By default, Moraine watches these JSONL sources (you can change this in config):
-
-- Codex: `~/.codex/sessions/**/*.jsonl`
-- Claude Code: `~/.claude/projects/**/*.jsonl`
-
-## Use Moraine With an Agent (MCP)
-
-MCP (Model Context Protocol) is not started by default. For an ad hoc session:
+Start the MCP server:
 
 ```bash
 moraine run mcp
 ```
 
-Agents typically call `search` to discover relevant events, then `open` to fetch surrounding context.
+Or start it automatically with `moraine up` by setting `runtime.start_mcp_on_up = true` in `~/.moraine/config.toml`.
 
-To start MCP automatically with `moraine up`, set `runtime.start_mcp_on_up=true` in `~/.moraine/config.toml`.
+To wire it into Claude Code, add this to your `.mcp.json`:
 
-For host integration details and the tool contract (`search`, `open`), see `docs/mcp/agent-interface.md`.
+```json
+{
+  "mcpServers": {
+    "moraine": {
+      "command": "moraine",
+      "args": ["run", "mcp"]
+    }
+  }
+}
+```
+
+The MCP server exposes two tools:
+
+- **`search`** — BM25 lexical search across indexed conversation events. Returns ranked hits with snippets.
+- **`open`** — fetch an event with surrounding context. Use this after `search` to reconstruct the conversation around a hit.
+
+For the full tool contract and integration guidance, see `docs/mcp/agent-interface.md`.
+
+## Query the Database Directly
+
+Moraine's ClickHouse tables are yours to query. The MCP search path is optimized for fast agent retrieval, but the underlying database holds the complete trace of every session — conversation turns, tool calls, token usage, timestamps, and more.
+
+Connect to ClickHouse and explore:
+
+```bash
+clickhouse client -d moraine
+```
+
+```sql
+-- sessions and their row counts
+SELECT session_id, count(*) as events
+FROM conversation_events
+GROUP BY session_id
+ORDER BY events DESC
+LIMIT 10;
+
+-- token usage across sessions
+SELECT session_id,
+       sum(input_tokens) as input,
+       sum(output_tokens) as output
+FROM conversation_events
+WHERE input_tokens > 0
+GROUP BY session_id
+ORDER BY output DESC
+LIMIT 10;
+```
+
+See `sql/` for the full schema and view definitions.
+
+## Watched Sources
+
+By default, Moraine watches:
+
+| Source | Path |
+|---|---|
+| Codex | `~/.codex/sessions/**/*.jsonl` |
+| Claude Code | `~/.claude/projects/**/*.jsonl` |
+
+Configurable in `~/.moraine/config.toml` under `[[ingest.sources]]`.
 
 ## Common Commands
 
-- `moraine status`: health + ingest heartbeat
-- `moraine logs`: service logs
-- `moraine down`: stop everything
+| Command | What it does |
+|---|---|
+| `moraine up` | Start all services (ClickHouse, ingestor, monitor) |
+| `moraine status` | Health check + ingest heartbeat |
+| `moraine logs` | View service logs |
+| `moraine down` | Stop everything |
 
-## Configuration (Optional)
+## Configuration
 
-Default config lives in `config/moraine.toml`. Runtime config is resolved in this order:
+Default config lives in `config/moraine.toml`. Runtime config is resolved in order:
 
-1. `--config <path>`
-2. `MORAINE_CONFIG` (and `MORAINE_MCP_CONFIG` for MCP)
+1. `--config <path>` flag
+2. `MORAINE_CONFIG` env var (and `MORAINE_MCP_CONFIG` for MCP)
 3. `~/.moraine/config.toml`
 
-To customize, start by copying `config/moraine.toml` to `~/.moraine/config.toml` and edit values there.
+To customize, copy `config/moraine.toml` to `~/.moraine/config.toml` and edit.
 
-## Install From Source (Optional)
+Moraine stores all runtime state under `~/.moraine`. If ClickHouse is not already installed, `moraine up` auto-installs a managed build.
+
+## Install From Source
 
 Requires a Rust toolchain (`cargo`, `rustc`):
 
@@ -86,16 +137,9 @@ for crate in moraine moraine-ingest moraine-monitor moraine-mcp; do
 done
 ```
 
-This installs all runtime binaries expected by `moraine up`.
-
-## More Details
+## Further Reading
 
 - Operations runbook: `docs/operations/build-and-operations.md`
 - Migration notes: `docs/operations/migration-guide.md`
 - System internals: `docs/core/system-architecture.md`
-
-## Source Layout Note
-
-Runtime development is authoritative in `apps/*` and `crates/*`.
-
-Legacy reference-only trees still exist under `rust/*` and `moraine-monitor/backend`; do not add new runtime logic there.
+- MCP tool contract: `docs/mcp/agent-interface.md`


### PR DESCRIPTION
## Summary

- Rewrites the opening to lead with what Moraine does for the user, not implementation internals
- Promotes two primary usage paths: **MCP agent memory** (fast search) and **direct database querying** (unified trace store)
- Adds concrete `.mcp.json` snippet for Claude Code integration
- Adds example SQL queries showing what you can do with the raw ClickHouse tables
- Replaces bullet lists with tables for scannability (watched sources, common commands)
- Drops internal-only "Source Layout Note" section

## Test plan

- [ ] Read through the diff and confirm tone/accuracy
- [ ] Verify the `.mcp.json` config snippet matches actual usage
- [ ] Confirm SQL examples run against a live Moraine database

🤖 Generated with [Claude Code](https://claude.com/claude-code)