### PR TITLE
fix(monitor): compute session active state from live clock

### DIFF
--- a/web/monitor/src/lib/components/sessions/SessionCard.svelte
+++ b/web/monitor/src/lib/components/sessions/SessionCard.svelte
@@ -30,7 +30,7 @@
 >
   <div class="mv-card-head">
     <div class="mv-card-title-row">
-      <StatusDot status={session.status} endedAt={session.endedAt} />
+      <StatusDot endedAt={session.endedAt} />
       <span class="mv-card-title">{session.title}</span>
     </div>
     <span class="mv-card-time">{fmtRelative(session.endedAt)}</span>

--- a/web/monitor/src/lib/components/sessions/SessionDetail.svelte
+++ b/web/monitor/src/lib/components/sessions/SessionDetail.svelte
@@ -39,7 +39,7 @@
 <div class="mv-detail mv-detail-{layout}">
   <div class="mv-detail-head">
     <div class="mv-detail-titlerow">
-      <StatusDot status={session.status} endedAt={session.endedAt} />
+      <StatusDot endedAt={session.endedAt} />
       <h3 class="mv-detail-title">{session.title}</h3>
       <div class="mv-viz-toggle" role="group" aria-label="Detail view">
         <button

--- a/web/monitor/src/lib/components/sessions/StatusDot.svelte
+++ b/web/monitor/src/lib/components/sessions/StatusDot.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import { isSessionActive } from '../../utils/sessionFormat';
-  import type { SessionStatus } from '../../types/sessions';
+  import { nowStore } from '../../state/clock';
 
-  export let status: SessionStatus;
   export let endedAt: number;
 
-  $: active = isSessionActive(status, endedAt);
+  $: active = isSessionActive(endedAt, $nowStore);
   $: label = active ? 'active' : 'idle';
 </script>
 

--- a/web/monitor/src/lib/state/clock.ts
+++ b/web/monitor/src/lib/state/clock.ts
@@ -1,0 +1,8 @@
+import { readable } from 'svelte/store';
+
+const TICK_INTERVAL_MS = 5_000;
+
+export const nowStore = readable(Date.now(), (set) => {
+  const interval = setInterval(() => set(Date.now()), TICK_INTERVAL_MS);
+  return () => clearInterval(interval);
+});

--- a/web/monitor/src/lib/utils/sessionFormat.ts
+++ b/web/monitor/src/lib/utils/sessionFormat.ts
@@ -61,6 +61,8 @@ export function summarizeArgs(args: Record<string, unknown> | undefined | null):
     .join(', ');
 }
 
-export function isSessionActive(status: string, endedAt: number, now: number = Date.now()): boolean {
-  return status === 'active' || now - endedAt < 60_000;
+export const ACTIVE_WINDOW_MS = 60_000;
+
+export function isSessionActive(endedAt: number, now: number = Date.now()): boolean {
+  return now - endedAt < ACTIVE_WINDOW_MS;
 }


### PR DESCRIPTION
## Summary
- `isSessionActive` had a sticky `status === 'active'` fallback: once the server tagged a session active, the UI kept showing active until the next 30s session poll.
- `StatusDot`'s reactive `$:` block only fired on prop changes, so idle sessions never flipped to idle in between polls even when `endedAt` was already stale.
- Added a `nowStore` readable that ticks every 5s and rewired `StatusDot` to derive active/idle purely from `Date.now() - endedAt < 60s`.

## Operational impact
- Pure frontend change; no config, migration, or service behavior changes.
- `StatusDot` no longer takes a `status` prop — updated the two callers (`SessionCard`, `SessionDetail`).

## Validation
- `bun run typecheck` → 0 errors, 0 warnings.
- `bun run test` → 12/12 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)