### PR TITLE
fix(install): install monitor UI assets with release bundle

### DIFF
--- a/scripts/ci/e2e-install-artifact.sh
+++ b/scripts/ci/e2e-install-artifact.sh
@@ -130,6 +130,11 @@ main() {
     echo "missing installed moraine binary: $installed_moraine" >&2
     exit 1
   fi
+  local installed_monitor_index="$HOME/.local/web/monitor/dist/index.html"
+  if [[ ! -f "$installed_monitor_index" ]]; then
+    echo "missing installed monitor assets: $installed_monitor_index" >&2
+    exit 1
+  fi
   local installed_config="$HOME/.moraine/config.toml"
   if [[ ! -f "$installed_config" ]]; then
     echo "missing installed config bootstrap: $installed_config" >&2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -405,6 +405,18 @@ for bin in $bins; do
   chmod +x "$install_dir/$bin"
 done
 
+monitor_dist_source="$extract_dir/web/monitor/dist"
+if [ ! -d "$monitor_dist_source" ]; then
+  echo "archive did not contain required monitor assets: web/monitor/dist"
+  exit 1
+fi
+
+install_root="$(dirname "$install_dir")"
+monitor_dist_dir="$install_root/web/monitor/dist"
+mkdir -p "$(dirname "$monitor_dist_dir")"
+rm -rf "$monitor_dist_dir"
+cp -R "$monitor_dist_source" "$monitor_dist_dir"
+
 for bin in $bins; do
   if ! "$install_dir/$bin" --help >/dev/null 2>&1; then
     echo "installed binary failed health check (--help): $install_dir/$bin"
@@ -425,6 +437,7 @@ write_install_receipt \
   "$checksum_url"
 
 echo "installed binaries to: $install_dir"
+echo "installed monitor assets to: $monitor_dist_dir"
 echo "wrote install receipt: $receipt_path"
 
 if ! bootstrap_runtime_config "$runtime_config_path" "$extract_dir/config/moraine.toml"; then


### PR DESCRIPTION
## Summary
- install `web/monitor/dist` during `scripts/install.sh` into the bundle-relative runtime location (`$HOME/.local/web/monitor/dist` by default)
- fail fast if monitor assets are missing from the bundle archive
- add an e2e install-artifact check that asserts `~/.local/web/monitor/dist/index.html` exists after install

## Why
Installed binaries could start `moraine up`, but `moraine-monitor` exited immediately because static assets were never installed and fallback resolved to a build-machine path.

## Operational Impact
- fresh installs now include monitor UI assets in the expected runtime location
- installer now surfaces a clear error if release bundles are missing monitor assets
- CI now guards against this regression in install-artifact flow

## Validation
- `bash -n scripts/install.sh` (pass)
- `bash -n scripts/ci/e2e-install-artifact.sh` (pass)

## Linked Issues
- none
