### PR TITLE
fix: bootstrap config during install before managed ClickHouse setup

### DIFF
--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -675,6 +675,21 @@ mod tests {
     }
 
     #[test]
+    fn load_config_accepts_minimal_comment_only_file() {
+        let path = write_temp_config(
+            r#"
+# Moraine default config.
+# Values omitted here are filled by built-in defaults.
+"#,
+            "minimal-comment-only",
+        );
+        let cfg = load_config(&path).expect("minimal config should load with defaults");
+        std::fs::remove_file(&path).ok();
+        assert_eq!(cfg.clickhouse.url, "http://127.0.0.1:8123");
+        assert!(!cfg.ingest.sources.is_empty());
+    }
+
+    #[test]
     fn load_config_errors_on_unknown_top_level_section() {
         let path = write_temp_config(
             r#"

--- a/scripts/ci/e2e-install-artifact.sh
+++ b/scripts/ci/e2e-install-artifact.sh
@@ -130,6 +130,12 @@ main() {
     echo "missing installed moraine binary: $installed_moraine" >&2
     exit 1
   fi
+  local installed_config="$HOME/.moraine/config.toml"
+  if [[ ! -f "$installed_config" ]]; then
+    echo "missing installed config bootstrap: $installed_config" >&2
+    exit 1
+  fi
+  "$installed_moraine" config get clickhouse.url --config "$installed_config" >/dev/null
 
   echo "[e2e-install] running functional stack + MCP smoke with installed moraine"
   unset MORAINE_SOURCE_TREE_MODE

--- a/scripts/package-moraine-release.sh
+++ b/scripts/package-moraine-release.sh
@@ -83,12 +83,13 @@ CHECKSUM_PATH="$OUTPUT_DIR/moraine-bundle-$TARGET.sha256"
 STAGE_DIR="$(mktemp -d)"
 trap 'rm -rf "$STAGE_DIR"' EXIT
 
-mkdir -p "$STAGE_DIR/bin" "$STAGE_DIR/web/monitor"
+mkdir -p "$STAGE_DIR/bin" "$STAGE_DIR/config" "$STAGE_DIR/web/monitor"
 
 cp "$PROJECT_ROOT/target/$TARGET/release/moraine" "$STAGE_DIR/bin/moraine"
 cp "$PROJECT_ROOT/target/$TARGET/release/moraine-ingest" "$STAGE_DIR/bin/moraine-ingest"
 cp "$PROJECT_ROOT/target/$TARGET/release/moraine-monitor" "$STAGE_DIR/bin/moraine-monitor"
 cp "$PROJECT_ROOT/target/$TARGET/release/moraine-mcp" "$STAGE_DIR/bin/moraine-mcp"
+cp "$PROJECT_ROOT/config/moraine.toml" "$STAGE_DIR/config/moraine.toml"
 cp -R "$PROJECT_ROOT/web/monitor/dist" "$STAGE_DIR/web/monitor/dist"
 
 build_timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
@@ -98,6 +99,7 @@ checksum_moraine="$(sha256_file "$STAGE_DIR/bin/moraine")"
 checksum_ingest="$(sha256_file "$STAGE_DIR/bin/moraine-ingest")"
 checksum_monitor="$(sha256_file "$STAGE_DIR/bin/moraine-monitor")"
 checksum_mcp="$(sha256_file "$STAGE_DIR/bin/moraine-mcp")"
+checksum_config="$(sha256_file "$STAGE_DIR/config/moraine.toml")"
 
 cat > "$STAGE_DIR/manifest.json" <<EOF
 {
@@ -119,7 +121,8 @@ cat > "$STAGE_DIR/manifest.json" <<EOF
     "bin/moraine": "$checksum_moraine",
     "bin/moraine-ingest": "$checksum_ingest",
     "bin/moraine-monitor": "$checksum_monitor",
-    "bin/moraine-mcp": "$checksum_mcp"
+    "bin/moraine-mcp": "$checksum_mcp",
+    "config/moraine.toml": "$checksum_config"
   },
   "web_assets": [
     "web/monitor/dist"


### PR DESCRIPTION
## What changed and why
Fresh-machine installs could fail during managed ClickHouse setup because `scripts/install.sh` ran `moraine clickhouse install` before `~/.moraine/config.toml` existed. This change bootstraps config during install so ClickHouse setup has a valid config path.

### Changes
- `scripts/install.sh`
  - Resolve runtime config path (`MORAINE_CONFIG` or `~/.moraine/config.toml`).
  - Bootstrap config if missing: copy `config/moraine.toml` from bundle when present, otherwise write a minimal comment-only config that relies on built-in defaults.
  - Pass `--config <resolved-path>` to `moraine clickhouse install`.
  - Verify bundled config checksum when present in manifest.
- `scripts/package-moraine-release.sh`
  - Include `config/moraine.toml` in release bundle.
  - Add config checksum to `manifest.json`.
- `scripts/ci/e2e-install-artifact.sh`
  - Assert installer bootstraps `~/.moraine/config.toml` in isolated HOME.
  - Validate loaded config via `moraine config get clickhouse.url --config ...`.
- `crates/moraine-config/src/lib.rs`
  - Add unit test proving minimal comment-only config loads using defaults.

## Operational impact
- Install script now writes a config file on fresh installs if missing.
- Managed ClickHouse install uses an explicit config path, avoiding startup failure due to missing config.
- Release bundles now include the default config template.

## Validation
- `sh -n scripts/install.sh`
- `bash -n scripts/package-moraine-release.sh`
- `bash -n scripts/ci/e2e-install-artifact.sh`
- `cargo test -p moraine-config --locked`
- `cargo fmt --all -- --check`
- Isolated smoke test: ran `scripts/install.sh` against existing `v0.2.0` bundle with fresh `HOME`; confirmed config bootstrap and successful `moraine config get clickhouse.url --config ~/.moraine/config.toml`.
