### PR TITLE
[codex] Canonicalize reasoning metadata

### DIFF
--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -503,6 +503,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             name: "012_add_inference_provider_and_rename_claude.sql",
             sql: include_str!("../../../sql/012_add_inference_provider_and_rename_claude.sql"),
         },
+        Migration {
+            version: "013",
+            name: "013_canonical_reasoning_metadata.sql",
+            sql: include_str!("../../../sql/013_canonical_reasoning_metadata.sql"),
+        },
     ]
 }
 

--- a/crates/moraine-ingest-core/src/normalize.rs
+++ b/crates/moraine-ingest-core/src/normalize.rs
@@ -244,6 +244,11 @@ fn update_u8_field(row: &mut Value, key: &str, value: u8) {
     }
 }
 
+fn mark_reasoning_metadata(row: &mut Map<String, Value>) {
+    row.insert("has_reasoning".to_string(), json!(1u8));
+    row.insert("content_types".to_string(), json!(["reasoning"]));
+}
+
 pub fn infer_session_id_from_file(source_file: &str) -> String {
     let stem = std::path::Path::new(source_file)
         .file_stem()
@@ -995,7 +1000,7 @@ fn normalize_hermes_trajectory(
                                 ctx,
                                 &segment_uid,
                                 "reasoning",
-                                "thinking",
+                                "reasoning",
                                 "assistant",
                                 &thinking,
                                 &compact_json(&json!({
@@ -1005,8 +1010,7 @@ fn normalize_hermes_trajectory(
                                 })),
                             ));
                             if let Some(obj) = row.as_object_mut() {
-                                obj.insert("content_types".to_string(), json!(["thinking"]));
-                                obj.insert("has_reasoning".to_string(), json!(1u8));
+                                mark_reasoning_metadata(obj);
                                 obj.insert("turn_index".to_string(), json!(current_turn_for_item));
                             }
                             update_string_field(&mut row, "model", &model);
@@ -1424,7 +1428,7 @@ fn normalize_hermes_session_message(
                     ctx,
                     &next_uid("reasoning"),
                     "reasoning",
-                    "thinking",
+                    "reasoning",
                     "assistant",
                     &reasoning_text,
                     &compact_json(&json!({
@@ -1436,8 +1440,7 @@ fn normalize_hermes_session_message(
                     update_string_field(&mut row, "model", &model);
                 }
                 if let Some(obj) = row.as_object_mut() {
-                    obj.insert("content_types".to_string(), json!(["thinking"]));
-                    obj.insert("has_reasoning".to_string(), json!(1u8));
+                    mark_reasoning_metadata(obj);
                     obj.insert("turn_index".to_string(), json!(turn_index));
                 }
                 hermes_stamp_time(&mut row, &hermes_event_dt(base_dt, sub_event_index));
@@ -1860,7 +1863,7 @@ fn normalize_codex_event(
                         &extract_message_text(&summary),
                         &payload_json,
                     );
-                    row.insert("has_reasoning".to_string(), json!(1u8));
+                    mark_reasoning_metadata(&mut row);
                     row.insert("item_id".to_string(), json!(to_str(payload_obj.get("id"))));
                     events.push(Value::Object(row));
                 }
@@ -1968,7 +1971,7 @@ fn normalize_codex_event(
                     json!(compact_json(&payload)),
                 );
             } else if payload_type == "agent_reasoning" {
-                row.insert("has_reasoning".to_string(), json!(1u8));
+                mark_reasoning_metadata(&mut row);
             }
             events.push(Value::Object(row));
         }
@@ -2045,6 +2048,9 @@ fn normalize_codex_event(
                         &text,
                         &compact_json(item),
                     );
+                    if kind == "reasoning" {
+                        mark_reasoning_metadata(&mut row);
+                    }
                     row.insert("origin_event_id".to_string(), json!(base_uid));
                     events.push(Value::Object(row));
 
@@ -2138,7 +2144,7 @@ fn normalize_codex_event(
                     &extract_message_text(&summary),
                     &compact_json(record),
                 );
-                row.insert("has_reasoning".to_string(), json!(1u8));
+                mark_reasoning_metadata(&mut row);
                 Value::Object(row)
             };
 
@@ -2283,13 +2289,12 @@ fn normalize_claude_event(
                                 ctx,
                                 &block_uid,
                                 "reasoning",
-                                "thinking",
+                                "reasoning",
                                 "assistant",
                                 &extract_message_text(item),
                                 &compact_json(item),
                             );
-                            r.insert("has_reasoning".to_string(), json!(1u8));
-                            r.insert("content_types".to_string(), json!(["thinking"]));
+                            mark_reasoning_metadata(&mut r);
                             r
                         }
                         "tool_use" => {
@@ -2622,13 +2627,12 @@ fn normalize_kimi_cli_wire_event(
                         ctx,
                         &uid,
                         "reasoning",
-                        "thinking",
+                        "reasoning",
                         "assistant",
                         &text,
                         &payload_json,
                     );
-                    row.insert("has_reasoning".to_string(), json!(1u8));
-                    row.insert("content_types".to_string(), json!(["thinking"]));
+                    mark_reasoning_metadata(&mut row);
                     events.push(Value::Object(row));
                 }
                 _ => {
@@ -3054,6 +3058,20 @@ mod tests {
     use serde_json::{json, Value};
     use std::collections::HashMap;
 
+    fn assert_canonical_reasoning_metadata(row: &Value) {
+        let expected_content_types = json!(["reasoning"]);
+        assert_eq!(
+            row.get("event_kind").and_then(Value::as_str),
+            Some("reasoning")
+        );
+        assert_eq!(
+            row.get("payload_type").and_then(Value::as_str),
+            Some("reasoning")
+        );
+        assert_eq!(row.get("content_types"), Some(&expected_content_types));
+        assert_eq!(row.get("has_reasoning").and_then(Value::as_u64), Some(1));
+    }
+
     #[test]
     fn codex_tool_call_normalization() {
         let record = json!({
@@ -3283,6 +3301,66 @@ mod tests {
     }
 
     #[test]
+    fn codex_reasoning_branches_use_canonical_metadata() {
+        let records = [
+            json!({
+                "timestamp": "2026-02-15T03:50:50.838Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [{"type": "summary_text", "text": "think through the request"}]
+                }
+            }),
+            json!({
+                "timestamp": "2026-02-15T03:50:51.838Z",
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "top-level reasoning"}]
+            }),
+            json!({
+                "timestamp": "2026-02-15T03:50:52.838Z",
+                "type": "compacted",
+                "payload": {
+                    "replacement_history": [
+                        {
+                            "type": "reasoning",
+                            "summary": [{"type": "summary_text", "text": "compacted reasoning"}]
+                        }
+                    ]
+                }
+            }),
+        ];
+
+        for (idx, record) in records.iter().enumerate() {
+            let out = normalize_record(
+                record,
+                "codex",
+                "codex",
+                "/Users/eric/.codex/sessions/2026/02/15/session-019c5f6a-49bd-7920-ac67-1dd8e33b0e95.jsonl",
+                1,
+                1,
+                idx as u64 + 20,
+                idx as u64 + 20,
+                "",
+                "",
+            )
+            .expect("codex reasoning record should normalize");
+
+            assert!(
+                out.error_rows.is_empty(),
+                "unexpected errors for case {idx}: {:?}",
+                out.error_rows
+            );
+            let reasoning = out
+                .event_rows
+                .iter()
+                .find(|row| row.get("event_kind").and_then(Value::as_str) == Some("reasoning"))
+                .expect("reasoning row");
+            assert_canonical_reasoning_metadata(reasoning);
+        }
+    }
+
+    #[test]
     fn claude_tool_use_and_result_blocks() {
         let record = json!({
             "type": "assistant",
@@ -3347,6 +3425,46 @@ mod tests {
             "anthropic"
         );
         assert!(out.error_rows.is_empty());
+    }
+
+    #[test]
+    fn claude_reasoning_block_uses_canonical_metadata() {
+        let record = json!({
+            "type": "assistant",
+            "sessionId": "7c666c01-d38e-4658-8650-854ffb5b626e",
+            "uuid": "assistant-2",
+            "parentUuid": "user-1",
+            "requestId": "req-2",
+            "timestamp": "2026-01-19T15:58:41.421Z",
+            "message": {
+                "model": "claude-opus-4-5-20251101",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "I should answer directly."
+                    }
+                ]
+            }
+        });
+
+        let out = normalize_record(
+            &record,
+            "claude",
+            "claude-code",
+            "/Users/eric/.claude/projects/p1/s1.jsonl",
+            55,
+            2,
+            12,
+            120,
+            "",
+            "",
+        )
+        .expect("claude reasoning event should normalize");
+
+        assert_eq!(out.event_rows.len(), 1);
+        assert!(out.error_rows.is_empty());
+        assert_canonical_reasoning_metadata(&out.event_rows[0]);
     }
 
     #[test]
@@ -3908,14 +4026,7 @@ mod tests {
             .iter()
             .find(|row| row.get("event_kind") == Some(&json!("reasoning")))
             .expect("reasoning row");
-        assert_eq!(
-            reasoning.get("payload_type").and_then(Value::as_str),
-            Some("thinking")
-        );
-        assert_eq!(
-            reasoning.get("has_reasoning").and_then(Value::as_u64),
-            Some(1)
-        );
+        assert_canonical_reasoning_metadata(reasoning);
 
         let tool_call = out
             .event_rows

--- a/crates/moraine-ingest-core/tests/hermes_fixture.rs
+++ b/crates/moraine-ingest-core/tests/hermes_fixture.rs
@@ -139,7 +139,7 @@ fn hermes_fixture_round_trips_vendor_model_split_and_tool_io() {
         "model must be the verbatim right-hand side of vendor/model split",
     );
 
-    // Reasoning (from <think>) is normalized with payload_type=thinking.
+    // Reasoning (from <think>) uses the canonical reasoning metadata shape.
     let reasoning = rec
         .event_rows
         .iter()
@@ -147,7 +147,15 @@ fn hermes_fixture_round_trips_vendor_model_split_and_tool_io() {
         .expect("reasoning row");
     assert_eq!(
         reasoning.get("payload_type").and_then(Value::as_str),
-        Some("thinking"),
+        Some("reasoning"),
+    );
+    assert_eq!(
+        reasoning.get("content_types"),
+        Some(&serde_json::json!(["reasoning"])),
+    );
+    assert_eq!(
+        reasoning.get("has_reasoning").and_then(Value::as_u64),
+        Some(1),
     );
 
     // tool_call event carries the tool_call_id and name from the embedded JSON.

--- a/crates/moraine-ingest-core/tests/hermes_session_fixture.rs
+++ b/crates/moraine-ingest-core/tests/hermes_session_fixture.rs
@@ -210,6 +210,16 @@ fn session_messages_map_openai_chat_roles_to_trace_events() {
     );
     assert_eq!(
         assistant_msg.event_rows[0]
+            .get("payload_type")
+            .and_then(Value::as_str),
+        Some("reasoning"),
+    );
+    assert_eq!(
+        assistant_msg.event_rows[0].get("content_types"),
+        Some(&json!(["reasoning"])),
+    );
+    assert_eq!(
+        assistant_msg.event_rows[0]
             .get("has_reasoning")
             .and_then(Value::as_u64),
         Some(1),

--- a/crates/moraine-ingest-core/tests/kimi_cli_fixture.rs
+++ b/crates/moraine-ingest-core/tests/kimi_cli_fixture.rs
@@ -83,6 +83,14 @@ fn kimi_wire_fixture_maps_messages_tools_and_tokens() {
         Some("reasoning")
     );
     assert_eq!(
+        reasoning.get("payload_type").and_then(Value::as_str),
+        Some("reasoning")
+    );
+    assert_eq!(
+        reasoning.get("content_types"),
+        Some(&serde_json::json!(["reasoning"]))
+    );
+    assert_eq!(
         reasoning.get("has_reasoning").and_then(Value::as_u64),
         Some(1)
     );

--- a/docs/core/unified-trace-schema.md
+++ b/docs/core/unified-trace-schema.md
@@ -50,7 +50,7 @@ This page maps raw trace fields into the unified `moraine.events` table so you c
 | `latency_ms` | Not populated (defaults to `0`). | Top-level `durationMs` for non-assistant/user rows. |
 | `retry_count` | Not populated (defaults to `0`). | Top-level `retryAttempt` for non-assistant/user rows. |
 | `service_tier` | `payload.rate_limits.plan_type` for token-count rows; otherwise empty. | `message.usage.service_tier`. |
-| `content_types` | From `payload.content[].type` (message branches) when present; otherwise empty array. | For blocks: explicit single-type arrays (`thinking`, `tool_use`, `tool_result`, or block type). For non-block message rows: extracted from `message.content[].type`. |
+| `content_types` | From `payload.content[].type` (message branches) when present; explicit `["reasoning"]` for reasoning rows; otherwise empty array. | For blocks: explicit single-type arrays (`reasoning` for thinking blocks, `tool_use`, `tool_result`, or block type). For non-block message rows: extracted from `message.content[].type`. |
 | `has_reasoning` | Set to `1` for explicit reasoning branches (`response_item.reasoning`, top-level `reasoning`, and `event_msg` with `agent_reasoning`); otherwise `0`. | Set to `1` for `thinking` blocks; otherwise `0`. |
 | `text_content` | Derived via recursive text extraction over relevant payload branches (message content, tool input/output, summaries, etc.), truncated to limit. | Derived via recursive text extraction over content blocks or full record payload, truncated to limit. |
 | `text_preview` | Derived from `text_content` and truncated to preview length. | Derived from `text_content` and truncated to preview length. |
@@ -59,6 +59,12 @@ This page maps raw trace fields into the unified `moraine.events` table so you c
 | `event_version` | Not from trace. Generated from current UNIX epoch milliseconds at normalization time. | Not from trace. Generated from current UNIX epoch milliseconds at normalization time. |
 
 Field defaults and provider-specific overrides come from `base_event_obj`, `normalize_codex_event`, `normalize_claude_event`, and `normalize_record`. [src: crates/moraine-ingest-core/src/normalize.rs:L78-L104, crates/moraine-ingest-core/src/normalize.rs:L172-L230, crates/moraine-ingest-core/src/normalize.rs:L259-L379, crates/moraine-ingest-core/src/normalize.rs:L440-L997, crates/moraine-ingest-core/src/normalize.rs:L999-L1320, crates/moraine-ingest-core/src/normalize.rs:L1322-L1415]
+
+## Reasoning Metadata Backfill
+
+Current normalizers use `event_kind=reasoning`, `payload_type=reasoning`, `content_types=["reasoning"]`, and `has_reasoning=1` for reasoning rows across Codex, Claude Code, Hermes, and Kimi CLI. Existing ClickHouse deployments may still contain historical Claude / Hermes / Kimi rows with `payload_type=thinking` or `content_types=["thinking"]`, plus older Codex reasoning rows with empty `content_types`. Migration `sql/013_canonical_reasoning_metadata.sql` mutates those historical rows in `moraine.events` and updates the search projections that copied the old `payload_type` value.
+
+If operators rebuild search tables manually after this migration, run `bin/backfill-search-index` only after the ClickHouse mutations have completed so `search_documents` and `search_postings` are regenerated from canonical event rows.
 
 ## Hermes ShareGPT Mapping
 
@@ -69,7 +75,7 @@ Hermes Agent trajectories are stored as ShareGPT-compatible JSONL where one line
 - Hermes encodes the LLM vendor in the record's `model` field as `vendor/model` (e.g. `anthropic/claude-sonnet-4.6`). The normalizer splits on the first `/`: the left side becomes `inference_provider` on every emitted row, and the right side is stored verbatim as `model`. Values with no slash keep `inference_provider` empty and store the whole string as `model`.
 - `conversations[].from == "system"` becomes `event_kind=system`, `actor_kind=system`.
 - `conversations[].from == "human"` becomes `event_kind=message`, `actor_kind=user`.
-- `conversations[].from == "gpt"` is segmented: plain text becomes `message`, `<think>...</think>` becomes `reasoning` with `payload_type=thinking`, and `<tool_call>...</tool_call>` becomes `tool_call` with `payload_type=tool_use`.
+- `conversations[].from == "gpt"` is segmented: plain text becomes `message`, `<think>...</think>` becomes `reasoning` with `payload_type=reasoning` and `content_types=["reasoning"]`, and `<tool_call>...</tool_call>` becomes `tool_call` with `payload_type=tool_use`.
 - `conversations[].from == "tool"` is segmented on `<tool_response>...</tool_response>` and normalized into `tool_result` rows plus `tool_io` response rows.
 - When Hermes emits only one top-level timestamp for the entire rollout, Moraine preserves event order by assigning microsecond offsets per generated canonical event. This keeps `v_conversation_trace` chronological within the rollout while preserving the original raw JSON in `raw_events`.
 
@@ -83,13 +89,13 @@ Live Hermes CLI / gateway sessions land at `~/.hermes/sessions/session_<ts>_<id>
 - The first time a session file is seen, the processor emits one `event_kind=session_meta` row carrying `model`, `platform`, `system_prompt`, and `tools[]`. Subsequent re-reads of the same file do not re-emit the meta row unless the processor's checkpoint has been reset.
 - OpenAI chat-completions messages map one-for-one:
   - `role == "user"` → one `event_kind=message` row with `actor_kind=user`.
-  - `role == "assistant"` → optional `event_kind=reasoning` (when `reasoning` is non-empty, `payload_type=thinking`, `has_reasoning=1`) followed by optional `event_kind=message` (when `content` is non-empty, `payload_type=agent_message`, `op_status=<finish_reason>`) followed by one `event_kind=tool_call` per entry in `tool_calls[]` (function name from `function.name`, arguments parsed from `function.arguments`, `tool_call_id` from `id`).
+  - `role == "assistant"` → optional `event_kind=reasoning` (when `reasoning` is non-empty, `payload_type=reasoning`, `content_types=["reasoning"]`, `has_reasoning=1`) followed by optional `event_kind=message` (when `content` is non-empty, `payload_type=agent_message`, `op_status=<finish_reason>`) followed by one `event_kind=tool_call` per entry in `tool_calls[]` (function name from `function.name`, arguments parsed from `function.arguments`, `tool_call_id` from `id`).
   - `role == "tool"` → one `event_kind=tool_result` row correlated to the originating call via `tool_call_id`, plus a matching `tool_io` response row.
   - `role == "system"` → one `event_kind=system` row.
 - All rows emitted from one message share `turn_index = message_index + 1`, giving each conversation turn a monotonically increasing sequence for `v_conversation_trace`. Within a single message, sub-events are time-offset by microsecond so the reasoning row sorts before the tool_call row that follows it.
 
 ## Kimi CLI Mapping
 
-Kimi CLI uses `~/.kimi/sessions/**/wire.jsonl`. Wire records with `message.type=TurnBegin` or `SteerInput` become `message` / `user_message` rows. `ContentPart` with `type=text` becomes an assistant message, while `type=think` becomes a `reasoning` / `thinking` row. `ToolCall` and `ToolResult` map to `tool_call` and `tool_result` plus `tool_io` rows keyed by the Kimi tool call id. `StatusUpdate.token_usage` maps input, output, and cache token counters. Session ids are derived from the parent session directory and namespaced as `kimi-cli:<session-id>`. The leading `{"type":"metadata","protocol_version":...}` header line is skipped during normalization — it's a per-file protocol marker, not a session event.
+Kimi CLI uses `~/.kimi/sessions/**/wire.jsonl`. Wire records with `message.type=TurnBegin` or `SteerInput` become `message` / `user_message` rows. `ContentPart` with `type=text` becomes an assistant message, while `type=think` becomes a canonical `reasoning` / `reasoning` row with `content_types=["reasoning"]`. `ToolCall` and `ToolResult` map to `tool_call` and `tool_result` plus `tool_io` rows keyed by the Kimi tool call id. `StatusUpdate.token_usage` maps input, output, and cache token counters. Session ids are derived from the parent session directory and namespaced as `kimi-cli:<session-id>`. The leading `{"type":"metadata","protocol_version":...}` header line is skipped during normalization — it's a per-file protocol marker, not a session event.
 
 The sibling `context.jsonl` file is not ingested: it's a materialized-turn view that Kimi writes from the same wire events, so anything in it is already captured via `wire.jsonl` (except the system prompt, which Moraine does not persist today).

--- a/sql/013_canonical_reasoning_metadata.sql
+++ b/sql/013_canonical_reasoning_metadata.sql
@@ -1,0 +1,36 @@
+-- Canonicalize historical reasoning metadata after the normalizers moved from
+-- the legacy `thinking` label to the canonical `reasoning` label.
+--
+-- These mutations are idempotent. They cover the canonical event table and
+-- the search projections that copy `payload_type` out of `events`.
+
+ALTER TABLE moraine.events
+  UPDATE payload_type = 'reasoning',
+         content_types = ['reasoning'],
+         has_reasoning = 1
+  WHERE event_kind = 'reasoning'
+    AND (payload_type != 'reasoning'
+         OR content_types != ['reasoning']
+         OR has_reasoning != 1);
+
+ALTER TABLE moraine.events
+  UPDATE content_types = ['reasoning'],
+         has_reasoning = 1
+  WHERE payload_type = 'agent_reasoning'
+    AND (content_types != ['reasoning']
+         OR has_reasoning != 1);
+
+ALTER TABLE moraine.search_documents
+  UPDATE payload_type = 'reasoning'
+  WHERE event_class = 'reasoning'
+    AND payload_type != 'reasoning';
+
+ALTER TABLE moraine.search_postings
+  UPDATE payload_type = 'reasoning'
+  WHERE event_class = 'reasoning'
+    AND payload_type != 'reasoning';
+
+ALTER TABLE moraine.search_hit_log
+  UPDATE payload_type = 'reasoning'
+  WHERE event_class = 'reasoning'
+    AND payload_type != 'reasoning';


### PR DESCRIPTION
## What Changed

- Canonicalizes normalized reasoning rows across Codex, Claude Code, Hermes, and Kimi CLI to `payload_type = "reasoning"`, `content_types = ["reasoning"]`, and `has_reasoning = 1`.
- Adds shared reasoning metadata stamping in the ingest normalizer and regression coverage for the affected harness paths.
- Adds migration `013_canonical_reasoning_metadata.sql` to backfill historical event/search rows from legacy `thinking` metadata to canonical `reasoning` metadata.
- Updates the unified trace schema docs with the canonical shape and backfill guidance.

## Why

Fixes Issue #269 Option B: reasoning rows previously had consistent `event_kind = "reasoning"` but inconsistent finer-grained metadata, which made `payload_type` and `content_types` filters miss rows depending on harness.

## Operational Impact

Existing deployments get an idempotent ClickHouse migration that mutates historical `moraine.events` rows and search projection payload labels. No schema shape change is required.

## Validation

- `cargo fmt --all -- --check`
- pre-commit strict clippy baseline via `scripts/ci/clippy-strict-baseline.sh`
- sandbox `cargo test --workspace --locked`
- sandbox `moraine db migrate` applied migration `013`
- sandbox `/api/health` check passed

Fixes #269