### PR TITLE
feat(mcp): deterministic sort and pagination for session listing

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo.rs
@@ -17,11 +17,12 @@ use crate::cursor::{
 };
 use crate::domain::{
     is_user_facing_content_event, Conversation, ConversationDetailOptions, ConversationListFilter,
-    ConversationMode, ConversationSearchHit, ConversationSearchQuery, ConversationSearchResults,
-    ConversationSearchStats, ConversationSummary, OpenContext, OpenEvent, OpenEventRequest, Page,
-    PageRequest, RepoConfig, SearchEventHit, SearchEventKind, SearchEventsQuery,
-    SearchEventsResult, SearchEventsStats, SearchEventsStrategy, SessionEventsDirection,
-    SessionEventsQuery, SessionMetadata, TraceEvent, Turn, TurnListFilter, TurnSummary,
+    ConversationListSort, ConversationMode, ConversationSearchHit, ConversationSearchQuery,
+    ConversationSearchResults, ConversationSearchStats, ConversationSummary, OpenContext,
+    OpenEvent, OpenEventRequest, Page, PageRequest, RepoConfig, SearchEventHit, SearchEventKind,
+    SearchEventsQuery, SearchEventsResult, SearchEventsStats, SearchEventsStrategy,
+    SessionEventsDirection, SessionEventsQuery, SessionMetadata, TraceEvent, Turn, TurnListFilter,
+    TurnSummary,
 };
 use crate::error::{RepoError, RepoResult};
 use crate::repo::ConversationRepository;
@@ -578,13 +579,14 @@ GROUP BY session_id"
 
     fn conversation_filter_sig(filter: &ConversationListFilter) -> String {
         format!(
-            "from={:?};to={:?};mode={}",
+            "from={:?};to={:?};mode={};sort={}",
             filter.from_unix_ms,
             filter.to_unix_ms,
             filter
                 .mode
                 .map(ConversationMode::as_str)
-                .unwrap_or("__none__")
+                .unwrap_or("__none__"),
+            filter.sort.as_str(),
         )
     }
 
@@ -2788,12 +2790,18 @@ impl ConversationRepository for ClickHouseConversationRepository {
 
         let limit = page.normalized_limit(self.cfg.max_results);
         let filter_sig = Self::conversation_filter_sig(&filter);
+        let sort = filter.sort;
 
         let cursor = if let Some(token) = page.cursor.as_deref() {
             let cursor: ConversationCursor = decode_cursor(token)?;
             if cursor.filter_sig != filter_sig {
                 return Err(RepoError::invalid_cursor(
                     "cursor does not match current conversation filter",
+                ));
+            }
+            if cursor.sort != sort {
+                return Err(RepoError::invalid_cursor(
+                    "cursor sort does not match requested sort order",
                 ));
             }
             Some(cursor)
@@ -2821,8 +2829,12 @@ impl ConversationRepository for ClickHouseConversationRepository {
         }
 
         if let Some(cursor) = &cursor {
+            let (time_cmp, session_cmp) = match sort {
+                ConversationListSort::Desc => ("<", "<"),
+                ConversationListSort::Asc => (">", ">"),
+            };
             where_clauses.push(format!(
-                "(toUnixTimestamp64Milli(s.last_event_time) < {} OR (toUnixTimestamp64Milli(s.last_event_time) = {} AND s.session_id < {}))",
+                "(toUnixTimestamp64Milli(s.last_event_time) {time_cmp} {} OR (toUnixTimestamp64Milli(s.last_event_time) = {} AND s.session_id {session_cmp} {}))",
                 cursor.last_event_unix_ms,
                 cursor.last_event_unix_ms,
                 sql_quote(&cursor.session_id)
@@ -2830,6 +2842,10 @@ impl ConversationRepository for ClickHouseConversationRepository {
         }
 
         let where_sql = where_clauses.join("\n  AND ");
+        let order_dir = match sort {
+            ConversationListSort::Desc => "DESC",
+            ConversationListSort::Asc => "ASC",
+        };
 
         let query = format!(
             "SELECT
@@ -2848,12 +2864,13 @@ impl ConversationRepository for ClickHouseConversationRepository {
 FROM {session_summary} AS s
 LEFT JOIN ({mode_subquery}) AS m ON m.session_id = s.session_id
 WHERE {where_sql}
-ORDER BY s.last_event_time DESC, s.session_id DESC
+ORDER BY s.last_event_time {order_dir}, s.session_id {order_dir}
 LIMIT {limit_plus}
 FORMAT JSONEachRow",
             session_summary = session_summary,
             mode_subquery = mode_subquery,
             where_sql = where_sql,
+            order_dir = order_dir,
             limit_plus = (limit as usize) + 1,
         );
 
@@ -2873,6 +2890,7 @@ FORMAT JSONEachRow",
                     last_event_unix_ms: last.last_event_unix_ms,
                     session_id: last.session_id.clone(),
                     filter_sig,
+                    sort,
                 })?)
             } else {
                 None

--- a/crates/moraine-conversations/src/cursor.rs
+++ b/crates/moraine-conversations/src/cursor.rs
@@ -2,7 +2,7 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::SessionEventsDirection;
+use crate::domain::{ConversationListSort, SessionEventsDirection};
 use crate::error::{RepoError, RepoResult};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -10,6 +10,8 @@ pub struct ConversationCursor {
     pub last_event_unix_ms: i64,
     pub session_id: String,
     pub filter_sig: String,
+    #[serde(default)]
+    pub sort: ConversationListSort,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -20,6 +20,23 @@ impl ConversationMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConversationListSort {
+    Asc,
+    #[default]
+    Desc,
+}
+
+impl ConversationListSort {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Asc => "asc",
+            Self::Desc => "desc",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ConversationListFilter {
     #[serde(default)]
@@ -28,6 +45,8 @@ pub struct ConversationListFilter {
     pub to_unix_ms: Option<i64>,
     #[serde(default)]
     pub mode: Option<ConversationMode>,
+    #[serde(default)]
+    pub sort: ConversationListSort,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -7,11 +7,12 @@ mod repo;
 pub use clickhouse_repo::ClickHouseConversationRepository;
 pub use domain::{
     is_user_facing_content_event, Conversation, ConversationDetailOptions, ConversationListFilter,
-    ConversationMode, ConversationSearchHit, ConversationSearchQuery, ConversationSearchResults,
-    ConversationSearchStats, ConversationSummary, OpenContext, OpenEvent, OpenEventRequest, Page,
-    PageRequest, RepoConfig, SearchEventHit, SearchEventKind, SearchEventsQuery,
-    SearchEventsResult, SearchEventsStats, SearchEventsStrategy, SessionEventsDirection,
-    SessionEventsQuery, SessionMetadata, TraceEvent, Turn, TurnListFilter, TurnSummary,
+    ConversationListSort, ConversationMode, ConversationSearchHit, ConversationSearchQuery,
+    ConversationSearchResults, ConversationSearchStats, ConversationSummary, OpenContext,
+    OpenEvent, OpenEventRequest, Page, PageRequest, RepoConfig, SearchEventHit, SearchEventKind,
+    SearchEventsQuery, SearchEventsResult, SearchEventsStats, SearchEventsStrategy,
+    SessionEventsDirection, SessionEventsQuery, SessionMetadata, TraceEvent, Turn, TurnListFilter,
+    TurnSummary,
 };
 pub use error::{RepoError, RepoResult};
 pub use repo::ConversationRepository;

--- a/crates/moraine-conversations/tests/repository_integration.rs
+++ b/crates/moraine-conversations/tests/repository_integration.rs
@@ -11,9 +11,9 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use moraine_clickhouse::ClickHouseClient;
 use moraine_config::ClickHouseConfig;
 use moraine_conversations::{
-    ClickHouseConversationRepository, ConversationListFilter, ConversationMode,
-    ConversationRepository, ConversationSearchQuery, PageRequest, RepoConfig, RepoError,
-    SearchEventKind, SearchEventsQuery, SessionEventsDirection, SessionEventsQuery,
+    ClickHouseConversationRepository, ConversationListFilter, ConversationListSort,
+    ConversationMode, ConversationRepository, ConversationSearchQuery, PageRequest, RepoConfig,
+    RepoError, SearchEventKind, SearchEventsQuery, SessionEventsDirection, SessionEventsQuery,
 };
 use serde_json::json;
 
@@ -201,6 +201,80 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
                         "first_event_uid": "evt-c-1",
                         "last_event_uid": "evt-c-42",
                         "last_actor_role": "assistant"
+                    }
+                ])),
+            );
+        }
+
+        if query.contains("FROM `moraine`.`v_session_summary` AS s")
+            && query.contains("ORDER BY s.last_event_time ASC")
+        {
+            if query.contains("s.session_id > 'sess_b'") {
+                return (
+                    StatusCode::OK,
+                    json_each_row(json!([
+                        {
+                            "session_id": "sess_c",
+                            "first_event_time": "2026-01-03 10:00:00",
+                            "first_event_unix_ms": 1767434400000_i64,
+                            "last_event_time": "2026-01-03 10:10:00",
+                            "last_event_unix_ms": 1767435000000_i64,
+                            "total_turns": 3,
+                            "total_events": 30,
+                            "user_messages": 6,
+                            "assistant_messages": 6,
+                            "tool_calls": 3,
+                            "tool_results": 3,
+                            "mode": "web_search"
+                        }
+                    ])),
+                );
+            }
+
+            return (
+                StatusCode::OK,
+                json_each_row(json!([
+                    {
+                        "session_id": "sess_a",
+                        "first_event_time": "2026-01-01 10:00:00",
+                        "first_event_unix_ms": 1767261600000_i64,
+                        "last_event_time": "2026-01-01 10:10:00",
+                        "last_event_unix_ms": 1767262200000_i64,
+                        "total_turns": 2,
+                        "total_events": 20,
+                        "user_messages": 4,
+                        "assistant_messages": 4,
+                        "tool_calls": 2,
+                        "tool_results": 2,
+                        "mode": "web_search"
+                    },
+                    {
+                        "session_id": "sess_b",
+                        "first_event_time": "2026-01-02 10:00:00",
+                        "first_event_unix_ms": 1767348000000_i64,
+                        "last_event_time": "2026-01-02 10:10:00",
+                        "last_event_unix_ms": 1767348600000_i64,
+                        "total_turns": 2,
+                        "total_events": 22,
+                        "user_messages": 4,
+                        "assistant_messages": 4,
+                        "tool_calls": 2,
+                        "tool_results": 2,
+                        "mode": "web_search"
+                    },
+                    {
+                        "session_id": "sess_c",
+                        "first_event_time": "2026-01-03 10:00:00",
+                        "first_event_unix_ms": 1767434400000_i64,
+                        "last_event_time": "2026-01-03 10:10:00",
+                        "last_event_unix_ms": 1767435000000_i64,
+                        "total_turns": 3,
+                        "total_events": 30,
+                        "user_messages": 6,
+                        "assistant_messages": 6,
+                        "tool_calls": 3,
+                        "tool_results": 3,
+                        "mode": "web_search"
                     }
                 ])),
             );
@@ -624,6 +698,7 @@ async fn list_conversations_applies_filters_and_cursor_pagination() {
         from_unix_ms: Some(1767261600000_i64),
         to_unix_ms: Some(1767500000000_i64),
         mode: Some(ConversationMode::WebSearch),
+        sort: ConversationListSort::Desc,
     };
 
     let first = repo
@@ -666,6 +741,107 @@ async fn list_conversations_applies_filters_and_cursor_pagination() {
     assert!(list_query.contains("ifNull(m.mode, 'chat') = 'web_search'"));
     assert!(list_query.contains("toUnixTimestamp64Milli(s.last_event_time) >= 1767261600000"));
     assert!(list_query.contains("toUnixTimestamp64Milli(s.last_event_time) < 1767500000000"));
+    assert!(list_query.contains("ORDER BY s.last_event_time DESC, s.session_id DESC"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_conversations_supports_ascending_sort_with_deterministic_cursor() {
+    let (repo, state) = build_repo().await;
+
+    let filter = ConversationListFilter {
+        from_unix_ms: Some(1767261600000_i64),
+        to_unix_ms: Some(1767500000000_i64),
+        mode: Some(ConversationMode::WebSearch),
+        sort: ConversationListSort::Asc,
+    };
+
+    let first = repo
+        .list_conversations(
+            filter.clone(),
+            PageRequest {
+                limit: 2,
+                cursor: None,
+            },
+        )
+        .await
+        .expect("first page");
+
+    assert_eq!(first.items.len(), 2);
+    assert_eq!(first.items[0].session_id, "sess_a");
+    assert_eq!(first.items[1].session_id, "sess_b");
+    assert!(first.next_cursor.is_some());
+
+    let second = repo
+        .list_conversations(
+            filter,
+            PageRequest {
+                limit: 2,
+                cursor: first.next_cursor,
+            },
+        )
+        .await
+        .expect("second page");
+
+    assert_eq!(second.items.len(), 1);
+    assert_eq!(second.items[0].session_id, "sess_c");
+    assert!(second.next_cursor.is_none());
+
+    let queries = state.queries.lock().expect("queries lock").clone();
+    let first_query = queries
+        .iter()
+        .find(|q| q.contains("ORDER BY s.last_event_time ASC, s.session_id ASC"))
+        .expect("ascending list query should be captured");
+    assert!(first_query.contains("ifNull(m.mode, 'chat') = 'web_search'"));
+
+    let paged_query = queries
+        .iter()
+        .find(|q| q.contains("s.session_id > 'sess_b'"))
+        .expect("ascending pagination query should include deterministic cursor predicate");
+    assert!(paged_query.contains("toUnixTimestamp64Milli(s.last_event_time) > 1767348600000"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_conversations_rejects_cursor_when_sort_changes() {
+    let (repo, _state) = build_repo().await;
+
+    let desc_filter = ConversationListFilter {
+        from_unix_ms: Some(1767261600000_i64),
+        to_unix_ms: Some(1767500000000_i64),
+        mode: Some(ConversationMode::WebSearch),
+        sort: ConversationListSort::Desc,
+    };
+    let asc_filter = ConversationListFilter {
+        sort: ConversationListSort::Asc,
+        ..desc_filter.clone()
+    };
+
+    let first = repo
+        .list_conversations(
+            desc_filter,
+            PageRequest {
+                limit: 1,
+                cursor: None,
+            },
+        )
+        .await
+        .expect("first page");
+    let cursor = first.next_cursor.expect("next cursor");
+
+    let err = repo
+        .list_conversations(
+            asc_filter,
+            PageRequest {
+                limit: 1,
+                cursor: Some(cursor),
+            },
+        )
+        .await
+        .expect_err("sort mismatch should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "invalid cursor: cursor does not match current conversation filter"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -3,9 +3,10 @@ use moraine_clickhouse::ClickHouseClient;
 use moraine_config::AppConfig;
 use moraine_conversations::{
     is_user_facing_content_event, ClickHouseConversationRepository, ConversationListFilter,
-    ConversationMode, ConversationRepository, ConversationSearchQuery, ConversationSearchResults,
-    OpenEventRequest, PageRequest, RepoConfig, RepoError, SearchEventKind, SearchEventsQuery,
-    SearchEventsResult, SessionEventsDirection, SessionEventsQuery,
+    ConversationListSort, ConversationMode, ConversationRepository, ConversationSearchQuery,
+    ConversationSearchResults, OpenEventRequest, PageRequest, RepoConfig, RepoError,
+    SearchEventKind, SearchEventsQuery, SearchEventsResult, SessionEventsDirection,
+    SessionEventsQuery,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -124,6 +125,8 @@ struct ListSessionsArgs {
     to_unix_ms: Option<i64>,
     #[serde(default)]
     mode: Option<ConversationMode>,
+    #[serde(default)]
+    sort: Option<ConversationListSort>,
     #[serde(default)]
     verbosity: Option<Verbosity>,
 }
@@ -313,6 +316,8 @@ struct SessionListProsePayload {
     sessions: Vec<SessionListProseSession>,
     #[serde(default)]
     next_cursor: Option<String>,
+    #[serde(default)]
+    sort: String,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -609,6 +614,12 @@ impl AppState {
                                 "enum": ["web_search", "mcp_internal", "tool_calling", "chat"],
                                 "description": SEARCH_CONVERSATIONS_MODE_DOC
                             },
+                            "sort": {
+                                "type": "string",
+                                "enum": ["asc", "desc"],
+                                "default": "desc",
+                                "description": "Sort by session end time then session_id. Use `desc` for newest-first or `asc` for oldest-first. Cursor tokens are deterministic for a fixed filter + sort."
+                            },
                             "verbosity": {
                                 "type": "string",
                                 "enum": ["prose", "full"],
@@ -719,12 +730,14 @@ impl AppState {
                 }
             }
             "list_sessions" => {
-                let args: ListSessionsArgs = if params.arguments.is_null() {
+                let mut args: ListSessionsArgs = if params.arguments.is_null() {
                     ListSessionsArgs::default()
                 } else {
                     serde_json::from_value(params.arguments)
                         .context("list_sessions expects a JSON object with optional filters")?
                 };
+                args.limit =
+                    validate_tool_limit("list_sessions", args.limit, self.cfg.mcp.max_results)?;
                 let verbosity = args.verbosity.unwrap_or_default();
                 let payload = self.list_sessions(args).await?;
                 match verbosity {
@@ -837,8 +850,10 @@ impl AppState {
             from_unix_ms,
             to_unix_ms,
             mode,
+            sort,
             verbosity: _,
         } = args;
+        let sort = sort.unwrap_or_default();
 
         let page = self
             .repo
@@ -847,6 +862,7 @@ impl AppState {
                     from_unix_ms,
                     to_unix_ms,
                     mode,
+                    sort,
                 },
                 PageRequest {
                     limit: limit.unwrap_or(self.cfg.mcp.max_results),
@@ -881,6 +897,7 @@ impl AppState {
             "from_unix_ms": from_unix_ms,
             "to_unix_ms": to_unix_ms,
             "mode": mode.map(ConversationMode::as_str),
+            "sort": sort.as_str(),
             "sessions": sessions,
             "next_cursor": page.next_cursor,
         }))
@@ -1361,6 +1378,12 @@ fn format_session_list_prose(payload: &Value) -> Result<String> {
     let mut out = String::new();
     out.push_str("Session List\n");
     out.push_str(&format!("Sessions: {}\n", parsed.sessions.len()));
+    let sort = if parsed.sort.is_empty() {
+        "desc"
+    } else {
+        parsed.sort.as_str()
+    };
+    out.push_str(&format!("Sort: {}\n", sort));
 
     if parsed.sessions.is_empty() {
         out.push_str("\nNo sessions.");
@@ -2026,11 +2049,13 @@ mod tests {
     fn format_session_list_handles_empty_result() {
         let payload = json!({
             "sessions": [],
+            "sort": "desc",
             "next_cursor": null
         });
 
         let text = format_session_list_prose(&payload).expect("format");
         assert!(text.contains("Session List"));
+        assert!(text.contains("Sort: desc"));
         assert!(text.contains("No sessions"));
     }
 
@@ -2048,11 +2073,13 @@ mod tests {
                     "mode": "web_search"
                 }
             ],
+            "sort": "asc",
             "next_cursor": "cursor-token"
         });
 
         let text = format_session_list_prose(&payload).expect("format");
         assert!(text.contains("session=sess-1"));
+        assert!(text.contains("Sort: asc"));
         assert!(text.contains("mode=web_search"));
         assert!(text.contains("next_cursor: cursor-token"));
     }


### PR DESCRIPTION
## Summary
Add deterministic sort and pagination controls for MCP session listing so callers can reliably page oldest-first or newest-first.

## What Changed
- Added `sort` support (`asc|desc`, default `desc`) to `list_sessions` tool arguments and schema.
- Threaded sort through conversations listing filters and cursor tokens.
- Updated ClickHouse list query generation to apply sort-specific ordering and cursor predicates.
- Added list-session limit validation to enforce configured max bound.
- Extended integration tests for ascending pagination behavior and cursor/sort consistency.

## Operational Impact
- `list_sessions` now accepts `sort` and returns it in payload.
- Cursor tokens are deterministic per filter+sort combination.
- Invalid `list_sessions.limit` now returns a structured tool error instead of silent clamping.

## Validation
- `cargo fmt --all`
- `cargo test -p moraine-mcp-core --locked`
- `cargo test -p moraine-conversations --locked`

Closes #207