### PR TITLE
feat(mcp): add agent session search interface

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo.rs
@@ -1195,7 +1195,7 @@ FORMAT JSONEachRow",
         let mode_subquery = self.mode_subquery();
         let query = format!(
             "SELECT
-  s.session_id,
+  s.session_id AS session_id,
   toString(s.first_event_time) AS first_event_time,
   toInt64(toUnixTimestamp64Milli(s.first_event_time)) AS first_event_unix_ms,
   toString(s.last_event_time) AS last_event_time,
@@ -3188,7 +3188,7 @@ impl ConversationRepository for ClickHouseConversationRepository {
 
         let query = format!(
             "SELECT
-  s.session_id,
+  s.session_id AS session_id,
   toString(s.first_event_time) AS first_event_time,
   toInt64(toUnixTimestamp64Milli(s.first_event_time)) AS first_event_unix_ms,
   toString(s.last_event_time) AS last_event_time,

--- a/crates/moraine-conversations/src/clickhouse_repo.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo.rs
@@ -21,8 +21,9 @@ use crate::domain::{
     ConversationSearchResults, ConversationSearchStats, ConversationSummary, OpenContext,
     OpenEvent, OpenEventRequest, Page, PageRequest, RepoConfig, SearchEventHit, SearchEventKind,
     SearchEventsQuery, SearchEventsResult, SearchEventsStats, SearchEventsStrategy,
-    SessionEventsDirection, SessionEventsQuery, SessionMetadata, TraceEvent, Turn, TurnListFilter,
-    TurnSummary,
+    SessionEventsDirection, SessionEventsQuery, SessionMetadata, SessionMetadataSearchHit,
+    SessionMetadataSearchQuery, SessionMetadataSearchResults, SessionMetadataSearchStats,
+    TraceEvent, Turn, TurnListFilter, TurnSummary,
 };
 use crate::error::{RepoError, RepoResult};
 use crate::repo::ConversationRepository;
@@ -69,6 +70,10 @@ struct ConversationSummaryRow {
     tool_calls: u64,
     tool_results: u64,
     mode: String,
+    #[serde(default)]
+    session_slug: String,
+    #[serde(default)]
+    session_summary: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -91,6 +96,49 @@ struct SessionMetadataRow {
     last_event_uid: String,
     #[serde(default)]
     last_actor_role: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SessionMetadataSearchRow {
+    session_id: String,
+    #[serde(default)]
+    first_event_time: String,
+    #[serde(default)]
+    first_event_unix_ms: i64,
+    #[serde(default)]
+    last_event_time: String,
+    #[serde(default)]
+    last_event_unix_ms: i64,
+    #[serde(default)]
+    total_turns: u32,
+    #[serde(default)]
+    total_events: u64,
+    #[serde(default)]
+    user_messages: u64,
+    #[serde(default)]
+    assistant_messages: u64,
+    #[serde(default)]
+    tool_calls: u64,
+    #[serde(default)]
+    tool_results: u64,
+    #[serde(default)]
+    mode: String,
+    #[serde(default)]
+    harness: String,
+    #[serde(default)]
+    inference_provider: String,
+    #[serde(default)]
+    session_slug: String,
+    #[serde(default)]
+    session_summary: String,
+    #[serde(default)]
+    meta_event_uid: String,
+    #[serde(default)]
+    score: f64,
+    #[serde(default)]
+    matched_terms: u16,
+    #[serde(default)]
+    metadata_text: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -377,6 +425,77 @@ impl ClickHouseConversationRepository {
 
     pub fn config(&self) -> &RepoConfig {
         &self.cfg
+    }
+
+    pub async fn search_session_metadata(
+        &self,
+        query: SessionMetadataSearchQuery,
+    ) -> RepoResult<SessionMetadataSearchResults> {
+        let query_text = query.query.trim();
+        if query_text.is_empty() {
+            return Err(RepoError::invalid_argument("query cannot be empty"));
+        }
+
+        Self::validate_time_bounds(query.from_unix_ms, query.to_unix_ms)?;
+        if let Some(session_id) = query.session_id.as_deref() {
+            Self::validate_session_id(session_id)?;
+        }
+
+        let query_id = Uuid::new_v4().to_string();
+        let started = Instant::now();
+
+        let terms_with_qf = tokenize_query(query_text, self.cfg.bm25_max_query_terms);
+        if terms_with_qf.is_empty() {
+            return Err(RepoError::invalid_argument(
+                "query has no searchable terms (tokens shorter than 2 characters are excluded)",
+            ));
+        }
+        let terms: Vec<String> = terms_with_qf.iter().map(|(term, _)| term.clone()).collect();
+
+        let requested_limit = query.limit.unwrap_or(self.cfg.max_results).max(1);
+        let limit = requested_limit.min(self.cfg.max_results);
+        let limit_capped = requested_limit > limit;
+
+        let min_should_match = query
+            .min_should_match
+            .unwrap_or(self.cfg.bm25_default_min_should_match)
+            .max(1)
+            .min(terms.len() as u16);
+        let min_score = query.min_score.unwrap_or(0.0);
+
+        let sql = self.build_search_session_metadata_sql(
+            &terms,
+            min_should_match,
+            min_score,
+            limit,
+            query.from_unix_ms,
+            query.to_unix_ms,
+            query.mode,
+            query.session_id.as_deref(),
+        )?;
+
+        let rows: Vec<SessionMetadataSearchRow> =
+            self.map_backend(self.ch.query_rows(&sql, None).await)?;
+        let hits = rows
+            .into_iter()
+            .enumerate()
+            .map(|(idx, row)| self.map_session_metadata_search_row(idx + 1, row, &terms))
+            .collect::<Vec<_>>();
+        let took_ms = started.elapsed().as_millis() as u32;
+
+        Ok(SessionMetadataSearchResults {
+            query_id,
+            query: query_text.to_string(),
+            terms,
+            stats: SessionMetadataSearchStats {
+                requested_limit,
+                effective_limit: limit,
+                limit_capped,
+                result_count: hits.len(),
+                took_ms,
+            },
+            hits,
+        })
     }
 
     async fn run_mcp_search_prewarm_queries(
@@ -786,6 +905,8 @@ GROUP BY session_id"
             tool_calls: row.tool_calls,
             tool_results: row.tool_results,
             mode: Self::parse_mode(&row.mode),
+            session_slug: non_empty_string(row.session_slug),
+            session_summary: non_empty_string(row.session_summary),
         }
     }
 
@@ -806,6 +927,45 @@ GROUP BY session_id"
             first_event_uid: row.first_event_uid,
             last_event_uid: row.last_event_uid,
             last_actor_role: row.last_actor_role,
+        }
+    }
+
+    fn map_session_metadata_search_row(
+        &self,
+        rank: usize,
+        row: SessionMetadataSearchRow,
+        terms: &[String],
+    ) -> SessionMetadataSearchHit {
+        let has_session_summary = !row.first_event_time.is_empty();
+        let snippet = evidence_snippet(
+            &row.session_summary,
+            &row.metadata_text,
+            terms,
+            self.cfg.preview_chars,
+        );
+
+        SessionMetadataSearchHit {
+            rank,
+            session_id: row.session_id,
+            first_event_time: has_session_summary.then_some(row.first_event_time),
+            first_event_unix_ms: has_session_summary.then_some(row.first_event_unix_ms),
+            last_event_time: has_session_summary.then_some(row.last_event_time),
+            last_event_unix_ms: has_session_summary.then_some(row.last_event_unix_ms),
+            total_turns: has_session_summary.then_some(row.total_turns),
+            total_events: has_session_summary.then_some(row.total_events),
+            user_messages: has_session_summary.then_some(row.user_messages),
+            assistant_messages: has_session_summary.then_some(row.assistant_messages),
+            tool_calls: has_session_summary.then_some(row.tool_calls),
+            tool_results: has_session_summary.then_some(row.tool_results),
+            mode: (!row.mode.is_empty()).then(|| Self::parse_mode(&row.mode)),
+            harness: non_empty_string(row.harness),
+            inference_provider: non_empty_string(row.inference_provider),
+            session_slug: non_empty_string(row.session_slug),
+            session_summary: non_empty_string(row.session_summary),
+            meta_event_uid: non_empty_string(row.meta_event_uid),
+            score: row.score,
+            matched_terms: row.matched_terms,
+            snippet,
         }
     }
 
@@ -850,6 +1010,153 @@ GROUP BY session_id"
 
     fn mode_filter_clause(mode: Option<ConversationMode>) -> Option<String> {
         mode.map(|m| format!("ifNull(m.mode, 'chat') = {}", sql_quote(m.as_str())))
+    }
+
+    fn build_search_session_metadata_sql(
+        &self,
+        terms: &[String],
+        min_should_match: u16,
+        min_score: f64,
+        limit: u16,
+        from_unix_ms: Option<i64>,
+        to_unix_ms: Option<i64>,
+        mode: Option<ConversationMode>,
+        session_id: Option<&str>,
+    ) -> RepoResult<String> {
+        if terms.is_empty() {
+            return Err(RepoError::invalid_argument(
+                "cannot build session metadata search query with empty terms",
+            ));
+        }
+
+        let events_table = self.table_ref("events");
+        let session_summary_table = self.table_ref("v_session_summary");
+        let mode_subquery = self.mode_subquery();
+        let terms_array_sql = sql_array_strings(terms);
+
+        let mut where_clauses = vec![
+            format!("meta.matched_terms >= {min_should_match}"),
+            format!("meta.score >= {min_score:.6}"),
+        ];
+        if let Some(from_unix_ms) = from_unix_ms {
+            where_clauses.push(format!(
+                "toUnixTimestamp64Milli(s.last_event_time) >= {from_unix_ms}"
+            ));
+        }
+        if let Some(to_unix_ms) = to_unix_ms {
+            where_clauses.push(format!(
+                "toUnixTimestamp64Milli(s.last_event_time) < {to_unix_ms}"
+            ));
+        }
+        if let Some(mode_clause) = Self::mode_filter_clause(mode) {
+            where_clauses.push(mode_clause);
+        }
+        if let Some(session_id) = session_id {
+            where_clauses.push(format!("meta.session_id = {}", sql_quote(session_id)));
+        }
+        let where_sql = where_clauses.join("\n  AND ");
+
+        Ok(format!(
+            "WITH
+  {terms_array_sql} AS q_terms
+SELECT
+  meta.session_id AS session_id,
+  if(s.session_id = '', '', toString(s.first_event_time)) AS first_event_time,
+  if(
+    s.session_id = '',
+    toInt64(0),
+    toInt64(toUnixTimestamp64Milli(s.first_event_time))
+  ) AS first_event_unix_ms,
+  if(s.session_id = '', '', toString(s.last_event_time)) AS last_event_time,
+  if(
+    s.session_id = '',
+    toInt64(0),
+    toInt64(toUnixTimestamp64Milli(s.last_event_time))
+  ) AS last_event_unix_ms,
+  if(s.session_id = '', toUInt32(0), toUInt32(s.total_turns)) AS total_turns,
+  if(s.session_id = '', toUInt64(0), toUInt64(s.total_events)) AS total_events,
+  if(s.session_id = '', toUInt64(0), toUInt64(s.user_messages)) AS user_messages,
+  if(s.session_id = '', toUInt64(0), toUInt64(s.assistant_messages)) AS assistant_messages,
+  if(s.session_id = '', toUInt64(0), toUInt64(s.tool_calls)) AS tool_calls,
+  if(s.session_id = '', toUInt64(0), toUInt64(s.tool_results)) AS tool_results,
+  ifNull(m.mode, 'chat') AS mode,
+  meta.harness AS harness,
+  meta.inference_provider AS inference_provider,
+  meta.session_slug AS session_slug,
+  meta.session_summary AS session_summary,
+  meta.meta_event_uid AS meta_event_uid,
+  meta.score AS score,
+  meta.matched_terms AS matched_terms,
+  leftUTF8(meta.metadata_text, {metadata_limit}) AS metadata_text
+FROM (
+  SELECT
+    searchable.session_id AS session_id,
+    searchable.meta_event_uid AS meta_event_uid,
+    searchable.harness AS harness,
+    searchable.inference_provider AS inference_provider,
+    searchable.session_slug AS session_slug,
+    searchable.session_summary AS session_summary,
+    searchable.metadata_text AS metadata_text,
+    toUInt16(arraySum(arrayMap(
+      term -> if(positionCaseInsensitiveUTF8(searchable.search_text, term) > 0, 1, 0),
+      q_terms
+    ))) AS matched_terms,
+    arraySum(arrayMap(
+      term ->
+        if(positionCaseInsensitiveUTF8(searchable.session_summary, term) > 0, 2.0, 0.0)
+        + if(positionCaseInsensitiveUTF8(searchable.session_slug, term) > 0, 1.5, 0.0)
+        + if(positionCaseInsensitiveUTF8(searchable.metadata_text, term) > 0, 1.0, 0.0),
+      q_terms
+    )) AS score
+  FROM (
+    SELECT
+      base.session_id AS session_id,
+      base.meta_event_uid AS meta_event_uid,
+      base.harness AS harness,
+      base.inference_provider AS inference_provider,
+      base.session_slug AS session_slug,
+      base.session_summary AS session_summary,
+      base.metadata_text AS metadata_text,
+      concat(base.session_summary, '\n', base.session_slug, '\n', base.metadata_text) AS search_text
+    FROM (
+      SELECT
+        e.session_id AS session_id,
+        argMax(e.event_uid, tuple(e.event_ts, e.event_uid)) AS meta_event_uid,
+        argMax(e.harness, tuple(e.event_ts, e.event_uid)) AS harness,
+        argMax(e.inference_provider, tuple(e.event_ts, e.event_uid)) AS inference_provider,
+        ifNull(argMax(nullIf(JSONExtractString(e.payload_json, 'slug'), ''), tuple(e.event_ts, e.event_uid)), '') AS session_slug,
+        ifNull(
+          argMax(
+            coalesce(
+              nullIf(JSONExtractString(e.payload_json, 'summary'), ''),
+              nullIf(JSONExtractString(e.payload_json, 'title'), ''),
+              nullIf(JSONExtractString(e.payload_json, 'name'), '')
+            ),
+            tuple(e.event_ts, e.event_uid)
+          ),
+          ''
+        ) AS session_summary,
+        argMax(e.payload_json, tuple(e.event_ts, e.event_uid)) AS metadata_text
+      FROM {events_table} AS e
+      WHERE e.event_kind = 'session_meta'
+      GROUP BY e.session_id
+    ) AS base
+  ) AS searchable
+) AS meta
+LEFT JOIN {session_summary_table} AS s ON s.session_id = meta.session_id
+ANY LEFT JOIN ({mode_subquery}) AS m ON m.session_id = meta.session_id
+WHERE {where_sql}
+ORDER BY meta.score DESC, meta.session_id ASC
+LIMIT {limit}
+FORMAT JSONEachRow",
+            terms_array_sql = terms_array_sql,
+            events_table = events_table,
+            session_summary_table = session_summary_table,
+            mode_subquery = mode_subquery,
+            where_sql = where_sql,
+            limit = limit,
+            metadata_limit = usize::from(self.cfg.preview_chars).saturating_mul(8),
+        ))
     }
 
     async fn load_turns_for_session(&self, session_id: &str) -> RepoResult<Vec<TurnSummary>> {
@@ -2841,6 +3148,7 @@ impl ConversationRepository for ClickHouseConversationRepository {
         };
 
         let session_summary = self.table_ref("v_session_summary");
+        let events_table = self.table_ref("events");
         let mode_subquery = self.mode_subquery();
 
         let mut where_clauses = vec!["1 = 1".to_string()];
@@ -2891,14 +3199,36 @@ impl ConversationRepository for ClickHouseConversationRepository {
   toUInt64(s.assistant_messages) AS assistant_messages,
   toUInt64(s.tool_calls) AS tool_calls,
   toUInt64(s.tool_results) AS tool_results,
-  ifNull(m.mode, 'chat') AS mode
+  ifNull(m.mode, 'chat') AS mode,
+  ifNull(meta.session_slug, '') AS session_slug,
+  ifNull(meta.session_summary, '') AS session_summary
 FROM {session_summary} AS s
 LEFT JOIN ({mode_subquery}) AS m ON m.session_id = s.session_id
+LEFT JOIN (
+  SELECT
+    session_id,
+    ifNull(argMax(nullIf(JSONExtractString(payload_json, 'slug'), ''), tuple(event_ts, event_uid)), '') AS session_slug,
+    ifNull(
+      argMax(
+        coalesce(
+          nullIf(JSONExtractString(payload_json, 'summary'), ''),
+          nullIf(JSONExtractString(payload_json, 'title'), ''),
+          nullIf(JSONExtractString(payload_json, 'name'), '')
+        ),
+        tuple(event_ts, event_uid)
+      ),
+      ''
+    ) AS session_summary
+  FROM {events_table}
+  WHERE event_kind = 'session_meta'
+  GROUP BY session_id
+) AS meta ON meta.session_id = s.session_id
 WHERE {where_sql}
 ORDER BY s.last_event_time {order_dir}, s.session_id {order_dir}
 LIMIT {limit_plus}
 FORMAT JSONEachRow",
             session_summary = session_summary,
+            events_table = events_table,
             mode_subquery = mode_subquery,
             where_sql = where_sql,
             order_dir = order_dir,
@@ -3894,6 +4224,71 @@ fn is_safe_filter_value(value: &str) -> bool {
     safe_value_re().is_match(value)
 }
 
+fn non_empty_string(value: String) -> Option<String> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn compact_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn first_term_match_index(value: &str, terms: &[String]) -> Option<usize> {
+    let lower = value.to_ascii_lowercase();
+    terms.iter().filter_map(|term| lower.find(term)).min()
+}
+
+fn snippet_around_match(value: &str, match_idx: Option<usize>, max_chars: usize) -> String {
+    let compact = compact_whitespace(value);
+    if compact.chars().count() <= max_chars {
+        return compact;
+    }
+
+    let byte_idx = match_idx
+        .and_then(|idx| value.get(..idx))
+        .map(compact_whitespace)
+        .map(|prefix| prefix.chars().count())
+        .unwrap_or(0);
+    let context_before = max_chars / 3;
+    let start = byte_idx.saturating_sub(context_before);
+    let mut snippet = compact
+        .chars()
+        .skip(start)
+        .take(max_chars)
+        .collect::<String>();
+    if start > 0 {
+        snippet.insert_str(0, "...");
+    }
+    if compact.chars().count() > start + max_chars {
+        snippet.push_str("...");
+    }
+    snippet
+}
+
+fn evidence_snippet(
+    session_summary: &str,
+    metadata_text: &str,
+    terms: &[String],
+    preview_chars: u16,
+) -> Option<String> {
+    let summary_match = first_term_match_index(session_summary, terms);
+    let metadata_match = first_term_match_index(metadata_text, terms);
+    let (source, match_idx) = if summary_match.is_some() {
+        (session_summary, summary_match)
+    } else if metadata_match.is_some() {
+        (metadata_text, metadata_match)
+    } else if !session_summary.is_empty() {
+        (session_summary, None)
+    } else {
+        (metadata_text, None)
+    };
+    if source.is_empty() {
+        return None;
+    }
+
+    let snippet = snippet_around_match(source, match_idx, usize::from(preview_chars).max(1));
+    (!snippet.is_empty()).then_some(snippet)
+}
+
 fn sql_quote(value: &str) -> String {
     format!("'{}'", value.replace('\\', "\\\\").replace('\'', "''"))
 }
@@ -3992,6 +4387,21 @@ mod tests {
         let out = sql_array_strings(&values);
         assert!(out.contains("'a'"));
         assert!(out.contains("'b''c'"));
+    }
+
+    #[test]
+    fn evidence_snippet_prefers_matching_metadata_over_nonmatching_summary() {
+        let terms = vec!["quartz".to_string()];
+        let snippet = evidence_snippet(
+            "General session summary.",
+            "{\"metadata\":{\"codename\":\"quartz\"}}",
+            &terms,
+            80,
+        );
+        assert_eq!(
+            snippet.as_deref(),
+            Some("{\"metadata\":{\"codename\":\"quartz\"}}")
+        );
     }
 
     #[test]

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -100,6 +100,10 @@ pub struct ConversationSummary {
     pub tool_calls: u64,
     pub tool_results: u64,
     pub mode: ConversationMode,
+    #[serde(default)]
+    pub session_slug: Option<String>,
+    #[serde(default)]
+    pub session_summary: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -408,6 +412,68 @@ pub struct ConversationSearchResults {
     pub terms: Vec<String>,
     pub stats: ConversationSearchStats,
     pub hits: Vec<ConversationSearchHit>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionMetadataSearchQuery {
+    pub query: String,
+    #[serde(default)]
+    pub limit: Option<u16>,
+    #[serde(default)]
+    pub min_score: Option<f64>,
+    #[serde(default)]
+    pub min_should_match: Option<u16>,
+    #[serde(default)]
+    pub from_unix_ms: Option<i64>,
+    #[serde(default)]
+    pub to_unix_ms: Option<i64>,
+    #[serde(default)]
+    pub mode: Option<ConversationMode>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMetadataSearchStats {
+    pub requested_limit: u16,
+    pub effective_limit: u16,
+    pub limit_capped: bool,
+    pub result_count: usize,
+    pub took_ms: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMetadataSearchHit {
+    pub rank: usize,
+    pub session_id: String,
+    pub first_event_time: Option<String>,
+    pub first_event_unix_ms: Option<i64>,
+    pub last_event_time: Option<String>,
+    pub last_event_unix_ms: Option<i64>,
+    pub total_turns: Option<u32>,
+    pub total_events: Option<u64>,
+    pub user_messages: Option<u64>,
+    pub assistant_messages: Option<u64>,
+    pub tool_calls: Option<u64>,
+    pub tool_results: Option<u64>,
+    pub mode: Option<ConversationMode>,
+    pub harness: Option<String>,
+    pub inference_provider: Option<String>,
+    pub session_slug: Option<String>,
+    pub session_summary: Option<String>,
+    pub meta_event_uid: Option<String>,
+    pub score: f64,
+    pub matched_terms: u16,
+    pub snippet: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMetadataSearchResults {
+    pub query_id: String,
+    pub query: String,
+    pub terms: Vec<String>,
+    pub stats: SessionMetadataSearchStats,
+    pub hits: Vec<SessionMetadataSearchHit>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -11,8 +11,9 @@ pub use domain::{
     ConversationSearchResults, ConversationSearchStats, ConversationSummary, OpenContext,
     OpenEvent, OpenEventRequest, Page, PageRequest, RepoConfig, SearchEventHit, SearchEventKind,
     SearchEventsQuery, SearchEventsResult, SearchEventsStats, SearchEventsStrategy,
-    SessionEventsDirection, SessionEventsQuery, SessionMetadata, TraceEvent, Turn, TurnListFilter,
-    TurnSummary,
+    SessionEventsDirection, SessionEventsQuery, SessionMetadata, SessionMetadataSearchHit,
+    SessionMetadataSearchQuery, SessionMetadataSearchResults, SessionMetadataSearchStats,
+    TraceEvent, Turn, TurnListFilter, TurnSummary,
 };
 pub use error::{RepoError, RepoResult};
 pub use repo::ConversationRepository;

--- a/crates/moraine-conversations/tests/repository_integration.rs
+++ b/crates/moraine-conversations/tests/repository_integration.rs
@@ -14,6 +14,7 @@ use moraine_conversations::{
     ClickHouseConversationRepository, ConversationListFilter, ConversationListSort,
     ConversationMode, ConversationRepository, ConversationSearchQuery, PageRequest, RepoConfig,
     RepoError, SearchEventKind, SearchEventsQuery, SessionEventsDirection, SessionEventsQuery,
+    SessionMetadataSearchQuery,
 };
 use serde_json::json;
 
@@ -114,7 +115,9 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
                         "assistant_messages": 6,
                         "tool_calls": 3,
                         "tool_results": 3,
-                        "mode": "web_search"
+                        "mode": "web_search",
+                        "session_slug": "project-c",
+                        "session_summary": "Session C summary"
                     },
                     {
                         "session_id": "sess_b",
@@ -343,7 +346,9 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
             );
         }
 
-        if query.contains("GROUP BY e.session_id") {
+        if query.contains("GROUP BY e.session_id")
+            && query.contains("FROM `moraine`.`search_postings` AS p")
+        {
             return (
                 StatusCode::OK,
                 json_each_row(json!([
@@ -468,6 +473,41 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
                         "harness": "codex",
                         "session_slug": "",
                         "session_summary": ""
+                    }
+                ])),
+            );
+        }
+
+        if query.contains("WITH\n  ['rare','summary'] AS q_terms")
+            && query.contains("FROM `moraine`.`events` AS e")
+            && query.contains("WHERE e.event_kind = 'session_meta'")
+            && query.contains("AS meta_event_uid")
+            && query.contains("AS matched_terms")
+        {
+            return (
+                StatusCode::OK,
+                json_each_row(json!([
+                    {
+                        "session_id": "sess_meta_summary",
+                        "first_event_time": "2026-01-05 10:00:00",
+                        "first_event_unix_ms": 1767607200000_i64,
+                        "last_event_time": "2026-01-05 10:15:00",
+                        "last_event_unix_ms": 1767608100000_i64,
+                        "total_turns": 4_u32,
+                        "total_events": 18_u64,
+                        "user_messages": 5_u64,
+                        "assistant_messages": 5_u64,
+                        "tool_calls": 1_u64,
+                        "tool_results": 1_u64,
+                        "mode": "chat",
+                        "harness": "codex",
+                        "inference_provider": "openai",
+                        "session_slug": "rare-summary-session",
+                        "session_summary": "Rare summary-only session about metadata discovery.",
+                        "meta_event_uid": "meta-rare-1",
+                        "score": 5.0,
+                        "matched_terms": 2_u16,
+                        "metadata_text": "{\"summary\":\"Rare summary-only session about metadata discovery.\"}"
                     }
                 ])),
             );
@@ -734,6 +774,11 @@ async fn list_conversations_applies_filters_and_cursor_pagination() {
     assert_eq!(first.items.len(), 2);
     assert_eq!(first.items[0].session_id, "sess_c");
     assert_eq!(first.items[1].session_id, "sess_b");
+    assert_eq!(first.items[0].session_slug.as_deref(), Some("project-c"));
+    assert_eq!(
+        first.items[0].session_summary.as_deref(),
+        Some("Session C summary")
+    );
     assert!(first.next_cursor.is_some());
 
     let second = repo
@@ -758,6 +803,8 @@ async fn list_conversations_applies_filters_and_cursor_pagination() {
         .expect("list query should be captured");
 
     assert!(list_query.contains("ifNull(m.mode, 'chat') = 'web_search'"));
+    assert!(list_query.contains("JSONExtractString(payload_json, 'summary')"));
+    assert!(list_query.contains("AS session_slug"));
     assert!(list_query.contains("toUnixTimestamp64Milli(s.last_event_time) >= 1767261600000"));
     assert!(list_query.contains("toUnixTimestamp64Milli(s.last_event_time) < 1767500000000"));
     assert!(list_query.contains("ORDER BY s.last_event_time DESC, s.session_id DESC"));
@@ -954,6 +1001,106 @@ async fn get_session_metadata_keeps_empty_boundary_fields_when_summary_exists() 
     assert!(metadata.first_event_uid.is_empty());
     assert!(metadata.last_event_uid.is_empty());
     assert!(metadata.last_actor_role.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_session_metadata_returns_summary_only_matches() {
+    let (repo, _state) = build_repo().await;
+
+    let result = repo
+        .search_session_metadata(SessionMetadataSearchQuery {
+            query: "rare summary".to_string(),
+            limit: Some(10),
+            min_score: Some(0.0),
+            min_should_match: Some(1),
+            from_unix_ms: None,
+            to_unix_ms: None,
+            mode: None,
+            session_id: None,
+        })
+        .await
+        .expect("search session metadata");
+
+    assert_eq!(result.query, "rare summary");
+    assert_eq!(result.terms, vec!["rare", "summary"]);
+    assert_eq!(result.stats.requested_limit, 10);
+    assert_eq!(result.stats.effective_limit, 10);
+    assert!(!result.stats.limit_capped);
+    assert_eq!(result.stats.result_count, 1);
+
+    let hit = &result.hits[0];
+    assert_eq!(hit.rank, 1);
+    assert_eq!(hit.session_id, "sess_meta_summary");
+    assert_eq!(hit.first_event_time.as_deref(), Some("2026-01-05 10:00:00"));
+    assert_eq!(hit.first_event_unix_ms, Some(1767607200000_i64));
+    assert_eq!(hit.last_event_time.as_deref(), Some("2026-01-05 10:15:00"));
+    assert_eq!(hit.last_event_unix_ms, Some(1767608100000_i64));
+    assert_eq!(hit.total_turns, Some(4));
+    assert_eq!(hit.total_events, Some(18));
+    assert_eq!(hit.user_messages, Some(5));
+    assert_eq!(hit.assistant_messages, Some(5));
+    assert_eq!(hit.tool_calls, Some(1));
+    assert_eq!(hit.tool_results, Some(1));
+    assert_eq!(hit.mode, Some(ConversationMode::Chat));
+    assert_eq!(hit.harness.as_deref(), Some("codex"));
+    assert_eq!(hit.inference_provider.as_deref(), Some("openai"));
+    assert_eq!(hit.session_slug.as_deref(), Some("rare-summary-session"));
+    assert_eq!(
+        hit.session_summary.as_deref(),
+        Some("Rare summary-only session about metadata discovery.")
+    );
+    assert_eq!(hit.meta_event_uid.as_deref(), Some("meta-rare-1"));
+    assert_eq!(hit.score, 5.0);
+    assert_eq!(hit.matched_terms, 2);
+    assert_eq!(
+        hit.snippet.as_deref(),
+        Some("Rare summary-only session about metadata discovery.")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_session_metadata_applies_time_mode_filters_and_caps_limit() {
+    let (repo, state) = build_repo_with_max_results(5).await;
+
+    let result = repo
+        .search_session_metadata(SessionMetadataSearchQuery {
+            query: "rare summary".to_string(),
+            limit: Some(25),
+            min_score: Some(1.5),
+            min_should_match: Some(2),
+            from_unix_ms: Some(1767600000000_i64),
+            to_unix_ms: Some(1767610000000_i64),
+            mode: Some(ConversationMode::Chat),
+            session_id: Some("sess_meta_summary".to_string()),
+        })
+        .await
+        .expect("search session metadata");
+
+    assert_eq!(result.stats.requested_limit, 25);
+    assert_eq!(result.stats.effective_limit, 5);
+    assert!(result.stats.limit_capped);
+
+    let queries = state.queries.lock().expect("queries lock").clone();
+    let metadata_search_query = queries
+        .iter()
+        .find(|q| {
+            q.contains("FROM `moraine`.`events` AS e")
+                && q.contains("WHERE e.event_kind = 'session_meta'")
+                && q.contains("AS meta_event_uid")
+        })
+        .expect("session metadata search query should be captured");
+
+    assert!(metadata_search_query.contains("meta.matched_terms >= 2"));
+    assert!(metadata_search_query.contains("meta.score >= 1.500000"));
+    assert!(!metadata_search_query.contains("search_postings"));
+    assert!(metadata_search_query
+        .contains("toUnixTimestamp64Milli(s.last_event_time) >= 1767600000000"));
+    assert!(
+        metadata_search_query.contains("toUnixTimestamp64Milli(s.last_event_time) < 1767610000000")
+    );
+    assert!(metadata_search_query.contains("ifNull(m.mode, 'chat') = 'chat'"));
+    assert!(metadata_search_query.contains("meta.session_id = 'sess_meta_summary'"));
+    assert!(metadata_search_query.contains("LIMIT 5"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/moraine-conversations/tests/repository_integration.rs
+++ b/crates/moraine-conversations/tests/repository_integration.rs
@@ -799,11 +799,15 @@ async fn list_conversations_applies_filters_and_cursor_pagination() {
     let queries = state.queries.lock().expect("queries lock").clone();
     let list_query = queries
         .iter()
-        .find(|q| q.contains("FROM `moraine`.`v_session_summary` AS s"))
+        .find(|q| {
+            q.contains("FROM `moraine`.`v_session_summary` AS s")
+                && q.contains("ORDER BY s.last_event_time")
+        })
         .expect("list query should be captured");
 
     assert!(list_query.contains("ifNull(m.mode, 'chat') = 'web_search'"));
     assert!(list_query.contains("JSONExtractString(payload_json, 'summary')"));
+    assert!(list_query.contains("s.session_id AS session_id"));
     assert!(list_query.contains("AS session_slug"));
     assert!(list_query.contains("toUnixTimestamp64Milli(s.last_event_time) >= 1767261600000"));
     assert!(list_query.contains("toUnixTimestamp64Milli(s.last_event_time) < 1767500000000"));

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -1,15 +1,19 @@
+#![recursion_limit = "256"]
+
 use anyhow::{anyhow, Context, Result};
 use moraine_clickhouse::ClickHouseClient;
 use moraine_config::AppConfig;
 use moraine_conversations::{
     is_user_facing_content_event, ClickHouseConversationRepository, ConversationDetailOptions,
     ConversationListFilter, ConversationListSort, ConversationMode, ConversationRepository,
-    ConversationSearchQuery, ConversationSearchResults, OpenEventRequest, PageRequest, RepoConfig,
-    RepoError, SearchEventKind, SearchEventsQuery, SearchEventsResult, SessionEventsDirection,
-    SessionEventsQuery, TurnListFilter,
+    ConversationSearchQuery, ConversationSearchResults, OpenEvent, OpenEventRequest, PageRequest,
+    RepoConfig, RepoError, SearchEventHit, SearchEventKind, SearchEventsQuery, SearchEventsResult,
+    SessionEventsDirection, SessionEventsQuery, SessionMetadataSearchHit,
+    SessionMetadataSearchQuery, TraceEvent, TurnListFilter,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -18,6 +22,16 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tracing::{debug, warn};
 
 const TOOL_LIMIT_MIN: u16 = 1;
+const SESSION_SEARCH_DEFAULT_LIMIT: u16 = 5;
+const SESSION_SEARCH_MAX_LIMIT: u16 = 20;
+const SESSION_SEARCH_DEFAULT_MATCHING_EVENTS_LIMIT: u16 = 5;
+const SESSION_SEARCH_MAX_MATCHING_EVENTS_LIMIT: u16 = 8;
+const SESSION_SEARCH_CONTEXT_BEFORE: u16 = 2;
+const SESSION_SEARCH_CONTEXT_AFTER: u16 = 2;
+const OPEN_SESSION_DEFAULT_LIMIT: u16 = 20;
+const OPEN_SESSION_MAX_LIMIT: u16 = 50;
+const OPEN_SESSION_DEFAULT_CONTEXT: u16 = 3;
+const OPEN_SESSION_MAX_CONTEXT: u16 = 10;
 
 const CONVERSATION_MODE_CLASSIFICATION_SEMANTICS: &str =
     "Sessions are classified into exactly one mode by first match on any event in the session: web_search > mcp_internal > tool_calling > chat.";
@@ -113,6 +127,79 @@ struct SearchConversationsArgs {
     verbosity: Option<Verbosity>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SessionSearchEventScope {
+    #[default]
+    Auto,
+    Messages,
+    All,
+}
+
+impl SessionSearchEventScope {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Messages => "messages",
+            Self::All => "all",
+        }
+    }
+
+    fn includes_tool_events(self, query: &str) -> bool {
+        match self {
+            Self::Auto => query_suggests_tool_events(query),
+            Self::Messages => false,
+            Self::All => true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RecencyPolicy {
+    #[default]
+    Auto,
+    Off,
+}
+
+impl RecencyPolicy {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Off => "off",
+        }
+    }
+
+    fn is_active_for_query(self, query: &str) -> bool {
+        matches!(self, Self::Auto) && query_suggests_recency(query)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchSessionDataArgs {
+    query: String,
+    #[serde(default)]
+    limit: Option<u16>,
+    #[serde(default)]
+    matching_events_limit: Option<u16>,
+    #[serde(default)]
+    event_scope: Option<SessionSearchEventScope>,
+    #[serde(default)]
+    recency_policy: Option<RecencyPolicy>,
+    #[serde(default)]
+    from_unix_ms: Option<i64>,
+    #[serde(default)]
+    to_unix_ms: Option<i64>,
+    #[serde(default)]
+    mode: Option<ConversationMode>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    include_context: Option<bool>,
+    #[serde(default)]
+    verbosity: Option<Verbosity>,
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct ListSessionsArgs {
     #[serde(default)]
@@ -134,6 +221,31 @@ struct ListSessionsArgs {
 #[derive(Debug, Deserialize)]
 struct GetSessionArgs {
     session_id: String,
+    #[serde(default)]
+    verbosity: Option<Verbosity>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenSessionArgs {
+    session_id: String,
+    #[serde(default)]
+    query: Option<String>,
+    #[serde(default)]
+    around_event_uid: Option<String>,
+    #[serde(default)]
+    limit: Option<u16>,
+    #[serde(default)]
+    cursor: Option<String>,
+    #[serde(default)]
+    before: Option<u16>,
+    #[serde(default)]
+    after: Option<u16>,
+    #[serde(default)]
+    event_scope: Option<SessionSearchEventScope>,
+    #[serde(default)]
+    include_payload_json: Option<bool>,
+    #[serde(default)]
+    include_system_events: Option<bool>,
     #[serde(default)]
     verbosity: Option<Verbosity>,
 }
@@ -517,7 +629,13 @@ struct SessionListProseSession {
     #[serde(default)]
     event_count: u64,
     #[serde(default)]
+    turn_count: u32,
+    #[serde(default)]
     mode: String,
+    #[serde(default)]
+    session_summary: Option<String>,
+    #[serde(default)]
+    next: String,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -570,6 +688,68 @@ struct GetSessionProseError {
     code: String,
     #[serde(default)]
     message: String,
+}
+
+#[derive(Debug, Clone)]
+struct SessionSearchEvidence {
+    event_uid: String,
+    event_order: Option<u64>,
+    turn_seq: Option<u32>,
+    event_time: Option<String>,
+    kind: String,
+    role: String,
+    snippet: String,
+}
+
+#[derive(Debug, Clone)]
+struct SessionSearchCandidate {
+    session_id: String,
+    first_event_time: Option<String>,
+    first_event_unix_ms: Option<i64>,
+    last_event_time: Option<String>,
+    last_event_unix_ms: Option<i64>,
+    mode: Option<String>,
+    event_count: Option<u64>,
+    turn_count: Option<u32>,
+    harness: Option<String>,
+    inference_provider: Option<String>,
+    session_slug: Option<String>,
+    session_summary: Option<String>,
+    score: f64,
+    matched_terms: u16,
+    event_count_considered: u32,
+    best_event_uid: Option<String>,
+    summary_event_uid: Option<String>,
+    summary_snippet: Option<String>,
+    evidence: Vec<SessionSearchEvidence>,
+    context: Vec<Value>,
+}
+
+impl SessionSearchCandidate {
+    fn new(session_id: String) -> Self {
+        Self {
+            session_id,
+            first_event_time: None,
+            first_event_unix_ms: None,
+            last_event_time: None,
+            last_event_unix_ms: None,
+            mode: None,
+            event_count: None,
+            turn_count: None,
+            harness: None,
+            inference_provider: None,
+            session_slug: None,
+            session_summary: None,
+            score: 0.0,
+            matched_terms: 0,
+            event_count_considered: 0,
+            best_event_uid: None,
+            summary_event_uid: None,
+            summary_snippet: None,
+            evidence: Vec::new(),
+            context: Vec::new(),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -652,8 +832,179 @@ impl AppState {
         json!({
             "tools": [
                 {
+                    "name": "search_session_data",
+                    "description": "Search prior Moraine sessions for decisions, fixes, errors, logs, codenames, config values, and files. Returns compact session-ranked evidence from summaries and events. Defaults include raw tool output for error/log queries and prefer current, final, corrected, or latest evidence when asked. Use list_sessions only for metadata browsing; use open_session only when snippets are insufficient.",
+                    "inputSchema": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "Natural-language search terms. Include exact names, errors, paths, status codes, codenames, config keys, or migration names from the user request."
+                            },
+                            "limit": {
+                                "type": "integer",
+                                "minimum": limit_min,
+                                "maximum": limit_max.min(SESSION_SEARCH_MAX_LIMIT),
+                                "default": SESSION_SEARCH_DEFAULT_LIMIT
+                            },
+                            "matching_events_limit": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": SESSION_SEARCH_MAX_MATCHING_EVENTS_LIMIT,
+                                "default": SESSION_SEARCH_DEFAULT_MATCHING_EVENTS_LIMIT,
+                                "description": "Maximum matching event snippets per session. Raise only for multi-evidence questions."
+                            },
+                            "event_scope": {
+                                "type": "string",
+                                "enum": ["auto", "messages", "all"],
+                                "default": "auto",
+                                "description": "Use auto unless the user explicitly wants only messages or all events. Auto includes tool output for raw/error/log/stack/status queries."
+                            },
+                            "recency_policy": {
+                                "type": "string",
+                                "enum": ["auto", "off"],
+                                "default": "auto",
+                                "description": "Auto prefers current/final/latest/corrected evidence and down-ranks stale, draft, provisional, or deprecated notes when the query asks for that."
+                            },
+                            "from_unix_ms": { "type": "integer" },
+                            "to_unix_ms": { "type": "integer" },
+                            "mode": {
+                                "type": "string",
+                                "enum": ["web_search", "mcp_internal", "tool_calling", "chat"],
+                                "description": SEARCH_CONVERSATIONS_MODE_DOC
+                            },
+                            "session_id": {
+                                "type": "string",
+                                "description": "Optional session id to restrict evidence to one known session."
+                            },
+                            "include_context": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "Opt in to bounded surrounding turns for top evidence. Defaults to compact snippets only."
+                            },
+                            "verbosity": {
+                                "type": "string",
+                                "enum": ["prose", "full"],
+                                "default": "prose"
+                            }
+                        },
+                        "required": ["query"]
+                    },
+                    "outputSchema": {
+                        "type": "object",
+                        "required": ["query", "event_scope", "recency_policy", "hits"],
+                        "properties": {
+                            "query": { "type": "string" },
+                            "event_scope": { "type": "string" },
+                            "effective_event_scope": { "type": "string" },
+                            "recency_policy": { "type": "string" },
+                            "recency_applied": { "type": "boolean" },
+                            "hits": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "required": ["rank", "session_id", "score", "evidence", "next"],
+                                    "properties": {
+                                        "rank": { "type": "integer" },
+                                        "session_id": { "type": "string" },
+                                        "score": { "type": "number" },
+                                        "last_event_time": { "type": ["string", "null"] },
+                                        "session_summary": { "type": ["string", "null"] },
+                                        "evidence": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": ["event_uid", "kind", "snippet"],
+                                                "properties": {
+                                                    "event_uid": { "type": "string" },
+                                                    "event_order": { "type": ["integer", "null"] },
+                                                    "turn_seq": { "type": ["integer", "null"] },
+                                                    "kind": { "type": "string" },
+                                                    "role": { "type": "string" },
+                                                    "snippet": { "type": "string" }
+                                                }
+                                            }
+                                        },
+                                        "next": { "type": "string" }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "annotations": {
+                        "readOnlyHint": true
+                    }
+                },
+                {
+                    "name": "open_session",
+                    "description": "Open one prior session after search_session_data returns a session_id. Use for transcript context, surrounding turns, or additional evidence when search snippets are insufficient. With query, return query-relevant windows first; without query, return a chronological page.",
+                    "inputSchema": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "session_id": { "type": "string" },
+                            "query": {
+                                "type": "string",
+                                "description": "Optional query for relevant windows before chronological paging."
+                            },
+                            "around_event_uid": {
+                                "type": "string",
+                                "description": "Optional event uid from search evidence; returns bounded before/after context around it."
+                            },
+                            "limit": { "type": "integer", "minimum": limit_min, "maximum": limit_max.min(OPEN_SESSION_MAX_LIMIT), "default": OPEN_SESSION_DEFAULT_LIMIT },
+                            "cursor": { "type": "string" },
+                            "before": { "type": "integer", "minimum": 0, "maximum": OPEN_SESSION_MAX_CONTEXT, "default": OPEN_SESSION_DEFAULT_CONTEXT },
+                            "after": { "type": "integer", "minimum": 0, "maximum": OPEN_SESSION_MAX_CONTEXT, "default": OPEN_SESSION_DEFAULT_CONTEXT },
+                            "event_scope": {
+                                "type": "string",
+                                "enum": ["auto", "messages", "all"],
+                                "default": "auto"
+                            },
+                            "include_payload_json": { "type": "boolean", "default": false },
+                            "include_system_events": { "type": "boolean", "default": false },
+                            "verbosity": {
+                                "type": "string",
+                                "enum": ["prose", "full"],
+                                "default": "prose"
+                            }
+                        },
+                        "required": ["session_id"]
+                    },
+                    "outputSchema": {
+                        "type": "object",
+                        "required": ["found", "session_id", "events"],
+                        "properties": {
+                            "found": { "type": "boolean" },
+                            "session_id": { "type": "string" },
+                            "query": { "type": ["string", "null"] },
+                            "around_event_uid": { "type": ["string", "null"] },
+                            "summary": { "type": ["object", "null"] },
+                            "events": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "event_uid": { "type": "string" },
+                                        "event_order": { "type": "integer" },
+                                        "turn_seq": { "type": "integer" },
+                                        "event_time": { "type": "string" },
+                                        "actor_role": { "type": "string" },
+                                        "kind": { "type": "string" },
+                                        "text": { "type": "string" }
+                                    }
+                                }
+                            },
+                            "next_cursor": { "type": ["string", "null"] }
+                        }
+                    },
+                    "annotations": {
+                        "readOnlyHint": true
+                    }
+                },
+                {
                     "name": "search",
-                    "description": "BM25 lexical search over Moraine indexed conversation events. Bag-of-words ranking: no phrase matching, no stemming. Word order does not matter.",
+                    "description": "Legacy event-level BM25 search over Moraine indexed conversation events. Prefer search_session_data for agent questions about prior session content.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -695,7 +1046,7 @@ impl AppState {
                 },
                 {
                     "name": "open",
-                    "description": "Open by `event_uid` with surrounding context, or open a session transcript by `session_id`. Callers must supply exactly one of `event_uid` or `session_id`.",
+                    "description": "Legacy open tool. Prefer open_session for session expansion. Opens by `event_uid` with surrounding context, or by `session_id`; callers must supply exactly one of `event_uid` or `session_id`.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -732,12 +1083,15 @@ impl AppState {
                                 "default": "prose"
                             }
                         }
+                    },
+                    "annotations": {
+                        "readOnlyHint": true
                     }
                 },
                 {
                     "name": "search_conversations",
                     "description": format!(
-                        "BM25 lexical search across whole conversations. {CONVERSATION_MODE_CLASSIFICATION_SEMANTICS} {SEARCH_CONVERSATIONS_MODE_DOC}"
+                        "Legacy session-level BM25 search across whole conversations. Prefer search_session_data for agent-facing retrieval. {CONVERSATION_MODE_CLASSIFICATION_SEMANTICS} {SEARCH_CONVERSATIONS_MODE_DOC}"
                     ),
                     "inputSchema": {
                         "type": "object",
@@ -771,7 +1125,7 @@ impl AppState {
                 },
                 {
                     "name": "list_sessions",
-                    "description": "List session metadata in a time window without requiring a search query.",
+                    "description": "List session metadata without searching content. Use for newest/latest session by time, date windows, mode filters, and browsing session summaries. Do not use for questions about what happened inside a session.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -796,6 +1150,37 @@ impl AppState {
                                 "default": "prose"
                             }
                         }
+                    },
+                    "outputSchema": {
+                        "type": "object",
+                        "required": ["sessions"],
+                        "properties": {
+                            "from_unix_ms": { "type": ["integer", "null"] },
+                            "to_unix_ms": { "type": ["integer", "null"] },
+                            "mode": { "type": ["string", "null"] },
+                            "sort": { "type": "string" },
+                            "sessions": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "required": ["session_id", "mode", "next"],
+                                    "properties": {
+                                        "session_id": { "type": "string" },
+                                        "mode": { "type": "string" },
+                                        "start_time": { "type": "string" },
+                                        "end_time": { "type": "string" },
+                                        "event_count": { "type": "integer" },
+                                        "turn_count": { "type": "integer" },
+                                        "session_summary": { "type": ["string", "null"] },
+                                        "next": { "type": "string" }
+                                    }
+                                }
+                            },
+                            "next_cursor": { "type": ["string", "null"] }
+                        }
+                    },
+                    "annotations": {
+                        "readOnlyHint": true
                     }
                 },
                 {
@@ -858,6 +1243,44 @@ impl AppState {
 
     async fn call_tool(&self, params: ToolCallParams) -> Result<Value> {
         match params.name.as_str() {
+            "search_session_data" => {
+                let mut args: SearchSessionDataArgs = serde_json::from_value(params.arguments)
+                    .context(
+                        "search_session_data expects a JSON object with at least {\"query\": ...}",
+                    )?;
+                let max_limit = self.cfg.mcp.max_results.min(SESSION_SEARCH_MAX_LIMIT);
+                args.limit = validate_tool_limit("search_session_data", args.limit, max_limit)?;
+                args.matching_events_limit = validate_tool_limit(
+                    "search_session_data matching_events_limit",
+                    args.matching_events_limit,
+                    SESSION_SEARCH_MAX_MATCHING_EVENTS_LIMIT,
+                )?;
+                let verbosity = args.verbosity.unwrap_or_default();
+                let payload = self.search_session_data(args).await?;
+                match verbosity {
+                    Verbosity::Full => Ok(tool_ok_full(payload)),
+                    Verbosity::Prose => Ok(tool_ok_hybrid(
+                        format_search_session_data_text(&payload)?,
+                        payload,
+                    )),
+                }
+            }
+            "open_session" => {
+                let mut args: OpenSessionArgs = serde_json::from_value(params.arguments)
+                    .context("open_session expects {\"session_id\": ...}")?;
+                let max_limit = self.cfg.mcp.max_results.min(OPEN_SESSION_MAX_LIMIT);
+                args.limit = validate_tool_limit("open_session", args.limit, max_limit)?;
+                validate_context_window("open_session before", args.before)?;
+                validate_context_window("open_session after", args.after)?;
+                let verbosity = args.verbosity.unwrap_or_default();
+                let payload = self.open_session(args).await?;
+                match verbosity {
+                    Verbosity::Full => Ok(tool_ok_full(payload)),
+                    Verbosity::Prose => {
+                        Ok(tool_ok_hybrid(format_open_session_text(&payload)?, payload))
+                    }
+                }
+            }
             "search" => {
                 let mut args: SearchArgs = serde_json::from_value(params.arguments)
                     .context("search expects a JSON object with at least {\"query\": ...}")?;
@@ -913,7 +1336,10 @@ impl AppState {
                 let payload = self.list_sessions(args).await?;
                 match verbosity {
                     Verbosity::Full => Ok(tool_ok_full(payload)),
-                    Verbosity::Prose => Ok(tool_ok_prose(format_session_list_prose(&payload)?)),
+                    Verbosity::Prose => Ok(tool_ok_hybrid(
+                        format_session_list_prose(&payload)?,
+                        payload,
+                    )),
                 }
             }
             "get_session" => {
@@ -1177,6 +1603,603 @@ impl AppState {
         serde_json::to_value(result).context("failed to encode search_conversations result payload")
     }
 
+    async fn search_session_data(&self, args: SearchSessionDataArgs) -> Result<Value> {
+        let query = args.query.trim().to_string();
+        if query.is_empty() {
+            return Err(anyhow!("query cannot be empty"));
+        }
+
+        let requested_scope = args.event_scope.unwrap_or_default();
+        let effective_include_tool_events = requested_scope.includes_tool_events(&query);
+        let effective_scope = if effective_include_tool_events {
+            "all"
+        } else {
+            "messages"
+        };
+        let recency_policy = args.recency_policy.unwrap_or_default();
+        let recency_applied = recency_policy.is_active_for_query(&query);
+        let limit = args.limit.unwrap_or(SESSION_SEARCH_DEFAULT_LIMIT);
+        let matching_events_limit = args
+            .matching_events_limit
+            .unwrap_or(SESSION_SEARCH_DEFAULT_MATCHING_EVENTS_LIMIT);
+        let include_context = args.include_context.unwrap_or(false);
+        let session_filter = args
+            .session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+
+        let search_limit = limit
+            .saturating_mul(4)
+            .max(limit)
+            .min(self.cfg.mcp.max_results.max(TOOL_LIMIT_MIN));
+
+        let conversation_results = self
+            .repo
+            .search_conversations(ConversationSearchQuery {
+                query: query.clone(),
+                limit: Some(search_limit),
+                min_score: None,
+                min_should_match: None,
+                from_unix_ms: args.from_unix_ms,
+                to_unix_ms: args.to_unix_ms,
+                mode: args.mode,
+                include_tool_events: Some(effective_include_tool_events),
+                exclude_codex_mcp: Some(true),
+            })
+            .await
+            .map_err(|err| anyhow!(err.to_string()))?;
+
+        let metadata_results = self
+            .repo
+            .search_session_metadata(SessionMetadataSearchQuery {
+                query: query.clone(),
+                limit: Some(search_limit),
+                min_score: None,
+                min_should_match: None,
+                from_unix_ms: args.from_unix_ms,
+                to_unix_ms: args.to_unix_ms,
+                mode: args.mode,
+                session_id: session_filter.clone(),
+            })
+            .await
+            .map_err(|err| anyhow!(err.to_string()))?;
+
+        let mut candidates = HashMap::<String, SessionSearchCandidate>::new();
+        for hit in conversation_results.hits {
+            if session_filter
+                .as_deref()
+                .is_some_and(|sid| sid != hit.session_id)
+            {
+                continue;
+            }
+            let candidate = candidates
+                .entry(hit.session_id.clone())
+                .or_insert_with(|| SessionSearchCandidate::new(hit.session_id.clone()));
+            candidate.first_event_time = hit
+                .first_event_time
+                .clone()
+                .or(candidate.first_event_time.take());
+            candidate.first_event_unix_ms =
+                hit.first_event_unix_ms.or(candidate.first_event_unix_ms);
+            candidate.last_event_time = hit
+                .last_event_time
+                .clone()
+                .or(candidate.last_event_time.take());
+            candidate.last_event_unix_ms = hit.last_event_unix_ms.or(candidate.last_event_unix_ms);
+            candidate.harness = hit.harness.clone().or(candidate.harness.take());
+            candidate.inference_provider = hit
+                .inference_provider
+                .clone()
+                .or(candidate.inference_provider.take());
+            candidate.session_slug = hit.session_slug.clone().or(candidate.session_slug.take());
+            candidate.session_summary = hit
+                .session_summary
+                .clone()
+                .or(candidate.session_summary.take());
+            candidate.score += hit.score;
+            candidate.matched_terms = candidate.matched_terms.max(hit.matched_terms);
+            candidate.event_count_considered = candidate
+                .event_count_considered
+                .saturating_add(hit.event_count_considered);
+            candidate.best_event_uid = hit
+                .best_event_uid
+                .clone()
+                .or(candidate.best_event_uid.take());
+        }
+
+        for hit in metadata_results.hits {
+            if session_filter
+                .as_deref()
+                .is_some_and(|sid| sid != hit.session_id)
+            {
+                continue;
+            }
+            self.merge_metadata_search_hit(&mut candidates, hit);
+        }
+
+        if let Some(session_id) = session_filter.as_deref() {
+            if !candidates.contains_key(session_id) {
+                let direct_events = self
+                    .repo
+                    .search_events(SearchEventsQuery {
+                        query: query.clone(),
+                        source: Some("moraine-mcp".to_string()),
+                        limit: Some(matching_events_limit),
+                        session_id: Some(session_id.to_string()),
+                        min_score: None,
+                        min_should_match: None,
+                        include_tool_events: Some(effective_include_tool_events),
+                        event_kinds: None,
+                        exclude_codex_mcp: Some(true),
+                        disable_cache: None,
+                        search_strategy: None,
+                    })
+                    .await
+                    .map_err(|err| anyhow!(err.to_string()))?;
+
+                if !direct_events.hits.is_empty() {
+                    let candidate = candidates
+                        .entry(session_id.to_string())
+                        .or_insert_with(|| SessionSearchCandidate::new(session_id.to_string()));
+                    for hit in direct_events.hits {
+                        candidate.score += hit.score;
+                        candidate.matched_terms =
+                            candidate.matched_terms.max(hit.matched_terms as u16);
+                        candidate.event_count_considered =
+                            candidate.event_count_considered.saturating_add(1);
+                        if candidate.best_event_uid.is_none() {
+                            candidate.best_event_uid = Some(hit.event_uid);
+                        }
+                        if candidate.first_event_time.is_none() && !hit.first_event_time.is_empty()
+                        {
+                            candidate.first_event_time = Some(hit.first_event_time);
+                        }
+                        if candidate.last_event_time.is_none() && !hit.last_event_time.is_empty() {
+                            candidate.last_event_time = Some(hit.last_event_time);
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut candidates = candidates.into_values().collect::<Vec<_>>();
+        for candidate in &mut candidates {
+            let event_results = self
+                .repo
+                .search_events(SearchEventsQuery {
+                    query: query.clone(),
+                    source: Some("moraine-mcp".to_string()),
+                    limit: Some(matching_events_limit),
+                    session_id: Some(candidate.session_id.clone()),
+                    min_score: None,
+                    min_should_match: None,
+                    include_tool_events: Some(effective_include_tool_events),
+                    event_kinds: None,
+                    exclude_codex_mcp: Some(true),
+                    disable_cache: None,
+                    search_strategy: None,
+                })
+                .await
+                .map_err(|err| anyhow!(err.to_string()))?;
+
+            for event_hit in event_results.hits {
+                candidate
+                    .evidence
+                    .push(self.search_event_evidence(&event_hit).await?);
+            }
+
+            self.add_summary_evidence(candidate);
+
+            if include_context {
+                if let Some(event_uid) = candidate
+                    .evidence
+                    .iter()
+                    .find(|event| !event.event_uid.is_empty())
+                    .map(|event| event.event_uid.clone())
+                {
+                    candidate.context = self
+                        .context_events_for_uid(
+                            &event_uid,
+                            SESSION_SEARCH_CONTEXT_BEFORE,
+                            SESSION_SEARCH_CONTEXT_AFTER,
+                            false,
+                            false,
+                        )
+                        .await?;
+                }
+            }
+        }
+
+        apply_recency_adjustments(&mut candidates, recency_applied);
+        candidates.sort_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then_with(|| b.last_event_unix_ms.cmp(&a.last_event_unix_ms))
+                .then_with(|| a.session_id.cmp(&b.session_id))
+        });
+        candidates.truncate(limit as usize);
+
+        let hits = candidates
+            .into_iter()
+            .enumerate()
+            .map(|(idx, candidate)| self.session_search_candidate_to_json(idx + 1, candidate))
+            .collect::<Vec<_>>();
+
+        Ok(json!({
+            "query": query,
+            "event_scope": requested_scope.as_str(),
+            "effective_event_scope": effective_scope,
+            "recency_policy": recency_policy.as_str(),
+            "recency_applied": recency_applied,
+            "matching_events_limit": matching_events_limit,
+            "include_context": include_context,
+            "stats": {
+                "result_count": hits.len(),
+                "requested_limit": limit,
+                "effective_limit": limit,
+                "conversation_query_id": conversation_results.query_id,
+                "metadata_query_id": metadata_results.query_id,
+            },
+            "hits": hits,
+        }))
+    }
+
+    fn merge_metadata_search_hit(
+        &self,
+        candidates: &mut HashMap<String, SessionSearchCandidate>,
+        hit: SessionMetadataSearchHit,
+    ) {
+        let candidate = candidates
+            .entry(hit.session_id.clone())
+            .or_insert_with(|| SessionSearchCandidate::new(hit.session_id.clone()));
+        candidate.first_event_time = hit.first_event_time.or(candidate.first_event_time.take());
+        candidate.first_event_unix_ms = hit.first_event_unix_ms.or(candidate.first_event_unix_ms);
+        candidate.last_event_time = hit.last_event_time.or(candidate.last_event_time.take());
+        candidate.last_event_unix_ms = hit.last_event_unix_ms.or(candidate.last_event_unix_ms);
+        candidate.mode = hit
+            .mode
+            .map(|mode| mode.as_str().to_string())
+            .or(candidate.mode.take());
+        candidate.event_count = hit.total_events.or(candidate.event_count);
+        candidate.turn_count = hit.total_turns.or(candidate.turn_count);
+        candidate.harness = hit.harness.or(candidate.harness.take());
+        candidate.inference_provider = hit
+            .inference_provider
+            .or(candidate.inference_provider.take());
+        candidate.session_slug = hit.session_slug.or(candidate.session_slug.take());
+        candidate.session_summary = hit.session_summary.or(candidate.session_summary.take());
+        candidate.score += hit.score * 1.25;
+        candidate.matched_terms = candidate.matched_terms.max(hit.matched_terms);
+        candidate.summary_event_uid = hit.meta_event_uid.or(candidate.summary_event_uid.take());
+        candidate.summary_snippet = hit.snippet.or(candidate.summary_snippet.take());
+    }
+
+    async fn search_event_evidence(&self, hit: &SearchEventHit) -> Result<SessionSearchEvidence> {
+        let mut event_order = None;
+        let mut turn_seq = None;
+        let mut event_time = None;
+        if let Ok(context) = self
+            .repo
+            .open_event(OpenEventRequest {
+                event_uid: hit.event_uid.clone(),
+                before: Some(0),
+                after: Some(0),
+                include_system_events: Some(true),
+            })
+            .await
+        {
+            if let Some(event) = context
+                .events
+                .iter()
+                .find(|event| event.event_uid == hit.event_uid)
+            {
+                event_order = Some(event.event_order);
+                turn_seq = Some(event.turn_seq);
+                event_time = Some(event.event_time.clone());
+            }
+        }
+
+        Ok(SessionSearchEvidence {
+            event_uid: hit.event_uid.clone(),
+            event_order,
+            turn_seq,
+            event_time,
+            kind: display_kind(&hit.event_class, &hit.payload_type),
+            role: hit.actor_role.clone(),
+            snippet: compact_text_line(
+                hit.text_content
+                    .as_deref()
+                    .unwrap_or(hit.text_preview.as_str()),
+                320,
+            ),
+        })
+    }
+
+    fn add_summary_evidence(&self, candidate: &mut SessionSearchCandidate) {
+        let Some(snippet) = candidate
+            .summary_snippet
+            .as_deref()
+            .or(candidate.session_summary.as_deref())
+            .map(|value| compact_text_line(value, 320))
+            .filter(|value| !value.is_empty())
+        else {
+            return;
+        };
+
+        if candidate.evidence.iter().any(|event| {
+            event.snippet == snippet
+                || candidate.summary_event_uid.as_deref() == Some(event.event_uid.as_str())
+        }) {
+            return;
+        }
+
+        candidate.evidence.push(SessionSearchEvidence {
+            event_uid: candidate
+                .summary_event_uid
+                .clone()
+                .unwrap_or_else(|| candidate.session_id.clone()),
+            event_order: None,
+            turn_seq: None,
+            event_time: candidate.last_event_time.clone(),
+            kind: "session_meta/session_meta".to_string(),
+            role: "system".to_string(),
+            snippet,
+        });
+    }
+
+    fn session_search_candidate_to_json(
+        &self,
+        rank: usize,
+        candidate: SessionSearchCandidate,
+    ) -> Value {
+        let evidence = candidate
+            .evidence
+            .into_iter()
+            .map(|event| {
+                json!({
+                    "event_uid": event.event_uid,
+                    "event_order": event.event_order,
+                    "turn_seq": event.turn_seq,
+                    "event_time": event.event_time,
+                    "kind": event.kind,
+                    "role": event.role,
+                    "snippet": event.snippet,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        json!({
+            "rank": rank,
+            "session_id": candidate.session_id,
+            "score": round_score(candidate.score),
+            "first_event_time": candidate.first_event_time,
+            "first_event_unix_ms": candidate.first_event_unix_ms,
+            "last_event_time": candidate.last_event_time,
+            "last_event_unix_ms": candidate.last_event_unix_ms,
+            "mode": candidate.mode,
+            "event_count": candidate.event_count,
+            "turn_count": candidate.turn_count,
+            "harness": candidate.harness,
+            "inference_provider": candidate.inference_provider,
+            "session_slug": candidate.session_slug,
+            "session_summary": candidate.session_summary,
+            "matched_terms": candidate.matched_terms,
+            "event_count_considered": candidate.event_count_considered,
+            "best_event_uid": candidate.best_event_uid,
+            "evidence": evidence,
+            "context": candidate.context,
+            "next": format!("open_session(session_id=\"{}\")", candidate.session_id),
+        })
+    }
+
+    async fn open_session(&self, args: OpenSessionArgs) -> Result<Value> {
+        let session_id = args.session_id.trim().to_string();
+        if session_id.is_empty() {
+            return Err(anyhow!("session_id cannot be empty"));
+        }
+
+        let query = args
+            .query
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        let around_event_uid = args
+            .around_event_uid
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        let limit = args.limit.unwrap_or(OPEN_SESSION_DEFAULT_LIMIT);
+        let before = args.before.unwrap_or(OPEN_SESSION_DEFAULT_CONTEXT);
+        let after = args.after.unwrap_or(OPEN_SESSION_DEFAULT_CONTEXT);
+        let include_payload_json = args.include_payload_json.unwrap_or(false);
+        let include_system_events = args.include_system_events.unwrap_or(false);
+        let event_scope = args.event_scope.unwrap_or_default();
+
+        let metadata = self
+            .repo
+            .get_session_metadata(&session_id)
+            .await
+            .map_err(|err| anyhow!(err.to_string()))?;
+        let Some(metadata) = metadata else {
+            return Ok(json!({
+                "open_mode": "session",
+                "found": false,
+                "session_id": session_id,
+                "query": query,
+                "around_event_uid": around_event_uid,
+                "events": [],
+                "next_cursor": Value::Null,
+            }));
+        };
+
+        let (events, next_cursor) = if let Some(event_uid) = around_event_uid.as_deref() {
+            let context = self
+                .repo
+                .open_event(OpenEventRequest {
+                    event_uid: event_uid.to_string(),
+                    before: Some(before),
+                    after: Some(after),
+                    include_system_events: Some(include_system_events),
+                })
+                .await
+                .map_err(|err| anyhow!(err.to_string()))?;
+            if context.found && context.session_id != session_id {
+                return Err(anyhow!(
+                    "around_event_uid belongs to session_id {} not {}",
+                    context.session_id,
+                    session_id
+                ));
+            }
+            (
+                context
+                    .events
+                    .into_iter()
+                    .map(|event| open_event_to_json(event, include_payload_json))
+                    .collect::<Vec<_>>(),
+                None,
+            )
+        } else if let Some(query) = query.as_deref() {
+            let include_tool_events = event_scope.includes_tool_events(query);
+            let search_results = self
+                .repo
+                .search_events(SearchEventsQuery {
+                    query: query.to_string(),
+                    source: Some("moraine-mcp".to_string()),
+                    limit: Some(limit),
+                    session_id: Some(session_id.clone()),
+                    min_score: None,
+                    min_should_match: None,
+                    include_tool_events: Some(include_tool_events),
+                    event_kinds: None,
+                    exclude_codex_mcp: Some(true),
+                    disable_cache: None,
+                    search_strategy: None,
+                })
+                .await
+                .map_err(|err| anyhow!(err.to_string()))?;
+
+            let mut by_uid = HashMap::<String, Value>::new();
+            for hit in search_results.hits {
+                let context = self
+                    .repo
+                    .open_event(OpenEventRequest {
+                        event_uid: hit.event_uid,
+                        before: Some(before),
+                        after: Some(after),
+                        include_system_events: Some(include_system_events),
+                    })
+                    .await
+                    .map_err(|err| anyhow!(err.to_string()))?;
+                for event in context.events {
+                    by_uid
+                        .entry(event.event_uid.clone())
+                        .or_insert_with(|| open_event_to_json(event, include_payload_json));
+                }
+                if by_uid.len() >= limit as usize {
+                    break;
+                }
+            }
+            let mut events = by_uid.into_values().collect::<Vec<_>>();
+            events.sort_by_key(|event| {
+                event
+                    .get("event_order")
+                    .and_then(Value::as_u64)
+                    .unwrap_or_default()
+            });
+            events.truncate(limit as usize);
+            (events, None)
+        } else {
+            let event_kinds = if matches!(event_scope, SessionSearchEventScope::Messages) {
+                Some(vec![SearchEventKind::Message, SearchEventKind::Reasoning])
+            } else {
+                None
+            };
+            let page = self
+                .repo
+                .list_session_events(
+                    SessionEventsQuery {
+                        session_id: session_id.clone(),
+                        direction: SessionEventsDirection::Forward,
+                        event_kinds,
+                    },
+                    PageRequest {
+                        limit,
+                        cursor: args.cursor,
+                    },
+                )
+                .await
+                .map_err(|err| anyhow!(err.to_string()))?;
+            let events = page
+                .items
+                .into_iter()
+                .filter(|event| {
+                    include_system_events
+                        || !is_low_information_system_event(&event.actor_role, &event.payload_type)
+                })
+                .map(|event| trace_event_to_json(event, include_payload_json))
+                .collect::<Vec<_>>();
+            (events, page.next_cursor)
+        };
+
+        Ok(json!({
+            "open_mode": "session",
+            "found": true,
+            "session_id": session_id,
+            "query": query,
+            "around_event_uid": around_event_uid,
+            "event_scope": event_scope.as_str(),
+            "include_payload_json": include_payload_json,
+            "include_system_events": include_system_events,
+            "limit": limit,
+            "before": before,
+            "after": after,
+            "summary": {
+                "start_time": metadata.first_event_time,
+                "start_unix_ms": metadata.first_event_unix_ms,
+                "end_time": metadata.last_event_time,
+                "end_unix_ms": metadata.last_event_unix_ms,
+                "event_count": metadata.total_events,
+                "turn_count": metadata.total_turns,
+                "mode": metadata.mode.as_str(),
+                "first_event_uid": metadata.first_event_uid,
+                "last_event_uid": metadata.last_event_uid,
+                "last_actor_role": metadata.last_actor_role,
+            },
+            "events": events,
+            "next_cursor": next_cursor,
+        }))
+    }
+
+    async fn context_events_for_uid(
+        &self,
+        event_uid: &str,
+        before: u16,
+        after: u16,
+        include_payload_json: bool,
+        include_system_events: bool,
+    ) -> Result<Vec<Value>> {
+        let context = self
+            .repo
+            .open_event(OpenEventRequest {
+                event_uid: event_uid.to_string(),
+                before: Some(before),
+                after: Some(after),
+                include_system_events: Some(include_system_events),
+            })
+            .await
+            .map_err(|err| anyhow!(err.to_string()))?;
+
+        Ok(context
+            .events
+            .into_iter()
+            .map(|event| open_event_to_json(event, include_payload_json))
+            .collect())
+    }
+
     async fn list_sessions(&self, args: ListSessionsArgs) -> Result<Value> {
         let ListSessionsArgs {
             limit,
@@ -1223,6 +2246,9 @@ impl AppState {
                     "tool_calls": summary.tool_calls,
                     "tool_results": summary.tool_results,
                     "mode": summary.mode.as_str(),
+                    "session_slug": summary.session_slug,
+                    "session_summary": summary.session_summary,
+                    "next": format!("open_session(session_id=\"{}\")", summary.session_id),
                 })
             })
             .collect::<Vec<_>>();
@@ -1401,6 +2427,177 @@ fn validate_tool_limit(
     }
 }
 
+fn validate_context_window(name: &str, value: Option<u16>) -> Result<()> {
+    if let Some(value) = value {
+        if value > OPEN_SESSION_MAX_CONTEXT {
+            return Err(anyhow!(
+                "{name} must be between 0 and {OPEN_SESSION_MAX_CONTEXT} (received {value})"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn query_tokens(query: &str) -> Vec<String> {
+    query
+        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_')
+        .filter_map(|token| {
+            let token = token.trim().to_ascii_lowercase();
+            (token.len() >= 2 && token.len() <= 64).then_some(token)
+        })
+        .collect()
+}
+
+fn query_suggests_tool_events(query: &str) -> bool {
+    let tokens = query_tokens(query);
+    tokens.iter().any(|token| {
+        matches!(
+            token.as_str(),
+            "raw"
+                | "tool"
+                | "output"
+                | "stderr"
+                | "stdout"
+                | "http"
+                | "status"
+                | "error"
+                | "errors"
+                | "failed"
+                | "failure"
+                | "exception"
+                | "stack"
+                | "trace"
+                | "traceback"
+                | "panic"
+                | "log"
+                | "logs"
+                | "cargo"
+                | "pytest"
+                | "curl"
+                | "body"
+                | "field"
+                | "rows"
+                | "inserted"
+                | "exit"
+        )
+    })
+}
+
+fn query_suggests_recency(query: &str) -> bool {
+    let tokens = query_tokens(query);
+    let has_not = tokens.iter().any(|token| token == "not");
+    let has_strong_current = tokens.iter().any(|token| {
+        matches!(
+            token.as_str(),
+            "latest" | "current" | "correct" | "corrected"
+        )
+    });
+    if has_not && !has_strong_current {
+        return false;
+    }
+
+    tokens.iter().any(|token| {
+        matches!(
+            token.as_str(),
+            "latest"
+                | "current"
+                | "final"
+                | "correct"
+                | "corrected"
+                | "settled"
+                | "superseded"
+                | "replace"
+                | "replaced"
+                | "new"
+                | "newer"
+                | "now"
+                | "deprecated"
+                | "provisional"
+        )
+    })
+}
+
+fn apply_recency_adjustments(candidates: &mut [SessionSearchCandidate], active: bool) {
+    if !active || candidates.is_empty() {
+        return;
+    }
+
+    let min_time = candidates
+        .iter()
+        .filter_map(|candidate| candidate.last_event_unix_ms)
+        .min();
+    let max_time = candidates
+        .iter()
+        .filter_map(|candidate| candidate.last_event_unix_ms)
+        .max();
+    let (min_time, max_time) = match (min_time, max_time) {
+        (Some(min_time), Some(max_time)) if max_time > min_time => (min_time, max_time),
+        _ => (0, 0),
+    };
+
+    for candidate in candidates {
+        if max_time > min_time {
+            if let Some(last) = candidate.last_event_unix_ms {
+                let recency = (last - min_time) as f64 / (max_time - min_time) as f64;
+                candidate.score += 3.0 * recency;
+            }
+        }
+
+        let text = candidate_rank_text(candidate);
+        if contains_any_rank_token(
+            &text,
+            &[
+                "final",
+                "current",
+                "correct",
+                "corrected",
+                "settled",
+                "latest",
+            ],
+        ) {
+            candidate.score += 2.0;
+        }
+        if contains_any_rank_token(
+            &text,
+            &[
+                "temporary",
+                "provisional",
+                "stale",
+                "draft",
+                "dry",
+                "dry_run",
+            ],
+        ) {
+            candidate.score -= 8.0;
+        }
+        if contains_any_rank_token(&text, &["deprecated", "superseded"]) {
+            candidate.score -= 2.0;
+        }
+    }
+}
+
+fn candidate_rank_text(candidate: &SessionSearchCandidate) -> String {
+    let mut chunks = Vec::<String>::new();
+    if let Some(summary) = candidate.session_summary.as_deref() {
+        chunks.push(summary.to_string());
+    }
+    for evidence in &candidate.evidence {
+        chunks.push(evidence.snippet.clone());
+    }
+    chunks.join(" ").to_ascii_lowercase()
+}
+
+fn contains_any_rank_token(text: &str, needles: &[&str]) -> bool {
+    let tokens = query_tokens(text);
+    tokens
+        .iter()
+        .any(|token| needles.iter().any(|needle| token == needle))
+}
+
+fn round_score(score: f64) -> f64 {
+    (score * 10_000.0).round() / 10_000.0
+}
+
 fn apply_search_content_policy(result: &mut SearchEventsResult, include_payload_json: bool) {
     for hit in &mut result.hits {
         if !is_user_facing_content_event(&hit.event_class, &hit.actor_role) {
@@ -1424,6 +2621,57 @@ fn apply_conversation_search_content_policy(
             hit.payload_json = None;
         }
     }
+}
+
+fn open_event_to_json(event: OpenEvent, include_payload_json: bool) -> Value {
+    let kind = display_kind(&event.event_class, &event.payload_type);
+    let text = compact_text_line(&event.text_content, 600);
+    let mut payload = json!({
+        "event_uid": event.event_uid,
+        "event_order": event.event_order,
+        "turn_seq": event.turn_seq,
+        "event_time": event.event_time,
+        "actor_role": event.actor_role,
+        "event_class": event.event_class,
+        "payload_type": event.payload_type,
+        "kind": kind,
+        "call_id": event.call_id,
+        "name": event.name,
+        "phase": event.phase,
+        "item_id": event.item_id,
+        "source_ref": event.source_ref,
+        "text": text,
+        "is_target": event.is_target,
+    });
+    if include_payload_json {
+        payload["payload_json"] = Value::String(event.payload_json);
+    }
+    payload
+}
+
+fn trace_event_to_json(event: TraceEvent, include_payload_json: bool) -> Value {
+    let kind = display_kind(&event.event_class, &event.payload_type);
+    let text = compact_text_line(&event.text_content, 600);
+    let mut payload = json!({
+        "event_uid": event.event_uid,
+        "event_order": event.event_order,
+        "turn_seq": event.turn_seq,
+        "event_time": event.event_time,
+        "actor_role": event.actor_role,
+        "event_class": event.event_class,
+        "payload_type": event.payload_type,
+        "kind": kind,
+        "call_id": event.call_id,
+        "name": event.name,
+        "phase": event.phase,
+        "item_id": event.item_id,
+        "source_ref": event.source_ref,
+        "text": text,
+    });
+    if include_payload_json {
+        payload["payload_json"] = Value::String(event.payload_json);
+    }
+    payload
 }
 
 fn rpc_ok(id: Value, result: Value) -> Value {
@@ -1459,6 +2707,19 @@ fn tool_ok_full(payload: Value) -> Value {
     })
 }
 
+fn tool_ok_hybrid(text: String, payload: Value) -> Value {
+    json!({
+        "content": [
+            {
+                "type": "text",
+                "text": text
+            }
+        ],
+        "structuredContent": payload,
+        "isError": false
+    })
+}
+
 fn tool_ok_prose(text: String) -> Value {
     json!({
         "content": [
@@ -1481,6 +2742,101 @@ fn tool_error_result(message: String) -> Value {
         ],
         "isError": true
     })
+}
+
+fn format_search_session_data_text(payload: &Value) -> Result<String> {
+    let query = payload.get("query").and_then(Value::as_str).unwrap_or("");
+    let hits = payload
+        .get("hits")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if hits.is_empty() {
+        return Ok(format!("No matching sessions found for \"{query}\"."));
+    }
+
+    let top = &hits[0];
+    let session_id = top
+        .get("session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("(unknown)");
+    let last_event_time = top
+        .get("last_event_time")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let summary = top
+        .get("session_summary")
+        .and_then(Value::as_str)
+        .map(|value| compact_text_line(value, 220))
+        .unwrap_or_default();
+    let evidence = top
+        .get("evidence")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .take(3)
+                .filter_map(|item| item.get("snippet").and_then(Value::as_str))
+                .map(|snippet| compact_text_line(snippet, 180))
+                .filter(|snippet| !snippet.is_empty())
+                .collect::<Vec<_>>()
+                .join(" | ")
+        })
+        .unwrap_or_default();
+
+    let mut out = format!("Top session {session_id}");
+    if !last_event_time.is_empty() {
+        out.push_str(&format!(" ending {last_event_time}"));
+    }
+    if !summary.is_empty() {
+        out.push_str(&format!(": {summary}"));
+    }
+    if !evidence.is_empty() {
+        out.push_str(&format!(" Evidence: {evidence}"));
+    }
+    if hits.len() > 1 {
+        out.push_str(&format!(" ({} sessions returned)", hits.len()));
+    }
+    Ok(out)
+}
+
+fn format_open_session_text(payload: &Value) -> Result<String> {
+    let session_id = payload
+        .get("session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("(unknown)");
+    if payload.get("found").and_then(Value::as_bool) == Some(false) {
+        return Ok(format!("Session {session_id} was not found."));
+    }
+
+    let events = payload
+        .get("events")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let summary = payload
+        .get("summary")
+        .and_then(|summary| summary.get("end_time"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let snippets = events
+        .iter()
+        .take(4)
+        .filter_map(|event| event.get("text").and_then(Value::as_str))
+        .map(|text| compact_text_line(text, 180))
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join(" | ");
+
+    let mut out = format!("Opened session {session_id}");
+    if !summary.is_empty() {
+        out.push_str(&format!(" ending {summary}"));
+    }
+    out.push_str(&format!(" with {} events", events.len()));
+    if !snippets.is_empty() {
+        out.push_str(&format!(". Evidence: {snippets}"));
+    }
+    Ok(out)
 }
 
 fn format_search_prose(payload: &Value) -> Result<String> {
@@ -1831,10 +3187,11 @@ fn format_session_list_prose(payload: &Value) -> Result<String> {
         };
 
         out.push_str(&format!(
-            "\n{}) session={} mode={} events={}\n",
+            "\n{}) session={} mode={} turns={} events={}\n",
             idx + 1,
             session.session_id,
             mode,
+            session.turn_count,
             session.event_count
         ));
         out.push_str(&format!(
@@ -1845,6 +3202,15 @@ fn format_session_list_prose(payload: &Value) -> Result<String> {
             "   end: {} (unix_ms={})\n",
             session.end_time, session.end_unix_ms
         ));
+        if let Some(summary) = session.session_summary.as_deref() {
+            let compact = compact_text_line(summary, 220);
+            if !compact.is_empty() {
+                out.push_str(&format!("   session_summary: {}\n", compact));
+            }
+        }
+        if !session.next.is_empty() {
+            out.push_str(&format!("   next: {}\n", session.next));
+        }
     }
 
     if let Some(cursor) = parsed.next_cursor.as_deref() {
@@ -2079,11 +3445,142 @@ pub async fn run_stdio(cfg: AppConfig) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use moraine_clickhouse::ClickHouseClient;
+
+    fn test_state() -> AppState {
+        let cfg = AppConfig::default();
+        let ch = ClickHouseClient::new(cfg.clickhouse.clone()).expect("clickhouse client");
+        let repo = ClickHouseConversationRepository::new(ch, RepoConfig::default());
+        AppState {
+            cfg,
+            repo,
+            prewarm_started: Arc::new(AtomicBool::new(false)),
+        }
+    }
 
     #[test]
     fn display_kind_compacts_payload_type_when_redundant() {
         assert_eq!(display_kind("message", "message"), "message");
         assert_eq!(display_kind("", "unknown"), "event");
+    }
+
+    #[test]
+    fn tools_list_publishes_session_first_surface_with_output_schemas() {
+        let state = test_state();
+        let payload = state.tools_list_result();
+        let tools = payload["tools"].as_array().expect("tools array");
+        let names = tools
+            .iter()
+            .filter_map(|tool| tool["name"].as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names[0], "search_session_data");
+        assert_eq!(names[1], "open_session");
+        assert!(names.contains(&"list_sessions"));
+
+        for tool_name in ["search_session_data", "open_session", "list_sessions"] {
+            let tool = tools
+                .iter()
+                .find(|tool| tool["name"].as_str() == Some(tool_name))
+                .expect("tool exists");
+            assert!(
+                tool.get("outputSchema").is_some(),
+                "{tool_name} has outputSchema"
+            );
+            assert_eq!(tool["annotations"]["readOnlyHint"], json!(true));
+        }
+
+        let search = tools
+            .iter()
+            .find(|tool| tool["name"].as_str() == Some("search_session_data"))
+            .expect("search_session_data exists");
+        assert_eq!(
+            search["inputSchema"]["properties"]["event_scope"]["default"],
+            json!("auto")
+        );
+        assert_eq!(
+            search["inputSchema"]["properties"]["recency_policy"]["default"],
+            json!("auto")
+        );
+    }
+
+    #[test]
+    fn hybrid_tool_result_includes_text_and_structured_content_by_default_shape() {
+        let payload = json!({
+            "query": "Iris batch size current setting",
+            "hits": [
+                {
+                    "session_id": "s-20260424-iris-final",
+                    "last_event_time": "2026-04-24 14:34:00",
+                    "session_summary": "Iris final current batch policy changed to IRIS_BATCH_SIZE=96.",
+                    "evidence": [
+                        {
+                            "snippet": "Final current Iris batch size policy: set IRIS_BATCH_SIZE=96."
+                        }
+                    ]
+                }
+            ]
+        });
+        let text = format_search_session_data_text(&payload).expect("format");
+        let result = tool_ok_hybrid(text, payload.clone());
+
+        assert_eq!(result["isError"], json!(false));
+        assert!(result["content"][0]["text"]
+            .as_str()
+            .expect("text")
+            .contains("Top session s-20260424-iris-final"));
+        assert_eq!(result["structuredContent"], payload);
+    }
+
+    #[test]
+    fn event_scope_auto_detects_raw_error_and_log_queries() {
+        assert!(query_suggests_tool_events(
+            "Where did the Juno stack trace panic happen?"
+        ));
+        assert!(query_suggests_tool_events("exact raw pytest error"));
+        assert!(query_suggests_tool_events("HTTP 422 status body from curl"));
+        assert!(!query_suggests_tool_events(
+            "Iris batch size current setting"
+        ));
+    }
+
+    #[test]
+    fn recency_policy_auto_detects_current_queries_but_not_not_final_history() {
+        assert!(query_suggests_recency(
+            "What is the current Iris batch size setting?"
+        ));
+        assert!(query_suggests_recency(
+            "correct current Mirage endpoint not provisional"
+        ));
+        assert!(!query_suggests_recency(
+            "Which Apollo value should not be treated as final?"
+        ));
+    }
+
+    #[test]
+    fn recency_adjustments_promote_final_over_stale_draft() {
+        let mut candidates = vec![
+            SessionSearchCandidate {
+                session_id: "old".to_string(),
+                last_event_unix_ms: Some(1000),
+                session_summary: Some("Temporary stale dry-run batch size setting".to_string()),
+                score: 10.0,
+                ..SessionSearchCandidate::new("old".to_string())
+            },
+            SessionSearchCandidate {
+                session_id: "final".to_string(),
+                last_event_unix_ms: Some(2000),
+                session_summary: Some("Final current batch size policy".to_string()),
+                score: 9.0,
+                ..SessionSearchCandidate::new("final".to_string())
+            },
+        ];
+
+        apply_recency_adjustments(&mut candidates, true);
+        candidates.sort_by(|a, b| b.score.total_cmp(&a.score));
+
+        assert_eq!(candidates[0].session_id, "final");
+        assert!(candidates[0].score > candidates[1].score);
     }
 
     #[test]

--- a/docs/mcp/agent-interface.md
+++ b/docs/mcp/agent-interface.md
@@ -1,182 +1,131 @@
-# Moraine MCP Interface
+# Moraine MCP Agent Interface
 
-## Service Contract
+## Contract
 
-`moraine-mcp` is a local, stateless [Model Context Protocol](https://modelcontextprotocol.io/) server that sits on top of ClickHouse-backed Moraine tables and exposes exactly two retrieval primitives to agent runtimes: lexical discovery (`search`) and trace reconstruction (`open`). It does not own ingestion, index construction, or background maintenance. Its contract boundary is intentionally narrow: accept JSON-RPC tool calls over stdio, execute bounded SQL reads against precomputed search structures and trace views, and return either agent-readable prose or full structured JSON. This keeps latency predictable, process startup cheap, and failure domains small enough that host runtimes can restart the process without any reindex step.
+Issue #290 narrows the agent-facing MCP surface to three session-first tools:
 
-Configuration confirms this posture. ClickHouse endpoint, protocol version, result limits, context defaults, and BM25 parameters are loaded from TOML with concrete defaults, and startup fails fast on parse or ping failure. The service therefore has no hidden mutable state that can drift from corpus truth: either it can reach ClickHouse and answer from current tables, or it fails immediately and visibly. [src: crates/moraine-config/src/lib.rs:L66-L98, crates/moraine-config/src/lib.rs:L563-L566, crates/moraine-mcp-core/src/lib.rs:L671-L673, config/moraine.toml:L1-L50]
+- `search_session_data`: answer questions about prior session content.
+- `open_session`: expand one known session when search snippets are not enough.
+- `list_sessions`: browse session metadata without searching content.
 
-## JSON-RPC Session Lifecycle
+The boundary is intentionally small. Agents should search sessions first, open only targeted sessions, and use metadata listing only for time/mode browsing. The MCP server remains a stateless stdio JSON-RPC process over ClickHouse-backed conversation tables; ingestion, schema maintenance, and index construction stay outside this service. The Rust MCP tool list publishes these three tools first, with explicit `inputSchema`, `outputSchema`, and read-only annotations, while lower-level compatibility tools remain available but de-emphasized. [src: crates/moraine-mcp-core/src/lib.rs:L827-L1180]
 
-The runtime is a long-lived async loop over newline-delimited JSON-RPC messages on stdin/stdout. Each non-empty line is parsed as `RpcRequest`; malformed lines are logged and skipped rather than terminating the server process. Supported base methods are `initialize`, `ping`, `tools/list`, and `tools/call`; unknown methods produce `-32601` responses when an `id` is present. Notifications such as `notifications/initialized` are accepted and ignored, which keeps compatibility with hosts that send startup chatter not requiring responses. [src: crates/moraine-mcp-core/src/lib.rs:L23-L29, crates/moraine-mcp-core/src/lib.rs:L215-L255, crates/moraine-mcp-core/src/lib.rs:L697-L710]
+## Tool Boundaries
 
-Initialization returns protocol and capability metadata sourced from runtime config and Cargo package version. Tool invocation is routed through typed argument decoding, and decode errors are surfaced as parameter errors (`-32602`) instead of ad hoc text. This separation between transport-level errors and tool-level errors is important for agent frameworks because they can decide whether to retry, revise arguments, or terminate based on standard JSON-RPC semantics. [src: crates/moraine-mcp-core/src/lib.rs:L216-L230, crates/moraine-mcp-core/src/lib.rs:L238-L250, crates/moraine-mcp-core/src/lib.rs:L332-L369]
+### `search_session_data`
 
-Reference excerpt:
+Primary entry point for content questions. Use it for decisions, fixes, errors, logs, codenames, config values, file paths, migrations, status codes, and "what did we decide?" prompts.
 
-```rust
-match req.method.as_str() {
-    "initialize" => { /* protocol + capabilities */ }
-    "ping" => id.map(|msg_id| rpc_ok(msg_id, json!({}))),
-    "tools/list" => id.map(|msg_id| rpc_ok(msg_id, self.tools_list_result())),
-    "tools/call" => { /* typed decode + call_tool */ }
-    _ => id.map(|msg_id| rpc_err(msg_id, -32601, &format!("method not found: {}", req.method))),
-}
-```
+Important arguments:
 
-[src: crates/moraine-mcp-core/src/lib.rs:L215-L255]
+- `query` is natural language plus any exact tokens from the user request.
+- `limit` defaults to `5`, caps at `20`, and is also bounded by the configured MCP maximum.
+- `matching_events_limit` defaults to `5` and caps at `8`; raise it only for multi-evidence questions.
+- `event_scope` defaults to `auto`; `auto` searches compact user-facing content but includes raw tool output for raw/error/log/stack/status/tool-output queries.
+- `recency_policy` defaults to `auto`; `auto` prefers current, final, latest, corrected evidence and down-ranks stale, draft, provisional, superseded, or deprecated material unless the user asks for history.
+- `from_unix_ms`, `to_unix_ms`, `mode`, and `session_id` narrow the search by time window, computed session mode, or one known session.
+- `include_context` defaults to `false`; set it only when snippets need nearby turns.
 
-## Tool Definitions and Input Schemas
+Default behavior returns session-ranked evidence, not event-ranked transcript dumps. The implementation combines conversation search, session-metadata search, per-session matching event snippets, summary evidence, optional bounded context, and recency adjustments. Internal MCP traces are suppressed by default so the model sees remembered work, not retrieval plumbing. [src: crates/moraine-mcp-core/src/lib.rs:L1593-L1920]
 
-`tools/list` publishes two tools with explicit JSON Schema fragments: `search` and `open`. `search` requires `query`, supports optional bounds such as `limit`, `min_score`, `min_should_match`, filtering options (`session_id`, `include_tool_events`, `exclude_codex_mcp`), and `verbosity`. `open` requires `event_uid`, supports context window controls (`before`, `after`), and the same `verbosity` selector. The published schemas are the authoritative wire contract for hosts; any client-side wrappers should derive from this payload rather than duplicating assumptions in separate code paths. [src: crates/moraine-mcp-core/src/lib.rs:L258-L299]
+### `open_session`
 
-The design intentionally keeps tool inventory minimal. Higher-level retrieval workflows are expected to be composed in the host runtime by calling `search`, selecting a candidate UID, and then calling `open` for surrounding evidence. This composition pattern is reflected directly in the prose formatter, which includes a suggested `open(event_uid=...)` continuation for each hit. [src: crates/moraine-mcp-core/src/lib.rs:L258-L299, crates/moraine-mcp-core/src/lib.rs:L507-L521]
+Expansion tool after `search_session_data` returns a `session_id`. Use it for transcript context, surrounding turns, or additional evidence when search snippets are insufficient. Do not call it just because search returned a hit with enough evidence to answer.
 
-Reference excerpt:
+Important arguments:
 
-```rust
+- `session_id` is required.
+- `query` optionally requests query-relevant windows first.
+- `around_event_uid` optionally requests bounded before/after context around one evidence event.
+- `event_scope` controls transcript breadth. `auto` uses query cues for tool-output windows, `messages` restricts chronological pages to messages/reasoning, and `all` broadens to normal event kinds.
+- `limit` defaults to `20` and caps at `50`; `cursor` paginates chronological pages.
+- `before` and `after` default to `3` and cap at `10` for event-centered windows.
+- `include_payload_json` should be explicit when exact raw payload JSON is needed.
+- `include_system_events` defaults to `false`.
+
+Without `query` or `around_event_uid`, `open_session` returns a chronological page with metadata and a cursor. With `query`, it searches within the session and returns relevant windows first. With `around_event_uid`, it returns bounded before/after context and verifies the event belongs to the requested session. [src: crates/moraine-mcp-core/src/lib.rs:L1921-L2119]
+
+### `list_sessions`
+
+Metadata-only browsing. Use it for newest/latest sessions by time, date windows, mode filters, pagination, and session inventory. Do not use it to answer questions about what happened inside a session.
+
+Important arguments:
+
+- `limit` defaults to the configured MCP maximum when omitted and is validated against server bounds.
+- `from_unix_ms` and `to_unix_ms` filter by session end time; `from_unix_ms` must be less than `to_unix_ms`.
+- `mode` filters the computed session mode: `web_search`, `mcp_internal`, `tool_calling`, or `chat`.
+- `sort` defaults to `desc`, so the newest session end time comes first.
+- `cursor` continues a deterministic page for the same filter and sort.
+
+Responses include compact rows: `session_id`, mode, start/end times, event and turn counts, `session_slug`, `session_summary`, and a next-call hint to `open_session`. [src: crates/moraine-mcp-core/src/lib.rs:L2121-L2186]
+
+## Response Shape
+
+Default tool results should be answer-first hybrid:
+
+- `content[0].text` gives a short answer or salience summary the model can use immediately.
+- `structuredContent` carries compact parseable evidence with stable IDs.
+- `isError=false` marks successful tool results.
+- `isError=true` returns a concise text error; transport and parameter errors still use JSON-RPC error envelopes where appropriate.
+
+`search_session_data` structured results should include `query`, requested and effective `event_scope`, `recency_policy`, `recency_applied`, `hits`, and per-hit `rank`, `session_id`, `score`, time bounds, `session_summary`, compact `evidence`, optional `context`, and a next-call hint such as `open_session(session_id="...")`. Evidence entries should carry stable `event_uid`, `event_order`, kind/role, snippet text, and raw output snippets only when the effective scope includes them.
+
+`open_session` structured results should include `found`, `session_id`, session metadata, effective scope, page/window metadata, `events`, and `next_cursor` when more transcript data exists.
+
+`list_sessions` structured results should include the effective filters, `sort`, `sessions`, and `next_cursor`.
+
+The published MCP metadata includes `outputSchema` for these structured payloads. For the three agent-facing tools, default `verbosity=prose` returns hybrid text plus `structuredContent`; `verbosity=full` returns pretty JSON text plus the same structured payload. Legacy tools may still use prose-only default responses. [src: crates/moraine-mcp-core/src/lib.rs:L886-L966, crates/moraine-mcp-core/src/lib.rs:L1146-L1178, crates/moraine-mcp-core/src/lib.rs:L1248-L1330]
+
+Example:
+
+```json
 {
-    "name": "search",
-    "description": "BM25 lexical search over Moraine indexed conversation events.",
-    "inputSchema": {
-        "type": "object",
-        "properties": {
-            "query": { "type": "string" },
-            "limit": { "type": "integer", "minimum": 1, "maximum": self.cfg.mcp.max_results },
-            "verbosity": { "type": "string", "enum": ["prose", "full"], "default": "prose" }
-        },
-        "required": ["query"]
+  "content": [
+    {
+      "type": "text",
+      "text": "Top session s-20260424-iris-final records the final Iris batch policy: IRIS_BATCH_SIZE=96 and IRIS_FLUSH_MS=250."
     }
+  ],
+  "structuredContent": {
+    "query": "Iris batch size current setting",
+    "event_scope": "auto",
+    "recency_policy": "auto",
+    "hits": [
+      {
+        "rank": 1,
+        "session_id": "s-20260424-iris-final",
+        "score": 11.94,
+        "last_event_time": "2026-04-24 14:34:00",
+        "session_summary": "Iris final current batch policy changed to IRIS_BATCH_SIZE=96 with IRIS_FLUSH_MS=250.",
+        "evidence": [
+          {
+            "event_uid": "evt-iris-final-03",
+            "event_order": 3,
+            "kind": "message/message",
+            "snippet": "Final current Iris batch size policy: set IRIS_BATCH_SIZE=96 and IRIS_FLUSH_MS=250."
+          }
+        ],
+        "next": "open_session(session_id=\"s-20260424-iris-final\")"
+      }
+    ]
+  },
+  "isError": false
 }
 ```
 
-[src: crates/moraine-mcp-core/src/lib.rs:L262-L281]
+## Recency And Raw Output
 
-## Search Tool Execution Semantics
+Recency is semantic, not just timestamp sorting. When the query asks for current, latest, final, corrected, or active state, the search contract should prefer evidence that marks a final/corrected state and demote stale drafts, provisional notes, deprecated values, and superseded answers. When the user asks for history, old or superseded evidence can rank normally.
 
-`search` begins by normalizing and validating request fields: query trimming, empty-query rejection, term tokenization with hard cap (`max_query_terms`), bounded `limit`, bounded `min_should_match`, optional session safety checks, and default filter controls from config. Query IDs are generated per call, and elapsed time is tracked from pre-tokenization to final payload assembly. These steps are not incidental bookkeeping; they are the service’s first-stage admission control and protect ClickHouse from pathological or malformed query shapes generated by upstream agents. [src: crates/moraine-conversations/src/clickhouse_repo.rs:L1131-L1168, crates/moraine-conversations/src/clickhouse_repo.rs:L1407-L1435, config/moraine.toml:L35-L50]
+Raw output is automatic under `event_scope=auto`. Queries containing cues such as raw, exact error, logs, stack trace, traceback, status, command output, HTTP status, panic, exception, or tool result should include the relevant tool/result payload snippets without requiring the agent to set a broader scope manually. Outside those cases, default snippets should stay compact and user-facing.
 
-Ranking is BM25-like and implemented by combining in-process IDF preparation with SQL-side term scoring over `search_postings`. Corpus totals and term frequencies are sourced from stats tables when available and transparently fall back to base-table aggregation when stats are missing, so bootstrap and partial-repair states still return results. SQL generation constrains candidate rows via `p.term IN [...]`, optional session filters, event-class/payload filters, and optional codex-mcp self-exclusion, then computes score per document with configured `k1` and `b`. The result set is ordered by score and truncated by the requested limit. [src: crates/moraine-conversations/src/clickhouse_repo.rs:L381-L410, crates/moraine-conversations/src/clickhouse_repo.rs:L413-L509, crates/moraine-conversations/src/clickhouse_repo.rs:L1186-L1214]
+## Legacy And De-Emphasized Tools
 
-Operationally, this means retrieval latency is tied to postings fanout and term selectivity rather than corpus-wide scans. The MCP process performs no full-table tokenization, no corpus rebuild, and no local index persistence; it simply compiles a bounded query against continuously maintained search tables. [src: crates/moraine-conversations/src/clickhouse_repo.rs:L413-L509, sql/004_search_index.sql:L82-L133, sql/004_search_index.sql:L147-L170]
+The current server still publishes broader implementation tools: `search`, `open`, `search_conversations`, `get_session`, and `get_session_events`. For issue #290, agents should treat them as legacy, compatibility, or internal-building-block surfaces.
 
-Reference excerpt:
+- `search` is event-ranked and useful for low-level debugging, but it is too narrow as the default agent retrieval tool.
+- `search_conversations` is the implementation basis for `search_session_data`, but the agent-facing name and result contract should be clearer and answer-first.
+- `open` is overloaded between event windows and session opening; `open_session` should make the session expansion path explicit.
+- `get_session` and `get_session_events` are lower-level metadata/event APIs. Prefer `open_session` unless a caller truly needs raw paginated event rows.
 
-```rust
-let query = args.query.trim();
-if query.is_empty() {
-    return Err(anyhow!("query cannot be empty"));
-}
-let terms_with_qf = tokenize_query(query, self.cfg.bm25.max_query_terms);
-let min_should_match = args
-    .min_should_match
-    .unwrap_or(self.cfg.bm25.default_min_should_match)
-    .max(1)
-    .min(terms.len() as u16);
-let query_sql = self.build_search_sql(/* terms, filters, bounds */)?;
-let mut rows: Vec<SearchRow> = self.ch.query_json_rows(&query_sql).await?;
-rows.sort_by(|a, b| b.score.total_cmp(&a.score));
-```
-
-[src: crates/moraine-conversations/src/clickhouse_repo.rs:L1132-L1158, crates/moraine-conversations/src/clickhouse_repo.rs:L1201-L1214]
-
-## Open Tool Execution Semantics
-
-`open` provides deterministic context reconstruction around one event UID. The implementation first validates `event_uid`, resolves target `(session_id, event_order, turn_seq)` from `v_conversation_trace`, then loads an ordered event window bounded by `before` and `after` offsets. If no target row exists, the response is a successful `found=false` payload rather than an exception, so hosts can branch on result state without treating misses as transport failures. [src: crates/moraine-conversations/src/clickhouse_repo.rs:L1031-L1053, crates/moraine-conversations/src/clickhouse_repo.rs:L1062-L1128]
-
-Window rows include compact context fields and full payload/token JSON, preserving both quick readability and deep inspection paths. Ordering is normalized in memory before emission, and prose formatting then partitions rows into before/target/after blocks with stable event order, which is useful for agents that need immediate narrative context instead of raw arrays. [src: crates/moraine-conversations/src/clickhouse_repo.rs:L1065-L1116, crates/moraine-mcp-core/src/lib.rs:L526-L589]
-
-The main architectural implication is that `open` depends on data-plane ordering contracts, not on search-rank ordering. Its fidelity therefore inherits from `v_conversation_trace` and source provenance in core tables, allowing a consistent answer to “what happened around this event” even when lexical ranking and trace chronology diverge. [src: sql/002_views.sql:L61-L80, sql/001_schema.sql:L27-L31]
-
-Reference excerpt:
-
-```rust
-let target_query = format!(
-    "SELECT session_id, event_order, turn_seq
-     FROM moraine.v_conversation_trace
-     WHERE event_uid = {}
-     ORDER BY event_order DESC LIMIT 1 FORMAT JSONEachRow",
-    sql_quote(event_uid)
-);
-let targets: Vec<OpenTargetRow> = self.ch.query_json_rows(&target_query).await?;
-let Some(target) = targets.first() else {
-    return Ok(json!({ "found": false, "event_uid": event_uid, "events": [] }));
-};
-```
-
-[src: crates/moraine-conversations/src/clickhouse_repo.rs:L1042-L1050]
-
-## Response Shapes and Verbosity
-
-The tool envelope is explicitly dual-mode. In `full` mode, responses include both `content` text and `structuredContent` carrying the entire JSON payload. In default `prose` mode, responses return a concise text form intended for direct LLM consumption with minimal parsing burden. Error envelopes set `isError=true` and provide a single text payload. This makes downstream handling straightforward for both strict schema consumers and text-first agents. [src: crates/moraine-mcp-core/src/lib.rs:L452-L488]
-
-Prose search output includes query metadata, hit count/latency, ranked hit summaries, snippet lines, and the next-step affordance to call `open`. Prose open output includes session and turn metadata, context-window settings, and ordered event blocks. Hosts that want deterministic machine transforms should request `full`; hosts optimizing for immediate model reasoning can stay on default `prose`. [src: crates/moraine-mcp-core/src/lib.rs:L490-L523, crates/moraine-mcp-core/src/lib.rs:L526-L589]
-
-Reference excerpt:
-
-```rust
-fn tool_ok_full(payload: Value) -> Value {
-    json!({
-        "content": [{ "type": "text", "text": serde_json::to_string_pretty(&payload).unwrap_or_else(|_| "{}".to_string()) }],
-        "structuredContent": payload,
-        "isError": false
-    })
-}
-
-fn tool_ok_prose(text: String) -> Value {
-    json!({ "content": [{ "type": "text", "text": text }], "isError": false })
-}
-```
-
-[src: crates/moraine-mcp-core/src/lib.rs:L452-L476]
-
-## Safety and Failure Semantics
-
-Input safety controls are strict but lightweight. Session and event filter values are validated with a safe-character regex before interpolation, SQL string literals are escaped, and unsupported characters produce deterministic request errors. Query tokenizer bounds prevent unbounded term lists, and limit clamps prevent oversized result sets even if hosts send extreme values. [src: crates/moraine-conversations/src/clickhouse_repo.rs:L214-L229, crates/moraine-conversations/src/clickhouse_repo.rs:L1146-L1164, crates/moraine-conversations/src/clickhouse_repo.rs:L1401-L1443]
-
-Failure handling favors continuity. Parse failures of incoming request lines are logged and ignored; transport loop continues. Search/open execution errors are converted into tool error payloads instead of process termination. Telemetry writes to `search_query_log` and `search_hit_log` are best-effort in both sync and async modes: failures are warned but do not poison the user-facing response path. This behavior is deliberate because retrieval correctness should not hinge on observability table availability. [src: crates/moraine-mcp-core/src/lib.rs:L243-L247, crates/moraine-mcp-core/src/lib.rs:L705-L710, crates/moraine-conversations/src/clickhouse_repo.rs:L640-L734, sql/004_search_index.sql:L180-L219]
-
-Client-side ClickHouse access is centralized in a small wrapper (`query_rows`, `insert_json_rows`, ping), with timeout and optional HTTP basic auth from config. This keeps surface area narrow and makes failure modes auditable to a small set of request paths. [src: crates/moraine-clickhouse/src/lib.rs:L43-L56, crates/moraine-clickhouse/src/lib.rs:L100-L129, crates/moraine-clickhouse/src/lib.rs:L181-L212]
-
-Reference excerpt:
-
-```rust
-fn safe_value_re() -> &'static Regex {
-    static SAFE_RE: OnceLock<Regex> = OnceLock::new();
-    SAFE_RE.get_or_init(|| Regex::new(r"^[A-Za-z0-9._:@/-]{1,256}$").expect("valid safe-value regex"))
-}
-
-fn sql_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\\', "\\\\").replace('\'', "''"))
-}
-```
-
-[src: crates/moraine-conversations/src/clickhouse_repo.rs:L1401-L1405, crates/moraine-conversations/src/clickhouse_repo.rs:L1441-L1443]
-
-## Integration Guidance for Agents
-
-Integrate `moraine-mcp` as a colocated subprocess started by the host agent runtime. The recommended operational path is `bin/moraine run mcp --config <path>`, which keeps one command surface across local environments.
-
-For host policy, default to `verbosity=prose` for first-pass retrieval, then issue targeted `verbosity=full` calls when the agent needs exact JSON fields (`payload_json`, `token_usage_json`, or source coordinates). Keep `exclude_codex_mcp=true` unless debugging MCP internals, and avoid raising `max_query_terms` without workload evidence because fanout cost rises rapidly on broad lexical tokens. [src: config/moraine.toml:L40-L50, crates/moraine-conversations/src/clickhouse_repo.rs:L1162-L1164, crates/moraine-conversations/src/clickhouse_repo.rs:L1407-L1424]
-
-For deterministic behavior across environments, pin config in `config/moraine.toml` and keep MCP policy in the `[mcp]` section. This avoids drift between service-specific config files.
-
-Reference excerpt:
-
-```rust
-#[derive(Debug, Args)]
-struct RunArgs {
-    #[arg(value_enum)]
-    service: Service,
-    #[arg(
-        trailing_var_arg = true,
-        allow_hyphen_values = true,
-        num_args = 0..
-    )]
-    args: Vec<String>,
-}
-```
-
-[src: apps/moraine/src/main.rs:L164-L173]
-
-In practice, the interface should be treated as a strict retrieval edge service: keep it stateless, keep calls bounded, and let ClickHouse remain the durable truth for both content and retrieval telemetry.
+Keep full transcript context opt-in. The successful default path for most content questions is one `search_session_data` call with enough evidence to answer, followed by `open_session` only when snippets are insufficient.


### PR DESCRIPTION
## Summary
- Add the session-first MCP tools `search_session_data` and `open_session`, and upgrade `list_sessions` with structured hybrid responses and output schemas.
- Add ClickHouse-backed session metadata search over `session_meta` summaries so summary-only sessions are retrievable, then merge that with conversation/event evidence, raw-output auto scope, and current/final/corrected ranking.
- Fix the ClickHouse JSONEachRow aliases for listed sessions after the sandbox MCP smoke exposed `s.session_id` keys from qualified select expressions.
- Document the agent contract and add repository/MCP tests for schemas, hybrid output, metadata search, filters, raw-output detection, recency ranking, and listed-session aliases.

## Operational impact
- MCP tool ordering and descriptions now favor the three agent-facing session tools; legacy tools remain available.
- No SQL migration or config change. The new search path uses existing `events`, `v_session_summary`, `session_meta`, and search index data.
- Search may issue bounded per-session event lookups to hydrate evidence snippets and optional context.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p moraine-mcp-core --locked`
- `cargo test -p moraine-conversations --locked`
- `cargo test --workspace --locked`
- `PATH="$HOME/.cargo/bin:$PATH" RUSTC_WRAPPER= CARGO_TARGET_DIR=target/clippy-baseline-rustup bash scripts/ci/clippy-strict-baseline.sh`
- `make docs-build`
- Sandbox `sb-290abc`: booted the Linux dev sandbox, ran targeted `moraine-mcp-core` and `moraine-conversations` crate tests, checked monitor health and ClickHouse ping, then tore it down. Outcome: tests passed, monitor returned `ok: true`, ClickHouse returned `Ok.`, and no sandbox remained.
- Sandbox MCP smoke `sb-290def`: booted a fresh sandbox, seeded `fixtures/hermes/sessions/session_20260418_142200_live01.json`, built `moraine-mcp`, initialized the stdio MCP server, verified the agent-facing tool prefix plus output schemas, and called `list_sessions`, `search_session_data`, and `open_session`. Outcome: top/opened session was `hermes:20260418_142200_live01`, raw query detection set `effective_event_scope=all`, monitor health returned `ok: true`, and teardown left no sandboxes running. This smoke caught the ClickHouse alias bug fixed in the follow-up commit.

Closes #290