### PR TITLE
docs(nav): surface orphaned sandbox and pypi-release pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,8 +63,11 @@ nav:
   - Architecture:
       - Design Tradeoffs: architecture/design-tradeoffs.md
       - Workspace Ownership: architecture/workspace-ownership.md
+  - Development:
+      - Dev Sandbox: development/sandbox.md
   - Operations:
       - Build and Operations: operations/build-and-operations.md
       - Environment Variables: operations/environment-variables.md
       - Replay Search Latency Benchmark: operations/replay-search-latency-benchmark.md
       - Migration Guide: operations/migration-guide.md
+      - PyPI Release: operations/pypi-release.md


### PR DESCRIPTION
## Summary

While reviewing `docs-deploy` I noticed the workflow has been green for every run on `main`, but the deployed site was missing two pages from its navigation. Both files are committed and publish at their direct URLs, but were never wired into `mkdocs.yml` — so anyone browsing the Pages site can't find them.

- `docs/development/sandbox.md` — added in [#234](https://github.com/eric-tramel/moraine/pull/234) (dev sandbox RFC)
- `docs/operations/pypi-release.md` — added in [#242](https://github.com/eric-tramel/moraine/pull/242) (PyPI OIDC release flow)

Evidence this was the gap: each `docs-deploy` build log emitted an mkdocs `INFO` line listing both under "pages exist in the docs directory, but are not included in the nav configuration" — alongside the intentional `_source/**` source-viewer pages. The `INFO` level meant `--strict` didn't fail, so the regression shipped silently.

This change:
- Adds a new top-level **Development** nav section for `development/sandbox.md`.
- Appends **PyPI Release** under the existing **Operations** section.

No content changes — nav only.

## Test plan

- [x] `make docs-build` passes under `--strict` locally.
- [x] `site/index.html` now contains `href="development/sandbox/"` and `href="operations/pypi-release/"`.
- [x] The mkdocs INFO block no longer lists these two pages as orphaned (only the expected `_source/**` stubs remain).
- [ ] After merge, confirm the deployed site shows **Development › Dev Sandbox** and **Operations › PyPI Release** in the left nav at https://eric-tramel.github.io/moraine/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)