### PR TITLE
[codex] feat(mcp): add list_sessions tool

### DIFF
--- a/.claude/skills/agent-smoke-e2e/SKILL.md
+++ b/.claude/skills/agent-smoke-e2e/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: agent-smoke-e2e
-description: End-to-end smoke check of the moraine MCP server. Exercises the public two-tool search workflow against a live moraine stack and prints a PASS/FAIL matrix.
+description: End-to-end smoke check of the moraine MCP server. Exercises the public retrieval workflow against a live moraine stack and prints a PASS/FAIL matrix.
 ---
 
 # agent-smoke-e2e
 
 You are running an end-to-end smoke test of the moraine MCP server.
 
-Your sole job is to call the public two-tool MCP retrieval workflow, validate
+Your sole job is to call the public MCP retrieval workflow, validate
 that responses are shaped as expected, and emit a final pass/fail matrix. Do not
 do anything else: no exploration, no reading files, no code changes. Treat this
 like a test runner with terse output and clear pass/fail signals.
 
 ## Setup Assumptions
 
-- The `moraine` MCP server is registered and exposes `mcp__moraine__search_sessions` and `mcp__moraine__open`.
+- The `moraine` MCP server is registered and exposes `mcp__moraine__search_sessions`, `mcp__moraine__open`, and `mcp__moraine__list_sessions`.
 - The stack may or may not have ingested sessions. Both cases are valid; the smoke test cares that tools respond with the contract shape.
 - Do not call any tool outside the `mcp__moraine__*` namespace.
 
@@ -46,7 +46,31 @@ If `data.results[0]` exists, capture:
 
 If there are no results, leave the three sample IDs as `null`.
 
-### 2. `open(event_id)`
+### 2. `list_sessions`
+
+Call `mcp__moraine__list_sessions` with:
+
+```json
+{
+  "start_datetime": "1970-01-01T00:00:00Z",
+  "end_datetime": "2100-01-01T00:00:00Z",
+  "limit": 5
+}
+```
+
+PASS if the response is an object with:
+
+- `tool: "list_sessions"`
+- `schema_version: "moraine.mcp.list_sessions.v1"`
+- `data.sessions` as an array
+
+If `data.sessions[0]` exists, capture:
+
+- `listed_session_id = data.sessions[0].open.session_id`
+
+If there are no listed sessions, leave `listed_session_id` as `null`.
+
+### 3. `open(event_id)`
 
 If `sample_event_id` is set, call `mcp__moraine__open` with:
 
@@ -59,7 +83,7 @@ and `data.kind: "event"`.
 
 If `sample_event_id` is null, record `SKIP no search result`.
 
-### 3. `open(turn_id)`
+### 4. `open(turn_id)`
 
 If `sample_turn_id` is set, call `mcp__moraine__open` with:
 
@@ -72,7 +96,7 @@ and `data.kind: "turn"`.
 
 If `sample_turn_id` is null, record `SKIP no search result`.
 
-### 4. `open(session_id)`
+### 5. `open(session_id)`
 
 If `sample_session_id` is set, call `mcp__moraine__open` with:
 
@@ -93,6 +117,19 @@ nonexistent typed session ID:
 PASS if the tool returns cleanly without an MCP/RPC error and includes an
 `error.code` such as `not_found`.
 
+### 6. `open(listed_session_id)`
+
+If `listed_session_id` is set, call `mcp__moraine__open` with:
+
+```json
+{ "id": "<listed_session_id>" }
+```
+
+PASS if the response is an object with `tool: "open"`, the same `request.id`,
+and `data.kind: "session"`.
+
+If `listed_session_id` is null, record `SKIP no listed session`.
+
 ## FAIL Conditions
 
 - The tool call raises an MCP/RPC error (`isError: true`, JSON-RPC error response, or tool not found).
@@ -107,14 +144,18 @@ After all checks, emit exactly this block and stop:
 ```text
 === agent-smoke-e2e ===
 search_sessions: PASS|FAIL [reason]
+list_sessions:   PASS|FAIL [reason]
 open_event_id:   PASS|FAIL|SKIP [reason]
 open_turn_id:    PASS|FAIL|SKIP [reason]
 open_session_id: PASS|FAIL [reason]
+open_listed_session_id: PASS|FAIL|SKIP [reason]
 ---
 search_results:  <N from search_sessions>
+listed_sessions: <N from list_sessions>
 sample_event_id: <id or null>
 sample_turn_id:  <id or null>
 sample_session_id: <id or null>
+listed_session_id: <id or null>
 overall:         PASS|FAIL
 =======================
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,6 +1163,7 @@ name = "moraine-mcp-core"
 version = "0.5.2"
 dependencies = [
  "anyhow",
+ "chrono",
  "moraine-clickhouse",
  "moraine-config",
  "moraine-conversations",

--- a/crates/moraine-conversations/src/clickhouse_repo.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo.rs
@@ -14,19 +14,21 @@ use tracing::warn;
 use uuid::Uuid;
 
 use crate::cursor::{
-    decode_cursor, encode_cursor, ConversationCursor, SessionEventCursor, TurnCursor,
+    decode_cursor, encode_cursor, ConversationCursor, McpSessionListCursor, SessionEventCursor,
+    TurnCursor,
 };
 use crate::domain::{
     is_user_facing_content_event, Conversation, ConversationDetailOptions, ConversationListFilter,
     ConversationListSort, ConversationMode, ConversationSearchHit, ConversationSearchQuery,
     ConversationSearchResults, ConversationSearchStats, ConversationSummary, McpEventOpen,
-    McpEventRef, McpEventSummary, McpEventType, McpSessionOpen, McpTurnCompact, McpTurnOpen,
-    McpTurnRef, OpenContext, OpenEvent, OpenEventRequest, Page, PageRequest, RepoConfig,
-    SearchEventHit, SearchEventKind, SearchEventsQuery, SearchEventsResult, SearchEventsStats,
-    SearchEventsStrategy, SearchMcpEventHit, SearchMcpEventsQuery, SearchMcpEventsResult,
-    SearchMcpEventsStats, SessionEventsDirection, SessionEventsQuery, SessionMetadata,
-    SessionMetadataSearchHit, SessionMetadataSearchQuery, SessionMetadataSearchResults,
-    SessionMetadataSearchStats, TraceEvent, Turn, TurnListFilter, TurnSummary,
+    McpEventRef, McpEventSummary, McpEventType, McpSessionListFilter, McpSessionListItem,
+    McpSessionOpen, McpTurnCompact, McpTurnOpen, McpTurnRef, OpenContext, OpenEvent,
+    OpenEventRequest, Page, PageRequest, RepoConfig, SearchEventHit, SearchEventKind,
+    SearchEventsQuery, SearchEventsResult, SearchEventsStats, SearchEventsStrategy,
+    SearchMcpEventHit, SearchMcpEventsQuery, SearchMcpEventsResult, SearchMcpEventsStats,
+    SessionEventsDirection, SessionEventsQuery, SessionMetadata, SessionMetadataSearchHit,
+    SessionMetadataSearchQuery, SessionMetadataSearchResults, SessionMetadataSearchStats,
+    TraceEvent, Turn, TurnListFilter, TurnSummary,
 };
 use crate::error::{RepoError, RepoResult};
 use crate::repo::ConversationRepository;
@@ -99,6 +101,27 @@ struct SessionMetadataRow {
     last_event_uid: String,
     #[serde(default)]
     last_actor_role: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct McpSessionListRow {
+    session_id: String,
+    first_event_time: String,
+    first_event_unix_ms: i64,
+    last_event_time: String,
+    last_event_unix_ms: i64,
+    total_turns: u32,
+    total_events: u64,
+    mode: String,
+    completed: u8,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    source: String,
+    #[serde(default)]
+    session_slug: String,
+    #[serde(default)]
+    session_summary: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -830,7 +853,7 @@ impl ClickHouseConversationRepository {
       OR (payload_type = 'tool_use' AND tool_name IN ('WebSearch', 'WebFetch'))
     ) > 0,
     'web_search',
-    countIf(source_name = 'codex-mcp' OR lowerUTF8(tool_name) IN ('search', 'open')) > 0,
+    countIf(source_name = 'codex-mcp' OR lowerUTF8(tool_name) IN ('search', 'open', 'list_sessions')) > 0,
     'mcp_internal',
     countIf(event_kind IN ('tool_call', 'tool_result') OR payload_type = 'tool_use') > 0,
     'tool_calling',
@@ -855,6 +878,19 @@ GROUP BY session_id"
             "from={:?};to={:?};mode={};sort={}",
             filter.from_unix_ms,
             filter.to_unix_ms,
+            filter
+                .mode
+                .map(ConversationMode::as_str)
+                .unwrap_or("__none__"),
+            filter.sort.as_str(),
+        )
+    }
+
+    fn mcp_session_list_filter_sig(filter: &McpSessionListFilter) -> String {
+        format!(
+            "start={};end={};mode={};sort={}",
+            filter.start_unix_ms,
+            filter.end_unix_ms,
             filter
                 .mode
                 .map(ConversationMode::as_str)
@@ -897,6 +933,15 @@ GROUP BY session_id"
                     "from_unix_ms must be strictly less than to_unix_ms",
                 ));
             }
+        }
+        Ok(())
+    }
+
+    fn validate_required_time_bounds(start_unix_ms: i64, end_unix_ms: i64) -> RepoResult<()> {
+        if start_unix_ms >= end_unix_ms {
+            return Err(RepoError::invalid_argument(
+                "start_unix_ms must be strictly less than end_unix_ms",
+            ));
         }
         Ok(())
     }
@@ -1374,6 +1419,24 @@ GROUP BY session_id"
             tool_calls: row.tool_calls,
             tool_results: row.tool_results,
             mode: Self::parse_mode(&row.mode),
+            session_slug: non_empty_string(row.session_slug),
+            session_summary: non_empty_string(row.session_summary),
+        }
+    }
+
+    fn map_mcp_session_list_row(row: McpSessionListRow) -> McpSessionListItem {
+        McpSessionListItem {
+            session_id: row.session_id,
+            first_event_time: row.first_event_time,
+            first_event_unix_ms: row.first_event_unix_ms,
+            last_event_time: row.last_event_time,
+            last_event_unix_ms: row.last_event_unix_ms,
+            total_turns: row.total_turns,
+            total_events: row.total_events,
+            mode: Self::parse_mode(&row.mode),
+            completed: row.completed != 0,
+            title: non_empty_string(row.title),
+            source: non_empty_string(row.source),
             session_slug: non_empty_string(row.session_slug),
             session_summary: non_empty_string(row.session_summary),
         }
@@ -2193,6 +2256,7 @@ FORMAT JSONEachRow",
             event.source_name == "codex-mcp"
                 || event.event.name.eq_ignore_ascii_case("search")
                 || event.event.name.eq_ignore_ascii_case("open")
+                || event.event.name.eq_ignore_ascii_case("list_sessions")
         }) {
             return ConversationMode::McpInternal;
         }
@@ -2599,7 +2663,8 @@ GROUP BY t.event_uid)"
                     "positionCaseInsensitiveUTF8(d.payload_json, 'codex-mcp') = 0".to_string(),
                 );
             }
-            where_clauses.push("lowerUTF8(d.name) NOT IN ('search', 'open')".to_string());
+            where_clauses
+                .push("lowerUTF8(d.name) NOT IN ('search', 'open', 'list_sessions')".to_string());
         }
 
         let where_sql = where_clauses.join("\n  AND ");
@@ -2976,7 +3041,10 @@ FORMAT JSONEachRow",
             if row.has_codex_mcp != 0 {
                 return false;
             }
-            if row.name.eq_ignore_ascii_case("search") || row.name.eq_ignore_ascii_case("open") {
+            if row.name.eq_ignore_ascii_case("search")
+                || row.name.eq_ignore_ascii_case("open")
+                || row.name.eq_ignore_ascii_case("list_sessions")
+            {
                 return false;
             }
         }
@@ -3833,7 +3901,8 @@ FORMAT JSONEachRow",
 
         if exclude_codex_mcp {
             postings_filters.push("p.source_name != 'codex-mcp'".to_string());
-            postings_filters.push("lowerUTF8(p.name) NOT IN ('search', 'open')".to_string());
+            postings_filters
+                .push("lowerUTF8(p.name) NOT IN ('search', 'open', 'list_sessions')".to_string());
         }
 
         if let Some(candidate_session_ids) = candidate_session_ids {
@@ -4918,6 +4987,185 @@ FORMAT JSONEachRow",
         let next_cursor = if rows.len() > limit as usize {
             if let Some(last) = items.last() {
                 Some(encode_cursor(&ConversationCursor {
+                    last_event_unix_ms: last.last_event_unix_ms,
+                    session_id: last.session_id.clone(),
+                    filter_sig,
+                    sort,
+                })?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        Ok(Page {
+            items: std::mem::take(&mut items),
+            next_cursor,
+        })
+    }
+
+    async fn list_mcp_sessions(
+        &self,
+        filter: McpSessionListFilter,
+        page: PageRequest,
+    ) -> RepoResult<Page<McpSessionListItem>> {
+        Self::validate_required_time_bounds(filter.start_unix_ms, filter.end_unix_ms)?;
+
+        let limit = page.normalized_limit(self.cfg.max_results);
+        let filter_sig = Self::mcp_session_list_filter_sig(&filter);
+        let sort = filter.sort;
+
+        let cursor = if let Some(token) = page.cursor.as_deref() {
+            let cursor: McpSessionListCursor = decode_cursor(token)?;
+            if cursor.filter_sig != filter_sig {
+                return Err(RepoError::invalid_cursor(
+                    "cursor does not match current list_sessions filter",
+                ));
+            }
+            if cursor.sort != sort {
+                return Err(RepoError::invalid_cursor(
+                    "cursor sort does not match requested sort order",
+                ));
+            }
+            Some(cursor)
+        } else {
+            None
+        };
+
+        let session_summary = self.table_ref("v_session_summary");
+        let events_table = self.table_ref("events");
+        let mode_subquery = self.mode_subquery();
+
+        let mut where_clauses = vec![
+            format!(
+                "toUnixTimestamp64Milli(s.last_event_time) >= {}",
+                filter.start_unix_ms
+            ),
+            format!(
+                "toUnixTimestamp64Milli(s.first_event_time) < {}",
+                filter.end_unix_ms
+            ),
+        ];
+        if let Some(mode_clause) = Self::mode_filter_clause(filter.mode) {
+            where_clauses.push(mode_clause);
+        }
+
+        if let Some(cursor) = &cursor {
+            let (time_cmp, session_cmp) = match sort {
+                ConversationListSort::Desc => ("<", "<"),
+                ConversationListSort::Asc => (">", ">"),
+            };
+            where_clauses.push(format!(
+                "(toUnixTimestamp64Milli(s.last_event_time) {time_cmp} {} OR (toUnixTimestamp64Milli(s.last_event_time) = {} AND s.session_id {session_cmp} {}))",
+                cursor.last_event_unix_ms,
+                cursor.last_event_unix_ms,
+                sql_quote(&cursor.session_id)
+            ));
+        }
+
+        let where_sql = where_clauses.join("\n  AND ");
+        let order_dir = match sort {
+            ConversationListSort::Desc => "DESC",
+            ConversationListSort::Asc => "ASC",
+        };
+
+        let query = format!(
+            "SELECT
+  s.session_id AS session_id,
+  toString(s.first_event_time) AS first_event_time,
+  toInt64(toUnixTimestamp64Milli(s.first_event_time)) AS first_event_unix_ms,
+  toString(s.last_event_time) AS last_event_time,
+  toInt64(toUnixTimestamp64Milli(s.last_event_time)) AS last_event_unix_ms,
+  toUInt32(s.total_turns) AS total_turns,
+  toUInt64(s.total_events) AS total_events,
+  ifNull(m.mode, 'chat') AS mode,
+  toUInt8(
+    ifNull(status.latest_terminal_turn_seq, toUInt32(0)) = toUInt32(s.total_turns)
+    AND ifNull(status.latest_terminal_payload_type, '') = 'task_complete'
+  ) AS completed,
+  ifNull(meta.title, '') AS title,
+  ifNull(meta.source, '') AS source,
+  ifNull(meta.session_slug, '') AS session_slug,
+  ifNull(meta.session_summary, '') AS session_summary
+FROM {session_summary} AS s
+LEFT JOIN ({mode_subquery}) AS m ON m.session_id = s.session_id
+LEFT JOIN (
+  SELECT
+    session_id,
+    maxIf(toUInt32(turn_index), payload_type IN ('task_complete', 'turn_aborted')) AS latest_terminal_turn_seq,
+    ifNull(
+      argMaxIf(payload_type, tuple(event_ts, event_uid), payload_type IN ('task_complete', 'turn_aborted')),
+      ''
+    ) AS latest_terminal_payload_type
+  FROM {events_table}
+  GROUP BY session_id
+) AS status ON status.session_id = s.session_id
+LEFT JOIN (
+  SELECT
+    session_id,
+    ifNull(
+      argMax(
+        coalesce(
+          nullIf(JSONExtractString(payload_json, 'title'), ''),
+          nullIf(JSONExtractString(payload_json, 'name'), ''),
+          nullIf(JSONExtractString(payload_json, 'summary'), '')
+        ),
+        tuple(event_ts, event_uid)
+      ),
+      ''
+    ) AS title,
+    ifNull(
+      argMax(
+        coalesce(
+          nullIf(JSONExtractString(payload_json, 'source'), ''),
+          nullIf(source_name, '')
+        ),
+        tuple(event_ts, event_uid)
+      ),
+      ''
+    ) AS source,
+    ifNull(argMax(nullIf(JSONExtractString(payload_json, 'slug'), ''), tuple(event_ts, event_uid)), '') AS session_slug,
+    ifNull(
+      argMax(
+        coalesce(
+          nullIf(JSONExtractString(payload_json, 'summary'), ''),
+          nullIf(JSONExtractString(payload_json, 'title'), ''),
+          nullIf(JSONExtractString(payload_json, 'name'), '')
+        ),
+        tuple(event_ts, event_uid)
+      ),
+      ''
+    ) AS session_summary
+  FROM {events_table}
+  WHERE event_kind = 'session_meta'
+  GROUP BY session_id
+) AS meta ON meta.session_id = s.session_id
+WHERE {where_sql}
+ORDER BY s.last_event_time {order_dir}, s.session_id {order_dir}
+LIMIT {limit_plus}
+FORMAT JSONEachRow",
+            session_summary = session_summary,
+            events_table = events_table,
+            mode_subquery = mode_subquery,
+            where_sql = where_sql,
+            order_dir = order_dir,
+            limit_plus = (limit as usize) + 1,
+        );
+
+        let rows: Vec<McpSessionListRow> =
+            self.map_backend(self.ch.query_rows(&query, None).await)?;
+
+        let mut items: Vec<McpSessionListItem> = rows
+            .iter()
+            .take(limit as usize)
+            .cloned()
+            .map(Self::map_mcp_session_list_row)
+            .collect();
+
+        let next_cursor = if rows.len() > limit as usize {
+            if let Some(last) = items.last() {
+                Some(encode_cursor(&McpSessionListCursor {
                     last_event_unix_ms: last.last_event_unix_ms,
                     session_id: last.session_id.clone(),
                     filter_sig,

--- a/crates/moraine-conversations/src/cursor.rs
+++ b/crates/moraine-conversations/src/cursor.rs
@@ -15,6 +15,15 @@ pub struct ConversationCursor {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpSessionListCursor {
+    pub last_event_unix_ms: i64,
+    pub session_id: String,
+    pub filter_sig: String,
+    #[serde(default)]
+    pub sort: ConversationListSort,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TurnCursor {
     pub last_turn_seq: u32,
     pub session_id: String,

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -50,6 +50,16 @@ pub struct ConversationListFilter {
     pub sort: ConversationListSort,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpSessionListFilter {
+    pub start_unix_ms: i64,
+    pub end_unix_ms: i64,
+    #[serde(default)]
+    pub mode: Option<ConversationMode>,
+    #[serde(default)]
+    pub sort: ConversationListSort,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TurnListFilter {
     #[serde(default)]
@@ -224,6 +234,27 @@ pub struct McpSessionOpen {
     pub turns: Vec<McpTurnCompact>,
     pub completed: bool,
     pub terminal_event_uid: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpSessionListItem {
+    pub session_id: String,
+    pub first_event_time: String,
+    pub first_event_unix_ms: i64,
+    pub last_event_time: String,
+    pub last_event_unix_ms: i64,
+    pub total_turns: u32,
+    pub total_events: u64,
+    pub mode: ConversationMode,
+    pub completed: bool,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub session_slug: Option<String>,
+    #[serde(default)]
+    pub session_summary: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -9,13 +9,14 @@ pub use domain::{
     is_user_facing_content_event, Conversation, ConversationDetailOptions, ConversationListFilter,
     ConversationListSort, ConversationMode, ConversationSearchHit, ConversationSearchQuery,
     ConversationSearchResults, ConversationSearchStats, ConversationSummary, McpEventOpen,
-    McpEventRef, McpEventSummary, McpEventType, McpSessionOpen, McpTurnCompact, McpTurnOpen,
-    McpTurnRef, OpenContext, OpenEvent, OpenEventRequest, Page, PageRequest, RepoConfig,
-    SearchEventHit, SearchEventKind, SearchEventsQuery, SearchEventsResult, SearchEventsStats,
-    SearchEventsStrategy, SearchMcpEventHit, SearchMcpEventsQuery, SearchMcpEventsResult,
-    SearchMcpEventsStats, SessionEventsDirection, SessionEventsQuery, SessionMetadata,
-    SessionMetadataSearchHit, SessionMetadataSearchQuery, SessionMetadataSearchResults,
-    SessionMetadataSearchStats, TraceEvent, Turn, TurnListFilter, TurnSummary,
+    McpEventRef, McpEventSummary, McpEventType, McpSessionListFilter, McpSessionListItem,
+    McpSessionOpen, McpTurnCompact, McpTurnOpen, McpTurnRef, OpenContext, OpenEvent,
+    OpenEventRequest, Page, PageRequest, RepoConfig, SearchEventHit, SearchEventKind,
+    SearchEventsQuery, SearchEventsResult, SearchEventsStats, SearchEventsStrategy,
+    SearchMcpEventHit, SearchMcpEventsQuery, SearchMcpEventsResult, SearchMcpEventsStats,
+    SessionEventsDirection, SessionEventsQuery, SessionMetadata, SessionMetadataSearchHit,
+    SessionMetadataSearchQuery, SessionMetadataSearchResults, SessionMetadataSearchStats,
+    TraceEvent, Turn, TurnListFilter, TurnSummary,
 };
 pub use error::{RepoError, RepoResult};
 pub use repo::ConversationRepository;

--- a/crates/moraine-conversations/src/repo.rs
+++ b/crates/moraine-conversations/src/repo.rs
@@ -2,10 +2,10 @@ use async_trait::async_trait;
 
 use crate::domain::{
     Conversation, ConversationDetailOptions, ConversationListFilter, ConversationSearchQuery,
-    ConversationSearchResults, McpEventOpen, McpSessionOpen, McpTurnOpen, OpenContext,
-    OpenEventRequest, Page, PageRequest, SearchEventsQuery, SearchEventsResult,
-    SearchMcpEventsQuery, SearchMcpEventsResult, SessionEventsQuery, SessionMetadata, TraceEvent,
-    Turn, TurnListFilter, TurnSummary,
+    ConversationSearchResults, McpEventOpen, McpSessionListFilter, McpSessionListItem,
+    McpSessionOpen, McpTurnOpen, OpenContext, OpenEventRequest, Page, PageRequest,
+    SearchEventsQuery, SearchEventsResult, SearchMcpEventsQuery, SearchMcpEventsResult,
+    SessionEventsQuery, SessionMetadata, TraceEvent, Turn, TurnListFilter, TurnSummary,
 };
 use crate::error::RepoResult;
 
@@ -26,6 +26,12 @@ pub trait ConversationRepository: Send + Sync {
     async fn get_session_metadata(&self, session_id: &str) -> RepoResult<Option<SessionMetadata>>;
 
     async fn get_mcp_session(&self, session_id: &str) -> RepoResult<Option<McpSessionOpen>>;
+
+    async fn list_mcp_sessions(
+        &self,
+        filter: McpSessionListFilter,
+        page: PageRequest,
+    ) -> RepoResult<Page<McpSessionListItem>>;
 
     async fn list_turns(
         &self,

--- a/crates/moraine-conversations/tests/repository_integration.rs
+++ b/crates/moraine-conversations/tests/repository_integration.rs
@@ -12,9 +12,9 @@ use moraine_clickhouse::ClickHouseClient;
 use moraine_config::ClickHouseConfig;
 use moraine_conversations::{
     ClickHouseConversationRepository, ConversationListFilter, ConversationListSort,
-    ConversationMode, ConversationRepository, ConversationSearchQuery, McpEventType, PageRequest,
-    RepoConfig, RepoError, SearchEventKind, SearchEventsQuery, SearchMcpEventsQuery,
-    SessionEventsDirection, SessionEventsQuery, SessionMetadataSearchQuery,
+    ConversationMode, ConversationRepository, ConversationSearchQuery, McpEventType,
+    McpSessionListFilter, PageRequest, RepoConfig, RepoError, SearchEventKind, SearchEventsQuery,
+    SearchMcpEventsQuery, SessionEventsDirection, SessionEventsQuery, SessionMetadataSearchQuery,
 };
 use serde_json::json;
 
@@ -137,6 +137,85 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
             .lock()
             .expect("query lock")
             .push(query.clone());
+
+        if query.contains("FROM `moraine`.`v_session_summary` AS s")
+            && query.contains("AS completed")
+            && query.contains("latest_terminal_payload_type")
+        {
+            if query.contains("s.session_id < 'sess_b'") {
+                return (
+                    StatusCode::OK,
+                    json_each_row(json!([
+                        {
+                            "session_id": "sess_a",
+                            "first_event_time": "2026-01-01 10:00:00",
+                            "first_event_unix_ms": 1767261600000_i64,
+                            "last_event_time": "2026-01-01 10:10:00",
+                            "last_event_unix_ms": 1767262200000_i64,
+                            "total_turns": 2,
+                            "total_events": 20,
+                            "mode": "web_search",
+                            "completed": 0_u8,
+                            "title": "",
+                            "source": "codex",
+                            "session_slug": "",
+                            "session_summary": ""
+                        }
+                    ])),
+                );
+            }
+
+            return (
+                StatusCode::OK,
+                json_each_row(json!([
+                    {
+                        "session_id": "sess_c",
+                        "first_event_time": "2026-01-03 10:00:00",
+                        "first_event_unix_ms": 1767434400000_i64,
+                        "last_event_time": "2026-01-03 10:10:00",
+                        "last_event_unix_ms": 1767435000000_i64,
+                        "total_turns": 3,
+                        "total_events": 30,
+                        "mode": "web_search",
+                        "completed": 1_u8,
+                        "title": "Session C title",
+                        "source": "codex",
+                        "session_slug": "project-c",
+                        "session_summary": "Session C summary"
+                    },
+                    {
+                        "session_id": "sess_b",
+                        "first_event_time": "2026-01-02 10:00:00",
+                        "first_event_unix_ms": 1767348000000_i64,
+                        "last_event_time": "2026-01-02 10:10:00",
+                        "last_event_unix_ms": 1767348600000_i64,
+                        "total_turns": 2,
+                        "total_events": 22,
+                        "mode": "web_search",
+                        "completed": 1_u8,
+                        "title": "Session B title",
+                        "source": "codex",
+                        "session_slug": "project-b",
+                        "session_summary": "Session B summary"
+                    },
+                    {
+                        "session_id": "sess_a",
+                        "first_event_time": "2026-01-01 10:00:00",
+                        "first_event_unix_ms": 1767261600000_i64,
+                        "last_event_time": "2026-01-01 10:10:00",
+                        "last_event_unix_ms": 1767262200000_i64,
+                        "total_turns": 2,
+                        "total_events": 20,
+                        "mode": "web_search",
+                        "completed": 0_u8,
+                        "title": "",
+                        "source": "codex",
+                        "session_slug": "",
+                        "session_summary": ""
+                    }
+                ])),
+            );
+        }
 
         if query.contains("FROM `moraine`.`v_session_summary` AS s")
             && query.contains("ORDER BY s.last_event_time DESC")
@@ -1736,6 +1815,108 @@ async fn list_conversations_rejects_cursor_when_sort_changes() {
     assert_eq!(
         err.to_string(),
         "invalid cursor: cursor does not match current conversation filter"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_mcp_sessions_uses_overlap_filter_and_cursor_pagination() {
+    let (repo, state) = build_repo().await;
+
+    let filter = McpSessionListFilter {
+        start_unix_ms: 1767261600000_i64,
+        end_unix_ms: 1767500000000_i64,
+        mode: Some(ConversationMode::WebSearch),
+        sort: ConversationListSort::Desc,
+    };
+
+    let first = repo
+        .list_mcp_sessions(
+            filter.clone(),
+            PageRequest {
+                limit: 2,
+                cursor: None,
+            },
+        )
+        .await
+        .expect("first page");
+
+    assert_eq!(first.items.len(), 2);
+    assert_eq!(first.items[0].session_id, "sess_c");
+    assert_eq!(first.items[0].title.as_deref(), Some("Session C title"));
+    assert_eq!(first.items[0].source.as_deref(), Some("codex"));
+    assert!(first.items[0].completed);
+    assert_eq!(first.items[1].session_id, "sess_b");
+    assert!(first.next_cursor.is_some());
+
+    let second = repo
+        .list_mcp_sessions(
+            filter,
+            PageRequest {
+                limit: 2,
+                cursor: first.next_cursor,
+            },
+        )
+        .await
+        .expect("second page");
+
+    assert_eq!(second.items.len(), 1);
+    assert_eq!(second.items[0].session_id, "sess_a");
+    assert!(!second.items[0].completed);
+    assert!(second.next_cursor.is_none());
+
+    let queries = state.queries.lock().expect("queries lock").clone();
+    let list_query = queries
+        .iter()
+        .find(|q| q.contains("AS completed") && q.contains("latest_terminal_payload_type"))
+        .expect("list_sessions query should be captured");
+
+    assert!(list_query.contains("toUnixTimestamp64Milli(s.last_event_time) >= 1767261600000"));
+    assert!(list_query.contains("toUnixTimestamp64Milli(s.first_event_time) < 1767500000000"));
+    assert!(list_query.contains("ifNull(m.mode, 'chat') = 'web_search'"));
+    assert!(list_query.contains("ORDER BY s.last_event_time DESC, s.session_id DESC"));
+    assert!(list_query.contains("payload_type IN ('task_complete', 'turn_aborted')"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_mcp_sessions_rejects_cursor_filter_mismatch() {
+    let (repo, _state) = build_repo().await;
+
+    let base_filter = McpSessionListFilter {
+        start_unix_ms: 1767261600000_i64,
+        end_unix_ms: 1767500000000_i64,
+        mode: Some(ConversationMode::WebSearch),
+        sort: ConversationListSort::Desc,
+    };
+
+    let first = repo
+        .list_mcp_sessions(
+            base_filter.clone(),
+            PageRequest {
+                limit: 1,
+                cursor: None,
+            },
+        )
+        .await
+        .expect("first page");
+    let cursor = first.next_cursor.expect("next cursor");
+
+    let err = repo
+        .list_mcp_sessions(
+            McpSessionListFilter {
+                mode: Some(ConversationMode::Chat),
+                ..base_filter
+            },
+            PageRequest {
+                limit: 1,
+                cursor: Some(cursor),
+            },
+        )
+        .await
+        .expect_err("filter mismatch should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "invalid cursor: cursor does not match current list_sessions filter"
     );
 }
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -6,6 +6,7 @@ description = "MCP protocol and tool routing core for Moraine"
 
 [dependencies]
 anyhow = "1.0"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.40", features = ["io-std", "io-util", "rt", "sync", "time"] }

--- a/crates/moraine-mcp-core/src/contract.rs
+++ b/crates/moraine-mcp-core/src/contract.rs
@@ -1,3 +1,4 @@
+use chrono::DateTime;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{json, Value};
 use std::fmt;
@@ -12,8 +13,10 @@ const BASE64_URL_ALPHABET: &[u8; 64] =
 
 pub const SEARCH_SESSIONS_TOOL: &str = "search_sessions";
 pub const OPEN_TOOL: &str = "open";
+pub const LIST_SESSIONS_TOOL: &str = "list_sessions";
 pub const SEARCH_SESSIONS_SCHEMA_VERSION: &str = "moraine.mcp.search_sessions.v1";
 pub const OPEN_SCHEMA_VERSION: &str = "moraine.mcp.open.v1";
+pub const LIST_SESSIONS_SCHEMA_VERSION: &str = "moraine.mcp.list_sessions.v1";
 pub const ERROR_SCHEMA_VERSION: &str = "moraine.mcp.error.v1";
 pub const SEARCH_SESSIONS_DEFAULT_N_HITS: u16 = 10;
 pub const SEARCH_SESSIONS_MIN_N_HITS: u16 = 1;
@@ -21,6 +24,12 @@ pub const SEARCH_SESSIONS_MAX_N_HITS: u16 = 50;
 pub const SEARCH_SESSIONS_MAX_QUERY_CHARS: usize = 4096;
 pub const SEARCH_SESSIONS_SLA_TARGET_MS: u64 = 750;
 pub const OPEN_SLA_TARGET_MS: u64 = 500;
+pub const LIST_SESSIONS_DEFAULT_LIMIT: u16 = 20;
+pub const LIST_SESSIONS_MIN_LIMIT: u16 = 1;
+pub const LIST_SESSIONS_DEFAULT_SLA_TARGET_MS: u64 = 300;
+pub const LIST_SESSIONS_BROAD_SLA_TARGET_MS: u64 = 1_000;
+pub const LIST_SESSIONS_FILTERED_BROAD_SLA_TARGET_MS: u64 = 1_200;
+pub const LIST_SESSIONS_DEADLINE_MS: u64 = 3_000;
 
 pub type ContractResult<T> = Result<T, ContractError>;
 
@@ -555,6 +564,136 @@ pub struct CanonicalSearchSessionsArgs {
     pub n_hits: u16,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ListSessionsMode {
+    WebSearch,
+    McpInternal,
+    ToolCalling,
+    Chat,
+}
+
+impl ListSessionsMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WebSearch => "web_search",
+            Self::McpInternal => "mcp_internal",
+            Self::ToolCalling => "tool_calling",
+            Self::Chat => "chat",
+        }
+    }
+}
+
+impl fmt::Display for ListSessionsMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ListSessionsSort {
+    Asc,
+    #[default]
+    Desc,
+}
+
+impl ListSessionsSort {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Asc => "asc",
+            Self::Desc => "desc",
+        }
+    }
+}
+
+impl fmt::Display for ListSessionsSort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ListSessionsArgs {
+    #[serde(default)]
+    pub start_datetime: Option<String>,
+    #[serde(default)]
+    pub end_datetime: Option<String>,
+    #[serde(default)]
+    pub limit: Option<u16>,
+    #[serde(default)]
+    pub cursor: Option<String>,
+    #[serde(default)]
+    pub mode: Option<ListSessionsMode>,
+    #[serde(default)]
+    pub sort: Option<ListSessionsSort>,
+}
+
+impl ListSessionsArgs {
+    pub fn validate(self, max_results: u16) -> ContractResult<CanonicalListSessionsArgs> {
+        let max_limit = max_results.max(LIST_SESSIONS_MIN_LIMIT);
+        let limit = self
+            .limit
+            .unwrap_or(LIST_SESSIONS_DEFAULT_LIMIT.min(max_limit));
+        if !(LIST_SESSIONS_MIN_LIMIT..=max_limit).contains(&limit) {
+            return Err(invalid_request_with_field(
+                "limit",
+                format!("limit must be between 1 and {max_limit}"),
+            ));
+        }
+
+        let Some(start_datetime) = self.start_datetime else {
+            return Err(list_sessions_datetime_required_error());
+        };
+        let Some(end_datetime) = self.end_datetime else {
+            return Err(list_sessions_datetime_required_error());
+        };
+
+        let start_datetime = start_datetime.trim().to_string();
+        let end_datetime = end_datetime.trim().to_string();
+        let start_unix_ms = parse_explicit_timezone_datetime("start_datetime", &start_datetime)?;
+        let end_unix_ms = parse_explicit_timezone_datetime("end_datetime", &end_datetime)?;
+        if end_unix_ms <= start_unix_ms {
+            return Err(invalid_request_with_field(
+                "end_datetime",
+                "end_datetime must be later than start_datetime",
+            ));
+        }
+
+        let cursor = self.cursor.map(|cursor| cursor.trim().to_string());
+        if matches!(cursor.as_deref(), Some("")) {
+            return Err(invalid_request_with_field(
+                "cursor",
+                "cursor must be a non-empty string when provided",
+            ));
+        }
+
+        Ok(CanonicalListSessionsArgs {
+            start_datetime,
+            end_datetime,
+            start_unix_ms,
+            end_unix_ms,
+            limit,
+            cursor,
+            mode: self.mode,
+            sort: self.sort.unwrap_or_default(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalListSessionsArgs {
+    pub start_datetime: String,
+    pub end_datetime: String,
+    pub start_unix_ms: i64,
+    pub end_unix_ms: i64,
+    pub limit: u16,
+    pub cursor: Option<String>,
+    pub mode: Option<ListSessionsMode>,
+    pub sort: ListSessionsSort,
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct OpenV1Args {
     #[serde(default)]
@@ -714,6 +853,13 @@ impl PerformanceBuilder {
     pub fn finish(&self) -> Performance {
         Performance::from_elapsed(self.started_at.elapsed(), self.sla_target_ms)
     }
+
+    pub fn with_sla_target(&self, sla_target_ms: u64) -> Self {
+        Self {
+            started_at: self.started_at,
+            sla_target_ms,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -843,6 +989,62 @@ fn unsupported_event_type(raw: &str, supported: Vec<&'static str>) -> ContractEr
         "field": "event_types",
         "supported": supported
     }))
+}
+
+fn list_sessions_datetime_required_error() -> ContractError {
+    ContractError::new(
+        ToolErrorCode::InvalidRequest,
+        "list_sessions requires start_datetime and end_datetime with explicit timezones",
+    )
+    .with_details(json!({
+        "example": {
+            "start_datetime": "2026-04-30T09:00:00-04:00",
+            "end_datetime": "2026-04-30T13:00:00-04:00"
+        }
+    }))
+}
+
+fn parse_explicit_timezone_datetime(field: &'static str, input: &str) -> ContractResult<i64> {
+    if input.is_empty() {
+        return Err(invalid_request_with_field(
+            field,
+            format!("{field} must be a non-empty RFC 3339 datetime"),
+        ));
+    }
+    if !has_explicit_timezone(input) {
+        return Err(invalid_request_with_field(
+            field,
+            format!("{field} must include an explicit timezone offset or Z"),
+        ));
+    }
+
+    DateTime::parse_from_rfc3339(input)
+        .map(|datetime| datetime.timestamp_millis())
+        .map_err(|error| {
+            invalid_request_with_field(
+                field,
+                format!("{field} must be a valid RFC 3339 datetime: {error}"),
+            )
+        })
+}
+
+fn has_explicit_timezone(input: &str) -> bool {
+    let input = input.trim();
+    if input.ends_with('Z') || input.ends_with('z') {
+        return true;
+    }
+
+    let bytes = input.as_bytes();
+    if bytes.len() < 6 {
+        return false;
+    }
+    let offset = &bytes[bytes.len() - 6..];
+    matches!(offset[0], b'+' | b'-')
+        && offset[1].is_ascii_digit()
+        && offset[2].is_ascii_digit()
+        && offset[3] == b':'
+        && offset[4].is_ascii_digit()
+        && offset[5].is_ascii_digit()
 }
 
 fn searchable_event_type_index(event_type: McpEventType) -> Option<usize> {

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "256"]
 
 pub mod contract;
+mod list_sessions_v1;
 mod open_v1;
 mod search_sessions_v1;
 
@@ -173,7 +174,7 @@ impl AppState {
                 },
                 {
                     "name": contract::OPEN_TOOL,
-                    "description": "Open a Moraine MCP ID returned by search_sessions or open. Accepts session, turn, and event IDs.",
+                    "description": "Open a Moraine MCP ID returned by search_sessions, list_sessions, or open. Accepts session, turn, and event IDs.",
                     "inputSchema": {
                         "type": "object",
                         "additionalProperties": false,
@@ -203,6 +204,64 @@ impl AppState {
                     "annotations": {
                         "readOnlyHint": true
                     }
+                },
+                {
+                    "name": contract::LIST_SESSIONS_TOOL,
+                    "description": "List Moraine sessions that overlap a start/end datetime range. Returns typed session IDs, compact metadata, pagination, and open handles. Use this for metadata browsing by time; use search_sessions for content search and open to inspect a selected session.",
+                    "inputSchema": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "start_datetime": {
+                                "type": "string",
+                                "description": "Inclusive lower bound for session activity. Must be RFC 3339 / ISO 8601 with an explicit timezone, for example 2026-04-30T09:00:00-04:00 or 2026-04-30T13:00:00Z."
+                            },
+                            "end_datetime": {
+                                "type": "string",
+                                "description": "Exclusive upper bound for session activity. Must be RFC 3339 / ISO 8601 with an explicit timezone and later than start_datetime."
+                            },
+                            "limit": {
+                                "type": ["integer", "null"],
+                                "minimum": contract::LIST_SESSIONS_MIN_LIMIT,
+                                "maximum": self.cfg.mcp.max_results.max(contract::LIST_SESSIONS_MIN_LIMIT),
+                                "default": contract::LIST_SESSIONS_DEFAULT_LIMIT.min(self.cfg.mcp.max_results.max(contract::LIST_SESSIONS_MIN_LIMIT))
+                            },
+                            "cursor": {
+                                "type": ["string", "null"],
+                                "description": "Opaque cursor from a previous list_sessions response with the same filter and sort values."
+                            },
+                            "mode": {
+                                "type": ["string", "null"],
+                                "enum": ["web_search", "mcp_internal", "tool_calling", "chat", null],
+                                "description": "Optional session mode filter."
+                            },
+                            "sort": {
+                                "type": ["string", "null"],
+                                "enum": ["desc", "asc", null],
+                                "default": "desc",
+                                "description": "Sort order by session updated_at and session ID."
+                            }
+                        },
+                        "required": ["start_datetime", "end_datetime"]
+                    },
+                    "outputSchema": {
+                        "type": "object",
+                        "required": ["schema_version", "tool", "request", "data", "warnings", "performance"],
+                        "properties": {
+                            "schema_version": { "type": "string" },
+                            "tool": { "const": contract::LIST_SESSIONS_TOOL },
+                            "request": { "type": "object" },
+                            "data": {
+                                "type": "object",
+                                "required": ["result_count", "limit", "truncated", "sessions", "next_cursor"]
+                            },
+                            "warnings": { "type": "array" },
+                            "performance": { "type": "object" }
+                        }
+                    },
+                    "annotations": {
+                        "readOnlyHint": true
+                    }
                 }
             ]
         })
@@ -211,6 +270,7 @@ impl AppState {
     async fn call_tool(&self, params: ToolCallParams) -> Result<Value> {
         match params.name.as_str() {
             contract::SEARCH_SESSIONS_TOOL => self.search_sessions_v1(params.arguments).await,
+            contract::LIST_SESSIONS_TOOL => self.list_sessions_v1(params.arguments).await,
             contract::OPEN_TOOL => self.open_v1(params.arguments).await,
             other => Err(anyhow!("unknown tool: {other}")),
         }
@@ -334,7 +394,7 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_publishes_two_tool_search_surface_with_output_schemas() {
+    fn tools_list_publishes_mcp_search_surface_with_output_schemas() {
         let state = test_state();
         let payload = state.tools_list_result();
         let tools = payload["tools"].as_array().expect("tools array");
@@ -343,9 +403,9 @@ mod tests {
             .filter_map(|tool| tool["name"].as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(names, ["search_sessions", "open"]);
+        assert_eq!(names, ["search_sessions", "open", "list_sessions"]);
 
-        for tool_name in ["search_sessions", "open"] {
+        for tool_name in ["search_sessions", "open", "list_sessions"] {
             let tool = tools
                 .iter()
                 .find(|tool| tool["name"].as_str() == Some(tool_name))
@@ -386,6 +446,33 @@ mod tests {
                 .get("evidence_policy")
                 .is_none(),
             "search_sessions should not advertise legacy evidence policy controls"
+        );
+
+        let list_sessions = tools
+            .iter()
+            .find(|tool| tool["name"].as_str() == Some("list_sessions"))
+            .expect("list_sessions exists");
+        assert_eq!(
+            list_sessions["inputSchema"]["required"],
+            json!(["start_datetime", "end_datetime"])
+        );
+        assert_eq!(
+            list_sessions["inputSchema"]["additionalProperties"],
+            json!(false)
+        );
+        assert_eq!(
+            list_sessions["inputSchema"]["properties"]["sort"]["default"],
+            json!("desc")
+        );
+        assert_eq!(
+            list_sessions["outputSchema"]["properties"]["data"]["required"],
+            json!([
+                "result_count",
+                "limit",
+                "truncated",
+                "sessions",
+                "next_cursor"
+            ])
         );
     }
 }

--- a/crates/moraine-mcp-core/src/list_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/list_sessions_v1.rs
@@ -1,0 +1,479 @@
+use super::{tool_ok_hybrid, AppState};
+use crate::contract::{
+    format_rfc3339_utc_millis, CanonicalListSessionsArgs, ContractError, ListSessionsArgs,
+    ListSessionsMode, ListSessionsSort, McpSessionId, Performance, ToolEnvelope, ToolErrorCode,
+    ToolErrorEnvelope, LIST_SESSIONS_BROAD_SLA_TARGET_MS, LIST_SESSIONS_DEADLINE_MS,
+    LIST_SESSIONS_DEFAULT_SLA_TARGET_MS, LIST_SESSIONS_FILTERED_BROAD_SLA_TARGET_MS,
+    LIST_SESSIONS_TOOL,
+};
+use anyhow::{Context, Result};
+use moraine_conversations::{
+    ConversationListSort as RepoListSort, ConversationMode as RepoConversationMode,
+    ConversationRepository, McpSessionListFilter, McpSessionListItem, Page, PageRequest, RepoError,
+};
+use serde_json::{json, Value};
+use tokio::time::{timeout, Duration};
+
+const LIST_SESSIONS_BROAD_WINDOW_MS: i64 = 30 * 24 * 60 * 60 * 1_000;
+
+impl AppState {
+    pub(crate) async fn list_sessions_v1(&self, arguments: Value) -> Result<Value> {
+        let perf = Performance::builder(LIST_SESSIONS_DEFAULT_SLA_TARGET_MS);
+        let raw_request = arguments.clone();
+
+        let args = match parse_list_sessions_args(arguments, self.cfg.mcp.max_results) {
+            Ok(args) => args,
+            Err(error) => {
+                return encode_list_sessions_error(raw_request, error, perf.finish());
+            }
+        };
+        let canonical_request = canonical_request_json(&args);
+        let args_perf = perf.with_sla_target(list_sessions_sla_target_ms(&args, false));
+
+        let repo_filter = McpSessionListFilter {
+            start_unix_ms: args.start_unix_ms,
+            end_unix_ms: args.end_unix_ms,
+            mode: args.mode.map(repo_mode),
+            sort: repo_sort(args.sort),
+        };
+        let repo_page = PageRequest {
+            limit: args.limit,
+            cursor: args.cursor.clone(),
+        };
+
+        let page_result = timeout(
+            Duration::from_millis(LIST_SESSIONS_DEADLINE_MS),
+            self.repo.list_mcp_sessions(repo_filter, repo_page),
+        )
+        .await;
+
+        let page = match page_result {
+            Ok(Ok(page)) => page,
+            Ok(Err(error)) => {
+                return encode_list_sessions_error(
+                    canonical_request,
+                    repo_error_to_contract_error(error),
+                    args_perf.finish(),
+                );
+            }
+            Err(_) => {
+                return encode_list_sessions_error(
+                    canonical_request,
+                    ContractError::new(
+                        ToolErrorCode::DeadlineExceeded,
+                        "list_sessions exceeded its response deadline",
+                    )
+                    .with_details(json!({ "deadline_ms": LIST_SESSIONS_DEADLINE_MS })),
+                    args_perf.finish(),
+                );
+            }
+        };
+
+        let performance = perf
+            .with_sla_target(list_sessions_sla_target_ms(
+                &args,
+                page.next_cursor.is_some(),
+            ))
+            .finish();
+        let data = match list_sessions_data_json(&args, &page) {
+            Ok(data) => data,
+            Err(error) => {
+                return encode_list_sessions_error(canonical_request, error, performance);
+            }
+        };
+
+        let payload = serde_json::to_value(ToolEnvelope::success(
+            LIST_SESSIONS_TOOL,
+            canonical_request,
+            data,
+            performance,
+        ))
+        .context("failed to encode list_sessions response envelope")?;
+        Ok(tool_ok_hybrid(format_list_sessions_text(&payload), payload))
+    }
+}
+
+fn parse_list_sessions_args(
+    arguments: Value,
+    max_results: u16,
+) -> Result<CanonicalListSessionsArgs, ContractError> {
+    serde_json::from_value::<ListSessionsArgs>(arguments)
+        .map_err(|error| {
+            ContractError::new(
+                ToolErrorCode::InvalidRequest,
+                "list_sessions expects a JSON object with start_datetime and end_datetime",
+            )
+            .with_details(json!({ "serde_error": error.to_string() }))
+        })?
+        .validate(max_results)
+}
+
+fn canonical_request_json(args: &CanonicalListSessionsArgs) -> Value {
+    json!({
+        "start_datetime": args.start_datetime,
+        "end_datetime": args.end_datetime,
+        "mode": args.mode.map(|mode| mode.as_str()),
+        "sort": args.sort.as_str(),
+        "limit": args.limit,
+        "cursor": args.cursor.as_deref(),
+    })
+}
+
+fn repo_mode(mode: ListSessionsMode) -> RepoConversationMode {
+    match mode {
+        ListSessionsMode::WebSearch => RepoConversationMode::WebSearch,
+        ListSessionsMode::McpInternal => RepoConversationMode::McpInternal,
+        ListSessionsMode::ToolCalling => RepoConversationMode::ToolCalling,
+        ListSessionsMode::Chat => RepoConversationMode::Chat,
+    }
+}
+
+fn repo_sort(sort: ListSessionsSort) -> RepoListSort {
+    match sort {
+        ListSessionsSort::Asc => RepoListSort::Asc,
+        ListSessionsSort::Desc => RepoListSort::Desc,
+    }
+}
+
+fn list_sessions_data_json(
+    args: &CanonicalListSessionsArgs,
+    page: &Page<McpSessionListItem>,
+) -> Result<Value, ContractError> {
+    let sessions = page
+        .items
+        .iter()
+        .enumerate()
+        .map(|(index, session)| session_json(index + 1, session))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(json!({
+        "result_count": sessions.len(),
+        "limit": args.limit,
+        "truncated": page.next_cursor.is_some(),
+        "sessions": sessions,
+        "next_cursor": page.next_cursor.as_deref(),
+    }))
+}
+
+fn list_sessions_sla_target_ms(args: &CanonicalListSessionsArgs, has_more: bool) -> u64 {
+    let is_broad_window =
+        args.end_unix_ms.saturating_sub(args.start_unix_ms) >= LIST_SESSIONS_BROAD_WINDOW_MS;
+    if is_broad_window || has_more {
+        if args.mode.is_some() {
+            LIST_SESSIONS_FILTERED_BROAD_SLA_TARGET_MS
+        } else {
+            LIST_SESSIONS_BROAD_SLA_TARGET_MS
+        }
+    } else {
+        LIST_SESSIONS_DEFAULT_SLA_TARGET_MS
+    }
+}
+
+fn session_json(rank: usize, session: &McpSessionListItem) -> Result<Value, ContractError> {
+    let session_id = mcp_session_id(&session.session_id)?;
+
+    Ok(json!({
+        "rank": rank,
+        "id": session_id,
+        "session": {
+            "id": session_id,
+            "title": session.title.as_deref(),
+            "source": session.source.as_deref(),
+            "started_at": format_rfc3339_utc_millis(session.first_event_unix_ms),
+            "updated_at": format_rfc3339_utc_millis(session.last_event_unix_ms),
+            "completed": session.completed,
+            "turn_count": session.total_turns,
+            "event_count": session.total_events,
+            "mode": session.mode.as_str(),
+            "session_slug": session.session_slug.as_deref(),
+            "session_summary": session.session_summary.as_deref(),
+        },
+        "open": {
+            "session_id": session_id,
+        }
+    }))
+}
+
+fn mcp_session_id(session_id: &str) -> Result<String, ContractError> {
+    McpSessionId::from_raw_session_id(session_id)
+        .map(|id| id.to_string())
+        .map_err(internal_id_error)
+}
+
+fn encode_list_sessions_error(
+    request: Value,
+    error: ContractError,
+    performance: Performance,
+) -> Result<Value> {
+    let payload = serde_json::to_value(ToolErrorEnvelope::error(
+        LIST_SESSIONS_TOOL,
+        request,
+        error,
+        performance,
+    ))
+    .context("failed to encode list_sessions error envelope")?;
+    Ok(tool_error_hybrid(
+        format_list_sessions_error_text(&payload),
+        payload,
+    ))
+}
+
+fn tool_error_hybrid(text: String, payload: Value) -> Value {
+    json!({
+        "content": [
+            {
+                "type": "text",
+                "text": text
+            }
+        ],
+        "structuredContent": payload,
+        "isError": false
+    })
+}
+
+fn format_list_sessions_text(payload: &Value) -> String {
+    let request = payload.get("request").unwrap_or(&Value::Null);
+    let start_datetime = request
+        .get("start_datetime")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let end_datetime = request
+        .get("end_datetime")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let data = payload.get("data").unwrap_or(&Value::Null);
+    let result_count = data
+        .get("result_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let mut lines = vec![format!(
+        "Found {result_count} session(s) overlapping {start_datetime} to {end_datetime}."
+    )];
+
+    if let Some(sessions) = data.get("sessions").and_then(Value::as_array) {
+        for session in sessions.iter().take(10) {
+            let rank = session.get("rank").and_then(Value::as_u64).unwrap_or(0);
+            let session_id = session
+                .pointer("/open/session_id")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let title = session
+                .pointer("/session/title")
+                .and_then(Value::as_str)
+                .or_else(|| {
+                    session
+                        .pointer("/session/session_summary")
+                        .and_then(Value::as_str)
+                })
+                .or_else(|| {
+                    session
+                        .pointer("/session/session_slug")
+                        .and_then(Value::as_str)
+                })
+                .unwrap_or("untitled session");
+            let updated_at = session
+                .pointer("/session/updated_at")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let mode = session
+                .pointer("/session/mode")
+                .and_then(Value::as_str)
+                .unwrap_or("chat");
+            lines.push(format!(
+                "{rank}. {updated_at} {mode} {title} ({session_id})"
+            ));
+        }
+    }
+
+    if data.get("next_cursor").and_then(Value::as_str).is_some() {
+        lines.push("More sessions are available with next_cursor.".to_string());
+    }
+
+    lines.join("\n")
+}
+
+fn format_list_sessions_error_text(payload: &Value) -> String {
+    let error = payload.get("error").unwrap_or(&Value::Null);
+    let code = error
+        .get("code")
+        .and_then(Value::as_str)
+        .unwrap_or("internal_error");
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("list_sessions failed");
+    format!("list_sessions error ({code}): {message}")
+}
+
+fn repo_error_to_contract_error(error: RepoError) -> ContractError {
+    match error {
+        RepoError::InvalidArgument(message) | RepoError::InvalidCursor(message) => {
+            ContractError::new(ToolErrorCode::InvalidRequest, message)
+        }
+        RepoError::Backend(message) | RepoError::Internal(message) => {
+            ContractError::new(ToolErrorCode::InternalError, message)
+        }
+    }
+}
+
+fn internal_id_error(error: ContractError) -> ContractError {
+    ContractError::new(
+        ToolErrorCode::InternalError,
+        format!("repository returned an invalid MCP identifier component: {error}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use moraine_conversations::ConversationMode;
+
+    #[test]
+    fn parses_and_canonicalizes_list_sessions_args() {
+        let args = parse_list_sessions_args(
+            json!({
+                "start_datetime": "2026-04-30T09:00:00-04:00",
+                "end_datetime": "2026-04-30T17:00:00Z",
+                "mode": "chat",
+                "sort": "asc",
+                "limit": 12,
+                "cursor": "abc"
+            }),
+            50,
+        )
+        .expect("valid args");
+
+        assert_eq!(args.start_unix_ms, 1_777_554_000_000);
+        assert_eq!(args.end_unix_ms, 1_777_568_400_000);
+        assert_eq!(args.mode, Some(ListSessionsMode::Chat));
+        assert_eq!(args.sort, ListSessionsSort::Asc);
+        assert_eq!(args.limit, 12);
+        assert_eq!(args.cursor.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn rejects_missing_unknown_and_naive_datetimes() {
+        let missing = parse_list_sessions_args(json!({}), 50).expect_err("missing rejected");
+        assert_eq!(missing.code(), ToolErrorCode::InvalidRequest);
+
+        let unknown = parse_list_sessions_args(
+            json!({
+                "start_datetime": "2026-04-30T09:00:00-04:00",
+                "end_datetime": "2026-04-30T13:00:00-04:00",
+                "extra": true
+            }),
+            50,
+        )
+        .expect_err("unknown field rejected");
+        assert_eq!(unknown.code(), ToolErrorCode::InvalidRequest);
+
+        let naive = parse_list_sessions_args(
+            json!({
+                "start_datetime": "2026-04-30T09:00:00",
+                "end_datetime": "2026-04-30T13:00:00-04:00"
+            }),
+            50,
+        )
+        .expect_err("naive datetime rejected");
+        assert_eq!(naive.code(), ToolErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn rejects_non_increasing_range_and_limit_over_cap() {
+        let range = parse_list_sessions_args(
+            json!({
+                "start_datetime": "2026-04-30T13:00:00Z",
+                "end_datetime": "2026-04-30T13:00:00Z"
+            }),
+            50,
+        )
+        .expect_err("empty range rejected");
+        assert_eq!(range.code(), ToolErrorCode::InvalidRequest);
+
+        let limit = parse_list_sessions_args(
+            json!({
+                "start_datetime": "2026-04-30T09:00:00-04:00",
+                "end_datetime": "2026-04-30T13:00:00-04:00",
+                "limit": 51
+            }),
+            50,
+        )
+        .expect_err("limit cap rejected");
+        assert_eq!(limit.code(), ToolErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn shapes_session_metadata_only_with_open_handle() {
+        let args = parse_list_sessions_args(
+            json!({
+                "start_datetime": "2026-04-30T09:00:00-04:00",
+                "end_datetime": "2026-04-30T13:00:00-04:00",
+                "limit": 1
+            }),
+            50,
+        )
+        .expect("valid args");
+        let page = Page {
+            items: vec![McpSessionListItem {
+                session_id: "sess-open".to_string(),
+                first_event_time: "2026-04-30 13:00:00".to_string(),
+                first_event_unix_ms: 1_777_554_000_000,
+                last_event_time: "2026-04-30 13:10:00".to_string(),
+                last_event_unix_ms: 1_777_554_600_000,
+                total_turns: 3,
+                total_events: 17,
+                mode: ConversationMode::ToolCalling,
+                completed: true,
+                title: Some("Build failure triage".to_string()),
+                source: Some("codex".to_string()),
+                session_slug: Some("build-failure".to_string()),
+                session_summary: Some("Build failure triage summary.".to_string()),
+            }],
+            next_cursor: None,
+        };
+
+        let data = list_sessions_data_json(&args, &page).expect("shape data");
+        let first = &data["sessions"][0];
+        assert_eq!(first["id"], json!("session:c2Vzcy1vcGVu"));
+        assert_eq!(first["open"]["session_id"], first["session"]["id"]);
+        assert_eq!(first["session"]["turn_count"], json!(3));
+        assert_eq!(first["session"]["event_count"], json!(17));
+        assert!(first.get("snippet").is_none());
+        assert!(first.get("events").is_none());
+        assert!(first.get("payload_json").is_none());
+    }
+
+    #[test]
+    fn selects_list_sessions_sla_for_broad_windows() {
+        let narrow = parse_list_sessions_args(
+            json!({
+                "start_datetime": "2026-04-30T09:00:00-04:00",
+                "end_datetime": "2026-04-30T13:00:00-04:00"
+            }),
+            50,
+        )
+        .expect("valid narrow args");
+        assert_eq!(
+            list_sessions_sla_target_ms(&narrow, false),
+            LIST_SESSIONS_DEFAULT_SLA_TARGET_MS
+        );
+        assert_eq!(
+            list_sessions_sla_target_ms(&narrow, true),
+            LIST_SESSIONS_BROAD_SLA_TARGET_MS
+        );
+
+        let broad_filtered = parse_list_sessions_args(
+            json!({
+                "start_datetime": "2026-01-01T00:00:00Z",
+                "end_datetime": "2026-03-01T00:00:00Z",
+                "mode": "chat"
+            }),
+            50,
+        )
+        .expect("valid broad filtered args");
+        assert_eq!(
+            list_sessions_sla_target_ms(&broad_filtered, false),
+            LIST_SESSIONS_FILTERED_BROAD_SLA_TARGET_MS
+        );
+    }
+}

--- a/docs/mcp-search-interface-spec.md
+++ b/docs/mcp-search-interface-spec.md
@@ -1,10 +1,10 @@
 # MCP Search Interface Specification
 
-This document specifies the desired behavior for Moraine's two primary MCP
-retrieval tools:
+This document specifies the desired behavior for Moraine's MCP retrieval tools:
 
 - `search_sessions`
 - `open`
+- `list_sessions`
 
 The scope of this document is the external interface contract: accepted inputs,
 output shapes, response behavior, errors, performance targets, and success
@@ -62,9 +62,9 @@ event:evt_01J9Q3Q2C4TD9K7F8M1N5R6P2A
 ```
 
 Implementations must return stable IDs for the lifetime of the indexed session
-data. An ID returned by `search_sessions` or `open` must be accepted by `open`
-unless the underlying session data has been deleted or the index has been
-rebuilt with incompatible IDs.
+data. An ID returned by `search_sessions`, `list_sessions`, or `open` must be
+accepted by `open` unless the underlying session data has been deleted or the
+index has been rebuilt with incompatible IDs.
 
 ### Time Format
 
@@ -732,6 +732,88 @@ Unsupported event type:
 }
 ```
 
+## Tool: `list_sessions`
+
+### Purpose
+
+`list_sessions` lists sessions that overlap a caller-supplied datetime range.
+Use it for metadata browsing by time; use `search_sessions` for content search
+and `open` to inspect a selected session.
+
+### Request Schema
+
+```json
+{
+  "start_datetime": "2026-04-30T09:00:00-04:00",
+  "end_datetime": "2026-04-30T13:00:00-04:00",
+  "limit": 20,
+  "cursor": null,
+  "mode": null,
+  "sort": "desc"
+}
+```
+
+Rules:
+
+- `start_datetime` is inclusive and `end_datetime` is exclusive.
+- Datetimes must be RFC 3339 / ISO 8601 strings with an explicit timezone
+  offset or `Z`.
+- Sessions match when `updated_at >= start_datetime` and
+  `started_at < end_datetime`.
+- `mode`, when present, is one of `web_search`, `mcp_internal`,
+  `tool_calling`, or `chat`.
+- `sort` is `desc` or `asc`, ordered by session `updated_at` and session ID.
+
+### Response Shape
+
+Successful responses use `moraine.mcp.list_sessions.v1` and return compact
+session metadata only:
+
+```json
+{
+  "schema_version": "moraine.mcp.list_sessions.v1",
+  "tool": "list_sessions",
+  "request": {},
+  "data": {
+    "result_count": 1,
+    "limit": 20,
+    "truncated": false,
+    "sessions": [
+      {
+        "rank": 1,
+        "id": "session:c2Vzcy0x",
+        "session": {
+          "id": "session:c2Vzcy0x",
+          "title": "Build failure triage",
+          "source": "codex",
+          "started_at": "2026-04-30T13:00:00.000Z",
+          "updated_at": "2026-04-30T13:10:00.000Z",
+          "completed": true,
+          "turn_count": 3,
+          "event_count": 17,
+          "mode": "tool_calling",
+          "session_slug": "build-failure",
+          "session_summary": "Build failure triage."
+        },
+        "open": {
+          "session_id": "session:c2Vzcy0x"
+        }
+      }
+    ],
+    "next_cursor": null
+  },
+  "warnings": [],
+  "performance": {
+    "elapsed_ms": 42,
+    "sla_target_ms": 300,
+    "met_sla": true
+  }
+}
+```
+
+`list_sessions` must not return event snippets, transcript text, or event
+payloads. To inspect a listed session, pass `open.session_id` to `open`.
+
 ## Tool: `open`
 
 ### Purpose
@@ -761,7 +843,8 @@ open({
 
 - Required.
 - Must be a string.
-- Must be a valid Moraine MCP ID returned by `search_sessions` or `open`.
+- Must be a valid Moraine MCP ID returned by `search_sessions`,
+  `list_sessions`, or `open`.
 - May refer to a session, turn, or event.
 
 Invalid inputs:
@@ -1560,6 +1643,22 @@ Missing object:
 | `n_hits > 50` | Return `invalid_request`. |
 | non-integer `n_hits` | Return `invalid_request`. |
 
+### `list_sessions`
+
+| Input combination | Expected behavior |
+|---|---|
+| `start_datetime` + `end_datetime` | List sessions overlapping the datetime range with defaults. |
+| range + `limit` | Return at most `limit` sessions. |
+| range + `cursor` | Return the next deterministic page for the same filter and sort. |
+| range + `mode` | Return only sessions with that mode. |
+| range + `sort=asc` | Return oldest matching sessions first by `updated_at`, then ID. |
+| missing datetime | Return `invalid_request`. |
+| datetime without timezone | Return `invalid_request`. |
+| `end_datetime <= start_datetime` | Return `invalid_request`. |
+| unknown field | Return `invalid_request`. |
+| invalid `mode` or `sort` | Return `invalid_request`. |
+| cursor with changed filter or sort | Return `invalid_request`. |
+
 ### `open`
 
 | Input combination | Expected behavior |
@@ -1582,6 +1681,7 @@ Required traversal paths:
 - Search hit to event: `search_sessions(...).data.results[].open.event_id`
 - Search hit to turn: `search_sessions(...).data.results[].open.turn_id`
 - Search hit to session: `search_sessions(...).data.results[].open.session_id`
+- Listed session to session: `list_sessions(...).data.sessions[].open.session_id`
 - Event to parent turn: `open(event).data.traversal.turn_id`
 - Event to parent session: `open(event).data.traversal.session_id`
 - Event to adjacent event: `open(event).data.traversal.previous_event_id` and
@@ -1640,6 +1740,24 @@ Deadline:
 - `search_sessions` should return a response or `deadline_exceeded` within
   5 seconds for warm-path requests up to 1M searchable documents.
 
+### `list_sessions` Targets
+
+For metadata-only requests with `limit <= 50`:
+
+| Scenario | P50 | P95 | P99 | Deadline |
+|---|---:|---:|---:|---:|
+| Typical window, <= 5k matching sessions | <= 50 ms | <= 300 ms | <= 750 ms | 2 s |
+| Broad window, <= 100k matching sessions | <= 200 ms | <= 1000 ms | <= 2000 ms | 3 s |
+| Single-mode filtered window, <= 100k matching sessions | <= 250 ms | <= 1200 ms | <= 2500 ms | 3 s |
+
+`list_sessions` should use session metadata or summary tables, avoid event text
+search, always enforce `limit`, and return a normal response or
+`deadline_exceeded` by the applicable deadline.
+
+The response `performance.sla_target_ms` advertises the applicable target:
+300 ms for typical metadata browse requests, 1000 ms for broad unfiltered
+windows, and 1200 ms for broad single-mode filtered windows.
+
 ### `open` Targets
 
 | Request | P50 | P95 | P99 |
@@ -1679,11 +1797,26 @@ An implementation is successful when:
 - Empty result sets return success with `results: []`.
 - Performance meets the `search_sessions` SLA for the target corpus sizes.
 
+### `list_sessions`
+
+An implementation is successful when:
+
+- Valid requests return sessions overlapping the requested datetime range.
+- Boundary behavior is inclusive at `start_datetime` and exclusive at
+  `end_datetime`.
+- Results are sorted deterministically and cursor-paginated.
+- Each session includes a typed session ID accepted by `open`.
+- The response contains compact metadata and no event snippets, event payloads,
+  or transcript text.
+- Invalid ranges, unknown fields, bad cursors, invalid modes, and invalid sort
+  values produce the specified errors.
+- Performance meets the `list_sessions` SLA for target corpus sizes.
+
 ### `open`
 
 An implementation is successful when:
 
-- `open` accepts every ID returned by `search_sessions`.
+- `open` accepts every ID returned by `search_sessions` and `list_sessions`.
 - Session IDs return session metadata and all known turn summaries.
 - Turn IDs return turn metadata, compact summaries, all known event summaries,
   and traversal references.
@@ -1707,7 +1840,8 @@ workflow:
 4. Call `open` on the parent session ID to inspect the broader session.
 5. Traverse adjacent events or turns using IDs returned by `open`.
 
-This workflow should not require any additional MCP tools.
+For time-window discovery, the agent can call `list_sessions`, select a
+returned `open.session_id`, and then call `open`.
 
 ## Explicit Non-Goals
 

--- a/scripts/bench/mcp_two_tool_sla.py
+++ b/scripts/bench/mcp_two_tool_sla.py
@@ -10,6 +10,7 @@ import select
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 from urllib.parse import urlencode
@@ -37,7 +38,7 @@ def non_negative_int(value: str) -> int:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Measure the Moraine MCP v1 search_sessions/open interface over JSON-RPC stdio. "
+            "Measure the Moraine MCP v1 search_sessions/open/list_sessions interface over JSON-RPC stdio. "
             "The tool calls are read-only; corpus and query selection use ClickHouse SELECTs only."
         )
     )
@@ -86,6 +87,25 @@ def parse_args() -> argparse.Namespace:
         action="append",
         default=[],
         help="Optional search_sessions event_types entry. May be repeated.",
+    )
+    parser.add_argument(
+        "--skip-list-sessions",
+        action="store_true",
+        help="Do not benchmark list_sessions.",
+    )
+    parser.add_argument(
+        "--list-start-datetime",
+        help="Explicit list_sessions start_datetime. Defaults to the corpus minimum session start.",
+    )
+    parser.add_argument(
+        "--list-end-datetime",
+        help="Explicit list_sessions end_datetime. Defaults to the corpus maximum session update plus 1 ms.",
+    )
+    parser.add_argument("--list-limit", type=positive_int, default=20)
+    parser.add_argument(
+        "--list-mode",
+        choices=["web_search", "mcp_internal", "tool_calling", "chat"],
+        help="Optional list_sessions mode filter.",
     )
     parser.add_argument(
         "--min-docs",
@@ -235,6 +255,40 @@ SELECT metric, value FROM (
     return {
         str(row["metric"]): int(row["value"])
         for row in clickhouse_select_json_each_row(ch_cfg, sql)
+    }
+
+
+def format_utc_rfc3339_ms(unix_ms: int) -> str:
+    return (
+        datetime.fromtimestamp(unix_ms / 1000, tz=timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def corpus_session_window(ch_cfg: dict[str, Any]) -> Optional[dict[str, Any]]:
+    database = ch_cfg["database"]
+    sql = f"""
+SELECT
+  count() AS sessions,
+  toInt64(toUnixTimestamp64Milli(min(first_event_time))) AS start_unix_ms,
+  toInt64(toUnixTimestamp64Milli(max(last_event_time))) AS end_unix_ms
+FROM {database}.v_session_summary
+FORMAT JSONEachRow
+""".strip()
+    rows = clickhouse_select_json_each_row(ch_cfg, sql)
+    if not rows:
+        return None
+    row = rows[0]
+    sessions = int(row.get("sessions", 0))
+    if sessions <= 0:
+        return None
+    start_unix_ms = int(row["start_unix_ms"])
+    end_unix_ms = int(row["end_unix_ms"]) + 1
+    return {
+        "sessions": sessions,
+        "start_datetime": format_utc_rfc3339_ms(start_unix_ms),
+        "end_datetime": format_utc_rfc3339_ms(end_unix_ms),
     }
 
 
@@ -390,6 +444,8 @@ def measured_tool_call(
         raise RuntimeError(f"{name} response missing structuredContent")
     if bool(result.get("isError")):
         raise RuntimeError(f"{name} returned isError=true: {structured}")
+    if "error" in structured:
+        raise RuntimeError(f"{name} returned error envelope: {structured['error']}")
     performance = structured.get("performance")
     if not isinstance(performance, dict):
         raise RuntimeError(f"{name} response missing performance object")
@@ -486,6 +542,20 @@ def first_hit_open_ids(search_payload: dict[str, Any]) -> dict[str, str]:
     }
 
 
+def first_list_session_open_id(list_payload: dict[str, Any]) -> Optional[str]:
+    sessions = list_payload.get("data", {}).get("sessions", [])
+    if not isinstance(sessions, list) or not sessions:
+        return None
+    first = sessions[0]
+    if not isinstance(first, dict):
+        return None
+    open_block = first.get("open")
+    if not isinstance(open_block, dict):
+        return None
+    value = open_block.get("session_id")
+    return value if isinstance(value, str) and value else None
+
+
 def unique_queries(args: argparse.Namespace, log_rows: list[dict[str, Any]]) -> list[str]:
     queries: list[str] = []
     seen: set[str] = set()
@@ -505,6 +575,7 @@ def main() -> int:
     try:
         ch_cfg = read_clickhouse_config(config)
         counts = corpus_counts(ch_cfg)
+        session_window = corpus_session_window(ch_cfg) if not args.skip_list_sessions else None
         log_rows = select_log_queries(ch_cfg, args.window, args.top_n_log_queries)
         queries = unique_queries(args, log_rows)
     except Exception as exc:
@@ -522,13 +593,48 @@ def main() -> int:
         )
         return 2
 
-    if not queries:
-        print("fatal: no queries supplied or selected", file=sys.stderr)
+    list_sessions_args: Optional[dict[str, Any]] = None
+    if not args.skip_list_sessions:
+        if bool(args.list_start_datetime) != bool(args.list_end_datetime):
+            print(
+                "fatal: --list-start-datetime and --list-end-datetime must be provided together",
+                file=sys.stderr,
+            )
+            return 2
+        if args.list_start_datetime and args.list_end_datetime:
+            list_sessions_args = {
+                "start_datetime": args.list_start_datetime,
+                "end_datetime": args.list_end_datetime,
+                "limit": args.list_limit,
+            }
+        elif session_window is not None:
+            list_sessions_args = {
+                "start_datetime": session_window["start_datetime"],
+                "end_datetime": session_window["end_datetime"],
+                "limit": args.list_limit,
+            }
+        else:
+            print("warning: no session window available; skipping list_sessions benchmark")
+        if list_sessions_args is not None and args.list_mode:
+            list_sessions_args["mode"] = args.list_mode
+
+    if list_sessions_args is not None:
+        print("list_sessions")
+        mode_suffix = f" mode={args.list_mode}" if args.list_mode else ""
+        print(
+            "  "
+            f"{list_sessions_args['start_datetime']} -> {list_sessions_args['end_datetime']} "
+            f"limit={list_sessions_args['limit']}{mode_suffix}"
+        )
+
+    if not queries and list_sessions_args is None:
+        print("fatal: no queries supplied or selected and no list_sessions window", file=sys.stderr)
         return 2
 
-    print("Queries")
-    for idx, query in enumerate(queries, start=1):
-        print(f"  {idx}. {query}")
+    if queries:
+        print("Queries")
+        for idx, query in enumerate(queries, start=1):
+            print(f"  {idx}. {query}")
 
     if args.dry_run:
         return 0
@@ -557,7 +663,10 @@ def main() -> int:
             for tool in tools_result.get("tools", [])
             if isinstance(tool, dict)
         }
-        missing_tools = {"search_sessions", "open"} - tool_names
+        expected_tools = {"search_sessions", "open"}
+        if list_sessions_args is not None:
+            expected_tools.add("list_sessions")
+        missing_tools = expected_tools - tool_names
         if missing_tools:
             raise RuntimeError(f"tools/list missing expected tools: {sorted(missing_tools)}")
 
@@ -609,6 +718,28 @@ def main() -> int:
                     if measured:
                         failures.append(f"query={query!r} run={run_idx}: {exc}")
 
+        if list_sessions_args is not None:
+            total_runs = args.warmup + args.repeats
+            for run_idx in range(total_runs):
+                measured = run_idx >= args.warmup
+                try:
+                    request_id, list_sample = measured_tool_call(
+                        proc,
+                        request_id,
+                        args.timeout_seconds,
+                        "list_sessions",
+                        dict(list_sessions_args),
+                    )
+                    if first_list_session_open_id(list_sample["structured"]) is None and measured:
+                        failures.append("list_sessions returned no open.session_id")
+                    if measured:
+                        sample = dict(list_sample)
+                        sample.pop("structured", None)
+                        samples.append(sample)
+                except Exception as exc:
+                    if measured:
+                        failures.append(f"list_sessions run={run_idx}: {exc}")
+
     except Exception as exc:
         failures.append(str(exc))
     finally:
@@ -642,6 +773,7 @@ def main() -> int:
             "repeats": args.repeats,
             "n_hits": args.n_hits,
             "open_kinds": open_kinds,
+            "list_sessions_args": list_sessions_args,
             "min_docs": args.min_docs,
             "moraine_bin": args.moraine_bin,
             "service_bin_dir": service_bin_dir,

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -353,7 +353,7 @@ EOF
     printf '%s' "$body" | json_ok_true "$python_bin"
   done
 
-  echo "[e2e] checking MCP initialize/tools/search_sessions/open (codex)"
+  echo "[e2e] checking MCP initialize/tools/search_sessions/open/list_sessions (codex)"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
     --moraine "$moraine_bin" \
     --config "$config_path" \
@@ -362,7 +362,7 @@ EOF
     --expect-source-file "$codex_fixture_file" \
     --expect-open-text "$codex_trace_marker"
 
-  echo "[e2e] checking MCP initialize/tools/search_sessions/open (claude)"
+  echo "[e2e] checking MCP initialize/tools/search_sessions/open/list_sessions (claude)"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
     --moraine "$moraine_bin" \
     --config "$config_path" \
@@ -373,8 +373,8 @@ EOF
 
   # Hermes synthesizes its own `hermes:<uid>` session id, so we do not pin
   # --expect-session-id; source file + trace marker are enough to prove the
-  # row round-tripped from fixture through ingest to MCP search_sessions/open.
-  echo "[e2e] checking MCP initialize/tools/search_sessions/open (hermes)"
+  # row round-tripped from fixture through ingest to MCP search_sessions/open/list_sessions.
+  echo "[e2e] checking MCP initialize/tools/search_sessions/open/list_sessions (hermes)"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
     --moraine "$moraine_bin" \
     --config "$config_path" \

--- a/scripts/ci/mcp_smoke.py
+++ b/scripts/ci/mcp_smoke.py
@@ -153,9 +153,9 @@ def contains_text(value: Any, needle: str) -> bool:
 
 
 def assert_tools_surface(tool_names_ordered: list[str]) -> None:
-    if tool_names_ordered != ["search_sessions", "open"]:
+    if tool_names_ordered != ["search_sessions", "open", "list_sessions"]:
         raise AssertionError(
-            "tools/list must publish the two-tool search surface exactly: "
+            "tools/list must publish the MCP search surface exactly: "
             f"{tool_names_ordered}"
         )
 
@@ -216,6 +216,47 @@ def open_ids_from_search_result(result: Dict[str, Any]) -> list[str]:
             raise AssertionError(f"search_sessions result missing {key}: {result}")
         open_ids.append(open_id)
     return list(dict.fromkeys(open_ids))
+
+
+def select_list_sessions_result(
+    sessions: list[Any],
+    expect_session_id: Optional[str],
+) -> Dict[str, Any]:
+    expected_session = expected_mcp_session_id(expect_session_id)
+
+    for result in sessions:
+        if not isinstance(result, dict):
+            continue
+        session_id = nested_string(result, "session", "id")
+        open_session_id = nested_string(result, "open", "session_id")
+        if expected_session is None or expected_session in {session_id, open_session_id}:
+            return result
+
+    debug_sessions = [
+        {
+            "id": session.get("id"),
+            "session_id": nested_string(session, "session", "id"),
+            "open_session_id": nested_string(session, "open", "session_id"),
+            "updated_at": nested_string(session, "session", "updated_at"),
+        }
+        for session in sessions
+        if isinstance(session, dict)
+    ][:5]
+    raise AssertionError(
+        "list_sessions did not return a session matching expected filters: "
+        f"session_id={expect_session_id}, sessions={debug_sessions}"
+    )
+
+
+def open_id_from_list_sessions_result(result: Dict[str, Any]) -> str:
+    open_id = nested_string(result, "open", "session_id")
+    session_id = nested_string(result, "session", "id")
+    if not open_id or open_id != session_id:
+        raise AssertionError(f"list_sessions result missing matching open.session_id: {result}")
+    for forbidden in ["snippet", "payload_json", "events", "text_content"]:
+        if forbidden in result:
+            raise AssertionError(f"list_sessions returned non-metadata field {forbidden}: {result}")
+    return open_id
 
 
 def open_payload_session_id(payload: Dict[str, Any]) -> Optional[str]:
@@ -350,6 +391,31 @@ def run_smoke(
             proc,
             next_id,
             open_ids_from_search_result(selected_result),
+            expect_session_id,
+            expect_open_text,
+        )
+
+        list_result = call_tool(
+            proc,
+            next_id,
+            "list_sessions",
+            {
+                "start_datetime": "2026-02-16T11:59:00Z",
+                "end_datetime": "2026-02-16T12:01:00Z",
+                "limit": 20,
+            },
+        )
+        next_id += 1
+        list_payload = assert_structured_content(list_result, "list_sessions")
+        sessions = list_payload["data"].get("sessions")
+        if not isinstance(sessions, list) or not sessions:
+            raise AssertionError("list_sessions returned no sessions for e2e fixture window")
+
+        selected_session = select_list_sessions_result(sessions, expect_session_id)
+        next_id = assert_open_search_ids(
+            proc,
+            next_id,
+            [open_id_from_list_sessions_result(selected_session)],
             expect_session_id,
             expect_open_text,
         )

--- a/scripts/dev/sandbox/README.md
+++ b/scripts/dev/sandbox/README.md
@@ -66,8 +66,8 @@ moraine "for real", stop; use `install.sh` instead.
 Code CLI inside the container (headless, `--dangerously-skip-permissions`),
 and drives the `/agent-smoke-e2e` skill at
 [`.claude/skills/agent-smoke-e2e/SKILL.md`](../../../.claude/skills/agent-smoke-e2e/SKILL.md).
-The skill exercises the public two-tool retrieval workflow
-(`search_sessions` and `open`) and emits a pass/fail matrix.
+The skill exercises the public retrieval workflow (`search_sessions`, `open`,
+and `list_sessions`) and emits a pass/fail matrix.
 
 The driver runs the skill **three times** — once each against Opus 4.7,
 Sonnet 4.6, and Haiku 4.5 — sharing a single sandbox boot. Each model gets


### PR DESCRIPTION
## What changed

- Added the MCP `list_sessions` tool with explicit RFC3339 datetime bounds, optional mode/sort/limit/cursor arguments, typed `session:...` open handles, metadata-only responses, pagination, and structured error envelopes.
- Added repository support for overlap-window session listing from ClickHouse session summary data, including cursor filter signatures and mode-aware ordering.
- Updated MCP tool publication, smoke coverage, agent smoke guidance, docs, and the SLA benchmark to cover `search_sessions`, `open`, and `list_sessions`.

Closes #313.

## Operational impact

- No schema migration required.
- MCP clients will now see `search_sessions`, `open`, and `list_sessions` in `tools/list`; legacy public tool names remain absent.
- `list_sessions` uses the existing `mcp.max_results` cap and applies the documented metadata-browse, broad-window, and filtered broad-window SLA targets.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p moraine-mcp-core --locked`
- `cargo test -p moraine-conversations --test repository_integration --locked list_mcp_sessions`
- `python3 -m py_compile scripts/bench/mcp_two_tool_sla.py scripts/ci/mcp_smoke.py`
- `cargo test --workspace --locked`
- `make clippy`
- Sandbox current-code smoke: `mcp smoke passed` using `sb-60aba6` fixture session; sandbox was torn down afterward.
- Host large corpus SLA: 342,487 events, 816 sessions, 194,949 search documents, 12,832,359 postings; `list_sessions` 20 samples over 2025-09-21T16:59:40.007Z -> 2026-04-30T15:43:51.170Z had server p50 213.50 ms, server p95 295.25 ms, server p99 299.05 ms, zero SLA misses.
