### PR TITLE
feat(install): Python wheel builder + moraine-cli package scaffolding

### DIFF
--- a/apps/moraine-monitor/src/cli.rs
+++ b/apps/moraine-monitor/src/cli.rs
@@ -32,12 +32,27 @@ fn source_tree_static_dir() -> PathBuf {
         .join("dist")
 }
 
-fn default_static_dir() -> PathBuf {
-    if let Ok(value) = std::env::var("MORAINE_MONITOR_STATIC_DIR") {
-        let configured = PathBuf::from(value);
-        if configured.exists() {
-            return configured;
+const MONITOR_DIST_ENV_KEYS: &[&str] = &["MORAINE_MONITOR_DIST", "MORAINE_MONITOR_STATIC_DIR"];
+
+fn env_override_static_dir_with_keys(keys: &[&str]) -> Option<PathBuf> {
+    for key in keys {
+        if let Ok(value) = std::env::var(key) {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let configured = PathBuf::from(trimmed);
+            if configured.exists() {
+                return Some(configured);
+            }
         }
+    }
+    None
+}
+
+fn default_static_dir() -> PathBuf {
+    if let Some(configured) = env_override_static_dir_with_keys(MONITOR_DIST_ENV_KEYS) {
+        return configured;
     }
 
     if let Ok(exe) = std::env::current_exe() {
@@ -109,7 +124,7 @@ pub fn parse_args() -> CliArgs {
 
 #[cfg(test)]
 mod tests {
-    use super::find_monitor_dir;
+    use super::{env_override_static_dir_with_keys, find_monitor_dir};
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -151,5 +166,40 @@ mod tests {
         assert_eq!(found, None);
 
         fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn env_override_returns_path_when_set_and_exists() {
+        let root = temp_root("env-override-primary");
+        let env_key = "MORAINE_MONITOR_DIST_TEST_PRIMARY";
+        std::env::set_var(env_key, root.to_string_lossy().to_string());
+
+        let found = env_override_static_dir_with_keys(&[env_key]);
+
+        std::env::remove_var(env_key);
+        fs::remove_dir_all(&root).ok();
+        assert_eq!(found, Some(root));
+    }
+
+    #[test]
+    fn env_override_none_when_unset() {
+        let found = env_override_static_dir_with_keys(&["MORAINE_MONITOR_DIST_TEST_UNSET_KEY"]);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn env_override_skips_missing_path_and_falls_through_to_alias() {
+        let root = temp_root("env-override-alias");
+        let primary = "MORAINE_MONITOR_DIST_TEST_ALIAS_PRIMARY";
+        let alias = "MORAINE_MONITOR_DIST_TEST_ALIAS_SECONDARY";
+        std::env::set_var(primary, "/tmp/moraine-monitor-dist-definitely-missing");
+        std::env::set_var(alias, root.to_string_lossy().to_string());
+
+        let found = env_override_static_dir_with_keys(&[primary, alias]);
+
+        std::env::remove_var(primary);
+        std::env::remove_var(alias);
+        fs::remove_dir_all(&root).ok();
+        assert_eq!(found, Some(root));
     }
 }

--- a/apps/moraine/src/main.rs
+++ b/apps/moraine/src/main.rs
@@ -1342,11 +1342,19 @@ fn monitor_dist_candidate(root: &Path) -> PathBuf {
     root.join("web").join("monitor").join("dist")
 }
 
+const MONITOR_DIST_ENV_KEYS: &[&str] = &["MORAINE_MONITOR_DIST", "MORAINE_MONITOR_STATIC_DIR"];
+
 fn resolve_monitor_static_dir(paths: &RuntimePaths) -> Option<PathBuf> {
-    if let Ok(value) = std::env::var("MORAINE_MONITOR_STATIC_DIR") {
-        let path = PathBuf::from(value);
-        if path.exists() {
-            return Some(path);
+    for key in MONITOR_DIST_ENV_KEYS {
+        if let Ok(value) = std::env::var(key) {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let path = PathBuf::from(trimmed);
+            if path.exists() {
+                return Some(path);
+            }
         }
     }
 

--- a/bindings/python/moraine-cli/README.md
+++ b/bindings/python/moraine-cli/README.md
@@ -1,0 +1,55 @@
+# moraine (PyPI distribution)
+
+This directory packages the Moraine CLI binaries as platform-tagged Python
+wheels so they can be installed with:
+
+```bash
+uv tool install moraine
+# or
+uvx moraine --help
+```
+
+The wheel contains **prebuilt binaries** — the exec-shim package
+(`moraine_cli/__init__.py`) calls `os.execvpe` into the bundled
+`moraine`, `moraine-ingest`, `moraine-monitor`, and `moraine-mcp` binaries
+with the bundled `web/monitor/dist/` and `config/moraine.toml` paths
+exposed via `MORAINE_MONITOR_DIST` / `MORAINE_DEFAULT_CONFIG` env vars.
+
+This is a packaging wrapper, not a Python library. It is **not** the
+pyo3 binding at `bindings/python/moraine_conversations/` — that ships
+separately.
+
+## How wheels are built
+
+Wheels are not produced by `maturin`, `setuptools`, or a direct
+`pip wheel .` — they are assembled from the already-built
+`moraine-bundle-<target>.tar.gz` release artifacts by
+[`scripts/build-python-wheels.py`](../../../scripts/build-python-wheels.py).
+
+This keeps the Rust build and the Python packaging cleanly separated and
+guarantees the wheel contents are byte-identical to the GitHub Releases
+bundle.
+
+See [RFC #219](https://github.com/eric-tramel/moraine/issues/219) for the
+full rationale.
+
+## Why building from source is refused
+
+Moraine needs a Rust toolchain *and* `bun` to produce the monitor
+frontend — way out of scope for `pip install`. The sdist is a stub that
+raises a clear error:
+
+```
+$ pip install moraine --no-binary moraine
+ERROR: moraine ships as prebuilt binary wheels only. Install via a
+       platform with a published wheel, or build from source with:
+       https://github.com/eric-tramel/moraine#install-from-source
+```
+
+See [`scripts/build-python-sdist.py`](../../../scripts/build-python-sdist.py).
+
+## Install from the main repo
+
+If you want the full source workflow (editable installs, Rust toolchain,
+development ClickHouse), see the top-level
+[README](../../../README.md) instead.

--- a/bindings/python/moraine-cli/moraine_cli/__init__.py
+++ b/bindings/python/moraine-cli/moraine_cli/__init__.py
@@ -1,0 +1,78 @@
+"""Exec shim for the bundled `moraine` binaries distributed via PyPI.
+
+Each console-script entry point in `pyproject.toml` maps to one of the
+`_moraine_*_main` helpers below, which resolve the packaged binary via
+`importlib.resources` and re-exec into it with `os.execvpe`. Bundled
+runtime assets (`web/monitor/dist/`, `config/moraine.toml`) are exposed
+to the binary via env vars so the Rust code can locate them without
+relying on filesystem conventions. See RFC #219.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from importlib.resources import as_file, files
+from typing import NoReturn
+
+from ._version import __version__
+
+__all__ = [
+    "__version__",
+    "_moraine_main",
+    "_moraine_ingest_main",
+    "_moraine_monitor_main",
+    "_moraine_mcp_main",
+]
+
+_MONITOR_DIST_ENV = "MORAINE_MONITOR_DIST"
+_DEFAULT_CONFIG_ENV = "MORAINE_DEFAULT_CONFIG"
+
+
+def _exec(bin_name: str) -> NoReturn:
+    root = files(__package__)
+    binaries = root / "_binaries"
+    data = root / "_data"
+
+    monitor_dist = data / "web" / "monitor" / "dist"
+    default_config = data / "config" / "moraine.toml"
+    binary = binaries / bin_name
+
+    # importlib.resources abstracts over wheels vs. editable installs; coerce
+    # each Traversable into a concrete filesystem path for exec + env vars.
+    with (
+        as_file(binary) as binary_path,
+        as_file(monitor_dist) as monitor_dist_path,
+        as_file(default_config) as default_config_path,
+    ):
+        env = os.environ.copy()
+        # setdefault — do not clobber overrides the user set explicitly.
+        env.setdefault(_MONITOR_DIST_ENV, str(monitor_dist_path))
+        env.setdefault(_DEFAULT_CONFIG_ENV, str(default_config_path))
+
+        argv = [bin_name, *sys.argv[1:]]
+        os.execvpe(str(binary_path), argv, env)
+
+    # execvpe does not return on success; the lines below only run if exec
+    # itself fails (e.g. ENOEXEC from a corrupted wheel).
+    raise SystemExit(
+        f"moraine: failed to exec bundled binary {bin_name!r}; "
+        "this usually means the wheel is corrupted or was built for a "
+        "different platform. Reinstall with: uv tool install --reinstall moraine"
+    )
+
+
+def _moraine_main() -> NoReturn:
+    _exec("moraine")
+
+
+def _moraine_ingest_main() -> NoReturn:
+    _exec("moraine-ingest")
+
+
+def _moraine_monitor_main() -> NoReturn:
+    _exec("moraine-monitor")
+
+
+def _moraine_mcp_main() -> NoReturn:
+    _exec("moraine-mcp")

--- a/bindings/python/moraine-cli/moraine_cli/_version.py
+++ b/bindings/python/moraine-cli/moraine_cli/_version.py
@@ -1,0 +1,8 @@
+"""Package version.
+
+Rewritten by `scripts/build-python-wheels.py` at build time so the PyPI
+wheel version tracks the release tag (see RFC #219). The default value
+here is a sentinel used only for editable installs from source.
+"""
+
+__version__ = "0.0.0+dev"

--- a/bindings/python/moraine-cli/pyproject.toml
+++ b/bindings/python/moraine-cli/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["hatchling>=1.21"]
+build-backend = "hatchling.build"
+
+[project]
+name = "moraine"
+dynamic = ["version"]
+description = "Moraine — unified trace indexer and MCP server for Claude Code / Codex"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+authors = [{ name = "Moraine Maintainers" }]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: MacOS",
+  "Operating System :: POSIX :: Linux",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Rust",
+  "Topic :: Software Development :: Libraries",
+]
+keywords = ["moraine", "claude-code", "codex", "mcp", "telemetry", "observability"]
+
+[project.scripts]
+moraine = "moraine_cli:_moraine_main"
+moraine-ingest = "moraine_cli:_moraine_ingest_main"
+moraine-monitor = "moraine_cli:_moraine_monitor_main"
+moraine-mcp = "moraine_cli:_moraine_mcp_main"
+
+[project.urls]
+Homepage = "https://github.com/eric-tramel/moraine"
+Issues = "https://github.com/eric-tramel/moraine/issues"
+Repository = "https://github.com/eric-tramel/moraine"
+
+# Hatchling is used only for the sdist + wheel *metadata* plumbing required by
+# pyproject.toml. Actual platform wheels are assembled by
+# scripts/build-python-wheels.py out of moraine-bundle-<target>.tar.gz
+# artifacts — see RFC #219 and issue #223. `pip install moraine --no-binary`
+# is explicitly rejected via scripts/build-python-sdist.py.
+[tool.hatch.version]
+path = "moraine_cli/_version.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["moraine_cli"]

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -513,10 +513,13 @@ fn repo_default_config_path() -> PathBuf {
     PathBuf::from("config/moraine.toml")
 }
 
+const DEFAULT_CONFIG_ENV_KEYS: &[&str] = &["MORAINE_DEFAULT_CONFIG"];
+
 fn resolve_config_path_with_overrides(
     raw_path: Option<PathBuf>,
     env_keys: &[&str],
     home_path: Option<PathBuf>,
+    default_env_keys: &[&str],
     repo_default: PathBuf,
 ) -> PathBuf {
     if let Some(path) = raw_path {
@@ -538,6 +541,19 @@ fn resolve_config_path_with_overrides(
         }
     }
 
+    for key in default_env_keys {
+        if let Ok(value) = std::env::var(key) {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let candidate = PathBuf::from(trimmed);
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+    }
+
     if repo_default.exists() {
         return repo_default;
     }
@@ -550,6 +566,7 @@ pub fn resolve_config_path(raw_path: Option<PathBuf>) -> PathBuf {
         raw_path,
         &["MORAINE_CONFIG"],
         home_config_path(),
+        DEFAULT_CONFIG_ENV_KEYS,
         repo_default_config_path(),
     )
 }
@@ -559,6 +576,7 @@ pub fn resolve_mcp_config_path(raw_path: Option<PathBuf>) -> PathBuf {
         raw_path,
         &["MORAINE_MCP_CONFIG", "MORAINE_CONFIG"],
         home_config_path(),
+        DEFAULT_CONFIG_ENV_KEYS,
         repo_default_config_path(),
     )
 }
@@ -568,6 +586,7 @@ pub fn resolve_monitor_config_path(raw_path: Option<PathBuf>) -> PathBuf {
         raw_path,
         &["MORAINE_MONITOR_CONFIG", "MORAINE_CONFIG"],
         home_config_path(),
+        DEFAULT_CONFIG_ENV_KEYS,
         repo_default_config_path(),
     )
 }
@@ -577,6 +596,7 @@ pub fn resolve_ingest_config_path(raw_path: Option<PathBuf>) -> PathBuf {
         raw_path,
         &["MORAINE_INGEST_CONFIG", "MORAINE_CONFIG"],
         home_config_path(),
+        DEFAULT_CONFIG_ENV_KEYS,
         repo_default_config_path(),
     )
 }
@@ -663,6 +683,7 @@ mod tests {
             raw,
             &["MORAINE_CONFIG"],
             Some(PathBuf::from("/tmp/home.toml")),
+            &[],
             PathBuf::from("/tmp/repo.toml"),
         );
         assert_eq!(chosen, PathBuf::from("/tmp/cli.toml"));
@@ -701,6 +722,7 @@ mod tests {
             None,
             &[env_key],
             Some(PathBuf::from("/tmp/from-home.toml")),
+            &[],
             PathBuf::from("/tmp/from-repo.toml"),
         );
 
@@ -717,11 +739,103 @@ mod tests {
             None,
             &["MORAINE_CONFIG_TEST_DOES_NOT_EXIST"],
             Some(PathBuf::from("/tmp/definitely-missing-home.toml")),
+            &[],
             repo_default.clone(),
         );
 
         std::fs::remove_file(&repo_default).ok();
         assert_eq!(chosen, repo_default);
+    }
+
+    #[test]
+    fn default_env_used_when_home_missing_and_path_exists() {
+        let default_path = std::env::temp_dir().join(format!(
+            "moraine-default-config-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::write(&default_path, "x=1").expect("write default");
+        let env_key = "MORAINE_DEFAULT_CONFIG_TEST_EXISTS";
+        std::env::set_var(env_key, default_path.to_string_lossy().to_string());
+
+        let chosen = resolve_config_path_with_overrides(
+            None,
+            &["MORAINE_CONFIG_TEST_DOES_NOT_EXIST"],
+            Some(PathBuf::from("/tmp/definitely-missing-home.toml")),
+            &[env_key],
+            PathBuf::from("/tmp/definitely-missing-repo-default.toml"),
+        );
+
+        std::env::remove_var(env_key);
+        std::fs::remove_file(&default_path).ok();
+        assert_eq!(chosen, default_path);
+    }
+
+    #[test]
+    fn default_env_skipped_when_path_missing() {
+        let repo_default = std::env::temp_dir().join(format!(
+            "moraine-default-repo-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::write(&repo_default, "x=1").expect("write repo default");
+        let env_key = "MORAINE_DEFAULT_CONFIG_TEST_MISSING";
+        std::env::set_var(env_key, "/tmp/definitely-missing-default.toml");
+
+        let chosen = resolve_config_path_with_overrides(
+            None,
+            &["MORAINE_CONFIG_TEST_DOES_NOT_EXIST"],
+            Some(PathBuf::from("/tmp/definitely-missing-home.toml")),
+            &[env_key],
+            repo_default.clone(),
+        );
+
+        std::env::remove_var(env_key);
+        std::fs::remove_file(&repo_default).ok();
+        assert_eq!(chosen, repo_default);
+    }
+
+    #[test]
+    fn default_env_does_not_override_home_when_home_exists() {
+        let home_path = std::env::temp_dir().join(format!(
+            "moraine-default-home-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let default_path = std::env::temp_dir().join(format!(
+            "moraine-default-lower-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::write(&home_path, "x=1").expect("write home");
+        std::fs::write(&default_path, "x=1").expect("write default");
+        let env_key = "MORAINE_DEFAULT_CONFIG_TEST_NOT_HIGHER";
+        std::env::set_var(env_key, default_path.to_string_lossy().to_string());
+
+        let chosen = resolve_config_path_with_overrides(
+            None,
+            &["MORAINE_CONFIG_TEST_DOES_NOT_EXIST"],
+            Some(home_path.clone()),
+            &[env_key],
+            PathBuf::from("/tmp/definitely-missing-repo-default.toml"),
+        );
+
+        std::env::remove_var(env_key);
+        std::fs::remove_file(&home_path).ok();
+        std::fs::remove_file(&default_path).ok();
+        assert_eq!(chosen, home_path);
     }
 
     #[test]

--- a/docs/operations/build-and-operations.md
+++ b/docs/operations/build-and-operations.md
@@ -89,9 +89,12 @@ Use one shared config schema at `config/moraine.toml`.
 Resolution precedence:
 
 1. `--config <path>`
-2. env override (`MORAINE_CONFIG`, plus `MORAINE_MCP_CONFIG` for MCP)
+2. env override (`MORAINE_CONFIG`, plus `MORAINE_MCP_CONFIG` for MCP, `MORAINE_MONITOR_CONFIG` for monitor, `MORAINE_INGEST_CONFIG` for ingest)
 3. `~/.moraine/config.toml` (if present)
-4. repo default `config/moraine.toml`
+4. `MORAINE_DEFAULT_CONFIG` fallback (if set and the referenced file exists) — packaging hook used by the `uv tool install moraine` wheel to point at its bundled default
+5. repo default `config/moraine.toml`
+
+The monitor binary resolves its static asset directory (`web/monitor/dist`) in this order: `--static-dir`, then `MORAINE_MONITOR_DIST` (canonical) or `MORAINE_MONITOR_STATIC_DIR` (legacy alias), then install-dir relative, then source-tree fallback. The `uv tool install moraine` wheel sets `MORAINE_MONITOR_DIST` in its exec shim so the bundled bytes are used without relying on path conventions.
 
 ## Start stack
 

--- a/docs/operations/environment-variables.md
+++ b/docs/operations/environment-variables.md
@@ -12,9 +12,11 @@ These variables affect runtime behavior of `moraine`, `moraine-ingest`, `moraine
 | `MORAINE_MCP_CONFIG` | MCP service | MCP config override. Falls back to `MORAINE_CONFIG` if unset. |
 | `MORAINE_MONITOR_CONFIG` | Monitor service | Monitor config override. Falls back to `MORAINE_CONFIG` if unset. |
 | `MORAINE_INGEST_CONFIG` | Ingest service | Ingest config override. Falls back to `MORAINE_CONFIG` if unset. |
+| `MORAINE_DEFAULT_CONFIG` | All services | Lowest-precedence fallback config path, consulted below `~/.moraine/config.toml` and above the compiled-in default. Only honored when the referenced file exists. Intended for package-manager distributions (e.g. the `uv tool install moraine` wheel) that ship a bundled default. |
 | `MORAINE_SERVICE_BIN_DIR` | `moraine` process manager | Overrides the directory probed for service binaries (`moraine-ingest`, `moraine-monitor`, `moraine-mcp`). |
 | `MORAINE_SOURCE_TREE_MODE` | `moraine` process manager | When truthy (`1`, `true`, `yes`, `on`), allows source-tree fallback probes (for example `target/debug/*`) when service binaries are not found in installed locations. |
-| `MORAINE_MONITOR_STATIC_DIR` | Monitor static asset resolution | Overrides monitor static asset directory when the given path exists. |
+| `MORAINE_MONITOR_DIST` | Monitor static asset resolution | Overrides the monitor static asset directory (normally `web/monitor/dist`) when the given path exists. Canonical name used by the `uv tool install moraine` wheel shim. Takes precedence over `MORAINE_MONITOR_STATIC_DIR`. |
+| `MORAINE_MONITOR_STATIC_DIR` | Monitor static asset resolution | Legacy alias for `MORAINE_MONITOR_DIST`. Honored when set and the path exists; prefer `MORAINE_MONITOR_DIST` in new configurations. |
 
 ## Installer (`scripts/install.sh`)
 

--- a/scripts/build-python-sdist.py
+++ b/scripts/build-python-sdist.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Build a stub source distribution for the `moraine` PyPI package.
+
+Moraine ships as prebuilt binary wheels only (see RFC #219). The sdist
+exists purely so PyPI has *something* to return for
+`pip install moraine --no-binary moraine`, and so `uv tool install`
+has a fallback when no platform wheel is available — but that fallback
+deliberately fails loudly rather than attempting a Rust + bun build.
+
+The generated tarball contains:
+
+  - pyproject.toml  — `build-backend = "moraine_build_refuser"`
+  - moraine_build_refuser.py  — the in-tree refusal backend
+  - README.md       — user-facing install instructions
+  - PKG-INFO        — PEP 643-compliant core metadata
+
+When pip/uv tries to build a wheel from this sdist, the backend's
+`build_wheel` immediately raises with a pointer to the real install
+paths.
+
+Usage:
+  python scripts/build-python-sdist.py --out-dir dist/wheels --version 0.4.1
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import re
+import sys
+import tarfile
+import time
+from pathlib import Path
+
+PACKAGE_NAME = "moraine"
+DESCRIPTION = "Moraine \u2014 unified trace indexer and MCP server for Claude Code / Codex"
+
+REFUSAL_MESSAGE = (
+    "moraine ships as prebuilt binary wheels only. Install via a "
+    "platform with a published wheel, or build from source with: "
+    "https://github.com/eric-tramel/moraine#install-from-source"
+)
+
+PYPROJECT_TEMPLATE = """\
+[build-system]
+requires = []
+build-backend = "moraine_build_refuser"
+backend-path = ["."]
+
+[project]
+name = "{name}"
+version = "{version}"
+description = "{description}"
+readme = "README.md"
+license = {{ text = "MIT" }}
+requires-python = ">=3.9"
+"""
+
+BACKEND_TEMPLATE = '''\
+"""In-tree PEP 517 backend that refuses to build moraine from source.
+
+See RFC #219. Moraine ships as prebuilt binary wheels; building from an
+sdist would require a Rust toolchain + bun for the monitor frontend,
+which is out of scope for `pip install`.
+"""
+
+MESSAGE = (
+    {message!r}
+)
+
+
+def _refuse(*_args, **_kwargs):
+    raise SystemExit("ERROR: " + MESSAGE)
+
+
+build_wheel = _refuse
+build_sdist = _refuse
+get_requires_for_build_wheel = _refuse
+get_requires_for_build_sdist = _refuse
+prepare_metadata_for_build_wheel = _refuse
+'''
+
+README_TEMPLATE = """\
+# moraine (source distribution)
+
+This sdist is a stub. Moraine distributes prebuilt binary wheels only
+(macOS arm64, Linux x86_64, Linux aarch64). Installing this sdist with
+`pip install moraine --no-binary moraine` will fail with a pointer to
+the source-install instructions.
+
+To install moraine:
+
+```bash
+# Recommended: a published platform wheel
+uv tool install moraine
+
+# Fallback on platforms without a wheel: the curl installer
+curl -fsSL https://raw.githubusercontent.com/eric-tramel/moraine/main/scripts/install.sh | sh
+```
+
+See https://github.com/eric-tramel/moraine for full docs.
+"""
+
+PKG_INFO_TEMPLATE = """\
+Metadata-Version: 2.1
+Name: {name}
+Version: {version}
+Summary: {description}
+License: MIT
+Requires-Python: >=3.9
+Description-Content-Type: text/markdown
+
+{readme}
+"""
+
+
+def _normalize_version(version: str) -> str:
+    if version.startswith("v") and re.match(r"^v\d", version):
+        return version[1:]
+    return version
+
+
+def _add_file(tar: tarfile.TarFile, arcname: str, payload: bytes, mtime: float) -> None:
+    info = tarfile.TarInfo(arcname)
+    info.size = len(payload)
+    info.mtime = int(mtime)
+    info.mode = 0o644
+    info.type = tarfile.REGTYPE
+    tar.addfile(info, io.BytesIO(payload))
+
+
+def build_sdist(*, version: str, out_dir: Path) -> Path:
+    version = _normalize_version(version)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    sdist_root = f"{PACKAGE_NAME}-{version}"
+    sdist_name = f"{sdist_root}.tar.gz"
+    sdist_path = out_dir / sdist_name
+    if sdist_path.exists():
+        sdist_path.unlink()
+
+    readme = README_TEMPLATE
+    pyproject = PYPROJECT_TEMPLATE.format(
+        name=PACKAGE_NAME,
+        version=version,
+        description=DESCRIPTION,
+    )
+    backend = BACKEND_TEMPLATE.format(message=REFUSAL_MESSAGE)
+    pkg_info = PKG_INFO_TEMPLATE.format(
+        name=PACKAGE_NAME,
+        version=version,
+        description=DESCRIPTION,
+        readme=readme,
+    )
+
+    now = time.time()
+    with tarfile.open(sdist_path, "w:gz") as tar:
+        _add_file(tar, f"{sdist_root}/pyproject.toml", pyproject.encode("utf-8"), now)
+        _add_file(tar, f"{sdist_root}/moraine_build_refuser.py", backend.encode("utf-8"), now)
+        _add_file(tar, f"{sdist_root}/README.md", readme.encode("utf-8"), now)
+        _add_file(tar, f"{sdist_root}/PKG-INFO", pkg_info.encode("utf-8"), now)
+
+    return sdist_path
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    sdist = build_sdist(version=args.version, out_dir=args.out_dir)
+    print(f"built: {sdist}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build-python-wheels.py
+++ b/scripts/build-python-wheels.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""Assemble platform-tagged Python wheels from moraine release bundles.
+
+Part of the PyPI distribution story tracked in RFC #219 / issue #223.
+
+Input per --target/--bundle pair:
+  - a moraine-bundle-<target>.tar.gz produced by
+    scripts/package-moraine-release.sh
+  - the target triple it was built for (drives the wheel's platform tag)
+
+Output:
+  - one moraine-<version>-py3-none-<plat>.whl per --target, laid out per
+    the wheel layout specified in the RFC.
+
+Design notes:
+  - stdlib + `packaging` only. We assemble the zip directly rather than
+    invoking setuptools/wheel — this keeps the dependency surface minimal
+    and makes the layout 1:1 with what the exec shim expects.
+  - Binaries are preserved with mode 0755 (ZIP external_attr upper bits).
+  - The wheel's platform tag is chosen per --target; Python ABI is
+    `py3-none-*` because the wheel is "pure Python exec shim + opaque
+    binary data" — we do not link against a specific CPython ABI.
+  - Bundle integrity is verified against manifest.json sha256 entries
+    before any files are copied into the wheel staging area.
+
+Usage:
+  python scripts/build-python-wheels.py \
+      --target x86_64-unknown-linux-gnu  --bundle dist/moraine-bundle-x86_64-unknown-linux-gnu.tar.gz \
+      --target aarch64-apple-darwin      --bundle dist/moraine-bundle-aarch64-apple-darwin.tar.gz \
+      --out-dir dist/wheels \
+      --version 0.4.1
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import sys
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+# Canonical metadata lives alongside the shim to keep the RFC's "hand-rolled"
+# builder self-contained. Everything the builder needs to know about target
+# triples + wheel layout sits in this file.
+
+TARGET_TO_WHEEL_PLATFORM = {
+    "x86_64-unknown-linux-gnu": "manylinux_2_17_x86_64",
+    "aarch64-unknown-linux-gnu": "manylinux_2_17_aarch64",
+    "aarch64-apple-darwin": "macosx_11_0_arm64",
+    "x86_64-apple-darwin": "macosx_11_0_x86_64",
+}
+
+PYTHON_TAG = "py3"
+ABI_TAG = "none"
+
+BUNDLE_BINARIES = ("moraine", "moraine-ingest", "moraine-monitor", "moraine-mcp")
+BUNDLE_CONFIG = "config/moraine.toml"
+BUNDLE_MONITOR_DIST = "web/monitor/dist"
+
+PACKAGE_NAME = "moraine"  # PyPI distribution name
+IMPORT_NAME = "moraine_cli"  # package name inside the wheel
+
+# Path inside the repo for the in-tree package skeleton. Used to copy the
+# exec shim (__init__.py, py.typed, _version.py) into the wheel.
+REPO_PACKAGE_ROOT = Path(__file__).resolve().parent.parent / "bindings/python/moraine-cli"
+
+DESCRIPTION = "Moraine \u2014 unified trace indexer and MCP server for Claude Code / Codex"
+
+
+# ----------------------------------------------------------------------------
+# Manifest verification
+# ----------------------------------------------------------------------------
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _verify_manifest(extract_dir: Path, manifest: dict) -> None:
+    checksums = manifest.get("checksums")
+    if not isinstance(checksums, dict) or not checksums:
+        raise RuntimeError(
+            "bundle manifest.json is missing or has an empty 'checksums' section"
+        )
+    for relpath, expected in checksums.items():
+        target = extract_dir / relpath
+        if not target.is_file():
+            raise RuntimeError(f"manifest references missing file: {relpath}")
+        actual = _sha256(target)
+        if actual != expected:
+            raise RuntimeError(
+                f"checksum mismatch for {relpath}: manifest={expected} actual={actual}"
+            )
+
+    for binary in BUNDLE_BINARIES:
+        rel = f"bin/{binary}"
+        if rel not in checksums:
+            raise RuntimeError(f"manifest is missing checksum for required binary {rel}")
+
+    monitor_index = extract_dir / BUNDLE_MONITOR_DIST / "index.html"
+    if not monitor_index.is_file():
+        raise RuntimeError(
+            f"bundle does not contain monitor UI assets at {BUNDLE_MONITOR_DIST}/index.html"
+        )
+
+
+# ----------------------------------------------------------------------------
+# Wheel assembly
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WheelRecordEntry:
+    arcname: str
+    sha256_b64: str
+    size: int
+
+
+def _urlsafe_b64nopad(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _write_member(
+    zf: zipfile.ZipFile,
+    arcname: str,
+    payload: bytes,
+    *,
+    executable: bool,
+    records: list[WheelRecordEntry],
+) -> None:
+    info = zipfile.ZipInfo(arcname)
+    # Full Unix st_mode (S_IFREG | perms) in the upper 16 bits of
+    # external_attr. pip / installer look at the file-type bits too —
+    # without S_IFREG they treat the entry as "not a regular file" and
+    # drop the executable bit on unpack.
+    mode = 0o100755 if executable else 0o100644
+    info.external_attr = mode << 16
+    info.compress_type = zipfile.ZIP_DEFLATED
+    # Deterministic mtime so wheels rebuilt from the same bundle are
+    # byte-identical modulo the zip container metadata.
+    info.date_time = (2000, 1, 1, 0, 0, 0)
+    zf.writestr(info, payload)
+
+    digest = hashlib.sha256(payload).digest()
+    records.append(
+        WheelRecordEntry(
+            arcname=arcname,
+            sha256_b64=_urlsafe_b64nopad(digest),
+            size=len(payload),
+        )
+    )
+
+
+def _read_file_bytes(path: Path) -> bytes:
+    with path.open("rb") as fh:
+        return fh.read()
+
+
+def _iter_files(root: Path):
+    for entry in sorted(root.rglob("*")):
+        if entry.is_file():
+            yield entry
+
+
+def _normalize_version(version: str) -> str:
+    # Allow the caller to pass a git tag like "v0.4.1"; strip the leading v.
+    if version.startswith("v") and re.match(r"^v\d", version):
+        return version[1:]
+    return version
+
+
+def _render_metadata(version: str, readme: str) -> str:
+    lines = [
+        "Metadata-Version: 2.1",
+        f"Name: {PACKAGE_NAME}",
+        f"Version: {version}",
+        f"Summary: {DESCRIPTION}",
+        "Home-page: https://github.com/eric-tramel/moraine",
+        "Author: Moraine Maintainers",
+        "License: MIT",
+        "Project-URL: Homepage, https://github.com/eric-tramel/moraine",
+        "Project-URL: Issues, https://github.com/eric-tramel/moraine/issues",
+        "Project-URL: Repository, https://github.com/eric-tramel/moraine",
+        "Keywords: moraine,claude-code,codex,mcp,telemetry,observability",
+        "Classifier: Development Status :: 4 - Beta",
+        "Classifier: License :: OSI Approved :: MIT License",
+        "Classifier: Operating System :: MacOS",
+        "Classifier: Operating System :: POSIX :: Linux",
+        "Classifier: Programming Language :: Python :: 3",
+        "Classifier: Programming Language :: Rust",
+        "Classifier: Topic :: Software Development :: Libraries",
+        "Requires-Python: >=3.9",
+        "Description-Content-Type: text/markdown",
+        "",
+        readme,
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _render_wheel_metadata(platform_tag: str) -> str:
+    tag = f"{PYTHON_TAG}-{ABI_TAG}-{platform_tag}"
+    lines = [
+        "Wheel-Version: 1.0",
+        "Generator: moraine-build-python-wheels (1.0)",
+        "Root-Is-Purelib: false",
+        f"Tag: {tag}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _render_entry_points() -> str:
+    lines = [
+        "[console_scripts]",
+        f"moraine = {IMPORT_NAME}:_moraine_main",
+        f"moraine-ingest = {IMPORT_NAME}:_moraine_ingest_main",
+        f"moraine-monitor = {IMPORT_NAME}:_moraine_monitor_main",
+        f"moraine-mcp = {IMPORT_NAME}:_moraine_mcp_main",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _render_record(records: list[WheelRecordEntry], record_arcname: str) -> str:
+    out = io.StringIO()
+    for entry in records:
+        out.write(f"{entry.arcname},sha256={entry.sha256_b64},{entry.size}\n")
+    out.write(f"{record_arcname},,\n")
+    return out.getvalue()
+
+
+def _render_version_module(version: str) -> str:
+    return (
+        '"""Package version, written by scripts/build-python-wheels.py."""\n'
+        f'__version__ = "{version}"\n'
+    )
+
+
+def build_wheel(
+    *,
+    target: str,
+    bundle: Path,
+    out_dir: Path,
+    version: str,
+) -> Path:
+    if target not in TARGET_TO_WHEEL_PLATFORM:
+        raise SystemExit(
+            f"unsupported target {target!r}; known targets: "
+            f"{sorted(TARGET_TO_WHEEL_PLATFORM)}"
+        )
+    platform_tag = TARGET_TO_WHEEL_PLATFORM[target]
+
+    if not bundle.is_file():
+        raise SystemExit(f"bundle not found: {bundle}")
+
+    version = _normalize_version(version)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="moraine-wheel-") as tmp:
+        extract_dir = Path(tmp) / "extracted"
+        extract_dir.mkdir()
+        with tarfile.open(bundle, "r:gz") as tf:
+            _safe_extract(tf, extract_dir)
+
+        manifest_path = extract_dir / "manifest.json"
+        if not manifest_path.is_file():
+            raise SystemExit(f"bundle {bundle.name} has no manifest.json")
+        manifest = json.loads(manifest_path.read_text())
+        bundle_target = manifest.get("target")
+        if bundle_target != target:
+            raise SystemExit(
+                f"manifest target {bundle_target!r} does not match --target {target!r}"
+            )
+        _verify_manifest(extract_dir, manifest)
+
+        readme_path = REPO_PACKAGE_ROOT / "README.md"
+        readme_body = readme_path.read_text() if readme_path.is_file() else ""
+
+        records: list[WheelRecordEntry] = []
+
+        wheel_name = (
+            f"{PACKAGE_NAME}-{version}-{PYTHON_TAG}-{ABI_TAG}-{platform_tag}.whl"
+        )
+        wheel_path = out_dir / wheel_name
+        if wheel_path.exists():
+            wheel_path.unlink()
+
+        dist_info = f"{PACKAGE_NAME}-{version}.dist-info"
+        record_arcname = f"{dist_info}/RECORD"
+
+        with zipfile.ZipFile(wheel_path, "w") as zf:
+            # 1. Package source (shim + marker files).
+            for src in _iter_files(REPO_PACKAGE_ROOT / IMPORT_NAME):
+                rel = src.relative_to(REPO_PACKAGE_ROOT)
+                arcname = str(rel).replace(os.sep, "/")
+                if arcname == f"{IMPORT_NAME}/_version.py":
+                    payload = _render_version_module(version).encode("utf-8")
+                else:
+                    payload = _read_file_bytes(src)
+                _write_member(zf, arcname, payload, executable=False, records=records)
+
+            # 2. Bundled binaries.
+            for binary in BUNDLE_BINARIES:
+                src = extract_dir / "bin" / binary
+                arcname = f"{IMPORT_NAME}/_binaries/{binary}"
+                _write_member(
+                    zf,
+                    arcname,
+                    _read_file_bytes(src),
+                    executable=True,
+                    records=records,
+                )
+
+            # 3. Bundled data: config + monitor dist tree + manifest.
+            config_src = extract_dir / BUNDLE_CONFIG
+            _write_member(
+                zf,
+                f"{IMPORT_NAME}/_data/{BUNDLE_CONFIG}",
+                _read_file_bytes(config_src),
+                executable=False,
+                records=records,
+            )
+
+            monitor_root = extract_dir / BUNDLE_MONITOR_DIST
+            for asset in _iter_files(monitor_root):
+                rel = asset.relative_to(extract_dir)
+                arcname = f"{IMPORT_NAME}/_data/{str(rel).replace(os.sep, '/')}"
+                _write_member(
+                    zf,
+                    arcname,
+                    _read_file_bytes(asset),
+                    executable=False,
+                    records=records,
+                )
+
+            _write_member(
+                zf,
+                f"{IMPORT_NAME}/_data/manifest.json",
+                _read_file_bytes(manifest_path),
+                executable=False,
+                records=records,
+            )
+
+            # 4. dist-info metadata.
+            _write_member(
+                zf,
+                f"{dist_info}/METADATA",
+                _render_metadata(version, readme_body).encode("utf-8"),
+                executable=False,
+                records=records,
+            )
+            _write_member(
+                zf,
+                f"{dist_info}/WHEEL",
+                _render_wheel_metadata(platform_tag).encode("utf-8"),
+                executable=False,
+                records=records,
+            )
+            _write_member(
+                zf,
+                f"{dist_info}/entry_points.txt",
+                _render_entry_points().encode("utf-8"),
+                executable=False,
+                records=records,
+            )
+
+            # 5. RECORD — itself listed with empty sha+size per spec.
+            _write_member(
+                zf,
+                record_arcname,
+                _render_record(records, record_arcname).encode("utf-8"),
+                executable=False,
+                records=[],  # do not self-reference RECORD's own row
+            )
+
+    return wheel_path
+
+
+def _safe_extract(tf: tarfile.TarFile, dest: Path) -> None:
+    # Guard against tarballs with paths escaping the extraction root.
+    dest_resolved = dest.resolve()
+    for member in tf.getmembers():
+        target_path = (dest / member.name).resolve()
+        if not str(target_path).startswith(str(dest_resolved) + os.sep) and target_path != dest_resolved:
+            raise SystemExit(f"refusing to extract unsafe path: {member.name}")
+    tf.extractall(dest)
+
+
+# ----------------------------------------------------------------------------
+# CLI
+# ----------------------------------------------------------------------------
+
+
+class _PairAction(argparse.Action):
+    """Collect --target T1 --bundle B1 --target T2 --bundle B2 pairs."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        pairs = getattr(namespace, "pairs", None)
+        if pairs is None:
+            pairs = []
+            setattr(namespace, "pairs", pairs)
+        if option_string == "--target":
+            pairs.append({"target": values})
+        elif option_string == "--bundle":
+            if not pairs or "bundle" in pairs[-1]:
+                parser.error("--bundle must follow a preceding --target")
+            pairs[-1]["bundle"] = values
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--target", action=_PairAction, help="Rust target triple for the next --bundle")
+    parser.add_argument("--bundle", action=_PairAction, help="Path to moraine-bundle-<target>.tar.gz")
+    parser.add_argument("--out-dir", type=Path, required=True, help="Output directory for built wheels")
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Version string for the wheels (typically the release tag with or without leading 'v')",
+    )
+    args = parser.parse_args(argv)
+    pairs = getattr(args, "pairs", None) or []
+    if not pairs:
+        parser.error("at least one --target/--bundle pair is required")
+    for idx, pair in enumerate(pairs):
+        if "bundle" not in pair:
+            parser.error(f"--target {pair['target']} is missing a following --bundle")
+    args.pairs = pairs
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    for pair in args.pairs:
+        wheel = build_wheel(
+            target=pair["target"],
+            bundle=Path(pair["bundle"]),
+            out_dir=args.out_dir,
+            version=args.version,
+        )
+        print(f"built: {wheel}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Workhorse change for PyPI distribution, stacked on top of [#239](https://github.com/eric-tramel/moraine/pull/239). Consumes the existing `moraine-bundle-*.tar.gz` release artifacts and repackages them as platform-tagged Python wheels for `uv tool install moraine`.

**Review note:** this PR is stacked on [#239](https://github.com/eric-tramel/moraine/pull/239) (base = `claude/brave-dhawan-fec8ee`). Re-base to `main` after #239 merges.

### Package scaffolding — `bindings/python/moraine-cli/`

- `pyproject.toml` — hatchling backend, dynamic version, 4 console scripts mapped to the exec shim
- `moraine_cli/__init__.py` — `os.execvpe` shim that sets `MORAINE_MONITOR_DIST` / `MORAINE_DEFAULT_CONFIG` (the env overrides from #222) to the in-wheel asset paths before handing off to the bundled binary
- `moraine_cli/_version.py` — sentinel rewritten by the wheel builder
- `moraine_cli/py.typed`, `README.md`

### `scripts/build-python-wheels.py`

- `--target <triple> --bundle <path>` pairs, repeatable per platform
- verifies the bundle's `manifest.json` sha256s before copying any files into the wheel
- assembles `moraine-<version>-py3-none-<plat>.whl` with stdlib only (no setuptools/wheel runtime dep)
- target triples → wheel platform tags:
  - `x86_64-unknown-linux-gnu` → `manylinux_2_17_x86_64`
  - `aarch64-unknown-linux-gnu` → `manylinux_2_17_aarch64`
  - `aarch64-apple-darwin` → `macosx_11_0_arm64`
  - `x86_64-apple-darwin` → `macosx_11_0_x86_64` (out-of-scope for launch per RFC, but cheap to keep in the table)
- **executable bit gotcha fixed during smoke test:** external_attr needs the full Unix `st_mode` (`S_IFREG | 0o755`, not just `0o755`), otherwise pip treats the entry as not-a-regular-file and drops `+x` on install

### `scripts/build-python-sdist.py`

- stub sdist with an in-tree PEP 517 backend (`moraine_build_refuser`) whose `get_requires_for_build_wheel` / `build_wheel` immediately raise with the RFC-specified message pointing at `uv tool install moraine` and the `curl | sh` fallback
- tested with `pip install --no-binary moraine <sdist.tar.gz>` — errors cleanly

## Test plan

Smoke-tested locally against a fabricated bundle (real Rust build wasn't necessary to exercise the packaging path):

- [x] Wheel builds without errors; `unzip -l` layout matches the RFC (binaries under `moraine_cli/_binaries/`, data under `moraine_cli/_data/`, 4 console scripts in `entry_points.txt`, manifest carried through)
- [x] `pip install` into a fresh `python3 -m venv` succeeds with executable bits preserved
- [x] All 4 console scripts (`moraine`, `moraine-ingest`, `moraine-monitor`, `moraine-mcp`) exec into the bundled binary with argv + env forwarded
- [x] `MORAINE_MONITOR_DIST` and `MORAINE_DEFAULT_CONFIG` are set by the shim to paths inside `site-packages/moraine_cli/_data/`
- [x] Sdist refuses with the correct error via `pip install --no-binary moraine`
- [ ] **CI dry-run wheel build (real bundle)** — tracked in [#224](https://github.com/eric-tramel/moraine/issues/224), upcoming PR
- [ ] **TestPyPI publish + `uv tool install` from `test.pypi.org`** — tracked in [#225](https://github.com/eric-tramel/moraine/issues/225), upcoming PR

Closes [#223](https://github.com/eric-tramel/moraine/issues/223). Builds on [#222](https://github.com/eric-tramel/moraine/issues/222) ([#239](https://github.com/eric-tramel/moraine/pull/239)). Unblocks [#224](https://github.com/eric-tramel/moraine/issues/224), [#225](https://github.com/eric-tramel/moraine/issues/225).

🤖 Generated with [Claude Code](https://claude.com/claude-code)