### PR TITLE
refactor(ingest): route kimi normalization through handlers

### DIFF
--- a/crates/moraine-ingest-core/src/sources/kimi_cli.rs
+++ b/crates/moraine-ingest-core/src/sources/kimi_cli.rs
@@ -1,5 +1,8 @@
 use super::shared::*;
-use super::{IngestSource, NormalizedPartials, Preflight, SourceRecordContext};
+use super::{
+    emitter::SourceEmitter, record_view::RecordView, IngestSource, NormalizedPartials, Preflight,
+    SourceRecordContext,
+};
 use serde_json::{json, Map, Value};
 
 pub(crate) static KIMI_CLI: KimiCli = KimiCli;
@@ -50,7 +53,7 @@ impl IngestSource for KimiCli {
         base_uid: &str,
         _model_hint: &str,
     ) -> NormalizedPartials {
-        normalize_kimi_cli_wire_event(record, ctx, top_type, base_uid).into()
+        normalize_kimi_cli_wire_event(record, ctx, top_type, base_uid)
     }
 }
 
@@ -95,15 +98,12 @@ fn kimi_wire_record_ts(record: &Value) -> String {
         .unwrap_or_default()
 }
 
-fn kimi_cli_event_uid(ctx: &RecordContext<'_>, record_fingerprint: &str, suffix: &str) -> String {
-    event_uid(
-        ctx.source_file,
-        ctx.source_generation,
-        ctx.source_line_no,
-        ctx.source_offset,
-        record_fingerprint,
-        &format!("kimi-cli:{suffix}"),
-    )
+fn kimi_cli_event_uid(
+    emitter: &SourceEmitter<'_>,
+    record_fingerprint: &str,
+    suffix: &str,
+) -> String {
+    emitter.uid(record_fingerprint, &format!("kimi-cli:{suffix}"))
 }
 
 fn normalize_kimi_cli_wire_event(
@@ -111,334 +111,358 @@ fn normalize_kimi_cli_wire_event(
     ctx: &RecordContext<'_>,
     top_type: &str,
     _base_uid: &str,
-) -> (Vec<Value>, Vec<Value>, Vec<Value>) {
-    let mut events = Vec::<Value>::new();
-    let links = Vec::<Value>::new();
-    let mut tools = Vec::<Value>::new();
+) -> NormalizedPartials {
+    let wire = KimiWireRecord::new(record, top_type);
+    let mut emitter = SourceEmitter::new(ctx);
 
-    let message = record.get("message").unwrap_or(record);
-    let msg_type = {
-        let message_type = to_str(message.get("type"));
-        if message_type.is_empty() {
+    dispatch_kimi_wire_record(&wire, &mut emitter);
+
+    let mut partials = emitter.finish();
+    stamp_kimi_placeholder_model(&mut partials.event_rows);
+    partials
+}
+
+struct KimiWireRecord<'a> {
+    msg_type: String,
+    payload: &'a Value,
+    payload_json: String,
+}
+
+impl<'a> KimiWireRecord<'a> {
+    fn new(record: &'a Value, top_type: &str) -> Self {
+        let view = RecordView::new(record);
+        let message = view.get("message").unwrap_or(record);
+        let message_view = RecordView::new(message);
+        let message_type = message_view.string_field("type");
+        let msg_type = if message_type.is_empty() {
             top_type.to_string()
         } else {
             message_type
+        };
+        let payload = message_view.get("payload").unwrap_or(record);
+        let payload_json = compact_json(payload);
+
+        Self {
+            msg_type,
+            payload,
+            payload_json,
+        }
+    }
+
+    fn msg_type(&self) -> &str {
+        &self.msg_type
+    }
+
+    fn payload(&self) -> &'a Value {
+        self.payload
+    }
+
+    fn payload_json(&self) -> &str {
+        &self.payload_json
+    }
+
+    fn payload_field(&self, key: &str) -> Option<&'a Value> {
+        self.payload.get(key)
+    }
+}
+
+fn dispatch_kimi_wire_record<'a>(wire: &KimiWireRecord<'a>, emitter: &mut SourceEmitter<'_>) {
+    match wire.msg_type() {
+        "TurnBegin" | "SteerInput" => handle_kimi_turn_begin(wire, emitter),
+        "TurnEnd" => {
+            handle_kimi_generic_progress(wire, emitter, "wire:turn_end", "summary", "", "summary")
+        }
+        "StepBegin" => handle_kimi_step_begin(wire, emitter),
+        "StepInterrupted" => handle_kimi_generic_progress(
+            wire,
+            emitter,
+            "wire:step_interrupted",
+            "progress",
+            &extract_message_text(wire.payload()),
+            "progress",
+        ),
+        "ContentPart" => handle_kimi_content_part(wire, emitter),
+        "ToolCall" => handle_kimi_tool_call(wire, emitter),
+        "ToolCallPart" => handle_kimi_tool_call_part(wire, emitter),
+        "ToolResult" => handle_kimi_tool_result(wire, emitter),
+        "StatusUpdate" => handle_kimi_status_update(wire, emitter),
+        "CompactionBegin" | "CompactionEnd" => {
+            handle_kimi_generic_progress(wire, emitter, "wire:compaction", "summary", "", "summary")
+        }
+        "HookTriggered" | "HookResolved" => handle_kimi_hook_event(wire, emitter),
+        "SubagentEvent" => handle_kimi_subagent_event(),
+        "MCPLoadingBegin" | "MCPLoadingEnd" | "MCPStatusSnapshot" | "BtwBegin" | "BtwEnd"
+        | "Notification" | "PlanDisplay" | "ApprovalRequest" | "ApprovalResponse"
+        | "QuestionRequest" | "QuestionResponse" => {
+            let suffix = format!("wire:{}", wire.msg_type());
+            handle_kimi_generic_progress(
+                wire,
+                emitter,
+                &suffix,
+                "progress",
+                &extract_message_text(wire.payload()),
+                "progress",
+            );
+        }
+        _ => handle_kimi_generic_progress(
+            wire,
+            emitter,
+            "wire:unknown",
+            "unknown",
+            &extract_message_text(wire.payload()),
+            "unknown",
+        ),
+    }
+}
+
+fn handle_kimi_turn_begin<'a>(wire: &KimiWireRecord<'a>, emitter: &mut SourceEmitter<'_>) {
+    let input = wire.payload_field("user_input").unwrap_or_else(null_value);
+    let uid = kimi_cli_event_uid(emitter, wire.payload_json(), "wire:user_input");
+    let event = emitter
+        .event(
+            &uid,
+            "message",
+            "user_message",
+            "user",
+            &extract_message_text(input),
+            wire.payload_json(),
+        )
+        .content_types(extract_content_types(input));
+    emitter.push_event(event);
+}
+
+fn handle_kimi_step_begin<'a>(wire: &KimiWireRecord<'a>, emitter: &mut SourceEmitter<'_>) {
+    let uid = kimi_cli_event_uid(emitter, wire.payload_json(), "wire:step_begin");
+    let event = emitter
+        .event(
+            &uid,
+            "progress",
+            "progress",
+            "system",
+            "",
+            wire.payload_json(),
+        )
+        .turn_index(to_u32(wire.payload_field("n")))
+        .op_kind("step_begin");
+    emitter.push_event(event);
+}
+
+fn handle_kimi_content_part<'a>(wire: &KimiWireRecord<'a>, emitter: &mut SourceEmitter<'_>) {
+    let part_type = to_str(wire.payload_field("type"));
+    match part_type.as_str() {
+        "think" => {
+            let uid = kimi_cli_event_uid(emitter, wire.payload_json(), "wire:content:think");
+            let text = to_str(wire.payload_field("think"));
+            let event = emitter
+                .event(
+                    &uid,
+                    "reasoning",
+                    "reasoning",
+                    "assistant",
+                    &text,
+                    wire.payload_json(),
+                )
+                .has_reasoning(true)
+                .content_types(["reasoning"]);
+            emitter.push_event(event);
+        }
+        _ => {
+            let text = if let Some(text) = wire.payload_field("text") {
+                extract_message_text(text)
+            } else {
+                extract_message_text(wire.payload())
+            };
+            let uid = kimi_cli_event_uid(emitter, wire.payload_json(), "wire:content:text");
+            let mut event = emitter.event(
+                &uid,
+                "message",
+                "agent_message",
+                "assistant",
+                &text,
+                wire.payload_json(),
+            );
+            if !part_type.is_empty() {
+                event = event.content_types([part_type]);
+            }
+            emitter.push_event(event);
+        }
+    }
+}
+
+fn handle_kimi_tool_call<'a>(wire: &KimiWireRecord<'a>, emitter: &mut SourceEmitter<'_>) {
+    let function = wire.payload_field("function").unwrap_or_else(null_value);
+    let tool_name = to_str(function.get("name"));
+    let arguments = to_str(function.get("arguments"));
+    let tool_call_id = to_str(wire.payload_field("id"));
+    let args = parse_json_string(&arguments).unwrap_or_else(|| {
+        if arguments.is_empty() {
+            Value::Object(Map::new())
+        } else {
+            json!({ "raw": arguments })
+        }
+    });
+    let input_json = compact_json(&args);
+    let input_text = {
+        let extracted = extract_message_text(&args);
+        if extracted.is_empty() {
+            input_json.clone()
+        } else {
+            extracted
         }
     };
-    let payload = message.get("payload").unwrap_or(record);
-    let payload_json = compact_json(payload);
 
-    let mut push_progress = |suffix: &str, kind: &str, text: String, payload_type: &str| {
-        let uid = kimi_cli_event_uid(ctx, &payload_json, suffix);
-        let mut row = base_event_obj(
-            ctx,
+    let uid = kimi_cli_event_uid(emitter, wire.payload_json(), "wire:tool_call");
+    let event = emitter
+        .event(
+            &uid,
+            "tool_call",
+            "tool_use",
+            "assistant",
+            &input_text,
+            wire.payload_json(),
+        )
+        .content_types(["tool_use"])
+        .tool_call_id(tool_call_id.clone())
+        .tool_name(tool_name.clone());
+    emitter.push_event(event);
+    emitter.push_tool_request(&uid, &tool_call_id, "", &tool_name, &input_json);
+}
+
+fn handle_kimi_tool_call_part<'a>(wire: &KimiWireRecord<'a>, emitter: &mut SourceEmitter<'_>) {
+    let uid = kimi_cli_event_uid(emitter, wire.payload_json(), "wire:tool_call_part");
+    let args_part = to_str(wire.payload_field("arguments_part"));
+    let event = emitter
+        .event(
+            &uid,
+            "progress",
+            "tool_use",
+            "assistant",
+            &args_part,
+            wire.payload_json(),
+        )
+        .op_kind("tool_call_part");
+    emitter.push_event(event);
+}
+
+fn handle_kimi_tool_result<'a>(wire: &KimiWireRecord<'a>, emitter: &mut SourceEmitter<'_>) {
+    let tool_call_id = to_str(wire.payload_field("tool_call_id"));
+    let return_value = wire
+        .payload_field("return_value")
+        .unwrap_or_else(null_value);
+    let is_error = to_u8_bool(return_value.get("is_error"));
+    let output = to_str(return_value.get("output"));
+    let message_text = to_str(return_value.get("message"));
+
+    let output_text = if !output.is_empty() {
+        output.clone()
+    } else {
+        message_text.clone()
+    };
+    let output_json = compact_json(return_value);
+
+    let uid = kimi_cli_event_uid(emitter, wire.payload_json(), "wire:tool_result");
+    let event = emitter
+        .event(
+            &uid,
+            "tool_result",
+            "tool_result",
+            "tool",
+            &output_text,
+            wire.payload_json(),
+        )
+        .content_types(["tool_result"])
+        .tool_call_id(tool_call_id.clone())
+        .tool_error(is_error);
+    emitter.push_event(event);
+    emitter.push_tool_response(
+        &uid,
+        &tool_call_id,
+        "",
+        "",
+        is_error,
+        "",
+        &output_json,
+        &output_text,
+    );
+}
+
+fn handle_kimi_status_update<'a>(wire: &KimiWireRecord<'a>, emitter: &mut SourceEmitter<'_>) {
+    let token_usage = wire.payload_field("token_usage").unwrap_or_else(null_value);
+    let uid = kimi_cli_event_uid(emitter, wire.payload_json(), "wire:status_update");
+    let event = emitter
+        .event(
+            &uid,
+            "event_msg",
+            "token_count",
+            "system",
+            "",
+            wire.payload_json(),
+        )
+        .token_accounting(TokenAccounting::kimi_generation(Some(token_usage)))
+        .item_id(to_str(wire.payload_field("message_id")));
+    emitter.push_event(event);
+}
+
+fn handle_kimi_hook_event<'a>(wire: &KimiWireRecord<'a>, emitter: &mut SourceEmitter<'_>) {
+    let event = to_str(wire.payload_field("event"));
+    let target = to_str(wire.payload_field("target"));
+    let text = if !event.is_empty() && !target.is_empty() {
+        format!("{event}: {target}")
+    } else {
+        event
+    };
+    handle_kimi_generic_progress(wire, emitter, "wire:hook", "event_msg", &text, "event_msg");
+}
+
+fn handle_kimi_generic_progress(
+    wire: &KimiWireRecord<'_>,
+    emitter: &mut SourceEmitter<'_>,
+    suffix: &str,
+    kind: &str,
+    text: &str,
+    payload_type: &str,
+) {
+    let uid = kimi_cli_event_uid(emitter, wire.payload_json(), suffix);
+    let event = emitter
+        .event(
             &uid,
             kind,
             payload_type,
             "system",
-            &text,
-            &payload_json,
-        );
-        row.insert("op_kind".to_string(), json!(msg_type));
-        events.push(Value::Object(row));
-    };
+            text,
+            wire.payload_json(),
+        )
+        .op_kind(wire.msg_type());
+    emitter.push_event(event);
+}
 
-    match msg_type.as_str() {
-        "TurnBegin" | "SteerInput" => {
-            let input = payload.get("user_input").unwrap_or(&Value::Null);
-            let uid = kimi_cli_event_uid(ctx, &payload_json, "wire:user_input");
-            let mut row = base_event_obj(
-                ctx,
-                &uid,
-                "message",
-                "user_message",
-                "user",
-                &extract_message_text(input),
-                &payload_json,
-            );
-            row.insert(
-                "content_types".to_string(),
-                json!(extract_content_types(input)),
-            );
-            events.push(Value::Object(row));
-        }
-        "TurnEnd" => {
-            push_progress("wire:turn_end", "summary", String::new(), "summary");
-        }
-        "StepBegin" => {
-            let uid = kimi_cli_event_uid(ctx, &payload_json, "wire:step_begin");
-            let mut row = base_event_obj(
-                ctx,
-                &uid,
-                "progress",
-                "progress",
-                "system",
-                "",
-                &payload_json,
-            );
-            row.insert("turn_index".to_string(), json!(to_u32(payload.get("n"))));
-            row.insert("op_kind".to_string(), json!("step_begin"));
-            events.push(Value::Object(row));
-        }
-        "StepInterrupted" => {
-            push_progress(
-                "wire:step_interrupted",
-                "progress",
-                extract_message_text(payload),
-                "progress",
-            );
-        }
-        "ContentPart" => {
-            let part_type = to_str(payload.get("type"));
-            match part_type.as_str() {
-                "think" => {
-                    let uid = kimi_cli_event_uid(ctx, &payload_json, "wire:content:think");
-                    let text = to_str(payload.get("think"));
-                    let mut row = base_event_obj(
-                        ctx,
-                        &uid,
-                        "reasoning",
-                        "reasoning",
-                        "assistant",
-                        &text,
-                        &payload_json,
-                    );
-                    mark_reasoning_metadata(&mut row);
-                    events.push(Value::Object(row));
-                }
-                _ => {
-                    let text = if let Some(text) = payload.get("text") {
-                        extract_message_text(text)
-                    } else {
-                        extract_message_text(payload)
-                    };
-                    let uid = kimi_cli_event_uid(ctx, &payload_json, "wire:content:text");
-                    let mut row = base_event_obj(
-                        ctx,
-                        &uid,
-                        "message",
-                        "agent_message",
-                        "assistant",
-                        &text,
-                        &payload_json,
-                    );
-                    if !part_type.is_empty() {
-                        row.insert("content_types".to_string(), json!([part_type]));
-                    }
-                    events.push(Value::Object(row));
-                }
-            }
-        }
-        "ToolCall" => {
-            let function = payload.get("function").unwrap_or(&Value::Null);
-            let tool_name = to_str(function.get("name"));
-            let arguments = to_str(function.get("arguments"));
-            let tool_call_id = to_str(payload.get("id"));
-            let args = parse_json_string(&arguments).unwrap_or_else(|| {
-                if arguments.is_empty() {
-                    Value::Object(Map::new())
-                } else {
-                    json!({ "raw": arguments })
-                }
-            });
-            let input_json = compact_json(&args);
-            let input_text = {
-                let extracted = extract_message_text(&args);
-                if extracted.is_empty() {
-                    input_json.clone()
-                } else {
-                    extracted
-                }
-            };
+fn handle_kimi_subagent_event() {
+    // Kimi writes every sub-agent event twice: once as a SubagentEvent envelope
+    // on the parent wire, and once as the real event inside
+    // `<session>/subagents/<agent_id>/wire.jsonl`. Emitting a normalized row
+    // here would double-count every sub-agent event as `progress` on the parent
+    // session (see #271). Skip the normalized row; the raw_events row is still
+    // written from the enclosing dispatcher, so the byte-level trace is
+    // preserved.
+}
 
-            let uid = kimi_cli_event_uid(ctx, &payload_json, "wire:tool_call");
-            let mut row = base_event_obj(
-                ctx,
-                &uid,
-                "tool_call",
-                "tool_use",
-                "assistant",
-                &input_text,
-                &payload_json,
-            );
-            row.insert("content_types".to_string(), json!(["tool_use"]));
-            row.insert("tool_call_id".to_string(), json!(tool_call_id.clone()));
-            row.insert("tool_name".to_string(), json!(tool_name.clone()));
-            events.push(Value::Object(row));
-
-            tools.push(build_tool_row(
-                ctx,
-                &uid,
-                &tool_call_id,
-                "",
-                &tool_name,
-                "request",
-                0,
-                &input_json,
-                "",
-                "",
-            ));
-        }
-        "ToolCallPart" => {
-            let uid = kimi_cli_event_uid(ctx, &payload_json, "wire:tool_call_part");
-            let args_part = to_str(payload.get("arguments_part"));
-            let mut row = base_event_obj(
-                ctx,
-                &uid,
-                "progress",
-                "tool_use",
-                "assistant",
-                &args_part,
-                &payload_json,
-            );
-            row.insert("op_kind".to_string(), json!("tool_call_part"));
-            events.push(Value::Object(row));
-        }
-        "ToolResult" => {
-            let tool_call_id = to_str(payload.get("tool_call_id"));
-            let return_value = payload.get("return_value").unwrap_or(&Value::Null);
-            let is_error = to_u8_bool(return_value.get("is_error"));
-            let output = to_str(return_value.get("output"));
-            let message_text = to_str(return_value.get("message"));
-
-            let output_text = if !output.is_empty() {
-                output.clone()
-            } else {
-                message_text.clone()
-            };
-            let output_json = compact_json(return_value);
-
-            let uid = kimi_cli_event_uid(ctx, &payload_json, "wire:tool_result");
-            let mut row = base_event_obj(
-                ctx,
-                &uid,
-                "tool_result",
-                "tool_result",
-                "tool",
-                &output_text,
-                &payload_json,
-            );
-            row.insert("content_types".to_string(), json!(["tool_result"]));
-            row.insert("tool_call_id".to_string(), json!(tool_call_id.clone()));
-            row.insert("tool_error".to_string(), json!(is_error));
-            events.push(Value::Object(row));
-
-            tools.push(build_tool_row(
-                ctx,
-                &uid,
-                &tool_call_id,
-                "",
-                "",
-                "response",
-                is_error,
-                "",
-                &output_json,
-                &output_text,
-            ));
-        }
-        "StatusUpdate" => {
-            let token_usage = payload.get("token_usage").unwrap_or(&Value::Null);
-            let input_other = to_u32(token_usage.get("input_other"));
-            let input_cache_read = to_u32(token_usage.get("input_cache_read"));
-            let input_cache_creation = to_u32(token_usage.get("input_cache_creation"));
-            let output = to_u32(token_usage.get("output"));
-
-            let uid = kimi_cli_event_uid(ctx, &payload_json, "wire:status_update");
-            let mut row = base_event_obj(
-                ctx,
-                &uid,
-                "event_msg",
-                "token_count",
-                "system",
-                "",
-                &payload_json,
-            );
-            row.insert(
-                "input_tokens".to_string(),
-                json!(input_other + input_cache_read + input_cache_creation),
-            );
-            row.insert("output_tokens".to_string(), json!(output));
-            row.insert("cache_read_tokens".to_string(), json!(input_cache_read));
-            row.insert(
-                "cache_write_tokens".to_string(),
-                json!(input_cache_creation),
-            );
-            stamp_token_accounting(
-                &mut row,
-                "generation",
-                generation_token_buckets(
-                    input_other as u64,
-                    output as u64,
-                    input_cache_read as u64,
-                    input_cache_creation as u64,
-                ),
-                token_native_units(&[]),
-            );
-            row.insert(
-                "token_usage_json".to_string(),
-                json!(compact_json(token_usage)),
-            );
-            row.insert(
-                "item_id".to_string(),
-                json!(to_str(payload.get("message_id"))),
-            );
-            events.push(Value::Object(row));
-        }
-        "CompactionBegin" | "CompactionEnd" => {
-            push_progress("wire:compaction", "summary", String::new(), "summary");
-        }
-        "HookTriggered" | "HookResolved" => {
-            let event = to_str(payload.get("event"));
-            let target = to_str(payload.get("target"));
-            let text = if !event.is_empty() && !target.is_empty() {
-                format!("{event}: {target}")
-            } else {
-                event
-            };
-            push_progress("wire:hook", "event_msg", text, "event_msg");
-        }
-        "SubagentEvent" => {
-            // Kimi writes every sub-agent event twice: once as a SubagentEvent
-            // envelope on the parent wire, and once as the real event inside
-            // `<session>/subagents/<agent_id>/wire.jsonl`. Emitting a normalized
-            // row here would double-count every sub-agent event as `progress`
-            // on the parent session (see #271). Skip the normalized row; the
-            // raw_events row is still written from the enclosing dispatcher,
-            // so the byte-level trace is preserved.
-        }
-        "MCPLoadingBegin" | "MCPLoadingEnd" | "MCPStatusSnapshot" | "BtwBegin" | "BtwEnd"
-        | "Notification" | "PlanDisplay" | "ApprovalRequest" | "ApprovalResponse"
-        | "QuestionRequest" | "QuestionResponse" => {
-            push_progress(
-                &format!("wire:{msg_type}"),
-                "progress",
-                extract_message_text(payload),
-                "progress",
-            );
-        }
-        _ => {
-            push_progress(
-                "wire:unknown",
-                "unknown",
-                extract_message_text(payload),
-                "unknown",
-            );
-        }
-    }
-
+fn stamp_kimi_placeholder_model(events: &mut [Value]) {
     // Why: the Kimi wire schema (MoonshotAI/kimi-cli wire/types.py) has no
     // record that carries the active model name, and neither do the sibling
-    // context.jsonl / state.json files. Without a placeholder, every Kimi
-    // event has an empty `model` and the monitor's tokens-by-model analytics
-    // (which filters out empty-model rows) never shows them. Stamping the
-    // harness slug here guarantees a single "kimi-cli" series so Kimi usage
-    // is at least visible cross-harness, even though we can't distinguish
-    // between configured Kimi models.
-    for row in events.iter_mut() {
+    // context.jsonl / state.json files. Without a placeholder, every Kimi event
+    // has an empty `model` and the monitor's tokens-by-model analytics (which
+    // filters out empty-model rows) never shows them. Stamping the harness slug
+    // here guarantees a single "kimi-cli" series so Kimi usage is at least
+    // visible cross-harness, even though we can't distinguish between
+    // configured Kimi models.
+    for row in events {
         if let Some(obj) = row.as_object_mut() {
             obj.insert("model".to_string(), json!("kimi-cli"));
         }
     }
+}
 
-    (events, links, tools)
+fn null_value<'a>() -> &'a Value {
+    static NULL_VALUE: Value = Value::Null;
+    &NULL_VALUE
 }

--- a/crates/moraine-ingest-core/src/sources/shared.rs
+++ b/crates/moraine-ingest-core/src/sources/shared.rs
@@ -466,6 +466,7 @@ pub(crate) fn sum_numeric_object(value: Option<&Value>) -> u64 {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn generation_token_buckets(
     input_text: u64,
     output_text: u64,


### PR DESCRIPTION
## Summary
- refactor Kimi wire normalization into KimiWireRecord plus named handlers
- route Kimi event/tool emission through SourceEmitter, EventBuilder, and TokenAccounting
- preserve placeholder model stamping, token math, tool rows, progress rows, UID material, and SubagentEvent no-row behavior

## Operational Impact
- internal Kimi ingest refactor only
- no schema/config/service behavior changes
- golden snapshots and source contracts remain unchanged

## Validation
- cargo fmt --all -- --check
- cargo test -p moraine-ingest-core --test kimi_cli_fixture --locked
- cargo test -p moraine-ingest-core --locked
- cargo test --workspace --locked
- pre-commit: make fmt + strict clippy

Closes #330