### PR TITLE
install: rename PyPI distribution to moraine-cli (re-target to main)

### DIFF
--- a/.github/workflows/ci-packaging.yml
+++ b/.github/workflows/ci-packaging.yml
@@ -23,6 +23,9 @@ jobs:
       DRYRUN_TARGET: x86_64-unknown-linux-gnu
       DRYRUN_VERSION: 0.0.0.dev0
       DRYRUN_WHEEL_PLATFORM: manylinux_2_17_x86_64
+      # PEP 427 normalization: `moraine-cli` → `moraine_cli` in wheel +
+      # sdist filenames. See scripts/build-python-wheels.py.
+      DRYRUN_DIST_NAME: moraine_cli
 
     steps:
       - name: Checkout
@@ -86,13 +89,13 @@ jobs:
 
       - name: Assert wheel layout
         if: github.event_name != 'pull_request' || steps.filter.outputs.packaging == 'true'
-        run: bash scripts/ci/assert-wheel-layout.sh "dist/wheels/moraine-$DRYRUN_VERSION-py3-none-$DRYRUN_WHEEL_PLATFORM.whl"
+        run: bash scripts/ci/assert-wheel-layout.sh "dist/wheels/$DRYRUN_DIST_NAME-$DRYRUN_VERSION-py3-none-$DRYRUN_WHEEL_PLATFORM.whl"
 
       - name: Install wheel + exec moraine --help (console script)
         if: github.event_name != 'pull_request' || steps.filter.outputs.packaging == 'true'
         run: |
           python3 -m venv /tmp/wheel-venv
-          /tmp/wheel-venv/bin/pip install --quiet "dist/wheels/moraine-$DRYRUN_VERSION-py3-none-$DRYRUN_WHEEL_PLATFORM.whl"
+          /tmp/wheel-venv/bin/pip install --quiet "dist/wheels/$DRYRUN_DIST_NAME-$DRYRUN_VERSION-py3-none-$DRYRUN_WHEEL_PLATFORM.whl"
           /tmp/wheel-venv/bin/moraine --help
           /tmp/wheel-venv/bin/moraine-ingest --help
           /tmp/wheel-venv/bin/moraine-monitor --help
@@ -100,7 +103,7 @@ jobs:
 
       - name: Assert sdist refuses to build
         if: github.event_name != 'pull_request' || steps.filter.outputs.packaging == 'true'
-        run: bash scripts/ci/assert-sdist-refuses.sh "dist/wheels/moraine-$DRYRUN_VERSION.tar.gz"
+        run: bash scripts/ci/assert-sdist-refuses.sh "dist/wheels/$DRYRUN_DIST_NAME-$DRYRUN_VERSION.tar.gz"
 
       - name: Upload dry-run wheel (artifact)
         if: github.event_name != 'pull_request' || steps.filter.outputs.packaging == 'true'

--- a/bindings/python/moraine-cli/README.md
+++ b/bindings/python/moraine-cli/README.md
@@ -1,13 +1,20 @@
-# moraine (PyPI distribution)
+# moraine-cli (PyPI distribution)
 
 This directory packages the Moraine CLI binaries as platform-tagged Python
 wheels so they can be installed with:
 
 ```bash
-uv tool install moraine
+uv tool install moraine-cli
 # or
-uvx moraine --help
+uvx --from moraine-cli moraine --help
 ```
+
+The PyPI distribution name is `moraine-cli` because the shorter
+`moraine` is already taken on PyPI by an unrelated InSAR postprocessing
+tool. The command-line entry points installed by the wheel are the
+original short names — `moraine`, `moraine-ingest`, `moraine-monitor`,
+`moraine-mcp` — so after `uv tool install moraine-cli` you still run
+`moraine up` the same as before.
 
 The wheel contains **prebuilt binaries** — the exec-shim package
 (`moraine_cli/__init__.py`) calls `os.execvpe` into the bundled
@@ -40,7 +47,7 @@ frontend — way out of scope for `pip install`. The sdist is a stub that
 raises a clear error:
 
 ```
-$ pip install moraine --no-binary moraine
+$ pip install moraine-cli --no-binary moraine-cli
 ERROR: moraine ships as prebuilt binary wheels only. Install via a
        platform with a published wheel, or build from source with:
        https://github.com/eric-tramel/moraine#install-from-source

--- a/bindings/python/moraine-cli/pyproject.toml
+++ b/bindings/python/moraine-cli/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling>=1.21"]
 build-backend = "hatchling.build"
 
 [project]
-name = "moraine"
+name = "moraine-cli"
 dynamic = ["version"]
 description = "Moraine — unified trace indexer and MCP server for Claude Code / Codex"
 readme = "README.md"

--- a/docs/operations/pypi-release.md
+++ b/docs/operations/pypi-release.md
@@ -1,8 +1,15 @@
 # PyPI release procedure
 
-Canonical runbook for shipping moraine to TestPyPI and real PyPI as
-`uv tool install moraine`. See [RFC #219](https://github.com/eric-tramel/moraine/issues/219)
+Canonical runbook for shipping moraine to PyPI as
+`uv tool install moraine-cli`. See [RFC #219](https://github.com/eric-tramel/moraine/issues/219)
 for the rationale.
+
+The PyPI distribution name is `moraine-cli` because the shorter
+`moraine` is already taken on PyPI by an unrelated InSAR tool. The
+binary + console-script names on the user's `PATH` are still the
+original short forms — `moraine`, `moraine-ingest`, `moraine-monitor`,
+`moraine-mcp` — since those are entry-point names, independent of the
+distribution name.
 
 Moraine publishes via **OIDC trusted publishing** — there is no
 long-lived PyPI token in the repo secrets. Trust is mediated by
@@ -11,34 +18,37 @@ web UI.
 
 ## One-time setup
 
-Repeat once per index (TestPyPI for rehearsal, PyPI for production). You
-only need to do this when bootstrapping a new package or re-registering
-after a transfer.
+### Production PyPI trusted publisher
 
-### TestPyPI trusted publisher
-
-1. Log in to <https://test.pypi.org/> with the account that will own the
+1. Log in to <https://pypi.org/> with the account that will own the
    package.
-2. Create the project `moraine` by publishing a manual `0.0.0.dev0`
-   placeholder wheel (`twine upload --repository testpypi …`), or rely
-   on the first publish run claiming the name. Trusted publishing works
-   even for a not-yet-created project via the "pending publisher" flow.
-3. Go to **Account → Publishing → Pending publishers → Add a new pending
-   publisher** and set:
-   - **PyPI project name:** `moraine`
+2. The project `moraine-cli` does not need to exist yet — PyPI's
+   "pending publisher" flow creates it on first publish.
+3. Go to **Account settings → Publishing → Pending publishers → Add a
+   new pending publisher** and set:
+   - **PyPI Project Name:** `moraine-cli`
    - **Owner:** `eric-tramel`
    - **Repository name:** `moraine`
    - **Workflow name:** `release-moraine.yml`
-   - **Environment name:** leave blank (we don't gate publishes on a
-     GitHub Environment today)
-4. Save. Once the first real publish happens, TestPyPI promotes this
-   from pending to active.
+   - **Environment name:** *leave blank* (we do not gate publishes on a
+     GitHub Environment today; see the follow-up note below)
+4. Click **Add**. On the first successful publish the pending publisher
+   is promoted to an active one.
 
-### Production PyPI trusted publisher
+**GitHub Environment as a future safety gate** (optional, not wired up
+today): creating a `pypi` Environment in the repo with required
+reviewers and adding `environment: pypi` to the `publish-pypi` job
+would require manual approval on every PyPI publish. Worth doing once
+the team grows; tracked separately from this runbook.
 
-Same as above, on <https://pypi.org/>. Do **not** promote the production
-publisher until the TestPyPI rehearsal has cleared the acceptance
-criteria in [issue #225](https://github.com/eric-tramel/moraine/issues/225).
+### TestPyPI trusted publisher (optional — for pre-production rehearsal)
+
+Same flow as above, on <https://test.pypi.org/>, using **PyPI Project
+Name:** `moraine-cli`. We do not use TestPyPI in the standard release
+path today — the production flow publishes release candidates (`rcN`)
+directly to PyPI, where `pip` and `uv tool install` treat them as
+installable only when the caller opts in with `--prerelease=allow`.
+Keep this section for teams that prefer a staging index.
 
 ## Tag + version conventions
 
@@ -57,12 +67,16 @@ Normalization is performed by `scripts/build-python-wheels.py` and
 mirrored inline in the `Resolve tag and PEP 440 version` step of the
 workflow — keep both in sync.
 
-## Rehearsal (TestPyPI)
+## Release flow (production PyPI)
 
-Run this end-to-end before every production release of material changes
-to the packaging scripts, the exec shim, or the bundle layout.
+The standard path is: cut a prerelease tag, publish it to PyPI, verify
+it on a clean macOS arm64 box and a clean `ubuntu:22.04` container,
+then cut the real tag. Prereleases on PyPI are invisible to normal
+`uv tool install moraine-cli` and `pip install moraine-cli` calls —
+they only resolve when the caller explicitly opts in (see the
+verification commands below).
 
-### 1. Cut the rehearsal tag
+### 1. Cut the prerelease tag
 
 ```bash
 git checkout main
@@ -76,15 +90,15 @@ builds bundles and uploads them to the GH Release. No PyPI publish
 happens on the tag-triggered run — `workflow_dispatch.inputs.target`
 defaults to `skip` and tag triggers ignore the `target` input entirely.
 
-### 2. Trigger the publish
+### 2. Trigger the PyPI publish
 
 Once the 3 bundles are up on GH Releases, dispatch the workflow with
-`target=test-pypi`:
+`target=pypi`:
 
 ```bash
 gh workflow run release-moraine.yml \
   -f tag=v0.4.1-rc.1 \
-  -f target=test-pypi
+  -f target=pypi
 ```
 
 The `publish-pypi` job:
@@ -92,25 +106,21 @@ The `publish-pypi` job:
 1. Rebuilds the bundles (same `release` matrix, `overwrite_files: true`).
 2. Downloads all three bundle tarballs from the GH Release.
 3. Runs `scripts/build-python-wheels.py` for each target + `scripts/build-python-sdist.py`.
-4. Uploads to <https://test.pypi.org/legacy/> via
-   `pypa/gh-action-pypi-publish@release/v1` using the OIDC trusted
-   publisher.
+4. Uploads to <https://pypi.org/> via `pypa/gh-action-pypi-publish@release/v1`
+   using the OIDC trusted publisher.
 
-### 3. Validate the install
+### 3. Verify the prerelease
 
 **macOS arm64** (host):
 
 ```bash
-uv tool install --reinstall \
-  --index https://test.pypi.org/simple/ \
-  --index-strategy unsafe-best-match \
-  moraine==0.4.1rc1
+uv tool install --reinstall --prerelease=allow moraine-cli==0.4.1rc1
 
 moraine --version
 moraine up
 moraine status
 moraine down
-uv tool uninstall moraine
+uv tool uninstall moraine-cli
 ```
 
 **Linux x86_64** (fresh `ubuntu:22.04` Docker container):
@@ -120,51 +130,48 @@ docker run --rm -it ubuntu:22.04 bash -lc '
   apt-get update -y && apt-get install -y curl ca-certificates
   curl -LsSf https://astral.sh/uv/install.sh | sh
   export PATH="$HOME/.local/bin:$PATH"
-  uv tool install \
-    --index https://test.pypi.org/simple/ \
-    --index-strategy unsafe-best-match \
-    moraine==0.4.1rc1
+  uv tool install --prerelease=allow moraine-cli==0.4.1rc1
   moraine --version
   moraine up
   moraine status
   moraine down
-  uv tool uninstall moraine
+  uv tool uninstall moraine-cli
 '
 ```
 
-### Acceptance checklist
+### Verification checklist
 
-- [ ] `uv tool install` succeeds on both platforms.
+- [ ] `uv tool install --prerelease=allow` succeeds on both platforms.
 - [ ] `moraine up` starts the stack (ClickHouse + monitor).
 - [ ] `moraine status` reports healthy.
 - [ ] Monitor UI serves at <http://127.0.0.1:8080/> (from the bundled
       `web/monitor/dist` inside the wheel — pointed to via
       `MORAINE_MONITOR_DIST`).
 - [ ] `moraine down` exits cleanly.
-- [ ] `uv tool uninstall moraine` removes the shim without residue
-      under `~/.local/share/uv/tools/moraine`.
+- [ ] `uv tool uninstall moraine-cli` removes the shim without residue
+      under `~/.local/share/uv/tools/moraine-cli`.
 
 If any step fails, fix the underlying issue, bump the RC suffix
-(`v0.4.1-rc.2`), and repeat.
+(`v0.4.1-rc.2`), and repeat. Yank the bad prerelease with
+`twine yank moraine-cli==0.4.1rc1 --reason "superseded by rc.2"`.
 
-## Production release
+### 4. Cut the real release
 
-Only after a clean TestPyPI rehearsal:
+Only after a clean RC verification:
 
-1. Cut the real tag (`git tag v0.4.1 && git push origin v0.4.1`) — the
-   `release` matrix builds and uploads bundles to the GH Release on
-   push.
-2. Manually dispatch:
+1. `git tag v0.4.1 && git push origin v0.4.1` — the `release` matrix
+   builds and uploads bundles to the GH Release on push.
+2. Dispatch the publish:
    ```bash
    gh workflow run release-moraine.yml \
      -f tag=v0.4.1 \
      -f target=pypi
    ```
-3. Confirm the wheels and sdist appear on <https://pypi.org/project/moraine/>.
+3. Confirm the wheels and sdist appear on <https://pypi.org/project/moraine-cli/>.
 4. **Canary week:** do *not* update the project README to recommend
-   `uv tool install moraine` yet. Post the install command in the team
-   channel only. Watch for issues. After a clean week, land the README
-   update (tracked separately in
+   `uv tool install moraine-cli` yet. Post the install command in the
+   team channel only. Watch for issues. After a clean week, land the
+   README update (tracked separately in
    [issue #228](https://github.com/eric-tramel/moraine/issues/228)).
 
 ## Rollback
@@ -176,5 +183,5 @@ manual dispatch with `target=pypi`.
 
 ```bash
 # example: yank a bad wheel set
-twine yank moraine==0.4.1 --reason "packaging regression; use 0.4.1.post1"
+twine yank moraine-cli==0.4.1 --reason "packaging regression; use 0.4.1.post1"
 ```

--- a/scripts/build-python-sdist.py
+++ b/scripts/build-python-sdist.py
@@ -32,8 +32,15 @@ import tarfile
 import time
 from pathlib import Path
 
-PACKAGE_NAME = "moraine"
+PACKAGE_NAME = "moraine-cli"
 DESCRIPTION = "Moraine \u2014 unified trace indexer and MCP server for Claude Code / Codex"
+
+# Sdist filenames follow the same PEP 427-style escaping modern build
+# tools use — replace runs of non-alphanumeric chars with underscores so
+# the archive name parses as {distribution}-{version}.tar.gz without
+# ambiguity (`moraine-cli-0.4.1` otherwise reads as distribution
+# `moraine` + version `cli-0.4.1`).
+SDIST_DISTRIBUTION_NAME = re.sub(r"[^A-Za-z0-9.]+", "_", PACKAGE_NAME)
 
 REFUSAL_MESSAGE = (
     "moraine ships as prebuilt binary wheels only. Install via a "
@@ -144,7 +151,7 @@ def build_sdist(*, version: str, out_dir: Path) -> Path:
     version = _normalize_version(version)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    sdist_root = f"{PACKAGE_NAME}-{version}"
+    sdist_root = f"{SDIST_DISTRIBUTION_NAME}-{version}"
     sdist_name = f"{sdist_root}.tar.gz"
     sdist_path = out_dir / sdist_name
     if sdist_path.exists():

--- a/scripts/build-python-wheels.py
+++ b/scripts/build-python-wheels.py
@@ -66,8 +66,14 @@ BUNDLE_BINARIES = ("moraine", "moraine-ingest", "moraine-monitor", "moraine-mcp"
 BUNDLE_CONFIG = "config/moraine.toml"
 BUNDLE_MONITOR_DIST = "web/monitor/dist"
 
-PACKAGE_NAME = "moraine"  # PyPI distribution name
+PACKAGE_NAME = "moraine-cli"  # PyPI distribution name
 IMPORT_NAME = "moraine_cli"  # package name inside the wheel
+
+# PEP 427 §5: each component of the wheel filename is escaped by
+# replacing runs of non-alphanumeric characters with a single
+# underscore. The .dist-info directory uses the same normalization.
+# The Name: field in METADATA keeps the original hyphenated form.
+WHEEL_DISTRIBUTION_NAME = re.sub(r"[^A-Za-z0-9.]+", "_", PACKAGE_NAME)
 
 # Path inside the repo for the in-tree package skeleton. Used to copy the
 # exec shim (__init__.py, py.typed, _version.py) into the wheel.
@@ -313,13 +319,13 @@ def build_wheel(
         records: list[WheelRecordEntry] = []
 
         wheel_name = (
-            f"{PACKAGE_NAME}-{version}-{PYTHON_TAG}-{ABI_TAG}-{platform_tag}.whl"
+            f"{WHEEL_DISTRIBUTION_NAME}-{version}-{PYTHON_TAG}-{ABI_TAG}-{platform_tag}.whl"
         )
         wheel_path = out_dir / wheel_name
         if wheel_path.exists():
             wheel_path.unlink()
 
-        dist_info = f"{PACKAGE_NAME}-{version}.dist-info"
+        dist_info = f"{WHEEL_DISTRIBUTION_NAME}-{version}.dist-info"
         record_arcname = f"{dist_info}/RECORD"
 
         with zipfile.ZipFile(wheel_path, "w") as zf:

--- a/scripts/ci/assert-sdist-refuses.sh
+++ b/scripts/ci/assert-sdist-refuses.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-usage: scripts/ci/assert-sdist-refuses.sh <path/to/moraine-X.Y.Z.tar.gz>
+usage: scripts/ci/assert-sdist-refuses.sh <path/to/moraine_cli-X.Y.Z.tar.gz>
 EOF
 }
 
@@ -33,9 +33,9 @@ trap 'rm -rf "$venv_dir" "$log"' EXIT
 python3 -m venv "$venv_dir"
 "$venv_dir/bin/pip" install --quiet --upgrade pip >/dev/null
 
-# Must fail. `--no-binary moraine` forces pip to build from the sdist
-# rather than picking up a cached wheel.
-if "$venv_dir/bin/pip" install --no-binary moraine "$sdist" >"$log" 2>&1; then
+# Must fail. `--no-binary moraine-cli` forces pip to build from the
+# sdist rather than picking up a cached wheel.
+if "$venv_dir/bin/pip" install --no-binary moraine-cli "$sdist" >"$log" 2>&1; then
   echo "ERROR: sdist install should have failed but succeeded" >&2
   cat "$log" >&2
   exit 1

--- a/scripts/ci/assert-wheel-layout.sh
+++ b/scripts/ci/assert-wheel-layout.sh
@@ -61,11 +61,11 @@ require_member "moraine_cli/_binaries/moraine-mcp"
 require_member "moraine_cli/_data/config/moraine.toml"
 require_member "moraine_cli/_data/web/monitor/dist/index.html"
 require_member "moraine_cli/_data/manifest.json"
-require_prefix "moraine-"         # dist-info directory
+require_prefix "moraine_cli-"     # dist-info directory (PEP 427 normalizes moraine-cli → moraine_cli)
 require_prefix "moraine_cli/_data/web/monitor/dist/"
 
 # dist-info files
-dist_info="$(printf '%s\n' "$members" | grep -E '^moraine-.*\.dist-info/' | head -1 | awk -F/ '{print $1}')"
+dist_info="$(printf '%s\n' "$members" | grep -E '^moraine_cli-.*\.dist-info/' | head -1 | awk -F/ '{print $1}')"
 if [[ -z "$dist_info" ]]; then
   echo "wheel has no <name>.dist-info/ directory" >&2
   exit 1


### PR DESCRIPTION
## Summary

Re-opens the rename landed in [#243](https://github.com/eric-tramel/moraine/pull/243) against `main`. #243 was merged into its stacked base (the #242 feature branch) rather than `main`, so when #242 squash-merged to main, the rename commit was left orphaned.

Cherry-picks the merge commit (`e348600`) onto current `origin/main`. No content change from #243 — identical 8-file, +111/-81 diff. The branch it merged into and current main have byte-identical trees, so the cherry-pick applied cleanly with no conflicts.

Context from #243 (still applies):
- Short name `moraine` on PyPI is taken by an unrelated InSAR tool (`kanglcn/moraine 0.9.0`) — claim `moraine-cli`
- Console-script names on the user's `PATH` are unchanged (`moraine`, `moraine-ingest`, `moraine-monitor`, `moraine-mcp`)
- PEP 427 normalization (`moraine-cli` → `moraine_cli` in wheel + sdist filenames)
- METADATA `Name:` field stays canonical hyphenated form
- Docs scrubbed; release runbook reshaped around "prereleases direct to PyPI, verify, then cut real tag"

## Why this matters right now

The PyPI trusted publisher you registered targets **`moraine-cli`**. Without this PR on main, the release workflow would build wheels as `moraine-0.4.2rc1-...whl` and the first publish attempt would fail with an OIDC project-name mismatch. Merge this, then tag.

## Test plan

- [x] Verified `c4a5928.tree == 9b410fa.tree` (#242's rebased commit vs its squash-merge to main) — no conflict surface
- [x] `grep '^name =' bindings/python/moraine-cli/pyproject.toml` → `moraine-cli`
- [x] `grep '^PACKAGE_NAME' scripts/build-python-{wheels,sdist}.py` → `moraine-cli`
- [ ] `packaging-dryrun` CI job will exercise the renamed filenames end-to-end (same file set as #243)

🤖 Generated with [Claude Code](https://claude.com/claude-code)