### PR TITLE
fix(conversations): alias derived-table columns in search_conversations SQL

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo.rs
@@ -1948,8 +1948,8 @@ FORMAT JSONEachRow",
   {terms_array_sql} AS q_terms,
   {idf_array_sql} AS q_idf
 SELECT
-  c.session_id,
-  c.score,
+  c.session_id AS session_id,
+  c.score AS score,
   toUInt16(c.matched_terms) AS matched_terms
 FROM (
   SELECT
@@ -2044,8 +2044,8 @@ FORMAT JSONEachRow",
   {terms_array_sql} AS q_terms,
   {idf_array_sql} AS q_idf
 SELECT
-  c.session_id,
-  c.score,
+  c.session_id AS session_id,
+  c.score AS score,
   toUInt16(c.matched_terms) AS matched_terms
 FROM (
   SELECT
@@ -2245,7 +2245,7 @@ FORMAT JSONEachRow",
   {terms_array_sql} AS q_terms,
   {idf_array_sql} AS q_idf{term_bits_with_sql}
 SELECT
-  c.session_id,
+  c.session_id AS session_id,
   if(s.session_id = '', '', toString(s.first_event_time)) AS first_event_time,
   if(
     s.session_id = '',
@@ -2258,11 +2258,11 @@ SELECT
     toInt64(0),
     toInt64(toUnixTimestamp64Milli(s.last_event_time))
   ) AS last_event_unix_ms,
-  c.provider,
-  c.score,
+  c.provider AS provider,
+  c.score AS score,
   toUInt16(c.matched_terms) AS matched_terms,
   toUInt32(c.event_count_considered) AS event_count_considered,
-  c.best_event_uid
+  c.best_event_uid AS best_event_uid
 FROM (
   SELECT
     e.session_id AS session_id,


### PR DESCRIPTION
## Summary

- `search_conversations` with a `mode` filter (`web_search`, `tool_calling`, `chat`, `mcp_internal`) fails with a ClickHouse JSONEachRow parse error
- Root cause: when the mode filter adds an `ANY LEFT JOIN`, ClickHouse qualifies output column names with the table alias (e.g. `c.session_id` instead of `session_id`), and the `ConversationSearchRow`/`ConversationCandidateRow` structs expect bare names
- Fix: add explicit `AS` aliases to all unaliased column references from derived table `c` in three SQL builder functions

## Test plan

- [x] `cargo test` — all 137 tests pass
- [x] Live verification: built release binary and tested `search_conversations` with all four mode values (`web_search`, `tool_calling`, `chat`, `mcp_internal`) — all return results successfully
- [x] Confirmed `search_conversations` without mode filter still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)