### PR TITLE
fix(mcp): drop top-level oneOf from open tool input_schema

### DIFF
--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -695,7 +695,7 @@ impl AppState {
                 },
                 {
                     "name": "open",
-                    "description": "Open by `event_uid` with surrounding context, or open a session transcript by `session_id`.",
+                    "description": "Open by `event_uid` with surrounding context, or open a session transcript by `session_id`. Callers must supply exactly one of `event_uid` or `session_id`.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -731,11 +731,7 @@ impl AppState {
                                 "enum": ["prose", "full"],
                                 "default": "prose"
                             }
-                        },
-                        "oneOf": [
-                            { "required": ["event_uid"] },
-                            { "required": ["session_id"] }
-                        ]
+                        }
                     }
                 },
                 {


### PR DESCRIPTION
## Summary

- The Anthropic API rejects tool definitions whose `input_schema` has `oneOf`, `allOf`, or `anyOf` at the top level (`400 invalid_request_error: input_schema does not support oneOf, allOf, or anyOf at the top level`). This crashes any Claude Code session that has the conversation-search MCP enabled.
- The `open` tool encoded its "exactly one of `event_uid` / `session_id`" constraint twice: once with a top-level `oneOf` in `inputSchema`, and once at runtime in the handler via `match (event_uid, session_id)` with descriptive errors. The runtime check is sufficient, so drop the schema-level `oneOf` and document the constraint in the tool description.
- The remaining `oneOf` occurrences in the file are nested inside property definitions (`event_kind`, `include_payload`) — those are legal per the API spec.

## Test plan

- [x] `cargo test -p moraine-mcp-core --lib` (27 passed)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked` (strict baseline, matches CI)
- [ ] Re-run a Claude Code session with the `conversation-search` MCP enabled and verify `tools/list` no longer gets rejected by the Anthropic API

🤖 Generated with [Claude Code](https://claude.com/claude-code)