### PR TITLE
[codex] render model latency spans in TurnViz

### DIFF
--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -1128,14 +1128,20 @@ fn build_turns(events: &[SessionEventRow]) -> Vec<Value> {
                 }));
             }
             ("message", "assistant", _) | (_, "assistant", "text") => {
-                turn.steps.push(json!({
+                let mut step = json!({
                     "kind": "assistant",
                     "at": event.event_ts_ms,
                     "text": preferred_text(event),
                     "tokens": event_output_tokens(event),
                     "endpointKind": event.endpoint_kind,
                     "nativeTokenUnits": nonzero_native_units(event),
-                }));
+                });
+                if event.latency_ms > 0 {
+                    if let Some(obj) = step.as_object_mut() {
+                        obj.insert("durationMs".into(), json!(event.latency_ms));
+                    }
+                }
+                turn.steps.push(step);
             }
             ("reasoning", _, _) | (_, _, "thinking") => {
                 let text = preferred_text(event);
@@ -1620,12 +1626,71 @@ mod tests {
         ))
     }
 
+    fn session_event(
+        event_kind: &str,
+        actor_kind: &str,
+        payload_type: &str,
+        at: i64,
+    ) -> SessionEventRow {
+        SessionEventRow {
+            session_id: "session-1".to_string(),
+            event_ts_ms: at,
+            event_kind: event_kind.to_string(),
+            actor_kind: actor_kind.to_string(),
+            payload_type: payload_type.to_string(),
+            tool_name: String::new(),
+            tool_call_id: String::new(),
+            tool_error: 0,
+            latency_ms: 0,
+            model: String::new(),
+            endpoint_kind: String::new(),
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            token_usage_buckets: HashMap::new(),
+            token_usage_native_units: HashMap::new(),
+            text_preview: String::new(),
+            text_content: String::new(),
+            tool_args_json: String::new(),
+        }
+    }
+
     #[test]
     fn identifier_safety_helper() {
         assert!(is_safe_identifier("events"));
         assert!(is_safe_identifier("_tmp_1"));
         assert!(!is_safe_identifier("1events"));
         assert!(!is_safe_identifier("events;drop"));
+    }
+
+    #[test]
+    fn build_turns_emits_assistant_latency_duration() {
+        let mut user = session_event("message", "user", "text", 1_000);
+        user.text_content = "run the tool".to_string();
+        let mut assistant = session_event("message", "assistant", "text", 5_500);
+        assistant.text_content = "done".to_string();
+        assistant.output_tokens = 42;
+        assistant.latency_ms = 4_500;
+
+        let turns = build_turns(&[user, assistant]);
+        let steps = turns[0]["steps"].as_array().expect("steps");
+
+        assert_eq!(steps[1]["durationMs"], json!(4_500));
+        assert_eq!(steps[1]["tokens"], json!(42));
+    }
+
+    #[test]
+    fn build_turns_omits_zero_assistant_latency_duration() {
+        let mut user = session_event("message", "user", "text", 1_000);
+        user.text_content = "fresh prompt".to_string();
+        let mut assistant = session_event("message", "assistant", "text", 1_600);
+        assistant.text_content = "first reply".to_string();
+
+        let turns = build_turns(&[user, assistant]);
+        let steps = turns[0]["steps"].as_array().expect("steps");
+
+        assert!(steps[1].get("durationMs").is_none());
     }
 
     #[test]

--- a/web/monitor/src/app.css
+++ b/web/monitor/src/app.css
@@ -1228,6 +1228,12 @@
   color: white;
 }
 
+.mv-tr-bar-duration {
+  background: color-mix(in oklab, var(--primary) 60%, var(--good));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, #fff 28%, transparent);
+  color: white;
+}
+
 .mv-tr-bar-tool_call {
   background: var(--warn);
   color: #fff;
@@ -1241,7 +1247,7 @@
 .mv-tr-bar-text {
   font-size: 0.6875rem;
   font-weight: 600;
-  letter-spacing: 0.01em;
+  letter-spacing: 0;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/web/monitor/src/lib/api/sessionsMock.ts
+++ b/web/monitor/src/lib/api/sessionsMock.ts
@@ -158,6 +158,7 @@ function makeGenerator(seed: number) {
 
     const assistantChunks = randInt(1, toolCount > 0 ? 3 : 2);
     let cursor = startedAt + randInt(200, 1800);
+    let pendingAssistantDurationMs: number | undefined;
 
     for (let i = 0; i < assistantChunks; i++) {
       steps.push({
@@ -165,7 +166,9 @@ function makeGenerator(seed: number) {
         at: cursor,
         text: ASSISTANT_TEXTS[randInt(0, ASSISTANT_TEXTS.length - 1)],
         tokens: randInt(60, 820),
+        durationMs: pendingAssistantDurationMs,
       });
+      pendingAssistantDurationMs = undefined;
       cursor += randInt(300, 4500);
 
       if (i < toolCount) {
@@ -175,7 +178,8 @@ function makeGenerator(seed: number) {
         const callAt = cursor;
         cursor += randInt(200, 6500);
         const resultAt = cursor;
-        cursor += randInt(100, 2200);
+        pendingAssistantDurationMs = randInt(100, 2200);
+        cursor += pendingAssistantDurationMs;
         const toolCall: ToolCallStep = {
           kind: 'tool_call',
           at: callAt,

--- a/web/monitor/src/lib/components/sessions/TurnViz.svelte
+++ b/web/monitor/src/lib/components/sessions/TurnViz.svelte
@@ -20,11 +20,45 @@
     return 'text' in step && typeof step.text === 'string';
   }
 
+  function stepDurationMs(step: Step): number | undefined {
+    if ('durationMs' in step && typeof step.durationMs === 'number' && step.durationMs > 0) {
+      return step.durationMs;
+    }
+    return undefined;
+  }
+
+  function traceRange(step: Step): { start: number; end: number } {
+    if (step.kind === 'tool_call') {
+      return { start: step.at, end: Math.max(step.at, step.resultAt) };
+    }
+
+    const durationMs = stepDurationMs(step);
+    if (durationMs) {
+      return { start: step.at - durationMs, end: step.at };
+    }
+
+    return { start: step.at, end: step.at + 600 };
+  }
+
+  function traceTooltip(step: Step): string {
+    if (step.kind === 'tool_call') {
+      return `${step.tool} tool call · ${fmtDuration(step.latencyMs)}`;
+    }
+
+    const durationMs = stepDurationMs(step);
+    if (durationMs) {
+      return `${step.kind} · model latency ${fmtDuration(durationMs)}`;
+    }
+
+    return step.kind;
+  }
+
   $: traceBounds = computeTraceBounds(turn);
 
   function computeTraceBounds(t: Turn): { start: number; span: number } {
-    const start = t.startedAt;
-    const ends = t.steps.map((s) => (s.kind === 'tool_call' ? s.resultAt : s.at));
+    const ranges = t.steps.map(traceRange);
+    const start = Math.min(t.startedAt, ...ranges.map((r) => r.start));
+    const ends = ranges.map((r) => r.end);
     const end = Math.max(t.endedAt, ...ends);
     return { start, span: Math.max(1, end - start) };
   }
@@ -96,8 +130,10 @@
     </div>
     {#each steps as step, i (keyFor(step, i))}
       {@const key = keyFor(step, i)}
-      {@const at = step.at}
-      {@const endAt = step.kind === 'tool_call' ? step.resultAt : step.at + 600}
+      {@const durationMs = stepDurationMs(step)}
+      {@const range = traceRange(step)}
+      {@const at = range.start}
+      {@const endAt = range.end}
       {@const leftPct = ((at - traceBounds.start) / traceBounds.span) * 100}
       {@const widthPct = Math.max(1, ((endAt - at) / traceBounds.span) * 100)}
       {@const expanded = expandedTools.has(key)}
@@ -107,14 +143,17 @@
         <div class="mv-tr-track">
           <button
             type="button"
-            class="mv-tr-bar mv-tr-bar-{step.kind}"
+            class="mv-tr-bar mv-tr-bar-{step.kind} {durationMs ? 'mv-tr-bar-duration' : ''}"
             class:is-error={step.kind === 'tool_call' && step.status === 'error'}
+            title={traceTooltip(step)}
             style="left: {leftPct}%; width: {widthPct}%"
             on:click={() => step.kind === 'tool_call' && dispatch('toggleTool', key)}
           >
             <span class="mv-tr-bar-text mono">
               {#if step.kind === 'tool_call'}
                 {step.tool} · {step.latencyMs}ms
+              {:else if durationMs}
+                {step.kind} · {fmtDuration(durationMs)}
               {:else if step.kind === 'assistant' && step.tokens}
                 {step.kind} · {step.tokens} tok
               {:else}

--- a/web/monitor/src/lib/types/sessions.ts
+++ b/web/monitor/src/lib/types/sessions.ts
@@ -27,6 +27,7 @@ export interface AssistantStep {
   at: number;
   text: string;
   tokens?: number;
+  durationMs?: number;
 }
 
 export interface ThinkingStep {


### PR DESCRIPTION
## Summary

- Surface nonzero assistant `latency_ms` values as optional `durationMs` fields in monitor session trace steps.
- Render duration-backed assistant trace bars backward from the assistant timestamp so the band covers model-side time after a tool result.
- Add tooltip text, distinct trace styling, mock-session coverage, and monitor-core tests for zero/nonzero latency serialization.

## Operational impact

- Monitor API gains an optional `durationMs` field on assistant steps.
- No schema, migration, or config changes.
- Assistant turns with `latency_ms = 0` keep the previous fallback trace width.

## Validation

- `cargo test -p moraine-monitor-core --locked`
- `cd web/monitor && bun install --frozen-lockfile`
- `cd web/monitor && bun run typecheck`
- `cd web/monitor && bun run test`
- `cd web/monitor && bun run build`
- Sandbox `sb-397024`: `curl /api/health`, `cargo test --workspace --locked` inside `/repo`, `curl /api/sessions?limit=1`, and root HTML smoke request; sandbox was torn down.
- Pre-commit hook passed: `cargo fmt --all -- --check` and `scripts/ci/clippy-strict-baseline.sh` with rustup cargo/rustc/clippy first in `PATH`.

Closes #264.