### PR TITLE
docs: point README links to Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,22 +23,10 @@ change across minor releases.
 
 ## Documentation
 
-- [Introduction](docs/index.md)
-- [Quickstart and Installation](docs/quickstart.md)
-- [Configuration](docs/configuration.md)
-- [MCP Search Interface Specification](docs/mcp-search-interface-spec.md)
-
-Build the documentation site with:
-
-```bash
-make docs-build
-```
-
-Serve it locally with:
-
-```bash
-make docs-serve
-```
+- [Introduction](https://eric-tramel.github.io/moraine/)
+- [Quickstart and Installation](https://eric-tramel.github.io/moraine/quickstart.html)
+- [Configuration](https://eric-tramel.github.io/moraine/configuration.html)
+- [MCP Search Interface Specification](https://eric-tramel.github.io/moraine/mcp-search-interface-spec.html)
 
 ## Quickstart
 


### PR DESCRIPTION
## What Changed and Why

Updates the README documentation links to point at the deployed GitHub Pages site instead of local `docs/*.md` paths. This makes the top-level README send readers to the rendered public documentation.

Removes the local `make docs-build` and `make docs-serve` instructions from the README documentation section, leaving the quickstart installation flow as the primary local command path.

## Operational Impact

Docs-only README change. No config, schema, migration, service behavior, build, or packaging impact.

## Validation

- `git diff --check`
- Verified all README documentation URLs return `200 text/html; charset=utf-8`:
  - `https://eric-tramel.github.io/moraine/`
  - `https://eric-tramel.github.io/moraine/quickstart.html`
  - `https://eric-tramel.github.io/moraine/configuration.html`
  - `https://eric-tramel.github.io/moraine/mcp-search-interface-spec.html`
- Pre-commit hook ran and skipped cargo checks because no Rust files were staged.

## Linked Issues

None.