### PR TITLE
docs: restore README media

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,25 @@
 # Moraine
 
+![Moraine Banner](https://github.com/user-attachments/assets/efa723e6-bcc9-4402-bbdf-083297f7e1e2)
+
 [![Docs](https://github.com/eric-tramel/moraine/actions/workflows/docs-deploy.yml/badge.svg)](https://eric-tramel.github.io/moraine/)
 
 Moraine is a local trace stack for agent work. It indexes sessions from agent
 harnesses such as Codex, Claude Code, Kimi CLI, and Hermes into ClickHouse,
 serves a monitor UI, and exposes MCP retrieval over the indexed history.
 
+Agents get searchable long-term memory through MCP. You get a unified local
+record of what happened across providers, including tools, tokens, and
+conversation history.
+
 Moraine is under active development. Config keys, schemas, and MCP tools can
 change across minor releases.
+
+## Screenshots
+
+<img width="1635" height="1170" alt="Moraine monitor session overview" src="https://github.com/user-attachments/assets/b1e67007-aa73-4c31-80b9-79c0d4fb91da" />
+
+<img width="1635" height="1170" alt="Moraine monitor trace details" src="https://github.com/user-attachments/assets/f7ec8582-8d3c-4745-bdbe-a2fe71df6004" />
 
 ## Documentation
 


### PR DESCRIPTION
## What Changed and Why

Restores the README banner and two monitor screenshots that previous README versions displayed near the top. The media still exists as GitHub user-attachment URLs; it disappeared when the docs refactor in `4259b26` / PR #296 replaced the README with a shorter documentation index.

The README keeps the current docs-focused structure and restores only the visual material plus a short agent/user positioning sentence.

## Operational Impact

Docs-only change. No config, schema, migration, service behavior, build, or packaging impact.

## Validation

- `git diff --check`
- `curl -fsSL -o /dev/null -w "%{http_code} %{content_type}\\n"` returned `200 image/jpeg` for the banner URL.
- The same GET check returned `200 image/png` for both screenshot URLs.
- Pre-commit hook ran and skipped cargo checks because no Rust files were staged.

## Linked Issues

None.