### PR TITLE
feat(mcp): default search logging to async and benchmark MCP source path

### DIFF
--- a/config/moraine.toml
+++ b/config/moraine.toml
@@ -39,7 +39,7 @@ default_context_before = 3
 default_context_after = 3
 default_include_tool_events = false
 default_exclude_codex_mcp = true
-async_log_writes = false
+async_log_writes = true
 protocol_version = "2024-11-05"
 
 [bm25]

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -190,7 +190,7 @@ impl Default for McpConfig {
             default_context_after: default_context_after(),
             default_include_tool_events: false,
             default_exclude_codex_mcp: true,
-            async_log_writes: false,
+            async_log_writes: true,
             protocol_version: default_protocol_version(),
         }
     }

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -330,7 +330,7 @@ impl Default for RepoConfig {
             default_context_after: 6,
             default_include_tool_events: false,
             default_exclude_codex_mcp: true,
-            async_log_writes: false,
+            async_log_writes: true,
             bm25_k1: 1.2,
             bm25_b: 0.75,
             bm25_default_min_score: 0.0,


### PR DESCRIPTION
## Summary
- switch MCP search event logging to async-by-default (`async_log_writes = true`) across runtime config defaults
- keep behavior configurable, but make non-blocking logging the default path for MCP deployments
- extend replay benchmark with `--request-source` so we can benchmark MCP-source behavior directly instead of always sending `benchmark-replay`

## Why
MCP search requests were still using the logging path in `moraine-conversations`, and when logging is synchronous it can add avoidable tail latency to request serving. The benchmark also previously hardcoded replay source, which bypassed this behavior and hid MCP-specific latency.

## Changes
- `config/moraine.toml`: set `[mcp].async_log_writes = true`
- `crates/moraine-config/src/lib.rs`: set `McpConfig::default().async_log_writes = true`
- `crates/moraine-conversations/src/domain.rs`: set `RepoConfig::default().async_log_writes = true`
- `scripts/bench/replay_search_latency.py`:
  - add `--request-source`
  - wire source into `search_events_json(...)`
  - print/include request source in summary + JSON output

## Benchmark (MCP source replay)
Command template:
`UV_CACHE_DIR=/tmp/uv-cache CARGO_HOME=/tmp/cargo-home uv run --script scripts/bench/replay_search_latency.py --config <config> --window 30d --top-n 10 --request-source moraine-mcp --no-oracle-quality-check [--use-search-cache]`

### no-cache (`--use-search-cache` omitted)
- blocking logging config (`async_log_writes=false`):
  - p50=0.300 ms, p95=1.564 ms, p99=2.676 ms, avg=0.529 ms
- non-blocking logging config (`async_log_writes=true`):
  - p50=0.294 ms, p95=1.428 ms, p99=2.189 ms, avg=0.484 ms

### cache (`--use-search-cache`)
- blocking logging config (`async_log_writes=false`):
  - p50=0.042 ms, p95=0.062 ms, p99=1.865 ms, avg=0.074 ms
- non-blocking logging config (`async_log_writes=true`):
  - p50=0.041 ms, p95=0.069 ms, p99=1.836 ms, avg=0.076 ms

Net: no-cache path improves on p50/p95/p99/avg for MCP-source requests while preserving behavior.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p moraine-config -p moraine-conversations -p moraine-mcp-core --locked`
