### PR TITLE
fix(ingest): release worker permit before reschedule send (#215)

### DIFF
--- a/crates/moraine-ingest-core/src/dispatch.rs
+++ b/crates/moraine-ingest-core/src/dispatch.rs
@@ -12,9 +12,9 @@ use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{mpsc, OwnedSemaphorePermit, RwLock};
 use tokio::task::JoinHandle;
-use tracing::debug;
+use tracing::{debug, error};
 
 #[cfg(not(unix))]
 use same_file::Handle;
@@ -124,6 +124,43 @@ pub(crate) fn complete_work(key: &str, dispatch: &Arc<Mutex<DispatchState>>) -> 
     }
 
     None
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_work_item(
+    config: AppConfig,
+    work: WorkItem,
+    permit: OwnedSemaphorePermit,
+    checkpoints: Arc<RwLock<HashMap<String, Checkpoint>>>,
+    sink_tx: mpsc::Sender<crate::SinkMessage>,
+    process_tx: mpsc::Sender<WorkItem>,
+    dispatch: Arc<Mutex<DispatchState>>,
+    metrics: Arc<Metrics>,
+) {
+    let key = work.key();
+
+    if let Err(exc) = process_file(&config, &work, checkpoints, sink_tx, &metrics).await {
+        error!(
+            "failed processing {}:{}: {exc}",
+            work.source_name, work.path
+        );
+        *metrics
+            .last_error
+            .lock()
+            .expect("metrics last_error mutex poisoned") = exc.to_string();
+    }
+
+    let reschedule = complete_work(&key, &dispatch);
+
+    // Release before the reschedule `send`; holding it across a full
+    // `process_tx` would deadlock the processor loop (issue #215).
+    drop(permit);
+
+    if let Some(item) = reschedule {
+        if process_tx.send(item).await.is_ok() {
+            metrics.queue_depth.fetch_add(1, Ordering::Relaxed);
+        }
+    }
 }
 
 pub(crate) async fn process_file(
@@ -391,12 +428,16 @@ fn truncate(input: &str, max_chars: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{complete_work, source_inode_for_file};
-    use crate::{DispatchState, WorkItem};
+    use super::{complete_work, run_work_item, source_inode_for_file};
+    use crate::model::Checkpoint;
+    use crate::{DispatchState, Metrics, SinkMessage, WorkItem};
+    use std::collections::HashMap;
     use std::fs;
     use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use tokio::sync::{mpsc, RwLock, Semaphore};
+    use tokio::time::timeout;
 
     fn sample_work(path: &str) -> WorkItem {
         WorkItem {
@@ -519,5 +560,72 @@ mod tests {
 
         let _ = fs::remove_file(&path);
         assert_ne!(original_id, replaced_id);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn run_work_item_releases_permit_before_reschedule_send() {
+        let path = unique_test_file("reschedule-no-deadlock");
+        fs::write(&path, "").expect("write empty jsonl");
+        let work = WorkItem {
+            source_name: "test-source".to_string(),
+            provider: "test-provider".to_string(),
+            path: path.to_string_lossy().to_string(),
+        };
+        let key = work.key();
+
+        let dispatch = Arc::new(Mutex::new(DispatchState::default()));
+        {
+            let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+            state.inflight.insert(key.clone());
+            state.dirty.insert(key.clone());
+            state.item_by_key.insert(key.clone(), work.clone());
+        }
+
+        let config = moraine_config::AppConfig::default();
+        let checkpoints = Arc::new(RwLock::new(HashMap::<String, Checkpoint>::new()));
+        let metrics = Arc::new(Metrics::default());
+
+        let (sink_tx, _sink_rx) = mpsc::channel::<SinkMessage>(8);
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(1);
+        process_tx
+            .send(work.clone())
+            .await
+            .expect("prime process_tx so reschedule send will block");
+
+        let sem = Arc::new(Semaphore::new(1));
+        let permit = sem
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("acquire initial permit");
+
+        let task = tokio::spawn(run_work_item(
+            config,
+            work,
+            permit,
+            checkpoints,
+            sink_tx,
+            process_tx,
+            dispatch,
+            metrics,
+        ));
+
+        let released = timeout(Duration::from_millis(500), sem.acquire()).await;
+        assert!(
+            released.is_ok(),
+            "permit must be released before the reschedule `send` blocks on a full channel"
+        );
+
+        process_rx.recv().await.expect("priming item");
+
+        let rescheduled = timeout(Duration::from_millis(500), process_rx.recv())
+            .await
+            .expect("rescheduled send should complete once channel drains")
+            .expect("rescheduled work item delivered");
+        assert_eq!(rescheduled.key(), key);
+
+        task.await.expect("run_work_item task should finish");
+
+        let _ = fs::remove_file(&path);
     }
 }

--- a/crates/moraine-ingest-core/src/lib.rs
+++ b/crates/moraine-ingest-core/src/lib.rs
@@ -8,7 +8,7 @@ mod sink;
 mod watch;
 
 use crate::checkpoint::checkpoint_key;
-use crate::dispatch::{complete_work, enqueue_work, process_file, spawn_debounce_task};
+use crate::dispatch::{enqueue_work, run_work_item, spawn_debounce_task};
 use crate::model::RowBatch;
 use crate::reconcile::spawn_reconcile_task;
 use crate::sink::spawn_sink_task;
@@ -21,7 +21,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, RwLock, Semaphore};
-use tracing::{error, info};
+use tracing::info;
 
 pub(crate) const WATCHER_BACKEND_UNKNOWN: u64 = 0;
 pub(crate) const WATCHER_BACKEND_NATIVE: u64 = 1;
@@ -149,42 +149,16 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
                     Err(_) => break,
                 };
 
-                let sink_tx_worker = sink_tx_clone.clone();
-                let process_tx_worker = process_tx_clone.clone();
-                let checkpoints_worker = checkpoints_clone.clone();
-                let dispatch_worker = dispatch_clone.clone();
-                let cfg_worker = cfg_clone.clone();
-                let metrics_worker = metrics_clone.clone();
-
-                tokio::spawn(async move {
-                    let _permit = permit;
-                    if let Err(exc) = process_file(
-                        &cfg_worker,
-                        &work,
-                        checkpoints_worker,
-                        sink_tx_worker,
-                        &metrics_worker,
-                    )
-                    .await
-                    {
-                        error!(
-                            "failed processing {}:{}: {exc}",
-                            work.source_name, work.path
-                        );
-                        *metrics_worker
-                            .last_error
-                            .lock()
-                            .expect("metrics last_error mutex poisoned") = exc.to_string();
-                    }
-
-                    let reschedule = complete_work(&key, &dispatch_worker);
-
-                    if let Some(item) = reschedule {
-                        if process_tx_worker.send(item).await.is_ok() {
-                            metrics_worker.queue_depth.fetch_add(1, Ordering::Relaxed);
-                        }
-                    }
-                });
+                tokio::spawn(run_work_item(
+                    cfg_clone.clone(),
+                    work,
+                    permit,
+                    checkpoints_clone.clone(),
+                    sink_tx_clone.clone(),
+                    process_tx_clone.clone(),
+                    dispatch_clone.clone(),
+                    metrics_clone.clone(),
+                ));
             }
         })
     };


### PR DESCRIPTION
## Summary
- Cold-start backfill with many files (≥ `max_file_workers`) deadlocks exactly once every worker has processed its first file: `queue_depth` pins at the `process_tx` capacity (1024), heartbeats stop, and threads park on futexes. Issue [#215](https://github.com/eric-tramel/moraine/issues/215).
- The worker task held its `OwnedSemaphorePermit` for the entire `async move { … }` block, including the trailing `process_tx.send(item).await` used to reschedule dirty files. When the watcher path marked an inflight file dirty during backfill, every completed worker blocked on pushing back into an already-full `process_tx` while still holding a permit. All 8 permits got pinned, the processor loop could no longer call `acquire_owned`, the channel could not drain, and backfill was wedged on its own `send` — a classic resource cycle.
- Extract the worker body into `dispatch::run_work_item` and `drop(permit)` between `complete_work` and the reschedule `send`. The processor can always make forward progress even while reschedule sends back-pressure on a full channel.

## Reproduction (cold-start e2e in `/tmp`)

Standalone ClickHouse (ports 18123/19000) + moraine schema + 2000 synthetic Claude-shaped JSONL files (30 lines each). Config: `max_file_workers=4`, `max_inflight_batches=1` (process_tx clamped to 1024). A concurrent Python writer appends to 300 random files in a loop so the native watcher keeps firing modify events while backfill runs — this is what drives inflight files into the `dirty` set and forces the reschedule path.

**Pre-fix (commit `2d9d9c8`):**

| cp | events | queue_depth | files_active | CPU |
|----|--------|-------------|--------------|-----|
| **4** | 120 | 1024 | 1 | 0% |

Frozen for 40+ seconds, never logged `rust ingestor running; waiting for shutdown signal` — the backfill loop itself is wedged on `process_tx.send`. `checkpoints == max_file_workers` is the exact signature from issue #215.

**Post-fix (this branch):**

| t+4s | t+20s | t+40s |
|------|-------|-------|
| cp=1100, ev=56K | cp=1816, ev=135K | cp=2477, ev=236K |

Checkpoints > 2000 because the writer keeps appending new generations while moraine keeps up. Backfill completes, ingestor reaches the shutdown-signal wait. No deadlock under the adversarial workload that deterministically wedged the pre-fix build.

## Test plan
- [x] `cargo test -p moraine-ingest-core` — 35 tests pass, including the new regression
- [x] `cargo check --workspace`
- [x] New unit regression: `run_work_item_releases_permit_before_reschedule_send` primes `process_tx` to capacity, spawns `run_work_item` on a dirty item, and asserts the semaphore permit is released within 500ms (it never is on `main`).
- [x] End-to-end cold-start repro in `/tmp/moraine-test-215` against a standalone ClickHouse: pre-fix binary deadlocks at `checkpoints=4=max_file_workers`; post-fix binary drives through 2000+ files under the same adversarial writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)