### PR TITLE
fix(ingest): sum kimi input buckets into input_tokens

### DIFF
--- a/crates/moraine-ingest-core/src/normalize.rs
+++ b/crates/moraine-ingest-core/src/normalize.rs
@@ -2778,7 +2778,10 @@ fn normalize_kimi_cli_wire_event(
                 "",
                 &payload_json,
             );
-            row.insert("input_tokens".to_string(), json!(input_other));
+            row.insert(
+                "input_tokens".to_string(),
+                json!(input_other + input_cache_read + input_cache_creation),
+            );
             row.insert("output_tokens".to_string(), json!(output));
             row.insert("cache_read_tokens".to_string(), json!(input_cache_read));
             row.insert(

--- a/crates/moraine-ingest-core/tests/kimi_cli_fixture.rs
+++ b/crates/moraine-ingest-core/tests/kimi_cli_fixture.rs
@@ -110,8 +110,19 @@ fn kimi_wire_fixture_maps_messages_tools_and_tokens() {
         usage.get("payload_type").and_then(Value::as_str),
         Some("token_count")
     );
-    assert_eq!(usage.get("input_tokens").and_then(Value::as_u64), Some(10));
+    // input_tokens = input_other + input_cache_read + input_cache_creation
+    // (10 + 2 + 1). cache reads/writes are a subset of total input, not
+    // additional on top — see issue #272.
+    assert_eq!(usage.get("input_tokens").and_then(Value::as_u64), Some(13));
     assert_eq!(usage.get("output_tokens").and_then(Value::as_u64), Some(5));
+    assert_eq!(
+        usage.get("cache_read_tokens").and_then(Value::as_u64),
+        Some(2)
+    );
+    assert_eq!(
+        usage.get("cache_write_tokens").and_then(Value::as_u64),
+        Some(1)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Kimi's `StatusUpdate.token_usage` splits input into three buckets (`input_other`, `input_cache_read`, `input_cache_creation`). The normalizer was mapping only `input_other` into the `input_tokens` column, leaving `cache_read_tokens + cache_write_tokens` potentially exceeding `input_tokens` — semantically backwards, since cache hits/writes are a subset of total input.
- Switch `input_tokens` to the full sum. `cache_read_tokens` and `cache_write_tokens` are unchanged (per-bucket breakdown).

## Operational impact

- No schema or config change.
- Downstream dashboards/queries that filter on `input_tokens` for Kimi sessions will now reflect true input consumption (previously under-reported by the cache fraction, which can be 50%+ on prompt-heavy workloads).
- Only affects newly ingested Kimi `StatusUpdate` rows; existing rows are not backfilled.

## Validation

- Updated [crates/moraine-ingest-core/tests/kimi_cli_fixture.rs](crates/moraine-ingest-core/tests/kimi_cli_fixture.rs) to assert `input_tokens = 13` (10+2+1) plus explicit checks on `cache_read_tokens` / `cache_write_tokens`.
- `cargo test -p moraine-ingest-core --locked` — all tests pass.
- Pre-commit (`cargo fmt --check` + clippy strict baseline) passes.

Closes #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)