### PR TITLE
fix(ingest): drop SubagentEvent from parent Kimi wire normalization

### DIFF
--- a/crates/moraine-ingest-core/src/normalize.rs
+++ b/crates/moraine-ingest-core/src/normalize.rs
@@ -2808,9 +2808,18 @@ fn normalize_kimi_cli_wire_event(
             };
             push_progress("wire:hook", "event_msg", text, "event_msg");
         }
+        "SubagentEvent" => {
+            // Kimi writes every sub-agent event twice: once as a SubagentEvent
+            // envelope on the parent wire, and once as the real event inside
+            // `<session>/subagents/<agent_id>/wire.jsonl`. Emitting a normalized
+            // row here would double-count every sub-agent event as `progress`
+            // on the parent session (see #271). Skip the normalized row; the
+            // raw_events row is still written from the enclosing dispatcher,
+            // so the byte-level trace is preserved.
+        }
         "MCPLoadingBegin" | "MCPLoadingEnd" | "MCPStatusSnapshot" | "BtwBegin" | "BtwEnd"
-        | "SubagentEvent" | "Notification" | "PlanDisplay" | "ApprovalRequest"
-        | "ApprovalResponse" | "QuestionRequest" | "QuestionResponse" => {
+        | "Notification" | "PlanDisplay" | "ApprovalRequest" | "ApprovalResponse"
+        | "QuestionRequest" | "QuestionResponse" => {
             push_progress(
                 &format!("wire:{msg_type}"),
                 "progress",

--- a/crates/moraine-ingest-core/tests/kimi_cli_fixture.rs
+++ b/crates/moraine-ingest-core/tests/kimi_cli_fixture.rs
@@ -115,6 +115,31 @@ fn kimi_wire_fixture_maps_messages_tools_and_tokens() {
 }
 
 #[test]
+fn kimi_subagent_event_emits_raw_row_but_no_normalized_event() {
+    // SubagentEvent envelopes on the parent wire duplicate events that are
+    // already captured via the sub-agent's own wire.jsonl. They must not
+    // produce a normalized event row (which would double-count every
+    // sub-agent event as `progress` on the parent, see #271), but the raw
+    // row is preserved so the byte-level trace remains intact.
+    let rows = normalize_lines("wire.jsonl");
+    let subagent_row = rows
+        .iter()
+        .find(|row| {
+            row.raw_row
+                .get("top_type")
+                .and_then(Value::as_str)
+                .map(|k| k == "SubagentEvent")
+                .unwrap_or(false)
+        })
+        .expect("fixture contains a SubagentEvent record");
+
+    assert!(!subagent_row.raw_row.is_null());
+    assert!(subagent_row.event_rows.is_empty());
+    assert!(subagent_row.tool_rows.is_empty());
+    assert!(subagent_row.error_rows.is_empty());
+}
+
+#[test]
 fn kimi_events_do_not_reuse_raw_record_uid() {
     let rows = normalize_lines("wire.jsonl");
     let mut event_uids = HashSet::new();

--- a/fixtures/kimi-cli/wire.jsonl
+++ b/fixtures/kimi-cli/wire.jsonl
@@ -6,3 +6,4 @@
 {"timestamp":1775953947.300000,"message":{"type":"ToolCall","payload":{"type":"function","id":"tool_abc","function":{"name":"ReadFile","arguments":"{\"path\":\"manifest.json\"}"},"extras":null}}}
 {"timestamp":1775953948.400000,"message":{"type":"ToolResult","payload":{"tool_call_id":"tool_abc","return_value":{"is_error":false,"output":"{\"ok\":true}","message":"Read file","display":[],"extras":null}}}}
 {"timestamp":1775953949.500000,"message":{"type":"StatusUpdate","payload":{"context_usage":0.1,"context_tokens":100,"max_context_tokens":1000,"token_usage":{"input_other":10,"output":5,"input_cache_read":2,"input_cache_creation":1},"message_id":"chatcmpl_test","plan_mode":false,"mcp_status":null}}}
+{"timestamp":1775953950.600000,"message":{"type":"SubagentEvent","payload":{"agent_id":"sub_xyz","event":{"type":"ContentPart","payload":{"type":"text","text":"sub-agent echo"}}}}}


### PR DESCRIPTION
## Summary
- Closes #271. Parent Kimi `wire.jsonl` files wrap every sub-agent event in a `SubagentEvent` envelope, while the sub-agent's own `wire.jsonl` emits the same events natively. The catchall branch in `normalize_kimi_cli_wire_event` was turning each parent-wire `SubagentEvent` into a `progress` row, duplicating sub-agent activity 1:1 on the parent session (~154 vs. 156 real events in the #268 e2e run) and polluting `event_kind=progress` counts with opaque re-serialized nested envelopes.
- Split `SubagentEvent` out of the catchall as a no-op. The raw_events row is still produced by the enclosing dispatcher (`raw_row` is built before the per-harness normalize fn runs), so the byte-level trace stays intact; only the normalized event row is dropped. The other catchall arms (`MCPLoadingBegin/End`, `MCPStatusSnapshot`, `BtwBegin/End`, `Notification`, `PlanDisplay`, `Approval*`, `Question*`) are unchanged.
- Extended `fixtures/kimi-cli/wire.jsonl` with a `SubagentEvent` line and added `kimi_subagent_event_emits_raw_row_but_no_normalized_event` to lock in all three acceptance bullets: no normalized event row, no tool/error rows, raw_row still populated.

## Operational impact
- No schema, config, or migration changes. After this lands, parent Kimi sessions ingested going forward will no longer emit `event_kind=progress` rows for sub-agent activity. Existing `moraine.events` rows from prior ingest runs are unaffected (re-ingest would idempotently skip already-seen events by UID).
- `moraine.raw_events` continues to carry every `SubagentEvent` line for byte-level replay.

## Validation
- `cargo test -p moraine-ingest-core --locked` — 48 lib + 3 kimi fixture tests pass (new test green).
- `cargo fmt --all -- --check` — clean.
- `bash scripts/ci/clippy-strict-baseline.sh` (via rustup-pinned toolchain to sidestep the Nix/rustup `rustc` mismatch documented in the repo's clippy notes) — clean.

## Test plan
- [x] Fixture test asserts zero `event_rows`, zero `tool_rows`, zero `error_rows`, non-null `raw_row` for a `SubagentEvent` line.
- [x] Pre-existing kimi fixture tests still pass (no index drift — the new line is appended at the end of the fixture).
- [ ] Optional post-merge: re-run the #268 e2e and confirm `progress` counts on parent sessions drop by roughly the sub-agent event count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)