### PR TITLE
fix(mcp): speed up session search evidence

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo.rs
@@ -196,6 +196,8 @@ struct OpenTargetRow {
 struct SearchRow {
     event_uid: String,
     session_id: String,
+    #[serde(default)]
+    event_time: String,
     source_name: String,
     harness: String,
     #[serde(default)]
@@ -235,6 +237,8 @@ struct FetchedPostingRow {
 struct SearchDocExtraRow {
     event_uid: String,
     session_id: String,
+    #[serde(default)]
+    event_time: String,
     source_name: String,
     harness: String,
     #[serde(default)]
@@ -394,6 +398,7 @@ struct TermPostingsCacheEntry {
 #[derive(Debug, Clone)]
 struct SearchDocExtraCacheEntry {
     session_id: String,
+    event_time: String,
     source_name: String,
     harness: String,
     inference_provider: String,
@@ -520,6 +525,7 @@ impl ClickHouseConversationRepository {
                     source: Some(BENCHMARK_REPLAY_SOURCE.to_string()),
                     limit: Some(limit),
                     session_id: None,
+                    session_ids: None,
                     min_score: None,
                     min_should_match: None,
                     include_tool_events: None,
@@ -548,6 +554,7 @@ impl ClickHouseConversationRepository {
                     source: Some(BENCHMARK_REPLAY_SOURCE.to_string()),
                     limit: Some(limit),
                     session_id: None,
+                    session_ids: None,
                     min_score: None,
                     min_should_match: None,
                     include_tool_events: None,
@@ -610,6 +617,7 @@ impl ClickHouseConversationRepository {
         event_kinds: Option<&[SearchEventKind]>,
         exclude_codex_mcp: bool,
         session_id: Option<&str>,
+        session_ids: Option<&[String]>,
         min_should_match: u16,
         min_score: f64,
         limit: u16,
@@ -625,8 +633,15 @@ impl ClickHouseConversationRepository {
                     .join(",")
             })
             .unwrap_or_default();
+        let session_ids_sig = session_ids
+            .map(|ids| {
+                let mut ids = ids.to_vec();
+                ids.sort_unstable();
+                ids.join(",")
+            })
+            .unwrap_or_default();
         format!(
-            "strategy={};incl_tools={include_tool_events};event_kinds={event_kind_sig};excl_codex={exclude_codex_mcp};session={};msm={min_should_match};min_score={min_score:.12};limit={limit};terms={}",
+            "strategy={};incl_tools={include_tool_events};event_kinds={event_kind_sig};excl_codex={exclude_codex_mcp};session={};sessions={session_ids_sig};msm={min_should_match};min_score={min_score:.12};limit={limit};terms={}",
             search_strategy.as_str(),
             session_id.unwrap_or(""),
             cache_terms.join(",")
@@ -1424,6 +1439,7 @@ FORMAT JSONEachRow",
         exclude_codex_mcp: bool,
         use_document_codex_flag: bool,
         session_id: Option<&str>,
+        session_ids: Option<&[String]>,
         min_should_match: u16,
         min_score: f64,
         limit: u16,
@@ -1447,6 +1463,7 @@ FORMAT JSONEachRow",
                 "(SELECT
   t.event_uid AS event_uid,
   any(t.session_id) AS session_id,
+  any(t.record_ts) AS event_time,
   any(t.source_name) AS source_name,
   any(t.harness) AS harness,
   any(t.inference_provider) AS inference_provider,
@@ -1468,6 +1485,7 @@ GROUP BY t.event_uid)"
                 "(SELECT
   t.event_uid AS event_uid,
   any(t.session_id) AS session_id,
+  any(t.record_ts) AS event_time,
   any(t.source_name) AS source_name,
   any(t.harness) AS harness,
   any(t.inference_provider) AS inference_provider,
@@ -1490,6 +1508,14 @@ GROUP BY t.event_uid)"
 
         if let Some(sid) = session_id {
             where_clauses.push(format!("d.session_id = {}", sql_quote(sid)));
+        }
+        if let Some(session_ids) = session_ids {
+            if !session_ids.is_empty() {
+                where_clauses.push(format!(
+                    "d.session_id IN {}",
+                    sql_array_strings(session_ids)
+                ));
+            }
         }
 
         if let Some(event_kinds) = event_kinds {
@@ -1536,6 +1562,7 @@ GROUP BY t.event_uid)"
 SELECT
   p.doc_id AS event_uid,
   any(d.session_id) AS session_id,
+  any(d.event_time) AS event_time,
   any(d.source_name) AS source_name,
   any(d.harness) AS harness,
   any(d.inference_provider) AS inference_provider,
@@ -1599,6 +1626,7 @@ FORMAT JSONEachRow",
                 "(SELECT
   t.event_uid AS event_uid,
   any(t.session_id) AS session_id,
+  any(t.record_ts) AS event_time,
   any(t.source_name) AS source_name,
   any(t.harness) AS harness,
   any(t.inference_provider) AS inference_provider,
@@ -1621,6 +1649,7 @@ GROUP BY t.event_uid)"
                 "(SELECT
   t.event_uid AS event_uid,
   any(t.session_id) AS session_id,
+  any(t.record_ts) AS event_time,
   any(t.source_name) AS source_name,
   any(t.harness) AS harness,
   any(t.inference_provider) AS inference_provider,
@@ -1644,6 +1673,7 @@ GROUP BY t.event_uid)"
             "SELECT
   d.event_uid AS event_uid,
   d.session_id AS session_id,
+  d.event_time AS event_time,
   d.source_name AS source_name,
   d.harness AS harness,
   d.inference_provider AS inference_provider,
@@ -1704,9 +1734,15 @@ FORMAT JSONEachRow",
         event_kinds: Option<&[SearchEventKind]>,
         exclude_codex_mcp: bool,
         session_id: Option<&str>,
+        session_ids: Option<&[String]>,
     ) -> bool {
         if let Some(sid) = session_id {
             if row.session_id != sid {
+                return false;
+            }
+        }
+        if let Some(session_ids) = session_ids {
+            if !session_ids.iter().any(|sid| sid == &row.session_id) {
                 return false;
             }
         }
@@ -1894,6 +1930,7 @@ FORMAT JSONEachRow",
             for row in fetched_rows {
                 let entry = SearchDocExtraCacheEntry {
                     session_id: row.session_id,
+                    event_time: row.event_time,
                     source_name: row.source_name,
                     harness: row.harness,
                     inference_provider: row.inference_provider,
@@ -1939,6 +1976,7 @@ FORMAT JSONEachRow",
         event_kinds: Option<&[SearchEventKind]>,
         exclude_codex_mcp: bool,
         session_id: Option<&str>,
+        session_ids: Option<&[String]>,
         min_should_match: u16,
         min_score: f64,
         limit: u16,
@@ -1952,6 +1990,7 @@ FORMAT JSONEachRow",
                 event_kinds,
                 exclude_codex_mcp,
                 session_id,
+                session_ids,
                 min_should_match,
                 min_score,
                 limit,
@@ -1970,6 +2009,7 @@ FORMAT JSONEachRow",
             event_kinds,
             exclude_codex_mcp,
             session_id,
+            session_ids,
             min_should_match,
             min_score,
             limit,
@@ -1986,6 +2026,7 @@ FORMAT JSONEachRow",
         event_kinds: Option<&[SearchEventKind]>,
         exclude_codex_mcp: bool,
         session_id: Option<&str>,
+        session_ids: Option<&[String]>,
         min_should_match: u16,
         min_score: f64,
         limit: u16,
@@ -2007,6 +2048,7 @@ FORMAT JSONEachRow",
             exclude_codex_mcp,
             use_document_codex_flag,
             session_id,
+            session_ids,
             min_should_match,
             min_score,
             limit,
@@ -2032,6 +2074,7 @@ FORMAT JSONEachRow",
         event_kinds: Option<&[SearchEventKind]>,
         exclude_codex_mcp: bool,
         session_id: Option<&str>,
+        session_ids: Option<&[String]>,
         min_should_match: u16,
         min_score: f64,
         limit: u16,
@@ -2046,6 +2089,7 @@ FORMAT JSONEachRow",
                     event_kinds,
                     exclude_codex_mcp,
                     session_id,
+                    session_ids,
                     min_should_match,
                     min_score,
                     limit,
@@ -2061,6 +2105,7 @@ FORMAT JSONEachRow",
                     event_kinds,
                     exclude_codex_mcp,
                     session_id,
+                    session_ids,
                     min_should_match,
                     min_score,
                     limit,
@@ -2174,6 +2219,7 @@ FORMAT JSONEachRow",
         event_kinds: Option<&[SearchEventKind]>,
         exclude_codex_mcp: bool,
         session_id: Option<&str>,
+        session_ids: Option<&[String]>,
         min_should_match: u16,
         min_score: f64,
         limit: u16,
@@ -2278,6 +2324,7 @@ FORMAT JSONEachRow",
                     event_kinds,
                     exclude_codex_mcp,
                     session_id,
+                    session_ids,
                 ) {
                     continue;
                 }
@@ -2285,6 +2332,7 @@ FORMAT JSONEachRow",
                 fast_rows.push(SearchRow {
                     event_uid: row.row.event_uid.clone(),
                     session_id: extra.session_id.clone(),
+                    event_time: extra.event_time.clone(),
                     source_name: extra.source_name.clone(),
                     harness: extra.harness.clone(),
                     inference_provider: extra.inference_provider.clone(),
@@ -2892,17 +2940,18 @@ FORMAT JSONEachRow",
             return Ok(HashMap::new());
         }
 
-        let session_summary_table = self.table_ref("v_session_summary");
+        let events_table = self.table_ref("events");
         let session_ids_sql = sql_array_strings(&unique_session_ids);
         let sql = format!(
             "SELECT
-  s.session_id AS session_id,
-  toString(s.first_event_time) AS first_event_time,
-  toString(s.last_event_time) AS last_event_time
-FROM {session_summary_table} AS s
-WHERE s.session_id IN {session_ids_sql}
+  session_id,
+  toString(min(event_ts)) AS first_event_time,
+  toString(max(event_ts)) AS last_event_time
+FROM {events_table}
+WHERE session_id IN {session_ids_sql}
+GROUP BY session_id
 FORMAT JSONEachRow",
-            session_summary_table = session_summary_table,
+            events_table = events_table,
             session_ids_sql = session_ids_sql,
         );
 
@@ -2956,6 +3005,7 @@ FORMAT JSONEachRow",
                     rank: idx + 1,
                     event_uid: row.event_uid,
                     session_id,
+                    event_time: (!row.event_time.is_empty()).then_some(row.event_time),
                     first_event_time,
                     last_event_time,
                     source_name: row.source_name,
@@ -3841,10 +3891,29 @@ FORMAT JSONEachRow",
         let disable_cache = query.disable_cache.unwrap_or(false);
         let effective_strategy = query.search_strategy.unwrap_or_default();
 
-        if let Some(session_id) = query.session_id.as_deref() {
+        let session_id = query.session_id.clone();
+        if let Some(session_id) = session_id.as_deref() {
             Self::validate_session_id(session_id)?;
         }
-        let session_id = query.session_id.as_deref();
+        let mut session_ids = query
+            .session_ids
+            .unwrap_or_default()
+            .into_iter()
+            .map(|session_id| session_id.trim().to_string())
+            .filter(|session_id| !session_id.is_empty())
+            .collect::<Vec<_>>();
+        session_ids.sort_unstable();
+        session_ids.dedup();
+        for session_id in &session_ids {
+            Self::validate_session_id(session_id)?;
+        }
+        let session_id = session_id.as_deref();
+        let session_ids = (!session_ids.is_empty()).then_some(session_ids);
+        let session_ids_ref = session_ids.as_deref();
+        let session_hint = session_id
+            .map(ToOwned::to_owned)
+            .or_else(|| session_ids_ref.map(|ids| ids.join(",")))
+            .unwrap_or_default();
 
         let (docs, total_doc_len) = self.corpus_stats().await?;
         if docs == 0 {
@@ -3879,6 +3948,7 @@ FORMAT JSONEachRow",
                     event_kinds.as_deref(),
                     exclude_codex_mcp,
                     session_id,
+                    session_ids_ref,
                     min_should_match,
                     min_score,
                     fetch_limit,
@@ -3894,6 +3964,7 @@ FORMAT JSONEachRow",
                 event_kinds.as_deref(),
                 exclude_codex_mcp,
                 session_id,
+                session_ids_ref,
                 min_should_match,
                 min_score,
                 limit,
@@ -3912,6 +3983,7 @@ FORMAT JSONEachRow",
                         event_kinds.as_deref(),
                         exclude_codex_mcp,
                         session_id,
+                        session_ids_ref,
                         min_should_match,
                         min_score,
                         fetch_limit,
@@ -3931,7 +4003,7 @@ FORMAT JSONEachRow",
                 &query_id,
                 source,
                 query_text,
-                session_id.unwrap_or(""),
+                &session_hint,
                 &terms,
                 limit,
                 min_should_match,
@@ -4345,6 +4417,7 @@ mod tests {
     fn sample_search_doc() -> SearchDocExtraCacheEntry {
         SearchDocExtraCacheEntry {
             session_id: "session-1".to_string(),
+            event_time: "2026-04-27T12:00:00.000Z".to_string(),
             source_name: "source".to_string(),
             harness: "harness".to_string(),
             inference_provider: "inference-provider".to_string(),
@@ -4376,6 +4449,7 @@ mod tests {
         SearchRow {
             event_uid: event_uid.to_string(),
             session_id: session_id.to_string(),
+            event_time: "2026-04-27T12:00:00.000Z".to_string(),
             source_name: "source".to_string(),
             harness: "harness".to_string(),
             inference_provider: "inference-provider".to_string(),
@@ -4438,7 +4512,7 @@ mod tests {
         row.has_codex_mcp = 1;
         assert!(
             !ClickHouseConversationRepository::passes_search_doc_filters(
-                &row, false, None, true, None
+                &row, false, None, true, None, None
             )
         );
     }
@@ -4449,7 +4523,7 @@ mod tests {
         row.name = "search".to_string();
         assert!(
             !ClickHouseConversationRepository::passes_search_doc_filters(
-                &row, false, None, true, None
+                &row, false, None, true, None, None
             )
         );
     }
@@ -4465,6 +4539,7 @@ mod tests {
             false,
             Some(&[SearchEventKind::ToolResult]),
             false,
+            None,
             None
         ));
         assert!(
@@ -4473,6 +4548,7 @@ mod tests {
                 true,
                 Some(&[SearchEventKind::Message]),
                 false,
+                None,
                 None
             )
         );
@@ -4489,6 +4565,7 @@ mod tests {
             true,
             Some(&[SearchEventKind::Reasoning]),
             false,
+            None,
             None
         ));
         assert!(
@@ -4497,6 +4574,7 @@ mod tests {
                 true,
                 Some(&[SearchEventKind::Message]),
                 false,
+                None,
                 None
             )
         );

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -230,6 +230,8 @@ pub struct SearchEventsQuery {
     #[serde(default)]
     pub session_id: Option<String>,
     #[serde(default)]
+    pub session_ids: Option<Vec<String>>,
+    #[serde(default)]
     pub min_score: Option<f64>,
     #[serde(default)]
     pub min_should_match: Option<u16>,
@@ -330,6 +332,8 @@ pub struct SearchEventHit {
     pub rank: usize,
     pub event_uid: String,
     pub session_id: String,
+    #[serde(default)]
+    pub event_time: Option<String>,
     pub first_event_time: String,
     pub last_event_time: String,
     pub source_name: String,

--- a/crates/moraine-conversations/tests/repository_integration.rs
+++ b/crates/moraine-conversations/tests/repository_integration.rs
@@ -284,10 +284,10 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
             );
         }
 
-        if query.contains("FROM `moraine`.`v_session_summary` AS s")
-            && query.contains("WHERE s.session_id IN")
-            && query.contains("toString(s.first_event_time) AS first_event_time")
-            && query.contains("toString(s.last_event_time) AS last_event_time")
+        if query.contains("FROM `moraine`.`events`")
+            && query.contains("WHERE session_id IN")
+            && query.contains("toString(min(event_ts)) AS first_event_time")
+            && query.contains("toString(max(event_ts)) AS last_event_time")
         {
             return (
                 StatusCode::OK,
@@ -1358,6 +1358,7 @@ async fn search_events_includes_session_time_bounds() {
             source: Some("integration-test".to_string()),
             limit: Some(10),
             session_id: None,
+            session_ids: None,
             min_score: Some(0.0),
             min_should_match: Some(1),
             include_tool_events: Some(true),
@@ -1396,6 +1397,7 @@ async fn search_events_documents_subquery_avoids_self_aliased_aggregates() {
             source: Some("integration-test".to_string()),
             limit: Some(10),
             session_id: None,
+            session_ids: None,
             min_score: Some(0.0),
             min_should_match: Some(1),
             include_tool_events: Some(true),

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -8,7 +8,7 @@ description = "MCP protocol and tool routing core for Moraine"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.40", features = ["io-std", "io-util", "sync", "time"] }
+tokio = { version = "1.40", features = ["io-std", "io-util", "rt", "sync", "time"] }
 tracing = "0.1"
 moraine-config = { path = "../moraine-config" }
 moraine-clickhouse = { path = "../moraine-clickhouse" }

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -175,6 +175,23 @@ impl RecencyPolicy {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum EvidencePolicy {
+    #[default]
+    Fast,
+    Complete,
+}
+
+impl EvidencePolicy {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Fast => "fast",
+            Self::Complete => "complete",
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct SearchSessionDataArgs {
     query: String,
@@ -186,6 +203,8 @@ struct SearchSessionDataArgs {
     event_scope: Option<SessionSearchEventScope>,
     #[serde(default)]
     recency_policy: Option<RecencyPolicy>,
+    #[serde(default)]
+    evidence_policy: Option<EvidencePolicy>,
     #[serde(default)]
     from_unix_ms: Option<i64>,
     #[serde(default)]
@@ -867,6 +886,12 @@ impl AppState {
                                 "default": "auto",
                                 "description": "Auto prefers current/final/latest/corrected evidence and down-ranks stale, draft, provisional, or deprecated notes when the query asks for that."
                             },
+                            "evidence_policy": {
+                                "type": "string",
+                                "enum": ["fast", "complete"],
+                                "default": "fast",
+                                "description": "Use fast for lowest latency. Use complete only when every returned session needs up to matching_events_limit per-session event evidence hits."
+                            },
                             "from_unix_ms": { "type": "integer" },
                             "to_unix_ms": { "type": "integer" },
                             "mode": {
@@ -900,6 +925,7 @@ impl AppState {
                             "effective_event_scope": { "type": "string" },
                             "recency_policy": { "type": "string" },
                             "recency_applied": { "type": "boolean" },
+                            "evidence_policy": { "type": "string" },
                             "hits": {
                                 "type": "array",
                                 "items": {
@@ -1380,6 +1406,7 @@ impl AppState {
                 source: Some("moraine-mcp".to_string()),
                 limit: args.limit,
                 session_id: args.session_id,
+                session_ids: None,
                 min_score: args.min_score,
                 min_should_match: args.min_should_match,
                 include_tool_events: args.include_tool_events,
@@ -1618,6 +1645,7 @@ impl AppState {
         };
         let recency_policy = args.recency_policy.unwrap_or_default();
         let recency_applied = recency_policy.is_active_for_query(&query);
+        let evidence_policy = args.evidence_policy.unwrap_or_default();
         let limit = args.limit.unwrap_or(SESSION_SEARCH_DEFAULT_LIMIT);
         let matching_events_limit = args
             .matching_events_limit
@@ -1728,6 +1756,7 @@ impl AppState {
                         source: Some("moraine-mcp".to_string()),
                         limit: Some(matching_events_limit),
                         session_id: Some(session_id.to_string()),
+                        session_ids: None,
                         min_score: None,
                         min_should_match: None,
                         include_tool_events: Some(effective_include_tool_events),
@@ -1765,14 +1794,25 @@ impl AppState {
         }
 
         let mut candidates = candidates.into_values().collect::<Vec<_>>();
-        for candidate in &mut candidates {
+        rank_session_search_candidates(&mut candidates, recency_applied, limit);
+        let candidate_session_ids = candidates
+            .iter()
+            .map(|candidate| candidate.session_id.clone())
+            .collect::<Vec<_>>();
+        let evidence_search_limit = matching_events_limit
+            .saturating_mul(candidate_session_ids.len() as u16)
+            .max(matching_events_limit)
+            .min(self.cfg.mcp.max_results.max(TOOL_LIMIT_MIN));
+        let mut evidence_by_session = HashMap::<String, Vec<SessionSearchEvidence>>::new();
+        if !candidate_session_ids.is_empty() {
             let event_results = self
                 .repo
                 .search_events(SearchEventsQuery {
                     query: query.clone(),
                     source: Some("moraine-mcp".to_string()),
-                    limit: Some(matching_events_limit),
-                    session_id: Some(candidate.session_id.clone()),
+                    limit: Some(evidence_search_limit),
+                    session_id: None,
+                    session_ids: Some(candidate_session_ids.clone()),
                     min_score: None,
                     min_should_match: None,
                     include_tool_events: Some(effective_include_tool_events),
@@ -1785,9 +1825,64 @@ impl AppState {
                 .map_err(|err| anyhow!(err.to_string()))?;
 
             for event_hit in event_results.hits {
-                candidate
-                    .evidence
-                    .push(self.search_event_evidence(&event_hit).await?);
+                let evidence = evidence_by_session
+                    .entry(event_hit.session_id.clone())
+                    .or_default();
+                if evidence.len() < matching_events_limit as usize {
+                    evidence.push(search_event_evidence(&event_hit));
+                }
+            }
+
+            if evidence_policy == EvidencePolicy::Complete {
+                let underfilled_session_ids = underfilled_evidence_sessions(
+                    &candidate_session_ids,
+                    &evidence_by_session,
+                    matching_events_limit,
+                );
+                let mut tasks = Vec::with_capacity(underfilled_session_ids.len());
+                for session_id in underfilled_session_ids {
+                    let repo = self.repo.clone();
+                    let query = query.clone();
+                    tasks.push(tokio::spawn(async move {
+                        let event_results = repo
+                            .search_events(SearchEventsQuery {
+                                query,
+                                source: Some("moraine-mcp".to_string()),
+                                limit: Some(matching_events_limit),
+                                session_id: Some(session_id.clone()),
+                                session_ids: None,
+                                min_score: None,
+                                min_should_match: None,
+                                include_tool_events: Some(effective_include_tool_events),
+                                event_kinds: None,
+                                exclude_codex_mcp: Some(true),
+                                disable_cache: None,
+                                search_strategy: None,
+                            })
+                            .await
+                            .map_err(|err| anyhow!(err.to_string()))?;
+
+                        let evidence = event_results
+                            .hits
+                            .iter()
+                            .map(search_event_evidence)
+                            .collect::<Vec<_>>();
+                        Ok::<_, anyhow::Error>((session_id, evidence))
+                    }));
+                }
+
+                for task in tasks {
+                    let (session_id, evidence) = task
+                        .await
+                        .context("failed to join supplemental evidence search")??;
+                    evidence_by_session.insert(session_id, evidence);
+                }
+            }
+        }
+
+        for candidate in &mut candidates {
+            if let Some(evidence) = evidence_by_session.remove(&candidate.session_id) {
+                candidate.evidence.extend(evidence);
             }
 
             self.add_summary_evidence(candidate);
@@ -1812,15 +1907,6 @@ impl AppState {
             }
         }
 
-        apply_recency_adjustments(&mut candidates, recency_applied);
-        candidates.sort_by(|a, b| {
-            b.score
-                .total_cmp(&a.score)
-                .then_with(|| b.last_event_unix_ms.cmp(&a.last_event_unix_ms))
-                .then_with(|| a.session_id.cmp(&b.session_id))
-        });
-        candidates.truncate(limit as usize);
-
         let hits = candidates
             .into_iter()
             .enumerate()
@@ -1833,6 +1919,7 @@ impl AppState {
             "effective_event_scope": effective_scope,
             "recency_policy": recency_policy.as_str(),
             "recency_applied": recency_applied,
+            "evidence_policy": evidence_policy.as_str(),
             "matching_events_limit": matching_events_limit,
             "include_context": include_context,
             "stats": {
@@ -1874,47 +1961,6 @@ impl AppState {
         candidate.matched_terms = candidate.matched_terms.max(hit.matched_terms);
         candidate.summary_event_uid = hit.meta_event_uid.or(candidate.summary_event_uid.take());
         candidate.summary_snippet = hit.snippet.or(candidate.summary_snippet.take());
-    }
-
-    async fn search_event_evidence(&self, hit: &SearchEventHit) -> Result<SessionSearchEvidence> {
-        let mut event_order = None;
-        let mut turn_seq = None;
-        let mut event_time = None;
-        if let Ok(context) = self
-            .repo
-            .open_event(OpenEventRequest {
-                event_uid: hit.event_uid.clone(),
-                before: Some(0),
-                after: Some(0),
-                include_system_events: Some(true),
-            })
-            .await
-        {
-            if let Some(event) = context
-                .events
-                .iter()
-                .find(|event| event.event_uid == hit.event_uid)
-            {
-                event_order = Some(event.event_order);
-                turn_seq = Some(event.turn_seq);
-                event_time = Some(event.event_time.clone());
-            }
-        }
-
-        Ok(SessionSearchEvidence {
-            event_uid: hit.event_uid.clone(),
-            event_order,
-            turn_seq,
-            event_time,
-            kind: display_kind(&hit.event_class, &hit.payload_type),
-            role: hit.actor_role.clone(),
-            snippet: compact_text_line(
-                hit.text_content
-                    .as_deref()
-                    .unwrap_or(hit.text_preview.as_str()),
-                320,
-            ),
-        })
     }
 
     fn add_summary_evidence(&self, candidate: &mut SessionSearchCandidate) {
@@ -2071,6 +2117,7 @@ impl AppState {
                     source: Some("moraine-mcp".to_string()),
                     limit: Some(limit),
                     session_id: Some(session_id.clone()),
+                    session_ids: None,
                     min_score: None,
                     min_should_match: None,
                     include_tool_events: Some(include_tool_events),
@@ -2577,6 +2624,56 @@ fn apply_recency_adjustments(candidates: &mut [SessionSearchCandidate], active: 
             candidate.score -= 2.0;
         }
     }
+}
+
+fn rank_session_search_candidates(
+    candidates: &mut Vec<SessionSearchCandidate>,
+    recency_active: bool,
+    limit: u16,
+) {
+    apply_recency_adjustments(candidates, recency_active);
+    candidates.sort_by(|a, b| {
+        b.score
+            .total_cmp(&a.score)
+            .then_with(|| b.last_event_unix_ms.cmp(&a.last_event_unix_ms))
+            .then_with(|| a.session_id.cmp(&b.session_id))
+    });
+    candidates.truncate(limit as usize);
+}
+
+fn search_event_evidence(hit: &SearchEventHit) -> SessionSearchEvidence {
+    SessionSearchEvidence {
+        event_uid: hit.event_uid.clone(),
+        event_order: None,
+        turn_seq: None,
+        event_time: hit.event_time.clone(),
+        kind: display_kind(&hit.event_class, &hit.payload_type),
+        role: hit.actor_role.clone(),
+        snippet: compact_text_line(
+            hit.text_content
+                .as_deref()
+                .unwrap_or(hit.text_preview.as_str()),
+            320,
+        ),
+    }
+}
+
+fn underfilled_evidence_sessions(
+    candidate_session_ids: &[String],
+    evidence_by_session: &HashMap<String, Vec<SessionSearchEvidence>>,
+    matching_events_limit: u16,
+) -> Vec<String> {
+    let target = matching_events_limit as usize;
+    candidate_session_ids
+        .iter()
+        .filter(|session_id| {
+            evidence_by_session
+                .get(*session_id)
+                .map(|evidence| evidence.len() < target)
+                .unwrap_or(true)
+        })
+        .cloned()
+        .collect()
 }
 
 fn candidate_rank_text(candidate: &SessionSearchCandidate) -> String {
@@ -3511,6 +3608,34 @@ mod tests {
             search["inputSchema"]["properties"]["recency_policy"]["default"],
             json!("auto")
         );
+        assert_eq!(
+            search["inputSchema"]["properties"]["evidence_policy"]["default"],
+            json!("fast")
+        );
+    }
+
+    #[test]
+    fn search_session_data_args_default_to_fast_evidence_policy() {
+        let args: SearchSessionDataArgs = serde_json::from_value(json!({
+            "query": "moraine search latency"
+        }))
+        .expect("parse search session args");
+
+        assert_eq!(
+            args.evidence_policy.unwrap_or_default(),
+            EvidencePolicy::Fast
+        );
+
+        let complete_args: SearchSessionDataArgs = serde_json::from_value(json!({
+            "query": "moraine search latency",
+            "evidence_policy": "complete"
+        }))
+        .expect("parse complete evidence policy");
+
+        assert_eq!(
+            complete_args.evidence_policy.unwrap_or_default(),
+            EvidencePolicy::Complete
+        );
     }
 
     #[test]
@@ -3590,6 +3715,130 @@ mod tests {
 
         assert_eq!(candidates[0].session_id, "final");
         assert!(candidates[0].score > candidates[1].score);
+    }
+
+    #[test]
+    fn rank_session_search_candidates_truncates_before_evidence_enrichment() {
+        let mut candidates = vec![
+            SessionSearchCandidate {
+                session_id: "low".to_string(),
+                score: 1.0,
+                last_event_unix_ms: Some(3000),
+                ..SessionSearchCandidate::new("low".to_string())
+            },
+            SessionSearchCandidate {
+                session_id: "high".to_string(),
+                score: 10.0,
+                last_event_unix_ms: Some(1000),
+                ..SessionSearchCandidate::new("high".to_string())
+            },
+            SessionSearchCandidate {
+                session_id: "tie-newer".to_string(),
+                score: 10.0,
+                last_event_unix_ms: Some(2000),
+                ..SessionSearchCandidate::new("tie-newer".to_string())
+            },
+        ];
+
+        rank_session_search_candidates(&mut candidates, false, 2);
+
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["tie-newer", "high"]
+        );
+    }
+
+    #[test]
+    fn search_event_evidence_uses_search_hit_without_trace_lookup() {
+        let hit = SearchEventHit {
+            rank: 1,
+            event_uid: "evt-1".to_string(),
+            session_id: "sess-1".to_string(),
+            event_time: Some("2026-04-27T12:00:00.000Z".to_string()),
+            first_event_time: String::new(),
+            last_event_time: String::new(),
+            source_name: "codex".to_string(),
+            harness: "codex".to_string(),
+            inference_provider: "openai".to_string(),
+            score: 1.0,
+            matched_terms: 1,
+            doc_len: 10,
+            event_class: "message".to_string(),
+            payload_type: "text".to_string(),
+            actor_role: "assistant".to_string(),
+            name: String::new(),
+            phase: String::new(),
+            source_ref: String::new(),
+            text_preview: "preview only".to_string(),
+            text_content: Some("full evidence text".to_string()),
+            payload_json: None,
+        };
+
+        let evidence = search_event_evidence(&hit);
+
+        assert_eq!(evidence.event_uid, "evt-1");
+        assert_eq!(evidence.kind, "message (text)");
+        assert_eq!(evidence.role, "assistant");
+        assert_eq!(evidence.event_order, None);
+        assert_eq!(evidence.turn_seq, None);
+        assert_eq!(
+            evidence.event_time.as_deref(),
+            Some("2026-04-27T12:00:00.000Z")
+        );
+        assert_eq!(evidence.snippet, "full evidence text");
+    }
+
+    #[test]
+    fn underfilled_evidence_sessions_preserves_per_session_coverage() {
+        let candidate_session_ids = vec![
+            "filled".to_string(),
+            "partial".to_string(),
+            "empty".to_string(),
+        ];
+        let mut evidence_by_session = HashMap::new();
+        evidence_by_session.insert(
+            "filled".to_string(),
+            vec![
+                SessionSearchEvidence {
+                    event_uid: "filled-1".to_string(),
+                    event_order: None,
+                    turn_seq: None,
+                    event_time: None,
+                    kind: "message".to_string(),
+                    role: "assistant".to_string(),
+                    snippet: "one".to_string(),
+                },
+                SessionSearchEvidence {
+                    event_uid: "filled-2".to_string(),
+                    event_order: None,
+                    turn_seq: None,
+                    event_time: None,
+                    kind: "message".to_string(),
+                    role: "assistant".to_string(),
+                    snippet: "two".to_string(),
+                },
+            ],
+        );
+        evidence_by_session.insert(
+            "partial".to_string(),
+            vec![SessionSearchEvidence {
+                event_uid: "partial-1".to_string(),
+                event_order: None,
+                turn_seq: None,
+                event_time: None,
+                kind: "message".to_string(),
+                role: "assistant".to_string(),
+                snippet: "one".to_string(),
+            }],
+        );
+
+        assert_eq!(
+            underfilled_evidence_sessions(&candidate_session_ids, &evidence_by_session, 2),
+            vec!["partial".to_string(), "empty".to_string()]
+        );
     }
 
     #[test]
@@ -3686,6 +3935,7 @@ mod tests {
                     rank: 1,
                     event_uid: "evt-1".to_string(),
                     session_id: "sess-1".to_string(),
+                    event_time: None,
                     first_event_time: String::new(),
                     last_event_time: String::new(),
                     source_name: "src".to_string(),
@@ -3708,6 +3958,7 @@ mod tests {
                     rank: 2,
                     event_uid: "evt-2".to_string(),
                     session_id: "sess-1".to_string(),
+                    event_time: None,
                     first_event_time: String::new(),
                     last_event_time: String::new(),
                     source_name: "src".to_string(),
@@ -3730,6 +3981,7 @@ mod tests {
                     rank: 3,
                     event_uid: "evt-3".to_string(),
                     session_id: "sess-1".to_string(),
+                    event_time: None,
                     first_event_time: String::new(),
                     last_event_time: String::new(),
                     source_name: "src".to_string(),


### PR DESCRIPTION
## Summary

Closes #298.

This fixes the `search_session_data` timeout path introduced in v0.5.0 by removing repeated per-hit `v_conversation_trace` scans from MCP search enrichment and making evidence completeness explicit.

The main changes are:
- Stop calling `open_event(before=0, after=0)` for every search evidence hit.
- Build evidence directly from `SearchEventHit` data.
- Rank and truncate session candidates before evidence enrichment.
- Batch evidence lookup across the final candidate sessions.
- Add `evidence_policy` to `search_session_data`: `fast` is the default lowest-latency batched path, while `complete` opts into concurrent per-session top-ups when the batch under-fills a session.
- Add `session_ids` support to `SearchEventsQuery` for efficient multi-session event search.
- Populate cheap per-hit `event_time` from `search_documents.record_ts`.
- Load search hit session time bounds from `events` instead of `v_conversation_trace`.

## Performance

Benchmarked against the host ClickHouse dataset:
- `events`: 328,112 rows
- `search_documents`: 184,580 rows
- `search_postings`: 11,707,468 rows
- `sessions`: 768

Benchmark query:

```json
{
  "query": "moraine cli v0.5.0 timeout search interface",
  "limit": 5,
  "matching_events_limit": 5,
  "verbosity": "full"
}
```

Results:
- Baseline v0.5.0 `search_session_data`: timed out after 130.0s
- First patched version after removing per-hit trace lookup: 24.1s
- Final default `evidence_policy=fast`: 4.20s
- Optional `evidence_policy=complete`: 11.47s
- Patched legacy `search` for comparison: 381ms

Default fast mode removes the pathological `limit * matching_events_limit` fanout where default settings could trigger up to 100 exact `open_event` trace-view lookups before returning only 5 sessions. Complete mode keeps the per-session evidence completeness guarantee by running top-ups only for sessions that the batch under-filled, and it runs those searches concurrently.

## Quality Check

The latest host run returned the same five session ids in both modes:

```text
session_ids=["019c6df8-88cb-7733-89d0-50f9f0ae95ec", "019dbdb8-64cb-7d62-8819-ddbf3b0a36cb", "019c59f9-6389-77a1-a0cb-304eecf935b6", "dafc16ee-8056-4431-bc7f-d87a548c0079", "019d08b7-650d-7501-bc99-72eca643eeee"]
```

Fast mode returns best-effort batched evidence and may under-fill per-session evidence counts:

```text
evidence_policy=fast
event_evidence_counts=[4,3,5,5,2]
```

Complete mode fills all requested per-session event evidence slots and matched direct per-session `search` results:

```text
evidence_policy=complete
event_evidence_counts=[5,5,5,5,5]
direct_per_session_mismatches=[]
```

For the complete-mode check, I compared each returned session's event evidence from `search_session_data` against a direct per-session `search` call with the same query, `limit=5`, `include_tool_events=false`, and `exclude_codex_mcp=true`. There were zero mismatches.

Session ranking quality is preserved in both modes because evidence enrichment does not affect candidate scoring: candidates are still scored from conversation and metadata search, then sorted by the same score/recency/session-id ordering. The change moves that sort earlier so we enrich only the final sessions.

## Operational Impact

No schema migration is required.

The response schema remains compatible and adds `evidence_policy` to the structured result. Evidence no longer fills `event_order` or `turn_seq` unless a later trace/materialized path is added, but those fields were already nullable and useful evidence fields are preserved: `event_uid`, `event_time`, `kind`, `role`, and `snippet`.

Default `search_session_data` now favors latency. Callers that require complete per-session evidence should pass `evidence_policy: "complete"`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p moraine-mcp-core --locked`
- `cargo test -p moraine-conversations --lib --locked`
- `cargo test -p moraine-conversations --test repository_integration --locked`
- `cargo build -p moraine-mcp --locked`
- pre-commit hook: strict clippy baseline passed