### PR TITLE
feat(install): honor MORAINE_MONITOR_DIST and MORAINE_DEFAULT_CONFIG env overrides

### DIFF
--- a/apps/moraine-monitor/src/cli.rs
+++ b/apps/moraine-monitor/src/cli.rs
@@ -32,12 +32,27 @@ fn source_tree_static_dir() -> PathBuf {
         .join("dist")
 }
 
-fn default_static_dir() -> PathBuf {
-    if let Ok(value) = std::env::var("MORAINE_MONITOR_STATIC_DIR") {
-        let configured = PathBuf::from(value);
-        if configured.exists() {
-            return configured;
+const MONITOR_DIST_ENV_KEYS: &[&str] = &["MORAINE_MONITOR_DIST", "MORAINE_MONITOR_STATIC_DIR"];
+
+fn env_override_static_dir_with_keys(keys: &[&str]) -> Option<PathBuf> {
+    for key in keys {
+        if let Ok(value) = std::env::var(key) {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let configured = PathBuf::from(trimmed);
+            if configured.exists() {
+                return Some(configured);
+            }
         }
+    }
+    None
+}
+
+fn default_static_dir() -> PathBuf {
+    if let Some(configured) = env_override_static_dir_with_keys(MONITOR_DIST_ENV_KEYS) {
+        return configured;
     }
 
     if let Ok(exe) = std::env::current_exe() {
@@ -109,7 +124,7 @@ pub fn parse_args() -> CliArgs {
 
 #[cfg(test)]
 mod tests {
-    use super::find_monitor_dir;
+    use super::{env_override_static_dir_with_keys, find_monitor_dir};
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -151,5 +166,40 @@ mod tests {
         assert_eq!(found, None);
 
         fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn env_override_returns_path_when_set_and_exists() {
+        let root = temp_root("env-override-primary");
+        let env_key = "MORAINE_MONITOR_DIST_TEST_PRIMARY";
+        std::env::set_var(env_key, root.to_string_lossy().to_string());
+
+        let found = env_override_static_dir_with_keys(&[env_key]);
+
+        std::env::remove_var(env_key);
+        fs::remove_dir_all(&root).ok();
+        assert_eq!(found, Some(root));
+    }
+
+    #[test]
+    fn env_override_none_when_unset() {
+        let found = env_override_static_dir_with_keys(&["MORAINE_MONITOR_DIST_TEST_UNSET_KEY"]);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn env_override_skips_missing_path_and_falls_through_to_alias() {
+        let root = temp_root("env-override-alias");
+        let primary = "MORAINE_MONITOR_DIST_TEST_ALIAS_PRIMARY";
+        let alias = "MORAINE_MONITOR_DIST_TEST_ALIAS_SECONDARY";
+        std::env::set_var(primary, "/tmp/moraine-monitor-dist-definitely-missing");
+        std::env::set_var(alias, root.to_string_lossy().to_string());
+
+        let found = env_override_static_dir_with_keys(&[primary, alias]);
+
+        std::env::remove_var(primary);
+        std::env::remove_var(alias);
+        fs::remove_dir_all(&root).ok();
+        assert_eq!(found, Some(root));
     }
 }

--- a/apps/moraine/src/main.rs
+++ b/apps/moraine/src/main.rs
@@ -1342,11 +1342,19 @@ fn monitor_dist_candidate(root: &Path) -> PathBuf {
     root.join("web").join("monitor").join("dist")
 }
 
+const MONITOR_DIST_ENV_KEYS: &[&str] = &["MORAINE_MONITOR_DIST", "MORAINE_MONITOR_STATIC_DIR"];
+
 fn resolve_monitor_static_dir(paths: &RuntimePaths) -> Option<PathBuf> {
-    if let Ok(value) = std::env::var("MORAINE_MONITOR_STATIC_DIR") {
-        let path = PathBuf::from(value);
-        if path.exists() {
-            return Some(path);
+    for key in MONITOR_DIST_ENV_KEYS {
+        if let Ok(value) = std::env::var(key) {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let path = PathBuf::from(trimmed);
+            if path.exists() {
+                return Some(path);
+            }
         }
     }
 

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -513,10 +513,13 @@ fn repo_default_config_path() -> PathBuf {
     PathBuf::from("config/moraine.toml")
 }
 
+const DEFAULT_CONFIG_ENV_KEYS: &[&str] = &["MORAINE_DEFAULT_CONFIG"];
+
 fn resolve_config_path_with_overrides(
     raw_path: Option<PathBuf>,
     env_keys: &[&str],
     home_path: Option<PathBuf>,
+    default_env_keys: &[&str],
     repo_default: PathBuf,
 ) -> PathBuf {
     if let Some(path) = raw_path {
@@ -538,6 +541,19 @@ fn resolve_config_path_with_overrides(
         }
     }
 
+    for key in default_env_keys {
+        if let Ok(value) = std::env::var(key) {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let candidate = PathBuf::from(trimmed);
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+    }
+
     if repo_default.exists() {
         return repo_default;
     }
@@ -550,6 +566,7 @@ pub fn resolve_config_path(raw_path: Option<PathBuf>) -> PathBuf {
         raw_path,
         &["MORAINE_CONFIG"],
         home_config_path(),
+        DEFAULT_CONFIG_ENV_KEYS,
         repo_default_config_path(),
     )
 }
@@ -559,6 +576,7 @@ pub fn resolve_mcp_config_path(raw_path: Option<PathBuf>) -> PathBuf {
         raw_path,
         &["MORAINE_MCP_CONFIG", "MORAINE_CONFIG"],
         home_config_path(),
+        DEFAULT_CONFIG_ENV_KEYS,
         repo_default_config_path(),
     )
 }
@@ -568,6 +586,7 @@ pub fn resolve_monitor_config_path(raw_path: Option<PathBuf>) -> PathBuf {
         raw_path,
         &["MORAINE_MONITOR_CONFIG", "MORAINE_CONFIG"],
         home_config_path(),
+        DEFAULT_CONFIG_ENV_KEYS,
         repo_default_config_path(),
     )
 }
@@ -577,6 +596,7 @@ pub fn resolve_ingest_config_path(raw_path: Option<PathBuf>) -> PathBuf {
         raw_path,
         &["MORAINE_INGEST_CONFIG", "MORAINE_CONFIG"],
         home_config_path(),
+        DEFAULT_CONFIG_ENV_KEYS,
         repo_default_config_path(),
     )
 }
@@ -663,6 +683,7 @@ mod tests {
             raw,
             &["MORAINE_CONFIG"],
             Some(PathBuf::from("/tmp/home.toml")),
+            &[],
             PathBuf::from("/tmp/repo.toml"),
         );
         assert_eq!(chosen, PathBuf::from("/tmp/cli.toml"));
@@ -701,6 +722,7 @@ mod tests {
             None,
             &[env_key],
             Some(PathBuf::from("/tmp/from-home.toml")),
+            &[],
             PathBuf::from("/tmp/from-repo.toml"),
         );
 
@@ -717,11 +739,103 @@ mod tests {
             None,
             &["MORAINE_CONFIG_TEST_DOES_NOT_EXIST"],
             Some(PathBuf::from("/tmp/definitely-missing-home.toml")),
+            &[],
             repo_default.clone(),
         );
 
         std::fs::remove_file(&repo_default).ok();
         assert_eq!(chosen, repo_default);
+    }
+
+    #[test]
+    fn default_env_used_when_home_missing_and_path_exists() {
+        let default_path = std::env::temp_dir().join(format!(
+            "moraine-default-config-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::write(&default_path, "x=1").expect("write default");
+        let env_key = "MORAINE_DEFAULT_CONFIG_TEST_EXISTS";
+        std::env::set_var(env_key, default_path.to_string_lossy().to_string());
+
+        let chosen = resolve_config_path_with_overrides(
+            None,
+            &["MORAINE_CONFIG_TEST_DOES_NOT_EXIST"],
+            Some(PathBuf::from("/tmp/definitely-missing-home.toml")),
+            &[env_key],
+            PathBuf::from("/tmp/definitely-missing-repo-default.toml"),
+        );
+
+        std::env::remove_var(env_key);
+        std::fs::remove_file(&default_path).ok();
+        assert_eq!(chosen, default_path);
+    }
+
+    #[test]
+    fn default_env_skipped_when_path_missing() {
+        let repo_default = std::env::temp_dir().join(format!(
+            "moraine-default-repo-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::write(&repo_default, "x=1").expect("write repo default");
+        let env_key = "MORAINE_DEFAULT_CONFIG_TEST_MISSING";
+        std::env::set_var(env_key, "/tmp/definitely-missing-default.toml");
+
+        let chosen = resolve_config_path_with_overrides(
+            None,
+            &["MORAINE_CONFIG_TEST_DOES_NOT_EXIST"],
+            Some(PathBuf::from("/tmp/definitely-missing-home.toml")),
+            &[env_key],
+            repo_default.clone(),
+        );
+
+        std::env::remove_var(env_key);
+        std::fs::remove_file(&repo_default).ok();
+        assert_eq!(chosen, repo_default);
+    }
+
+    #[test]
+    fn default_env_does_not_override_home_when_home_exists() {
+        let home_path = std::env::temp_dir().join(format!(
+            "moraine-default-home-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let default_path = std::env::temp_dir().join(format!(
+            "moraine-default-lower-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::write(&home_path, "x=1").expect("write home");
+        std::fs::write(&default_path, "x=1").expect("write default");
+        let env_key = "MORAINE_DEFAULT_CONFIG_TEST_NOT_HIGHER";
+        std::env::set_var(env_key, default_path.to_string_lossy().to_string());
+
+        let chosen = resolve_config_path_with_overrides(
+            None,
+            &["MORAINE_CONFIG_TEST_DOES_NOT_EXIST"],
+            Some(home_path.clone()),
+            &[env_key],
+            PathBuf::from("/tmp/definitely-missing-repo-default.toml"),
+        );
+
+        std::env::remove_var(env_key);
+        std::fs::remove_file(&home_path).ok();
+        std::fs::remove_file(&default_path).ok();
+        assert_eq!(chosen, home_path);
     }
 
     #[test]

--- a/docs/operations/build-and-operations.md
+++ b/docs/operations/build-and-operations.md
@@ -89,9 +89,12 @@ Use one shared config schema at `config/moraine.toml`.
 Resolution precedence:
 
 1. `--config <path>`
-2. env override (`MORAINE_CONFIG`, plus `MORAINE_MCP_CONFIG` for MCP)
+2. env override (`MORAINE_CONFIG`, plus `MORAINE_MCP_CONFIG` for MCP, `MORAINE_MONITOR_CONFIG` for monitor, `MORAINE_INGEST_CONFIG` for ingest)
 3. `~/.moraine/config.toml` (if present)
-4. repo default `config/moraine.toml`
+4. `MORAINE_DEFAULT_CONFIG` fallback (if set and the referenced file exists) — packaging hook used by the `uv tool install moraine` wheel to point at its bundled default
+5. repo default `config/moraine.toml`
+
+The monitor binary resolves its static asset directory (`web/monitor/dist`) in this order: `--static-dir`, then `MORAINE_MONITOR_DIST` (canonical) or `MORAINE_MONITOR_STATIC_DIR` (legacy alias), then install-dir relative, then source-tree fallback. The `uv tool install moraine` wheel sets `MORAINE_MONITOR_DIST` in its exec shim so the bundled bytes are used without relying on path conventions.
 
 ## Start stack
 

--- a/docs/operations/environment-variables.md
+++ b/docs/operations/environment-variables.md
@@ -12,9 +12,11 @@ These variables affect runtime behavior of `moraine`, `moraine-ingest`, `moraine
 | `MORAINE_MCP_CONFIG` | MCP service | MCP config override. Falls back to `MORAINE_CONFIG` if unset. |
 | `MORAINE_MONITOR_CONFIG` | Monitor service | Monitor config override. Falls back to `MORAINE_CONFIG` if unset. |
 | `MORAINE_INGEST_CONFIG` | Ingest service | Ingest config override. Falls back to `MORAINE_CONFIG` if unset. |
+| `MORAINE_DEFAULT_CONFIG` | All services | Lowest-precedence fallback config path, consulted below `~/.moraine/config.toml` and above the compiled-in default. Only honored when the referenced file exists. Intended for package-manager distributions (e.g. the `uv tool install moraine` wheel) that ship a bundled default. |
 | `MORAINE_SERVICE_BIN_DIR` | `moraine` process manager | Overrides the directory probed for service binaries (`moraine-ingest`, `moraine-monitor`, `moraine-mcp`). |
 | `MORAINE_SOURCE_TREE_MODE` | `moraine` process manager | When truthy (`1`, `true`, `yes`, `on`), allows source-tree fallback probes (for example `target/debug/*`) when service binaries are not found in installed locations. |
-| `MORAINE_MONITOR_STATIC_DIR` | Monitor static asset resolution | Overrides monitor static asset directory when the given path exists. |
+| `MORAINE_MONITOR_DIST` | Monitor static asset resolution | Overrides the monitor static asset directory (normally `web/monitor/dist`) when the given path exists. Canonical name used by the `uv tool install moraine` wheel shim. Takes precedence over `MORAINE_MONITOR_STATIC_DIR`. |
+| `MORAINE_MONITOR_STATIC_DIR` | Monitor static asset resolution | Legacy alias for `MORAINE_MONITOR_DIST`. Honored when set and the path exists; prefer `MORAINE_MONITOR_DIST` in new configurations. |
 
 ## Installer (`scripts/install.sh`)
 


### PR DESCRIPTION
## Summary

Prerequisite for the PyPI wheel exec shim described in [#219](https://github.com/eric-tramel/moraine/issues/219). The `uv tool install moraine` wheel vendors `web/monitor/dist/` and `config/moraine.toml` inside the installed package and needs the binaries to honor env vars pointing at those bundled paths.

- `MORAINE_MONITOR_DIST` — new canonical env var that overrides the monitor static asset directory when the given path exists. `MORAINE_MONITOR_STATIC_DIR` is kept as a legacy alias (lower priority) so the dev-sandbox Dockerfile keeps working.
- `MORAINE_DEFAULT_CONFIG` — new lowest-precedence file fallback, consulted between `~/.moraine/config.toml` and the compiled-in `config/moraine.toml` default. Only honored when the referenced file exists. Existing precedence (`--config` > `MORAINE_CONFIG` > `~/.moraine/config.toml`) is unchanged.

Closes [#222](https://github.com/eric-tramel/moraine/issues/222). Unblocks [#223](https://github.com/eric-tramel/moraine/issues/223) (wheel builder + `moraine-cli` scaffolding).

## Test plan

- [x] `cargo test -p moraine-config -p moraine-monitor -p moraine` — 17 + 5 + 34 tests green; 6 new tests (3 for `MORAINE_DEFAULT_CONFIG` precedence, 3 for `MORAINE_MONITOR_DIST` resolution incl. legacy-alias fallback)
- [x] `cargo clippy --workspace --all-targets --locked -- -Dwarnings …` (strict baseline) clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Sanity-run `bin/moraine up` on a host where `MORAINE_MONITOR_DIST=/tmp/dummy-dist` points at a throwaway dist tree and confirm the monitor serves from that path

🤖 Generated with [Claude Code](https://claude.com/claude-code)