### PR TITLE
chore(release): cut v0.4.4

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.4.3)"
+        description: "Tag to release (for example v0.4.4)"
         required: true
         type: string
       target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "moraine"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "serde",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest-core"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp-core"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "moraine-clickhouse",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor-core"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/moraine-ingest/Cargo.toml
+++ b/apps/moraine-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "Moraine ingest service binary"
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "Moraine MCP stdio server"
 

--- a/apps/moraine-monitor/Cargo.toml
+++ b/apps/moraine-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "Moraine monitor HTTP/UI service"
 

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "Unified runtime control plane for Moraine services"
 

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-clickhouse"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "Shared Moraine ClickHouse client and query helpers"
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-config"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "Shared Moraine configuration schema and loaders"
 

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-conversations"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "High-level read/query APIs for Moraine conversations"
 

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest-core"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "Core ingestion pipeline internals for Moraine"
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp-core"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "MCP protocol and tool routing core for Moraine"
 

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor-core"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "Analytics and query logic for Moraine monitor service"
 

--- a/docs/operations/build-and-operations.md
+++ b/docs/operations/build-and-operations.md
@@ -83,7 +83,7 @@ To upgrade a curl-installed instance, re-run the installer.
 
 Tag-driven GitHub Actions release workflow:
 
-1. Push a semantic tag (example: `v0.4.3`).
+1. Push a semantic tag (example: `v0.4.4`).
 2. Workflow `.github/workflows/release-moraine.yml` builds:
    - `x86_64-unknown-linux-gnu`
    - `aarch64-unknown-linux-gnu`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ install directory precedence:
 
 examples:
   scripts/install.sh
-  MORAINE_INSTALL_VERSION=v0.4.3 scripts/install.sh
+  MORAINE_INSTALL_VERSION=v0.4.4 scripts/install.sh
   MORAINE_INSTALL_ASSET_BASE_URL=http://127.0.0.1:8080 \
     MORAINE_INSTALL_VERSION=ci-e2e scripts/install.sh
   MORAINE_INSTALL_DIR="$HOME/bin" MORAINE_INSTALL_SKIP_CLICKHOUSE=1 scripts/install.sh


### PR DESCRIPTION
## Summary
Bump workspace crate versions from 0.4.3 to 0.4.4 and refresh release/install doc examples. Release headlines Kimi CLI ingest support.

## Changes since v0.4.3
- feat(ingest): add Kimi CLI source ([#268](https://github.com/eric-tramel/moraine/pull/268))
- fix(ingest): sum kimi input buckets into input_tokens ([#275](https://github.com/eric-tramel/moraine/pull/275))
- fix(ingest): drop SubagentEvent from parent Kimi wire normalization ([#276](https://github.com/eric-tramel/moraine/pull/276))
- docs(nav): surface orphaned sandbox and pypi-release pages in mkdocs nav ([#267](https://github.com/eric-tramel/moraine/pull/267))

## Test plan
- [x] `cargo check --workspace --locked`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -Dwarnings ...` (CI strict baseline)
- [ ] After merge: tag `v0.4.4` on main to fire `.github/workflows/release-moraine.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)