### PR TITLE
fix(maintenance): stop merge train after first repair by default

### DIFF
--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -99,6 +99,7 @@ Main outputs:
 2. Validate readiness (draft status, optional approval, required checks, mergeability).
 3. Merge ready PRs sequentially.
 4. For behind/conflicting PRs, launch a Codex repair session in a fresh worktree to integrate latest base branch and push the updated head branch.
+5. Stop after the first repair attempt by default so one run does not trigger a full repair cascade.
 
 Quick start (queue label `merge-queue`):
 
@@ -126,6 +127,7 @@ Common options:
 - `--merge-method METHOD`: `squash|merge|rebase`.
 - `--require-approval`: require `reviewDecision=APPROVED` before merge.
 - `--no-repair`: disable Codex-based repair for behind/conflicting PRs.
+- `--continue-after-repair`: process additional PRs after a repair attempt (default is to stop after the first repair to avoid repair cascades).
 - `--repair-gate CMD`: validation command run after repair (default `cargo test --workspace --locked`).
 - `--cleanup-worktrees`: remove successful repair worktrees at the end.
 


### PR DESCRIPTION
## Summary
- stop merge-train processing after the first repair attempt by default
- avoid repair cascades where one run rebases/repairs many PRs after each upstream merge
- add `--continue-after-repair` as an explicit opt-in for the previous behavior
- document the new default behavior in `maintenance/README.md`

## Why
The first merge-train script version could repair PR A, then continue repairing PRs B/C/... in the same run. In a busy queue this creates a slow cascade of updates instead of converging one PR at a time.

This change enforces train semantics by halting after the first repair attempt so the next run can merge or reevaluate from a stable head.

## Operational Impact
- maintenance script behavior changes only (`maintenance/run_merge_train.sh`)
- default flow is now safer for serial queue progression
- operators can still opt into old behavior with `--continue-after-repair`

## Validation
- `bash -n maintenance/run_merge_train.sh`
- `maintenance/run_merge_train.sh --help`
- `maintenance/run_merge_train.sh --dry-run --all-open --pr-limit 2 --max-merges 1`

## Linked Issues
- none
