### PR TITLE
chore(release): cut v0.3.1

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.3.0)"
+        description: "Tag to release (for example v0.3.1)"
         required: true
         type: string
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "moraine"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "moraine-clickhouse",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/moraine-ingest/Cargo.toml
+++ b/apps/moraine-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Moraine ingest service binary"
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Moraine MCP stdio server"
 

--- a/apps/moraine-monitor/Cargo.toml
+++ b/apps/moraine-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Moraine monitor HTTP/UI service"
 

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Unified runtime control plane for Moraine services"
 

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-clickhouse"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Shared Moraine ClickHouse client and query helpers"
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-config"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Shared Moraine configuration schema and loaders"
 

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-conversations"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "High-level read/query APIs for Moraine conversations"
 

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest-core"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Core ingestion pipeline internals for Moraine"
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp-core"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "MCP protocol and tool routing core for Moraine"
 

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor-core"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Analytics and query logic for Moraine monitor service"
 

--- a/docs/operations/build-and-operations.md
+++ b/docs/operations/build-and-operations.md
@@ -71,7 +71,7 @@ Installer environment configuration:
 
 Tag-driven GitHub Actions release workflow:
 
-1. Push a semantic tag (example: `v0.3.0`).
+1. Push a semantic tag (example: `v0.3.1`).
 2. Workflow `.github/workflows/release-moraine.yml` builds:
    - `x86_64-unknown-linux-gnu`
    - `aarch64-unknown-linux-gnu`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,7 +27,7 @@ install directory precedence:
 
 examples:
   scripts/install.sh
-  MORAINE_INSTALL_VERSION=v0.3.0 scripts/install.sh
+  MORAINE_INSTALL_VERSION=v0.3.1 scripts/install.sh
   MORAINE_INSTALL_ASSET_BASE_URL=http://127.0.0.1:8080 \
     MORAINE_INSTALL_VERSION=ci-e2e scripts/install.sh
   MORAINE_INSTALL_DIR="$HOME/bin" MORAINE_INSTALL_SKIP_CLICKHOUSE=1 scripts/install.sh


### PR DESCRIPTION
## What changed and why
- Bumped all workspace crate versions from `0.3.0` to `0.3.1` for the v0.3.1 release cut.
- Updated release/install documentation examples from `v0.3.0` to `v0.3.1`.
- Refreshed `Cargo.lock` to match workspace crate version bumps.

## Operational impact
- Enables publishing release artifacts under tag `v0.3.1` via `.github/workflows/release-moraine.yml`.
- Installer docs now point to the current release tag example.

## Validation
- `cargo check --workspace --locked`
- `cargo fmt --all -- --check`

## Scope
- Includes updates merged after `v0.3.0` (currently #201 and #199).
