### PR TITLE
feat(sandbox): agent-driven MCP smoke test (opus/sonnet/haiku)

### DIFF
--- a/.claude/skills/agent-smoke-e2e/SKILL.md
+++ b/.claude/skills/agent-smoke-e2e/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: agent-smoke-e2e
+description: End-to-end smoke check of the moraine MCP server. Exercises every MCP tool against a live moraine stack and prints a per-tool PASS/FAIL matrix. Use inside the dev sandbox after a fresh build to confirm the MCP binary actually serves its tools and returns shaped responses.
+---
+
+# agent-smoke-e2e
+
+You are running an end-to-end smoke test of the moraine MCP server.
+
+Your sole job is to call each of the six MCP tools exposed by the `moraine` MCP server, validate that the response is shaped as expected, and emit a final pass/fail matrix. Do **not** do anything else — no exploration, no reading files, no code changes. Treat this like a test runner: terse output, clear pass/fail signals, no prose.
+
+## Setup assumptions
+
+- The `moraine` MCP server is registered and its tools are available as `mcp__moraine__search`, `mcp__moraine__open`, `mcp__moraine__search_conversations`, `mcp__moraine__list_sessions`, `mcp__moraine__get_session`, and `mcp__moraine__get_session_events`.
+- The stack may or may not have ingested sessions. Both cases are valid — the smoke test cares that tools *respond*, not that they return data.
+- Do not call any tool outside the `mcp__moraine__*` namespace.
+
+## Test sequence
+
+Run each check below in order. For each: call the tool with the arguments listed, inspect the response, then record PASS or FAIL (with a one-line reason on FAIL).
+
+### 1. `list_sessions`
+
+Call `mcp__moraine__list_sessions` with `limit: 5`, `sort: "desc"`.
+
+- **PASS** if the response is a JSON object with a `sessions` array (empty is fine).
+- Capture `sample_session_id = sessions[0].session_id` if present. If the list is empty, leave it as `null` — later tests that need a real session will self-skip with a note.
+
+### 2. `search`
+
+Call `mcp__moraine__search` with `query: "moraine"`, `limit: 5`, `verbosity: "prose"`.
+
+- **PASS** if the response is an object with a `hits` array (empty is fine).
+- Capture `sample_event_uid = hits[0].event_uid` if present.
+
+### 3. `search_conversations`
+
+Call `mcp__moraine__search_conversations` with `query: "moraine"`, `limit: 5`.
+
+- **PASS** if the response is an object with a `hits` (or equivalent sessions) array. Empty is fine.
+
+### 4. `open`
+
+- If `sample_event_uid` is set from step 2, call `mcp__moraine__open` with `event_uid: sample_event_uid`, `verbosity: "prose"`. **PASS** if `found: true` and an `events` array is present.
+- If `sample_event_uid` is null, call `mcp__moraine__open` with `event_uid: "smoke-nonexistent-uid"`. **PASS** if the tool returns cleanly (not an RPC error) with `found: false` or an equivalent empty result. We are testing that the tool handles the call, not that data exists.
+
+### 5. `get_session`
+
+- If `sample_session_id` is set from step 1, call `mcp__moraine__get_session` with `session_id: sample_session_id`. **PASS** if the response echoes the same `session_id` and includes metadata fields (e.g. `event_count`, `start_time`, or similar).
+- If `sample_session_id` is null, call with `session_id: "smoke-nonexistent-session"`. **PASS** if the tool returns cleanly (not an RPC error) with a not-found marker.
+
+### 6. `get_session_events`
+
+- If `sample_session_id` is set, call `mcp__moraine__get_session_events` with `session_id: sample_session_id`, `limit: 5`, `direction: "forward"`. **PASS** if the response has an `events` array (empty is acceptable only when the captured session has zero events, which is unusual — flag as WARN if so).
+- If `sample_session_id` is null, call with `session_id: "smoke-nonexistent-session"`, `limit: 5`. **PASS** if the tool returns cleanly with an empty `events` array and no RPC error.
+
+## FAIL conditions (applies to every step)
+
+- The tool call raises an MCP/RPC error (`isError: true`, JSON-RPC error response, or tool not found).
+- The response is missing the core array (`sessions`/`hits`/`events`) entirely (not just empty).
+- A JSON-RPC layer error surfaces (e.g. schema validation rejection).
+
+## Output
+
+After all six checks, emit **exactly** this block (no extra commentary before or after):
+
+```
+=== agent-smoke-e2e ===
+list_sessions:        PASS|FAIL [reason]
+search:               PASS|FAIL [reason]
+search_conversations: PASS|FAIL [reason]
+open:                 PASS|FAIL [reason]
+get_session:          PASS|FAIL [reason]
+get_session_events:   PASS|FAIL [reason]
+---
+sessions_in_stack: <N from list_sessions>
+sample_session_id: <id or null>
+sample_event_uid:  <uid or null>
+overall:           PASS|FAIL
+=======================
+```
+
+`overall: PASS` only if every line above is PASS. A single FAIL flips overall to FAIL.
+
+Stop after emitting the block. Do not volunteer follow-up analysis, suggest fixes, or ask questions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,10 @@ which sandbox is yours.
 | `moraine-sandbox list` | One-line-per-sandbox table. |
 | `moraine-sandbox down <id>` / `down --all` | Stop, remove the container + all named volumes + the `/tmp/moraine-sandbox-<id>/` config dir. |
 
+### Agent-driven MCP smoke test
+
+For a higher-level sanity check than `cargo test` can give, use `scripts/dev/sandbox/agent-smoke-e2e` (self-documented; run with `--help`). It boots a fresh sandbox, runs the `/agent-smoke-e2e` skill (see `.claude/skills/agent-smoke-e2e/SKILL.md`) against Opus/Sonnet/Haiku in sequence, and aggregates a PASS/FAIL matrix across every `moraine-mcp` tool. Use it before cutting a release, or when you've touched anything in `moraine-mcp-core` / the MCP tool surface. Requires `ANTHROPIC_API_KEY` in the environment.
+
 ### Isolation worktrees (spawned via the Agent SDK's `isolation: "worktree"`)
 
 If you were spawned into a temporary worktree (e.g. `/Users/.../.claude/worktrees/agent-<id>/`), its branch may be **`main`**, not the branch the parent session is working on. The Agent SDK currently branches isolation worktrees from the repo root's `HEAD`, not the calling process's current branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/scripts/dev/sandbox/Dockerfile
+++ b/scripts/dev/sandbox/Dockerfile
@@ -54,6 +54,18 @@ RUN apt-get update \
         build-essential \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Node.js (for the Claude Code CLI used by the agent-smoke-e2e driver).
+# NodeSource's setup script is the upstream-recommended path and pins us to a
+# current LTS line. We install npm with it so `npm install -g @anthropic-ai/claude-code`
+# just works for the smoke-test flow; non-smoke sandbox users pay ~50 MB once,
+# which is cheap compared to the rust toolchain that dominates image size.
+ARG NODE_MAJOR=20
+RUN curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g @anthropic-ai/claude-code \
+    && claude --version
+
 # Install sccache. Binary targets linux-musl for static linkage so it runs
 # regardless of glibc version. When the host (macOS) and the container (linux)
 # both point RUSTC_WRAPPER=sccache at a shared disk cache, their entries are

--- a/scripts/dev/sandbox/README.md
+++ b/scripts/dev/sandbox/README.md
@@ -60,10 +60,47 @@ supported runtime for end users. Production install remains `install.sh` /
 PyPI — see issue #219. If you find yourself reaching for this to run
 moraine "for real", stop; use `install.sh` instead.
 
+## Agent-driven smoke test (`agent-smoke-e2e`)
+
+`scripts/dev/sandbox/agent-smoke-e2e` boots a fresh sandbox, runs the Claude
+Code CLI inside the container (headless, `--dangerously-skip-permissions`),
+and drives the `/agent-smoke-e2e` skill at
+[`.claude/skills/agent-smoke-e2e/SKILL.md`](../../../.claude/skills/agent-smoke-e2e/SKILL.md).
+The skill exercises every `moraine-mcp` tool (`search`, `open`,
+`search_conversations`, `list_sessions`, `get_session`,
+`get_session_events`) and emits a pass/fail matrix.
+
+The driver runs the skill **three times** — once each against Opus 4.7,
+Sonnet 4.6, and Haiku 4.5 — sharing a single sandbox boot. Each model gets
+a fresh `moraine-mcp` subprocess (claude spins one up per invocation), so
+runs are independent from the server's perspective. The driver aggregates
+the three verdicts; exit 0 requires all three to PASS. Override the model
+set with `MORAINE_SMOKE_MODELS="id1 id2 ..."` for ad-hoc runs.
+
+```bash
+# One-shot: boot, run opus/sonnet/haiku in sequence, report, tear down.
+export ANTHROPIC_API_KEY=sk-ant-...
+scripts/dev/sandbox/agent-smoke-e2e
+
+# Only one model, e.g. during a regression bisect:
+MORAINE_SMOKE_MODELS="claude-sonnet-4-6" scripts/dev/sandbox/agent-smoke-e2e
+```
+
+Complements `scripts/ci/mcp_smoke.py` (raw JSON-RPC) by driving the MCP
+tools through an actual agent — catches regressions in tool discovery,
+argument validation, and LLM-shaped payloads that the raw protocol smoke
+doesn't exercise.
+
+`ANTHROPIC_API_KEY` is required. On macOS, `claude login` stores creds in
+Keychain and they're unreachable from the Linux container — so exporting an
+API key is the supported path for this smoke test.
+
 ## See also
 
 - `docs/development/sandbox.md` — the long-form guide: flags, build
   strategies, mounts, config generation, caveats, troubleshooting.
 - `scripts/ci/e2e-stack.sh` — the non-interactive CI gate with synthetic
   fixtures. Complementary to this sandbox, not replaced by it.
+- `scripts/ci/mcp_smoke.py` — raw JSON-RPC smoke against `moraine-mcp`.
+  `agent-smoke-e2e` is the agent-level companion.
 - RFC: `gh issue view 232`.

--- a/scripts/dev/sandbox/agent-smoke-e2e
+++ b/scripts/dev/sandbox/agent-smoke-e2e
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# Moraine dev sandbox — agent-driven MCP smoke test.
+#
+# End-to-end exercise of the built moraine-mcp binary through a real Claude
+# Code agent session. Complements scripts/ci/mcp_smoke.py (raw JSON-RPC) by
+# driving the tools the way an actual agent would: through MCP tool discovery,
+# with real LLM-shaped payloads, and through a full sandbox boot/build cycle.
+#
+# Flow:
+#   1. Boot a fresh moraine sandbox (--mount-host-sessions so there's real
+#      data to search over; the skill is tolerant of empty stacks too).
+#   2. For each model in {opus, sonnet, haiku}, exec `claude` inside the
+#      sandbox with:
+#        * --dangerously-skip-permissions  (auto-approve all tool calls)
+#        * --model <model-id>              (the row under test)
+#        * --mcp-config pointing at /opt/moraine/bin/moraine-mcp
+#        * a prompt that invokes the /agent-smoke-e2e skill from /repo
+#   3. Capture stdout per run, match the trailing `overall: PASS|FAIL` line.
+#   4. Tear the sandbox down (always, even on failure — leftover sandboxes
+#      are load-bearing leaks per RFC #232).
+#   5. Exit 0 only if all three model runs PASSed.
+#
+# The sandbox boots once and is shared across all three runs — boot/build is
+# the expensive part, so repeating it per model would be wasteful. Each run
+# gets its own fresh MCP server subprocess (claude starts a new one per
+# invocation) so runs are independent from the server's point of view.
+#
+# Credentials: passes ANTHROPIC_API_KEY through from the host environment.
+# On macOS the normal `claude login` flow stores creds in Keychain, which
+# isn't reachable from a Linux container — so for this smoke test, callers
+# must have ANTHROPIC_API_KEY exported. The script errors early if not.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SANDBOX_CLI="${SCRIPT_DIR}/moraine-sandbox"
+PROJECT_PREFIX="moraine-sandbox-"
+
+# Model ids under test. Keep in sync with the knowledge cutoff guidance in
+# the global CLAUDE.md: Opus 4.7, Sonnet 4.6, Haiku 4.5 are the current
+# family. Override via MORAINE_SMOKE_MODELS (space-separated ids) for ad-hoc
+# runs against other models without editing the script.
+DEFAULT_MODELS=(
+    "claude-opus-4-7"
+    "claude-sonnet-4-6"
+    "claude-haiku-4-5"
+)
+
+log()  { printf '[smoke-e2e] %s\n' "$*" >&2; }
+warn() { printf '[smoke-e2e] WARN: %s\n' "$*" >&2; }
+die()  { printf '[smoke-e2e] ERROR: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+    cat >&2 <<EOF
+Usage: agent-smoke-e2e [--id <id>] [--keep] [--rebuild] [--no-host-sessions]
+
+Runs the /agent-smoke-e2e skill against the in-sandbox moraine-mcp once per
+model in {opus-4.7, sonnet-4.6, haiku-4.5} and aggregates verdicts.
+
+  --id <id>           Reuse an existing sandbox id instead of booting a new
+                      one. When set, the script never tears down on exit.
+  --keep              Leave the sandbox running after the runs (no teardown).
+  --rebuild           Forward --rebuild to moraine-sandbox up (forces a cold
+                      cargo build of the workspace inside the container).
+  --no-host-sessions  Boot without mounting host session archives. The test
+                      still passes — the skill tolerates empty stacks — but
+                      exercises less of the data path.
+
+Environment:
+  ANTHROPIC_API_KEY       Required. Passed through to the in-container CLI.
+  MORAINE_SMOKE_MODELS    Optional. Space-separated model ids to run against
+                          instead of the default opus/sonnet/haiku trio.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Flags
+# ---------------------------------------------------------------------------
+
+given_id=""
+keep=0
+rebuild=0
+mount_host_sessions=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --id)               given_id="${2:-}"; [[ -n "$given_id" ]] || die "--id requires a value"; shift 2 ;;
+        --keep)             keep=1; shift ;;
+        --rebuild)          rebuild=1; shift ;;
+        --no-host-sessions) mount_host_sessions=0; shift ;;
+        -h|--help)          usage; exit 0 ;;
+        *)                  usage; die "unknown flag: $1" ;;
+    esac
+done
+
+# Resolve model list: env override (space-separated) wins, else defaults.
+models=()
+if [[ -n "${MORAINE_SMOKE_MODELS:-}" ]]; then
+    # shellcheck disable=SC2206
+    models=(${MORAINE_SMOKE_MODELS})
+else
+    models=("${DEFAULT_MODELS[@]}")
+fi
+[[ "${#models[@]}" -gt 0 ]] || die "no models configured — set MORAINE_SMOKE_MODELS or restore defaults"
+
+# ---------------------------------------------------------------------------
+# Pre-flight
+# ---------------------------------------------------------------------------
+
+command -v docker >/dev/null 2>&1 || die "docker is required"
+[[ -x "$SANDBOX_CLI" ]] || die "moraine-sandbox CLI not found at $SANDBOX_CLI"
+
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+    die "ANTHROPIC_API_KEY is not set; the in-container claude CLI needs it to authenticate"
+fi
+
+# ---------------------------------------------------------------------------
+# Boot sandbox (or adopt an existing one)
+# ---------------------------------------------------------------------------
+
+owned_sandbox=0
+if [[ -n "$given_id" ]]; then
+    id="$given_id"
+    log "reusing sandbox ${id}"
+else
+    up_args=(--quiet)
+    (( mount_host_sessions )) && up_args+=(--mount-host-sessions)
+    (( rebuild ))             && up_args+=(--rebuild)
+    log "booting sandbox (moraine-sandbox up ${up_args[*]})"
+    id="$("$SANDBOX_CLI" up "${up_args[@]}")"
+    owned_sandbox=1
+    log "booted ${id}"
+fi
+
+project="${PROJECT_PREFIX}${id}"
+
+# Unified trap. tmp_files is a cumulative list of every tmp file we've
+# created across model runs, cleaned up together on exit so we never leak a
+# scratch file regardless of where failure strikes.
+tmp_files=()
+cleanup() {
+    local rc=$?
+    if [[ "${#tmp_files[@]}" -gt 0 ]]; then
+        rm -f "${tmp_files[@]}"
+    fi
+    if (( owned_sandbox )) && (( ! keep )); then
+        log "tearing down ${id}"
+        "$SANDBOX_CLI" down "$id" || warn "teardown returned non-zero (state may be partial)"
+    elif (( keep )); then
+        log "leaving ${id} up (--keep)"
+    fi
+    exit "$rc"
+}
+trap cleanup EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# Shared run configuration
+# ---------------------------------------------------------------------------
+
+# Inline MCP config so we don't depend on /repo/.mcp.json's host-relative
+# path (./target/debug/moraine-mcp won't exist in the read-only /repo
+# mount). The in-container binary lives at /opt/moraine/bin/moraine-mcp and
+# needs --config pointing at the generated sandbox config.
+mcp_config=$(cat <<'JSON'
+{
+  "mcpServers": {
+    "moraine": {
+      "command": "/opt/moraine/bin/moraine-mcp",
+      "args": ["--config", "/sandbox/moraine.toml"]
+    }
+  }
+}
+JSON
+)
+
+prompt='Run the agent-smoke-e2e skill. Follow it verbatim and emit the final PASS/FAIL block as specified, then stop.'
+
+# ---------------------------------------------------------------------------
+# Run the skill once per model
+# ---------------------------------------------------------------------------
+
+# Parallel arrays: verdicts[i] ∈ {PASS,FAIL,?}, rcs[i] = claude exit code.
+verdicts=()
+rcs=()
+
+for model in "${models[@]}"; do
+    log "=== run: model=${model} ==="
+
+    tmp_out="$(mktemp)"
+    tmp_err="$(mktemp)"
+    tmp_files+=("$tmp_out" "$tmp_err")
+
+    # Use `docker exec` (not `docker compose exec`) so we don't need to
+    # re-seed the compose-file env vars (SANDBOX_REPO_ROOT etc.) that
+    # `docker compose` parses even for exec. The moraine container's name
+    # matches the compose project name, which is what we want.
+    set +e
+    docker exec \
+        -i \
+        -u moraine \
+        -w /repo \
+        -e "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" \
+        -e "HOME=/home/moraine" \
+        "$project" \
+        claude \
+            --dangerously-skip-permissions \
+            --model "$model" \
+            --mcp-config "$mcp_config" \
+            -p "$prompt" \
+        >"$tmp_out" 2>"$tmp_err"
+    claude_rc=$?
+    set -e
+    rcs+=("$claude_rc")
+
+    log "claude (${model}) exited with code ${claude_rc}"
+
+    printf '\n----- claude stdout (%s) -----\n' "$model" >&2
+    cat "$tmp_out" >&2
+    printf '\n----- claude stderr (%s) -----\n' "$model" >&2
+    cat "$tmp_err" >&2
+    printf '\n--------------------------------\n' >&2
+
+    # Match the `overall:` line emitted by the skill. Search stdout first,
+    # fall back to stderr in case claude routed the final block there.
+    # Last match wins so we don't trip on earlier plan text.
+    verdict="$(grep -E '^overall:[[:space:]]+(PASS|FAIL)$' "$tmp_out" "$tmp_err" 2>/dev/null | tail -n1 | awk '{print $NF}')"
+    if [[ -z "$verdict" ]]; then
+        warn "${model}: no 'overall: PASS|FAIL' line found — skill did not complete cleanly"
+        verdict="?"
+    fi
+    verdicts+=("$verdict")
+    log "${model}: ${verdict}"
+done
+
+# ---------------------------------------------------------------------------
+# Aggregate + report
+# ---------------------------------------------------------------------------
+
+overall="PASS"
+summary=""
+for i in "${!models[@]}"; do
+    model="${models[$i]}"
+    verdict="${verdicts[$i]}"
+    rc="${rcs[$i]}"
+    printf -v row '  %-24s %s  (claude exit=%s)\n' "$model" "$verdict" "$rc"
+    summary+="$row"
+    if [[ "$verdict" != "PASS" ]]; then
+        overall="FAIL"
+    fi
+done
+
+printf '\n==== agent-smoke-e2e summary ====\n' >&2
+printf '%b' "$summary" >&2
+printf '  overall:                  %s\n' "$overall" >&2
+printf '=================================\n' >&2
+
+if [[ "$overall" == "PASS" ]]; then
+    exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary

- Adds `scripts/dev/sandbox/agent-smoke-e2e`, a driver that boots a fresh moraine sandbox and runs the Claude Code CLI headless inside the container three times — once each against Opus 4.7, Sonnet 4.6, and Haiku 4.5 — against a new `/agent-smoke-e2e` skill that exercises every moraine-mcp tool and emits a strict PASS/FAIL matrix.
- Adds Node.js 20 + `@anthropic-ai/claude-code` to the sandbox Dockerfile so the in-container CLI exists; callers pass `ANTHROPIC_API_KEY` through.
- Complements `scripts/ci/mcp_smoke.py` (raw JSON-RPC) by catching issues that only surface through real tool discovery + LLM-shaped payloads.

## Why

We had no end-to-end check of the built `moraine-mcp` binary driven the way an agent would actually drive it. That gap surfaced in the last release. This harness runs the same code paths a real user's agent would, across three model tiers, from a clean sandbox boot.

First run of the harness immediately caught a schema drift in the skill itself (verbosity value not in the tool's enum) — Opus/Sonnet correctly failed, Haiku silently auto-corrected. Exactly the kind of signal this is designed to produce.

## Usage

```bash
export ANTHROPIC_API_KEY=sk-ant-...
scripts/dev/sandbox/agent-smoke-e2e
```

Override model set with `MORAINE_SMOKE_MODELS="id1 id2 ..."`. `--keep` leaves the sandbox up; `--id <id>` reuses an existing one.

## Test plan

- [x] Built the sandbox image locally; Node + claude-code install cleanly into the rust:1-bookworm base.
- [x] Ran the driver end-to-end twice. First run exposed a real schema bug in the skill. After fix:
  ```
  ==== agent-smoke-e2e summary ====
    claude-opus-4-7          PASS  (claude exit=0)
    claude-sonnet-4-6        PASS  (claude exit=0)
    claude-haiku-4-5         PASS  (claude exit=0)
    overall:                  PASS
  =================================
  ```
- [x] Teardown clean — no leftover containers or volumes.
- [ ] (not automated in CI yet — this is a developer/release-QA tool, not a CI gate. Follow-up if we want it in GH Actions.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)