### PR TITLE
release: TestPyPI/PyPI publish job via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -10,6 +10,15 @@ on:
         description: "Tag to release (for example v0.4.1)"
         required: true
         type: string
+      target:
+        description: "PyPI publish target — tag-triggered runs always skip. Choose explicitly on manual dispatches."
+        required: false
+        type: choice
+        default: skip
+        options:
+          - skip
+          - test-pypi
+          - pypi
 
 jobs:
   release:
@@ -61,3 +70,100 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-pypi:
+    name: publish-pypi
+    needs: release
+    # Tag-triggered runs always skip. Only manual dispatches with an
+    # explicit test-pypi / pypi target publish. See RFC #219 and
+    # docs/operations/pypi-release.md for the rehearsal procedure.
+    if: github.event_name == 'workflow_dispatch' && (github.event.inputs.target == 'test-pypi' || github.event.inputs.target == 'pypi')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC for PyPI/TestPyPI trusted publishing
+      contents: read  # for gh release download
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Resolve tag and PEP 440 version
+        id: meta
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+        # The wheel builder's --version must be PEP 440 compliant so
+        # twine / pypi accept the upload. Git tags use dash-separated
+        # pre-release segments (v0.3.1-rc.1); translate them to the
+        # canonical form here rather than in every call site.
+        run: |
+          python3 - <<'PY' >>"$GITHUB_OUTPUT"
+          import os, re
+          tag = os.environ["TAG"]
+          version = tag[1:] if re.match(r"^v\d", tag) else tag
+          # e.g. 0.3.1-rc.1 -> 0.3.1rc1, 0.4.0-beta.2 -> 0.4.0b2
+          for pre, canon in (("rc", "rc"), ("beta", "b"), ("alpha", "a")):
+              version = re.sub(rf"-{pre}\.?(\d+)", rf"{canon}\1", version)
+          # .dev / .post kept as-is; stdlib re is fine for these cases.
+          print(f"tag={tag}")
+          print(f"version={version}")
+          PY
+
+      - name: Download bundle artifacts from GH Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p dist
+          gh release download "${{ steps.meta.outputs.tag }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern 'moraine-bundle-*.tar.gz' \
+            --dir dist/
+
+      - name: Build wheels + stub sdist
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          mkdir -p dist/wheels
+          for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu aarch64-apple-darwin; do
+            python3 scripts/build-python-wheels.py \
+              --target "$target" \
+              --bundle "dist/moraine-bundle-$target.tar.gz" \
+              --out-dir dist/wheels \
+              --version "$VERSION"
+          done
+          python3 scripts/build-python-sdist.py \
+            --out-dir dist/wheels \
+            --version "$VERSION"
+          ls -la dist/wheels
+
+      - name: Publish to TestPyPI
+        if: github.event.inputs.target == 'test-pypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/wheels/
+          repository-url: https://test.pypi.org/legacy/
+          # skip-existing avoids a hard failure on rehearsal tag rebuilds
+          # where the same version has already been pushed.
+          skip-existing: true
+          verbose: true
+
+      - name: Publish to PyPI
+        if: github.event.inputs.target == 'pypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/wheels/
+          skip-existing: false
+          verbose: true
+
+      - name: Upload built wheels as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: moraine-pypi-artifacts-${{ steps.meta.outputs.version }}
+          path: dist/wheels/*
+          retention-days: 30

--- a/docs/operations/pypi-release.md
+++ b/docs/operations/pypi-release.md
@@ -1,0 +1,180 @@
+# PyPI release procedure
+
+Canonical runbook for shipping moraine to TestPyPI and real PyPI as
+`uv tool install moraine`. See [RFC #219](https://github.com/eric-tramel/moraine/issues/219)
+for the rationale.
+
+Moraine publishes via **OIDC trusted publishing** — there is no
+long-lived PyPI token in the repo secrets. Trust is mediated by
+per-repo+per-workflow+per-environment claims configured on the PyPI
+web UI.
+
+## One-time setup
+
+Repeat once per index (TestPyPI for rehearsal, PyPI for production). You
+only need to do this when bootstrapping a new package or re-registering
+after a transfer.
+
+### TestPyPI trusted publisher
+
+1. Log in to <https://test.pypi.org/> with the account that will own the
+   package.
+2. Create the project `moraine` by publishing a manual `0.0.0.dev0`
+   placeholder wheel (`twine upload --repository testpypi …`), or rely
+   on the first publish run claiming the name. Trusted publishing works
+   even for a not-yet-created project via the "pending publisher" flow.
+3. Go to **Account → Publishing → Pending publishers → Add a new pending
+   publisher** and set:
+   - **PyPI project name:** `moraine`
+   - **Owner:** `eric-tramel`
+   - **Repository name:** `moraine`
+   - **Workflow name:** `release-moraine.yml`
+   - **Environment name:** leave blank (we don't gate publishes on a
+     GitHub Environment today)
+4. Save. Once the first real publish happens, TestPyPI promotes this
+   from pending to active.
+
+### Production PyPI trusted publisher
+
+Same as above, on <https://pypi.org/>. Do **not** promote the production
+publisher until the TestPyPI rehearsal has cleared the acceptance
+criteria in [issue #225](https://github.com/eric-tramel/moraine/issues/225).
+
+## Tag + version conventions
+
+The release workflow key `workflow_dispatch.inputs.tag` accepts:
+
+| Tag                     | Normalized version | Notes                                 |
+| ----------------------- | ------------------ | ------------------------------------- |
+| `v0.4.1`                | `0.4.1`            | Standard release                      |
+| `v0.4.1-rc.1`           | `0.4.1rc1`         | Rehearsal / release candidate         |
+| `v0.4.1-beta.2`         | `0.4.1b2`          | Public beta                           |
+| `v0.4.1-alpha.1`        | `0.4.1a1`          | Internal alpha                        |
+| `v0.4.1.post1`          | `0.4.1.post1`      | Wheel-only packaging fix (no Rust rebuild) |
+| `v0.4.1.dev0`           | `0.4.1.dev0`       | Unattached dev build, manual dispatch only |
+
+Normalization is performed by `scripts/build-python-wheels.py` and
+mirrored inline in the `Resolve tag and PEP 440 version` step of the
+workflow — keep both in sync.
+
+## Rehearsal (TestPyPI)
+
+Run this end-to-end before every production release of material changes
+to the packaging scripts, the exec shim, or the bundle layout.
+
+### 1. Cut the rehearsal tag
+
+```bash
+git checkout main
+git pull --ff-only
+git tag v0.4.1-rc.1
+git push origin v0.4.1-rc.1
+```
+
+Pushing the tag kicks off the `release` matrix (3 platforms) which
+builds bundles and uploads them to the GH Release. No PyPI publish
+happens on the tag-triggered run — `workflow_dispatch.inputs.target`
+defaults to `skip` and tag triggers ignore the `target` input entirely.
+
+### 2. Trigger the publish
+
+Once the 3 bundles are up on GH Releases, dispatch the workflow with
+`target=test-pypi`:
+
+```bash
+gh workflow run release-moraine.yml \
+  -f tag=v0.4.1-rc.1 \
+  -f target=test-pypi
+```
+
+The `publish-pypi` job:
+
+1. Rebuilds the bundles (same `release` matrix, `overwrite_files: true`).
+2. Downloads all three bundle tarballs from the GH Release.
+3. Runs `scripts/build-python-wheels.py` for each target + `scripts/build-python-sdist.py`.
+4. Uploads to <https://test.pypi.org/legacy/> via
+   `pypa/gh-action-pypi-publish@release/v1` using the OIDC trusted
+   publisher.
+
+### 3. Validate the install
+
+**macOS arm64** (host):
+
+```bash
+uv tool install --reinstall \
+  --index https://test.pypi.org/simple/ \
+  --index-strategy unsafe-best-match \
+  moraine==0.4.1rc1
+
+moraine --version
+moraine up
+moraine status
+moraine down
+uv tool uninstall moraine
+```
+
+**Linux x86_64** (fresh `ubuntu:22.04` Docker container):
+
+```bash
+docker run --rm -it ubuntu:22.04 bash -lc '
+  apt-get update -y && apt-get install -y curl ca-certificates
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+  uv tool install \
+    --index https://test.pypi.org/simple/ \
+    --index-strategy unsafe-best-match \
+    moraine==0.4.1rc1
+  moraine --version
+  moraine up
+  moraine status
+  moraine down
+  uv tool uninstall moraine
+'
+```
+
+### Acceptance checklist
+
+- [ ] `uv tool install` succeeds on both platforms.
+- [ ] `moraine up` starts the stack (ClickHouse + monitor).
+- [ ] `moraine status` reports healthy.
+- [ ] Monitor UI serves at <http://127.0.0.1:8080/> (from the bundled
+      `web/monitor/dist` inside the wheel — pointed to via
+      `MORAINE_MONITOR_DIST`).
+- [ ] `moraine down` exits cleanly.
+- [ ] `uv tool uninstall moraine` removes the shim without residue
+      under `~/.local/share/uv/tools/moraine`.
+
+If any step fails, fix the underlying issue, bump the RC suffix
+(`v0.4.1-rc.2`), and repeat.
+
+## Production release
+
+Only after a clean TestPyPI rehearsal:
+
+1. Cut the real tag (`git tag v0.4.1 && git push origin v0.4.1`) — the
+   `release` matrix builds and uploads bundles to the GH Release on
+   push.
+2. Manually dispatch:
+   ```bash
+   gh workflow run release-moraine.yml \
+     -f tag=v0.4.1 \
+     -f target=pypi
+   ```
+3. Confirm the wheels and sdist appear on <https://pypi.org/project/moraine/>.
+4. **Canary week:** do *not* update the project README to recommend
+   `uv tool install moraine` yet. Post the install command in the team
+   channel only. Watch for issues. After a clean week, land the README
+   update (tracked separately in
+   [issue #228](https://github.com/eric-tramel/moraine/issues/228)).
+
+## Rollback
+
+PyPI does not allow version deletion — use `twine yank` to mark a
+version as unsafe-to-install while keeping it downloadable for existing
+resolvers. The forward fix is to cut `vX.Y.Z.post1` and republish via a
+manual dispatch with `target=pypi`.
+
+```bash
+# example: yank a bad wheel set
+twine yank moraine==0.4.1 --reason "packaging regression; use 0.4.1.post1"
+```

--- a/scripts/build-python-sdist.py
+++ b/scripts/build-python-sdist.py
@@ -114,9 +114,20 @@ Description-Content-Type: text/markdown
 """
 
 
+_PEP440_PRE_MAP = (
+    ("rc", "rc"),
+    ("beta", "b"),
+    ("alpha", "a"),
+)
+
+
 def _normalize_version(version: str) -> str:
+    # Mirrors scripts/build-python-wheels.py._normalize_version so the
+    # sdist and wheels in the same release share a normalized version.
     if version.startswith("v") and re.match(r"^v\d", version):
-        return version[1:]
+        version = version[1:]
+    for prefix, canonical in _PEP440_PRE_MAP:
+        version = re.sub(rf"-{prefix}\.?(\d+)", rf"{canonical}\1", version)
     return version
 
 

--- a/scripts/build-python-wheels.py
+++ b/scripts/build-python-wheels.py
@@ -175,10 +175,30 @@ def _iter_files(root: Path):
             yield entry
 
 
+_PEP440_PRE_MAP = (
+    ("rc", "rc"),
+    ("beta", "b"),
+    ("alpha", "a"),
+)
+
+
 def _normalize_version(version: str) -> str:
-    # Allow the caller to pass a git tag like "v0.4.1"; strip the leading v.
+    """Normalize a git tag to a PEP 440 version.
+
+    - Strips a leading `v` (so `v0.4.1` → `0.4.1`).
+    - Maps dashed pre-release segments to their PEP 440 canonical form
+      (`0.3.1-rc.1` → `0.3.1rc1`, `0.4.0-beta.2` → `0.4.0b2`).
+    - Leaves `.devN` / `.postN` segments untouched — those are already
+      PEP 440 compliant in git tags.
+
+    The release workflow pre-normalizes before calling this script, but
+    dev-time invocations (smoke tests, ad-hoc rebuilds) often pass a raw
+    git tag; keeping the normalization here means both paths work.
+    """
     if version.startswith("v") and re.match(r"^v\d", version):
-        return version[1:]
+        version = version[1:]
+    for prefix, canonical in _PEP440_PRE_MAP:
+        version = re.sub(rf"-{prefix}\.?(\d+)", rf"{canonical}\1", version)
     return version
 
 


### PR DESCRIPTION
## Summary

First half of the PyPI publish pipeline per [RFC #219](https://github.com/eric-tramel/moraine/issues/219) / [#225](https://github.com/eric-tramel/moraine/issues/225). Extends [.github/workflows/release-moraine.yml](.github/workflows/release-moraine.yml) with a new `publish-pypi` job that rebuilds wheels from the release bundles and ships them to TestPyPI or real PyPI via a `workflow_dispatch`-gated publish.

**No long-lived PyPI token** — publishes use OIDC trusted publishing (`permissions: id-token: write`).

## What changed

### Workflow

- New `workflow_dispatch.inputs.target` choice input `[skip, test-pypi, pypi]`, default `skip`.
- Tag-triggered runs always skip (`github.event.inputs.target` is empty, so the conditional collapses to false).
- New `publish-pypi` job, `needs: release`:
  - checks out at the requested tag, sets up Python 3.12
  - resolves the PEP 440 version from the git tag (`v0.4.1-rc.1` → `0.4.1rc1`)
  - downloads all three bundle tarballs from the GH Release via `gh release download`
  - runs [scripts/build-python-wheels.py](scripts/build-python-wheels.py) for each target + [scripts/build-python-sdist.py](scripts/build-python-sdist.py)
  - publishes via `pypa/gh-action-pypi-publish@release/v1`, `repository-url` flips between `test.pypi.org/legacy/` and default PyPI based on the target input
  - uploads built wheels as a workflow artifact (30-day retention) for audit

### Scripts

[scripts/build-python-wheels.py](scripts/build-python-wheels.py) and [scripts/build-python-sdist.py](scripts/build-python-sdist.py) now normalize dashed pre-release segments into PEP 440 canonical form (`rc` / `beta` / `alpha` → `rc` / `b` / `a`). The workflow pre-normalizes inline too, so both paths produce the same version — verified below.

### Docs

New [docs/operations/pypi-release.md](docs/operations/pypi-release.md) runbook:
- one-time trusted publisher setup (TestPyPI + PyPI)
- supported tag shapes table
- rehearsal procedure (tag → dispatch → validate on macOS arm64 + fresh `ubuntu:22.04` container)
- production release flow + canary-week reminder
- yank / rollback guidance

## Test plan

- [x] `yaml.safe_load` parses the workflow
- [x] Normalizer parity check: inline workflow step, `build-python-wheels._normalize_version`, and `build-python-sdist._normalize_version` produce identical output across 7 tag shapes (`v0.4.1`, `v0.4.1-rc.1`, `v0.4.1-beta.2`, `v0.4.1-alpha.1`, `v0.4.1.post1`, `v0.4.1.dev0`, `0.4.1rc1`)
- [x] End-to-end local rehearsal: fabricated a `v0.4.1-rc.1` bundle, ran the builders, `packaging.utils.parse_wheel_filename` and `packaging.version.Version` parse both artifacts as `0.4.1rc1` (the form PyPI expects for the `moraine==0.4.1rc1` install spec)
- [ ] **Human-driven acceptance** (from the issue):
  - [ ] Register trusted publisher on `test.pypi.org` per the runbook
  - [ ] Cut rehearsal tag `v0.4.1-rc.1` and dispatch with `target=test-pypi`
  - [ ] `uv tool install --index https://test.pypi.org/simple/ --index-strategy unsafe-best-match moraine==0.4.1rc1` on macOS arm64
  - [ ] Same on fresh `ubuntu:22.04` Docker container
  - [ ] `moraine up && moraine status && moraine down` on both

This PR closes the **code side** of [#225](https://github.com/eric-tramel/moraine/issues/225). The operational setup steps (trusted publisher config on `test.pypi.org`, first rehearsal tag) are the remaining work tracked in the issue.

Part of [#219](https://github.com/eric-tramel/moraine/issues/219). Unblocks [#226](https://github.com/eric-tramel/moraine/issues/226) (production PyPI + canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)