### PR TITLE
fix(ingest): stamp placeholder model on Kimi CLI events

### DIFF
--- a/crates/moraine-ingest-core/src/normalize.rs
+++ b/crates/moraine-ingest-core/src/normalize.rs
@@ -2840,6 +2840,20 @@ fn normalize_kimi_cli_wire_event(
         }
     }
 
+    // Why: the Kimi wire schema (MoonshotAI/kimi-cli wire/types.py) has no
+    // record that carries the active model name, and neither do the sibling
+    // context.jsonl / state.json files. Without a placeholder, every Kimi
+    // event has an empty `model` and the monitor's tokens-by-model analytics
+    // (which filters out empty-model rows) never shows them. Stamping the
+    // harness slug here guarantees a single "kimi-cli" series so Kimi usage
+    // is at least visible cross-harness, even though we can't distinguish
+    // between configured Kimi models.
+    for row in events.iter_mut() {
+        if let Some(obj) = row.as_object_mut() {
+            obj.insert("model".to_string(), json!("kimi-cli"));
+        }
+    }
+
     (events, links, tools)
 }
 
@@ -3978,6 +3992,80 @@ mod tests {
             tool_response.get("output_text").and_then(Value::as_str),
             Some("{\"forecast\":\"rain\"}")
         );
+    }
+
+    #[test]
+    fn kimi_cli_status_update_stamps_placeholder_model() {
+        let record = json!({
+            "timestamp": 1776735761.27701_f64,
+            "message": {
+                "type": "StatusUpdate",
+                "payload": {
+                    "message_id": "msg_abc",
+                    "context_usage": 0.42,
+                    "token_usage": {
+                        "input_other": 1234,
+                        "input_cache_read": 56,
+                        "input_cache_creation": 78,
+                        "output": 90
+                    }
+                }
+            }
+        });
+
+        let out = normalize_record(
+            &record,
+            "kimi-cli",
+            "kimi-cli",
+            "/Users/eric/.kimi/sessions/work-abc/sess-xyz/wire.jsonl",
+            1,
+            1,
+            5,
+            500,
+            "",
+            "",
+        )
+        .expect("kimi status update should normalize");
+
+        assert_eq!(out.event_rows.len(), 1);
+        let row = out.event_rows[0].as_object().unwrap();
+        assert_eq!(row.get("model").and_then(Value::as_str), Some("kimi-cli"));
+        // input_tokens sums input_other + input_cache_read + input_cache_creation
+        // (1234 + 56 + 78), per #275.
+        assert_eq!(row.get("input_tokens").and_then(Value::as_u64), Some(1368));
+        assert_eq!(row.get("output_tokens").and_then(Value::as_u64), Some(90));
+        assert_eq!(out.model_hint, "kimi-cli");
+    }
+
+    #[test]
+    fn kimi_cli_content_part_stamps_placeholder_model() {
+        let record = json!({
+            "timestamp": 1776735761.27701_f64,
+            "message": {
+                "type": "ContentPart",
+                "payload": {
+                    "type": "text",
+                    "text": "hello there"
+                }
+            }
+        });
+
+        let out = normalize_record(
+            &record,
+            "kimi-cli",
+            "kimi-cli",
+            "/Users/eric/.kimi/sessions/work-abc/sess-xyz/wire.jsonl",
+            1,
+            1,
+            6,
+            600,
+            "",
+            "",
+        )
+        .expect("kimi content part should normalize");
+
+        let row = out.event_rows[0].as_object().unwrap();
+        assert_eq!(row.get("model").and_then(Value::as_str), Some("kimi-cli"));
     }
 
     #[test]

--- a/crates/moraine-ingest-core/tests/kimi_cli_fixture.rs
+++ b/crates/moraine-ingest-core/tests/kimi_cli_fixture.rs
@@ -123,6 +123,19 @@ fn kimi_wire_fixture_maps_messages_tools_and_tokens() {
         usage.get("cache_write_tokens").and_then(Value::as_u64),
         Some(1)
     );
+
+    // Every emitted Kimi event row should carry the harness-slug placeholder
+    // model ("kimi-cli") so they are visible in tokens-by-model analytics —
+    // the wire schema does not expose the underlying model name.
+    for record in &rows {
+        for event in &record.event_rows {
+            assert_eq!(
+                event.get("model").and_then(Value::as_str),
+                Some("kimi-cli"),
+                "every kimi event should carry a placeholder model"
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Closes #270.
- Kimi wire records (`MoonshotAI/kimi-cli` `wire/types.py`) carry no model name on any event, and neither do the sibling `context.jsonl` / `state.json` files. As a result every Kimi event landed with `model=''`, which made Kimi sessions invisible in the monitor's tokens-by-model analytics (which filters out empty-model rows) and surfaced `models: []` on `/api/sessions`.
- Stamp the harness slug `"kimi-cli"` as a placeholder model on every Kimi event row in the normalizer. Per-Kimi-model granularity isn't recoverable from the wire stream, but cross-harness attribution now works: Kimi sessions appear as a single `"kimi-cli"` series in the chart and as `models: ["kimi-cli"]` on `/api/sessions`.

## Investigation notes (per the issue's acceptance criteria)

I inspected `MoonshotAI/kimi-cli/src/kimi_cli/wire/types.py` and the on-disk `~/.kimi/sessions/<work>/<sess>/{wire.jsonl,context.jsonl,state.json}` artifacts:

- `WireFileMetadata` carries only `protocol_version`.
- `StatusUpdate` carries `token_usage`, `context_usage`, `message_id`, `plan_mode`, `mcp_status` — no model.
- No `SessionStart`-style record exists; the first per-turn record is `TurnBegin` (only `user_input`).
- `SessionState` (state.json, version=1) has no chosen-model field.
- `context.jsonl` is the LLM message log only.
- The active model lives in-memory on `LLM`/`Soul` and is resolved from `~/.config/kimi/` config + optional `KIMI_MODEL_NAME` env override at process start.

So the wire stream genuinely doesn't carry it. Following the issue's option (1) ("hardcode a vendor placeholder") because option (4) (monitor fallback) would require teaching the analytics SQL + sessions payload to mix harness labels and model labels in the same `model` axis, which is more invasive for the same end result.

## Test plan

- [x] `cargo test -p moraine-ingest-core --locked`
- [x] `cargo clippy --workspace --all-targets --locked -- -Dwarnings -A...` (strict baseline, matches CI)
- [x] Sandbox e2e: ingested `fixtures/kimi-cli/wire.jsonl` into a fresh sandbox; confirmed:
    - `SELECT model FROM events WHERE harness='kimi-cli'` → `'kimi-cli'` (was `''`)
    - `/api/analytics?range=30d` `series.tokens` → `[{model:'kimi-cli',tokens:5}]` (was `[]`)
    - `/api/sessions?since=30d` Kimi session `models` → `["kimi-cli"]` (was `[]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)