### PR TITLE
[codex] fix local cargo checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -28,10 +28,10 @@ if [[ -z "$staged_rust" ]]; then
   exit 0
 fi
 
-echo "[pre-commit] cargo fmt --all -- --check"
-cargo fmt --all -- --check
+echo "[pre-commit] make fmt"
+make fmt
 
 echo "[pre-commit] clippy (strict baseline, matches CI)"
-bash scripts/ci/clippy-strict-baseline.sh
+make clippy
 
 echo "[pre-commit] ok"

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,32 @@
 SHELL := /bin/bash
 UV ?= uv
 DOCS_ADDR ?= 127.0.0.1:8000
+RUSTUP ?= rustup
+RUST_TOOLCHAIN ?= stable
+RUSTUP_BIN_DIR ?= $(shell command -v $(RUSTUP) >/dev/null 2>&1 && dirname "$$(command -v $(RUSTUP))" || printf '%s' "$$HOME/.cargo/bin")
+USE_RUSTUP ?= 1
+CARGO_CMD ?= cargo
 
-.PHONY: help docs-build docs-serve docs-clean docs-prepare sandbox-up sandbox-down sandbox-list hooks-install
+ifeq ($(USE_RUSTUP),1)
+CARGO_ENV = PATH='$(RUSTUP_BIN_DIR):$(PATH)' RUSTUP_TOOLCHAIN='$(RUST_TOOLCHAIN)'
+DEFAULT_CARGO_TARGET_DIR = target/rustup-$(RUST_TOOLCHAIN)
+else
+CARGO_ENV =
+DEFAULT_CARGO_TARGET_DIR = target/host
+endif
+
+CARGO_TARGET_DIR ?= $(DEFAULT_CARGO_TARGET_DIR)
+RUST_LABEL = $(if $(filter 1,$(USE_RUSTUP)),$(RUST_TOOLCHAIN) via $(RUSTUP_BIN_DIR),host PATH)
+
+.PHONY: help fmt clippy build test ci-check docs-build docs-serve docs-clean docs-prepare sandbox-up sandbox-down sandbox-list hooks-install
 
 help:
 	@echo "Available targets:"
+	@echo "  make fmt            Check Rust formatting"
+	@echo "  make clippy         Run strict clippy baseline"
+	@echo "  make build          Build all workspace crates"
+	@echo "  make test           Run workspace tests"
+	@echo "  make ci-check       Run local CI checks: fmt, clippy, build, test"
 	@echo "  make docs-build     Build static docs site into ./site"
 	@echo "  make docs-serve     Run live docs server at $(DOCS_ADDR)"
 	@echo "  make docs-clean     Remove generated docs site output"
@@ -14,6 +35,29 @@ help:
 	@echo "  make sandbox-down   Tear down all dev sandboxes owned by this user"
 	@echo "  make sandbox-list   List running dev sandboxes"
 	@echo "  make hooks-install  Enable repo-managed git hooks (fmt + clippy pre-commit)"
+	@echo ""
+	@echo "Rust toolchain: $(RUST_LABEL)"
+	@echo "Cargo command: $(CARGO_CMD)"
+	@echo "Cargo target dir: $(CARGO_TARGET_DIR)"
+	@echo "Override with: make ci-check USE_RUSTUP=0 CARGO_TARGET_DIR=target/nix"
+
+fmt:
+	@echo "[fmt] $(RUST_LABEL)"
+	@$(CARGO_ENV) $(CARGO_CMD) fmt --all -- --check
+
+clippy:
+	@echo "[clippy] $(RUST_LABEL); target $(CARGO_TARGET_DIR)"
+	@$(CARGO_ENV) CARGO_TARGET_DIR='$(CARGO_TARGET_DIR)' MORAINE_CARGO='$(CARGO_CMD)' bash scripts/ci/clippy-strict-baseline.sh
+
+build:
+	@echo "[build] $(RUST_LABEL); target $(CARGO_TARGET_DIR)"
+	@$(CARGO_ENV) CARGO_TARGET_DIR='$(CARGO_TARGET_DIR)' $(CARGO_CMD) build --workspace --locked
+
+test:
+	@echo "[test] $(RUST_LABEL); target $(CARGO_TARGET_DIR)"
+	@$(CARGO_ENV) CARGO_TARGET_DIR='$(CARGO_TARGET_DIR)' $(CARGO_CMD) test --workspace --locked
+
+ci-check: fmt clippy build test
 
 hooks-install:
 	scripts/dev/install-hooks.sh

--- a/scripts/ci/clippy-strict-baseline.sh
+++ b/scripts/ci/clippy-strict-baseline.sh
@@ -10,4 +10,20 @@ CLIPPY_BASELINE_FLAGS=(
   -Aclippy::too_many_arguments
 )
 
-cargo clippy --workspace --all-targets --locked -- -Dwarnings "${CLIPPY_BASELINE_FLAGS[@]}"
+if [[ -n "${MORAINE_CARGO:-}" ]]; then
+  # shellcheck disable=SC2206
+  CARGO_CMD=(${MORAINE_CARGO})
+elif [[ -n "${CARGO_CMD:-}" ]]; then
+  # shellcheck disable=SC2206
+  CARGO_CMD=(${CARGO_CMD})
+elif command -v rustup >/dev/null 2>&1; then
+  rustup_bin="$(dirname "$(command -v rustup)")"
+  export PATH="${rustup_bin}:${PATH}"
+  export RUSTUP_TOOLCHAIN="${RUST_TOOLCHAIN:-stable}"
+  CARGO_CMD=(cargo)
+else
+  CARGO_CMD=(cargo)
+fi
+
+echo "[clippy] using: ${CARGO_CMD[*]}"
+"${CARGO_CMD[@]}" clippy --workspace --all-targets --locked -- -Dwarnings "${CLIPPY_BASELINE_FLAGS[@]}"


### PR DESCRIPTION
## What changed

- Added `make fmt`, `make clippy`, `make build`, `make test`, and `make ci-check` targets.
- Defaulted local Make-driven Rust checks to the Rustup `stable` toolchain by prepending the Rustup bin directory and setting `RUSTUP_TOOLCHAIN`.
- Isolated Make-driven build artifacts under `target/rustup-stable` by default so Nix and Rustup artifacts do not collide.
- Routed the pre-commit hook through the Make targets and taught the clippy baseline script to honor the selected cargo command.

## Why

Local checks were mixing Nix-provided `cargo`/`rustc` with Rustup-provided tools, which can make clippy and CI-style checks fail with incompatible compiler artifact errors.

## Impact

Developers can run `make ci-check` for the same local fmt, clippy, build, and test sequence without needing to manually sanitize `PATH` or clean shared `target` artifacts. Nix users can still opt into host toolchain behavior with `make ci-check USE_RUSTUP=0 CARGO_TARGET_DIR=target/nix`.

## Validation

- `make ci-check`