### PR TITLE
chore(release): cut v0.5.2

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.5.1)"
+        description: "Tag to release (for example v0.5.2)"
         required: true
         type: string
       target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "moraine"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "moraine-clickhouse",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/moraine-ingest/Cargo.toml
+++ b/apps/moraine-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Moraine ingest service binary"
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Moraine MCP stdio server"
 

--- a/apps/moraine-monitor/Cargo.toml
+++ b/apps/moraine-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Moraine monitor HTTP/UI service"
 

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Unified runtime control plane for Moraine services"
 

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-clickhouse"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Shared Moraine ClickHouse client and query helpers"
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-config"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Shared Moraine configuration schema and loaders"
 

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-conversations"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "High-level read/query APIs for Moraine conversations"
 

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest-core"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Core ingestion pipeline internals for Moraine"
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp-core"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "MCP protocol and tool routing core for Moraine"
 

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor-core"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Analytics and query logic for Moraine monitor service"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ install directory precedence:
 
 examples:
   scripts/install.sh
-  MORAINE_INSTALL_VERSION=v0.5.1 scripts/install.sh
+  MORAINE_INSTALL_VERSION=v0.5.2 scripts/install.sh
   MORAINE_INSTALL_ASSET_BASE_URL=http://127.0.0.1:8080 \
     MORAINE_INSTALL_VERSION=ci-e2e scripts/install.sh
   MORAINE_INSTALL_DIR="$HOME/bin" MORAINE_INSTALL_SKIP_CLICKHOUSE=1 scripts/install.sh


### PR DESCRIPTION
## What changed

- Bumped all Moraine workspace packages from `0.5.1` to `0.5.2`.
- Updated `Cargo.lock` for the workspace package versions.
- Updated the release workflow dispatch example and installer help example to `v0.5.2`.

## Release notes

Moraine `v0.5.2` focuses on the reworked MCP search interface. MCP clients now see a compact two-tool retrieval surface: `search_sessions` for event-ranked discovery and `open` for expanding the returned event, turn, or session handles.

Highlights:

- `search_sessions` returns compact, progressive-discovery results with typed `session:`, `turn:`, and `event:` IDs instead of full conversation payloads.
- `open` accepts IDs returned by search or prior opens, so agents can move from a search hit to the surrounding event, turn, or session without guessing follow-up tool calls.
- The MCP response contract now uses structured success/error envelopes, including in-band validation and not-found errors that do not fail the JSON-RPC call.
- Search/open reads now use indexed event search and direct event traversal, with smoke coverage and SLA benchmarking added around the new workflow.

## Operational impact

- MCP clients should use `search_sessions` and `open` as the public retrieval flow.
- No schema migration is required for this release; the search/open paths use the existing event and search index tables.
- No runtime config changes are required.

## Validation

- `cargo metadata --locked --no-deps --format-version 1` confirmed all workspace packages at `0.5.2`.
- Dev sandbox `sb-052052` booted successfully and monitor `/api/health` returned healthy.
- Inside the dev sandbox: `cargo fmt --all -- --check` passed.
- Inside the dev sandbox: `cargo test --workspace --locked` passed.
- Inside the dev sandbox, from a temporary writable repo copy: `bash scripts/ci/e2e-stack.sh` passed, including MCP `search_sessions`/`open` smoke checks for Codex, Claude, and Hermes fixtures.
- `scripts/dev/sandbox/agent-smoke-e2e --id sb-052052` passed for `claude-opus-4-7`, `claude-sonnet-4-6`, and `claude-haiku-4-5`.
- Inside the dev sandbox: `make clippy USE_RUSTUP=0 CARGO_CMD=cargo CARGO_TARGET_DIR=/home/moraine/target` passed.
- Commit hook passed repo-managed fmt and strict clippy baseline.
- Dev sandbox `sb-052052` was torn down after validation.

After this PR lands, create/push the `v0.5.2` tag to trigger `release-moraine` asset builds, then use the release notes above as the GitHub release body.
