### PR TITLE
chore(release): cut v0.5.3

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.5.2)"
+        description: "Tag to release (for example v0.5.3)"
         required: true
         type: string
       target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "moraine"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/moraine-ingest/Cargo.toml
+++ b/apps/moraine-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Moraine ingest service binary"
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Moraine MCP stdio server"
 

--- a/apps/moraine-monitor/Cargo.toml
+++ b/apps/moraine-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Moraine monitor HTTP/UI service"
 

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Unified runtime control plane for Moraine services"
 

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-clickhouse"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Shared Moraine ClickHouse client and query helpers"
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-config"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Shared Moraine configuration schema and loaders"
 

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-conversations"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "High-level read/query APIs for Moraine conversations"
 

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest-core"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Core ingestion pipeline internals for Moraine"
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp-core"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "MCP protocol and tool routing core for Moraine"
 

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor-core"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Analytics and query logic for Moraine monitor service"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ install directory precedence:
 
 examples:
   scripts/install.sh
-  MORAINE_INSTALL_VERSION=v0.5.2 scripts/install.sh
+  MORAINE_INSTALL_VERSION=v0.5.3 scripts/install.sh
   MORAINE_INSTALL_ASSET_BASE_URL=http://127.0.0.1:8080 \
     MORAINE_INSTALL_VERSION=ci-e2e scripts/install.sh
   MORAINE_INSTALL_DIR="$HOME/bin" MORAINE_INSTALL_SKIP_CLICKHOUSE=1 scripts/install.sh


### PR DESCRIPTION
## What changed

- Bumped all Moraine workspace packages from `0.5.2` to `0.5.3`.
- Updated `Cargo.lock` for the workspace package versions.
- Updated the release workflow dispatch example and installer help example to `v0.5.3`.

## Release notes

Moraine `v0.5.3` adds a time-window MCP session browser. MCP clients now have a three-tool retrieval surface: `search_sessions` for ranked discovery, `list_sessions` for chronological session browsing, and `open` for expanding typed handles.

Highlights:

- `list_sessions` lists sessions that overlap an explicit RFC3339 datetime range, with required timezone offsets, cursor pagination, optional mode filtering, and stable `session:...` IDs.
- Listed sessions return metadata only: title/source/timestamps/completion/turn and event counts, plus an `open.session_id` handle for follow-up inspection.
- `tools/list` now publishes `search_sessions`, `open`, and `list_sessions`; legacy public tool names remain absent.
- The MCP smoke path, agent smoke guidance, and SLA benchmark now cover the full `search_sessions`/`list_sessions`/`open` retrieval workflow.

## Operational impact

- MCP clients can use `list_sessions` for time-window traversal without pulling transcript text or event payloads.
- No schema migration is required; the tool reads existing session summary and event metadata.
- No runtime config changes are required. `list_sessions.limit` remains capped by `mcp.max_results`.

## Validation

- `cargo metadata --locked --no-deps --format-version 1` confirmed all workspace packages at `0.5.3`.
- `cargo fmt --all -- --check`
- `cargo test --workspace --locked`
- `make clippy`

After this PR lands, create/push the `v0.5.3` tag to trigger `release-moraine` asset builds and PyPI publishing, then use the release notes above as the GitHub release body.
