### PR TITLE
fix(conversations): point get_session boundary-uid subquery at v_conversation_trace

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo.rs
@@ -916,10 +916,10 @@ FORMAT JSONEachRow",
     async fn load_session_metadata(&self, session_id: &str) -> RepoResult<Option<SessionMetadata>> {
         let session_summary = self.table_ref("v_session_summary");
         let mode_subquery = self.mode_subquery();
-        let events_table = self.table_ref("events");
+        let trace_table = self.table_ref("v_conversation_trace");
         let query = format!(
             "SELECT
-  s.session_id,
+  s.session_id AS session_id,
   toString(s.first_event_time) AS first_event_time,
   toInt64(toUnixTimestamp64Milli(s.first_event_time)) AS first_event_unix_ms,
   toString(s.last_event_time) AS last_event_time,
@@ -939,10 +939,10 @@ LEFT JOIN ({mode_subquery}) AS m ON m.session_id = s.session_id
 LEFT JOIN (
   SELECT
     session_id,
-    argMin(event_uid, tuple(event_ts, event_order, event_uid)) AS first_event_uid,
-    argMax(event_uid, tuple(event_ts, event_order, event_uid)) AS last_event_uid,
-    argMax(actor_role, tuple(event_ts, event_order, event_uid)) AS last_actor_role
-  FROM {events_table}
+    argMin(event_uid, tuple(event_time, event_order, event_uid)) AS first_event_uid,
+    argMax(event_uid, tuple(event_time, event_order, event_uid)) AS last_event_uid,
+    argMax(actor_role, tuple(event_time, event_order, event_uid)) AS last_actor_role
+  FROM {trace_table}
   WHERE session_id = {session_id_sql}
   GROUP BY session_id
 ) AS e ON e.session_id = s.session_id
@@ -951,7 +951,7 @@ LIMIT 1
 FORMAT JSONEachRow",
             session_summary = session_summary,
             mode_subquery = mode_subquery,
-            events_table = events_table,
+            trace_table = trace_table,
             session_id_sql = sql_quote(session_id),
         );
 

--- a/crates/moraine-conversations/tests/repository_integration.rs
+++ b/crates/moraine-conversations/tests/repository_integration.rs
@@ -149,8 +149,9 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
         }
 
         if query.contains("FROM `moraine`.`v_session_summary` AS s")
-            && query.contains("argMin(event_uid, tuple(event_ts, event_order, event_uid))")
-            && query.contains("argMax(actor_role, tuple(event_ts, event_order, event_uid))")
+            && query.contains("argMin(event_uid, tuple(event_time, event_order, event_uid))")
+            && query.contains("argMax(actor_role, tuple(event_time, event_order, event_uid))")
+            && query.contains("FROM `moraine`.`v_conversation_trace`")
             && query.contains("WHERE s.session_id =")
         {
             if query.contains("WHERE s.session_id = 'sess-missing'") {
@@ -887,10 +888,29 @@ async fn get_session_metadata_returns_stable_summary_fields() {
     let queries = state.queries.lock().expect("queries lock").clone();
     let metadata_query = queries
         .iter()
-        .find(|q| q.contains("argMin(event_uid, tuple(event_ts, event_order, event_uid))"))
+        .find(|q| q.contains("argMin(event_uid, tuple(event_time, event_order, event_uid))"))
         .expect("session metadata query should be captured");
-    assert!(metadata_query.contains("argMax(actor_role, tuple(event_ts, event_order, event_uid))"));
+    assert!(
+        metadata_query.contains("argMax(actor_role, tuple(event_time, event_order, event_uid))")
+    );
     assert!(metadata_query.contains("WHERE s.session_id = 'sess_c'"));
+    // Regression: event_order exists only in v_conversation_trace, never in
+    // moraine.events. The mode subquery legitimately reads from events, so
+    // scope this check to the argMin/argMax subquery by asserting the
+    // v_conversation_trace table is immediately above the event_uid argMin.
+    let metadata_subquery_slice = metadata_query
+        .split_once("argMin(event_uid, tuple(event_time")
+        .and_then(|(head, _)| head.rsplit_once("SELECT"))
+        .map(|(_, tail)| tail)
+        .expect("metadata subquery head should be present");
+    assert!(
+        !metadata_subquery_slice.contains("FROM `moraine`.`events`"),
+        "argMin/argMax subquery must read from v_conversation_trace, not events: {metadata_query}",
+    );
+    assert!(
+        metadata_query.contains("FROM `moraine`.`v_conversation_trace`"),
+        "metadata subquery must read event_order from v_conversation_trace: {metadata_query}",
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary
Two stacked bugs were hiding in `get_session`, surfacing the moment a real ClickHouse (25.12.5.44) sat behind the MCP server:

1. The boundary-event-uid subquery read `argMin(event_uid, tuple(event_ts, event_order, event_uid))` from `moraine.events`, but `event_order` is a per-session window-function column that only exists on the `v_conversation_trace` view. Every call returned `Code 47: Unknown expression or function identifier 'event_order'`.
2. Once (1) was fixed, a second bug surfaced: the outer `SELECT s.session_id, …` lacked an alias, so the JSONEachRow payload came back keyed `s.session_id`, which serde couldn't deserialize into `SessionMetadataRow::session_id`.

Route the subquery through `v_conversation_trace` (matching every other `event_order` lookup in this file) and alias `s.session_id AS session_id` so the row parses. Tighten the existing integration test to assert the subquery reads from `v_conversation_trace` — the mock harness can't see the column-mismatch, so an explicit table assertion is the smallest regression surface we can add without real-CH infra in CI.

## Test plan
- [x] `cargo test -p moraine-conversations` (19/19, including the tightened `get_session_metadata_returns_stable_summary_fields`)
- [x] `cargo clippy --workspace --all-targets --locked -- -Dwarnings …` (strict baseline, clean)
- [x] End-to-end against ClickHouse 25.12.5.44 via `scripts/dev/sandbox/moraine-sandbox` with a seeded hermes fixture:
  - `get_session` returns populated metadata (`first_event_uid`, `last_event_uid`, `last_actor_role`, `mode=tool_calling`) with `isError=false`
  - `search_conversations`, `search`, `list_sessions`, `get_session_events`, `open` all still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)