### PR TITLE
docs(ingest): publish harness author workflow

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,10 +80,109 @@ format = "jsonl"
 
 Supported `harness` values are `codex`, `claude-code`, `kimi-cli`, and
 `hermes`. Each value maps to a registered ingest source adapter; see
-[Ingest Sources](development/ingest-sources.md) for the development contract.
+[Ingest Sources](development/ingest-sources.md) for the adapter contract and
+[Harness Author Workflow](development/harness-author-workflow.md) for source
+development steps.
+
 `glob` selects files to ingest. `watch_root` is the directory Moraine watches
-for changes. `format` can usually be omitted; set it when a source needs an
-explicit parser such as `jsonl` or `session_json`.
+for changes. `format` controls the file parser:
+
+| Format | Use for |
+| --- | --- |
+| `jsonl` | Append-only newline-delimited trace records. This is the default for most sources. |
+| `session_json` | One JSON file per live session that is rewritten in place. Moraine emits only newly appended synthetic session records. |
+
+When `format` is omitted, Moraine infers it. Hermes sources with a `.json` glob
+are inferred as `session_json`; otherwise sources are treated as `jsonl`.
+
+## Source Matrix
+
+The default template in `config/moraine.toml` enables these source families:
+
+| Source | Harness | Default glob | Watch root | Format |
+| --- | --- | --- | --- | --- |
+| Codex | `codex` | `~/.codex/sessions/**/*.jsonl` | `~/.codex/sessions` | inferred `jsonl` |
+| Claude Code | `claude-code` | `~/.claude/projects/**/*.jsonl` | `~/.claude/projects` | inferred `jsonl` |
+| Kimi CLI | `kimi-cli` | `~/.kimi/sessions/**/wire.jsonl` | `~/.kimi/sessions` | inferred `jsonl` |
+| Hermes live sessions | `hermes` | `~/.hermes/sessions/session_*.json` | `~/.hermes/sessions` | `session_json` |
+| Hermes trajectories | `hermes` | user-provided trajectory JSONL | trajectory output directory | `jsonl` |
+
+Hermes supports both live session JSON and offline trajectory JSONL because the
+harness is the same but the file format differs. Use a separate
+`[[ingest.sources]]` entry for each watched directory.
+
+## Source Examples
+
+Codex:
+
+```toml
+[[ingest.sources]]
+name = "codex"
+harness = "codex"
+enabled = true
+glob = "~/.codex/sessions/**/*.jsonl"
+watch_root = "~/.codex/sessions"
+```
+
+Claude Code:
+
+```toml
+[[ingest.sources]]
+name = "claude"
+harness = "claude-code"
+enabled = true
+glob = "~/.claude/projects/**/*.jsonl"
+watch_root = "~/.claude/projects"
+```
+
+Kimi CLI:
+
+```toml
+[[ingest.sources]]
+name = "kimi-cli"
+harness = "kimi-cli"
+enabled = true
+glob = "~/.kimi/sessions/**/wire.jsonl"
+watch_root = "~/.kimi/sessions"
+format = "jsonl"
+```
+
+Hermes live sessions:
+
+```toml
+[[ingest.sources]]
+name = "hermes"
+harness = "hermes"
+enabled = true
+glob = "~/.hermes/sessions/session_*.json"
+watch_root = "~/.hermes/sessions"
+format = "session_json"
+```
+
+Hermes trajectories:
+
+```toml
+[[ingest.sources]]
+name = "hermes-trajectories"
+harness = "hermes"
+enabled = true
+glob = "~/trajectories/**/*.jsonl"
+watch_root = "~/trajectories"
+format = "jsonl"
+```
+
+## Adding Harnesses
+
+The config crate validates harness names before ingest-core runs, but
+`moraine-config` cannot call the ingest adapter registry without creating a
+dependency cycle. Adding a harness therefore requires coordinated updates:
+
+- Add and register the adapter under `crates/moraine-ingest-core/src/sources/`.
+- Add the harness string to `moraine_config::KNOWN_INGEST_HARNESSES`.
+- Update defaults in `crates/moraine-config/src/lib.rs` and
+  `config/moraine.toml` when the source should ship enabled by default.
+- Update this page and the ingest source development docs.
+- Run the registry/config sync tests and ingest fixture contract tests.
 
 The `[ingest]` table controls batching and watcher behavior:
 

--- a/docs/development/harness-author-workflow.md
+++ b/docs/development/harness-author-workflow.md
@@ -1,0 +1,199 @@
+# Harness Author Workflow
+
+This workflow covers adding or changing an ingest source from module creation
+through fixtures, config, CI, and sandbox validation. It assumes the source will
+write normalized Moraine events into the shared ClickHouse schema.
+
+## 1. Start From The Source Contract
+
+Create or update a source module under
+`crates/moraine-ingest-core/src/sources/`. Implement `IngestSource` and keep
+`normalize()` as a router:
+
+```rust
+fn normalize(
+    &self,
+    record: &Value,
+    ctx: &RecordContext<'_>,
+    top_type: &str,
+    base_uid: &str,
+    model_hint: &str,
+) -> NormalizedPartials {
+    let record = ExampleRecord::new(record, top_type, base_uid, model_hint);
+    let mut emitter = SourceEmitter::new(ctx);
+    dispatch_example_record(&record, &mut emitter);
+    emitter.finish()
+}
+```
+
+Put source-specific parsing in source-local context structs and handlers. Use
+shared helpers only for cross-source row contracts.
+
+## 2. Define Source Metadata
+
+Handle provider, model, timestamp, and session identity before emitting rows:
+
+- `default_inference_provider()` for static providers.
+- `source_metadata()` for record-derived providers or model hints.
+- `record_ts()` for source timestamp conversion.
+- `top_type()` for the record discriminator.
+- `session_id()` for stable sessions, including source-specific namespacing.
+- `preflight()` for non-event records that should be skipped before raw rows.
+
+Do not infer provider/model through config alone. The normalized event row must
+carry the source truth for downstream search, monitor, MCP, and analytics.
+
+## 3. Emit Rows Through Builders
+
+Use `SourceEmitter` and `EventBuilder` for event rows:
+
+```rust
+let uid = emitter.uid_for_json(block, "example:block:0");
+let event = emitter
+    .event_for_json(&uid, "message", "message", "assistant", text, block)
+    .model(model)
+    .content_types(["text"])
+    .turn_index(turn_index);
+emitter.push_event(event);
+```
+
+Use emitter helpers for links and tool IO:
+
+```rust
+emitter.push_external_link(&uid, external_parent_id, "parent_uuid", "{}");
+emitter.push_tool_request(&uid, tool_call_id, "", tool_name, input_json);
+emitter.push_tool_response(&uid, tool_call_id, "", tool_name, 0, "", output_json, output_text);
+```
+
+Use `TokenAccounting` instead of hand-building token maps:
+
+```rust
+let accounting = TokenAccounting::openai_generation(record.get("usage"));
+let event = event.token_accounting(accounting);
+```
+
+The shared token bucket keys are schema-controlled. Adding or renaming a key is
+a schema migration task, not only an adapter change.
+
+## 4. Preserve Cross-Cutting Invariants
+
+Every source must preserve these invariants:
+
+- Stable deterministic event UIDs based on source file coordinate, payload, and
+  source-local suffix.
+- Canonical event kind, payload type, actor kind, and link type values.
+- Distinct normalized event links and source external-id links.
+- Tool rows that reference emitted event UIDs.
+- Token buckets that are present on every event row, even when values are zero.
+- Model/provider/session semantics that match the source format.
+- Timestamp parse errors routed through generic ingest error rows.
+- Synthetic timestamps advanced only for emitted rows.
+
+If a source needs correlation state, keep it source-local. Hermes trajectory
+uses pending tool-call FIFO state and backpatches call ids; that behavior should
+not move into shared helpers unless another source needs the same contract.
+
+## 5. Register And Configure
+
+Register the adapter in `sources::registry()`. If the harness is new, also add
+it to `moraine_config::KNOWN_INGEST_HARNESSES`. This duplication is deliberate:
+`moraine-config` cannot depend on ingest-core without a cycle.
+
+For default or documented sources, update:
+
+- `crates/moraine-config/src/lib.rs` default source list and config tests.
+- `config/moraine.toml` example source entries.
+- `docs/configuration.md` source matrix and examples.
+- Registry/config sync tests in ingest-core.
+
+Choose `format` carefully:
+
+- Omit it for normal JSONL sources when inference is sufficient.
+- Use `jsonl` for append-only newline-delimited trace records.
+- Use `session_json` for one JSON file per live session that is rewritten in
+  place. The session processor emits only newly appended synthetic records.
+
+## 6. Add Fixtures
+
+Add small deterministic fixtures under `fixtures/<source>/` and cover them with
+tests under `crates/moraine-ingest-core/tests/`. Prefer public normalization
+entry points over calling adapter internals.
+
+For each source family, assert:
+
+- Raw row harness/provider/session/top-type fields.
+- Representative event kinds and payload types.
+- Link rows and tool IO rows.
+- Token accounting scalars and buckets.
+- Model/provider/session hints across sequential records.
+- Error behavior for malformed input where relevant.
+
+Add or update golden snapshots with:
+
+```bash
+cargo test -p moraine-ingest-core --test golden_fixtures --locked
+```
+
+Only update golden files when the behavior change is intentional and reviewed.
+
+## 7. Validate End To End
+
+Run focused checks first:
+
+```bash
+cargo fmt --all -- --check
+cargo test -p moraine-ingest-core --locked
+cargo test --workspace --locked
+```
+
+If the change touches ingest, MCP, monitor, ClickHouse schema, or source formats,
+run the functional stack:
+
+```bash
+bash scripts/ci/e2e-stack.sh
+```
+
+That script ingests Codex, Claude Code, Kimi CLI, Hermes trajectory, and Hermes
+session JSON fixtures into ClickHouse, then verifies row counts, representative
+fields, token buckets, monitor routes, and MCP search/open/list behavior.
+
+## 8. Use The Dev Sandbox For QA
+
+For ingest, monitor, MCP, or schema work, run QA in the sandbox rather than
+against your host install. Use `--quiet` so the sandbox id cannot be lost under
+output truncation, and always tear it down:
+
+```bash
+id=$(scripts/dev/sandbox/moraine-sandbox up --quiet)
+scripts/dev/sandbox/moraine-sandbox status "$id"
+scripts/dev/sandbox/moraine-sandbox shell "$id"
+scripts/dev/sandbox/moraine-sandbox down "$id"
+```
+
+Inside the shell, the worktree is mounted read-only at `/repo`; run commands
+from there:
+
+```bash
+cd /repo
+cargo test -p moraine-ingest-core --locked
+bash scripts/ci/e2e-stack.sh
+```
+
+Do not pipe `moraine-sandbox up` through `head`, `tail`, or similar commands.
+Leftover sandboxes leak ClickHouse data and consume host ports.
+
+## PR Checklist
+
+Before opening or merging a PR:
+
+- Adapter code is split into source-local handlers and shared helpers are only
+  used for shared row contracts.
+- Config harness lists, defaults, docs, and registry tests are in sync.
+- Fixtures and golden snapshots cover raw, event, link, tool, token, and error
+  rows.
+- `cargo fmt --all -- --check` passes.
+- Focused ingest tests and `cargo test --workspace --locked` pass.
+- `cargo clippy --workspace --all-targets -- -D warnings` passes when the
+  change touches code.
+- `bash scripts/ci/e2e-stack.sh` passes for source format changes.
+- Sandbox QA has been run and the sandbox has been torn down.

--- a/docs/development/ingest-sources.md
+++ b/docs/development/ingest-sources.md
@@ -1,77 +1,166 @@
 # Ingest Sources
 
-Moraine normalizes each supported trace wire format through a source adapter in
-`crates/moraine-ingest-core/src/sources/`. The public ingest entry point remains
-`normalize::normalize_record`; source adapters own the per-harness behavior that
-used to live behind the hardcoded dispatcher in `normalize.rs`.
+Moraine normalizes agent trace files through source adapters in
+`crates/moraine-ingest-core/src/sources/`. Each adapter owns one harness wire
+format and returns normalized event, link, and tool rows. The generic ingest
+wrapper keeps cross-source behavior centralized: raw rows, timestamp parse
+errors, session/model hints, source references, schema-domain checks, and sink
+fan-out.
 
-## Source Contract
+The adapter boundary is intentionally small. New source work should add parsing
+and source-local handlers in `sources/<name>.rs`, then use shared builders for
+all rows that leave the adapter.
+
+## Source Map
+
+| Harness | Module | Default provider | Typical format | Notes |
+| --- | --- | --- | --- | --- |
+| `codex` | `sources/codex.rs` | `openai` | `jsonl` | OpenAI/Codex events, response items, tool calls, compaction, token counts. |
+| `claude-code` | `sources/claude_code.rs` | `anthropic` | `jsonl` | Claude Code message blocks, operational records, parent/tool external links. |
+| `kimi-cli` | `sources/kimi_cli.rs` | `moonshot` | `jsonl` | Kimi `wire.jsonl`; skips metadata headers and drops parent `SubagentEvent` rows. |
+| `hermes` | `sources/hermes.rs` | record-derived | `jsonl` or `session_json` | ShareGPT trajectories and live Hermes session JSON with vendor/model splitting. |
+
+## Adapter Contract
 
 Each adapter implements `IngestSource` from `sources/mod.rs`:
 
-- `harness()` returns the stable value written to the ClickHouse `harness`
-  column.
-- `default_inference_provider()` returns the static provider when the source has
-  one. Sources such as Hermes that encode the provider per record return `None`
-  and fill it in from `source_metadata()`.
-- `preflight()` skips or rewrites non-event records before generic raw/error row
-  handling. Kimi CLI uses this to skip its metadata header.
-- `record_ts()` extracts the timestamp string consumed by the generic timestamp
-  parser. Kimi CLI converts Unix-seconds wire timestamps here.
-- `top_type()` returns the source-level event discriminator used inside the
-  adapter.
-- `session_id()` resolves the stable session id from the record, source file,
-  prior session hint, top type, and base raw UID.
-- `normalize()` emits event, link, and tool rows. The generic wrapper writes raw
-  rows, timestamp error rows, context fields, and model hints.
+| Method | Responsibility |
+| --- | --- |
+| `harness()` | Stable harness string written to ClickHouse and matched by config. |
+| `default_inference_provider()` | Static provider when the source has one. Return `None` when provider is record-derived. |
+| `format()` | Source default format. Most sources use `Jsonl`; config can still select parser behavior. |
+| `preflight()` | Skip or rewrite source records before generic raw/error handling. Kimi skips its metadata header here. |
+| `source_metadata()` | Per-record provider and model hint discovery. Hermes splits `vendor/model` here. |
+| `record_ts()` | Timestamp string consumed by the shared parser. Kimi converts Unix-second wire timestamps here. |
+| `top_type()` | Source-level discriminator used for dispatch inside the adapter. |
+| `session_id()` | Stable session id derived from record fields, file path, prior session hint, or raw UID. |
+| `normalize()` | Emit `NormalizedPartials`: event rows, event link rows, and tool IO rows. |
 
-Adapters return `NormalizedPartials`; the framework handles the rest of the
-`NormalizedRecord`.
+`normalize()` receives a `RecordContext`. That context has already been stamped
+with source name, harness, provider, session id, source file coordinates, and
+parsed timestamps. Adapters should not rebuild those fields by hand.
 
 ## Shared Helpers
 
-Use `sources/shared.rs` for common row construction and invariants:
+Use `sources/shared.rs` for common invariants:
 
-- scalar conversion helpers such as `to_str`, `to_u32`, and `to_u8_bool`
-- timestamp helpers and session id inference
-- canonical event, payload, and link type enforcement
-- `RecordContext`, `base_event_obj`, `build_link_row`, and `build_tool_row`
-- token accounting helpers such as `TokenBuckets`, `generation_token_buckets`,
-  and `openai_generation_token_buckets`
+- Scalar conversion helpers such as `to_str`, `to_u32`, `to_u8_bool`, and
+  `extract_message_text`.
+- Timestamp helpers, session id inference, and stable `event_uid` generation.
+- Domain canonicalization for event kind, payload type, link type, and model
+  names where the source allows generic canonicalization.
+- `RecordContext`, `base_event_obj`, `build_link_row`, and `build_tool_row`.
+- `TokenAccounting` for legacy token columns plus `token_usage_buckets` and
+  `token_usage_native_units`.
 
-Source modules should prefer these helpers over duplicating row-building logic.
-Rows emitted from an adapter should already be in the shared event/link/tool
-domain before returning to `normalize_record`.
+Use `sources/emitter.rs` for row construction:
 
-## Adding A Source
+- `SourceEmitter` owns a `RecordContext` and accumulates `NormalizedPartials`.
+- `EventBuilder` wraps `base_event_obj` with typed setters for common columns.
+- `push_tool_request`, `push_tool_response`, and link helpers keep row shape in
+  sync with shared constructors.
 
-1. Add `crates/moraine-ingest-core/src/sources/<name>.rs`.
-2. Implement `IngestSource` for a zero-sized adapter type.
-3. Register the adapter in `sources::registry()`.
-4. Add the harness name to `moraine_config::KNOWN_INGEST_HARNESSES`.
-5. Add fixtures under `fixtures/<name>/` and tests under
-   `crates/moraine-ingest-core/tests/`.
-6. Document any source-specific config examples in `docs/configuration.md`.
+Use `sources/record_view.rs` when a source benefits from structured field reads
+or table-driven dispatch. It gives path-aware errors and keeps handler routing
+explicit without ad hoc `Value` indexing everywhere.
 
-The config crate is intentionally lower-level than ingest-core, so it cannot
-call the ingest registry without a dependency cycle. The ingest-core registry
-test checks that its registered harnesses match the config validation list.
+## Handler Pattern
 
-## Fixture Expectations
+Keep `normalize()` thin. It should usually create a source-local record context,
+construct a `SourceEmitter`, dispatch to named handlers, and return
+`emitter.finish()`.
 
-New fixture tests should call `normalize_record` through the public wrapper, not
-adapter internals. Assert both normalized rows and the generic rows that the
-framework owns:
+Prefer source-local helpers for source semantics:
 
-- `raw_row.harness`, `raw_row.inference_provider`, `raw_row.top_type`, and
-  `raw_row.session_id`
-- event row `event_kind`, `payload_type`, `actor_kind`, `model`, timestamp, and
-  token fields
-- link row `linked_event_uid` versus `linked_external_id`
-- tool row request/response phases, tool ids, previews, and error flags
-- `session_hint` and `model_hint` continuity across sequential records
+- `normalize_*_record` or `dispatch_*_record` for top-level routing.
+- `handle_*` or `emit_*` functions for source event families.
+- Small context structs for repeated record fields, token accounting, model
+  state, pending tool correlation, and timestamp sequencing.
+- Source-specific parsing and correlation in the source module, not in shared
+  helpers.
 
-For token usage records, assert both legacy aggregate columns and
-`token_usage_buckets`. Bucket totals should not exceed their aggregate input or
-output token columns unless the upstream wire format explicitly reports a native
-unit outside token accounting.
+Shared helpers should only grow when more than one source needs the same row
+contract or schema-domain rule. Source quirks such as Hermes trajectory tool
+backpatching, Kimi placeholder models, or Claude external parent UUID links
+belong in the source module.
+
+## Row Invariants
+
+Adapters must emit rows that already satisfy the normalized schema domain:
+
+- Event UIDs are deterministic for the source file coordinate, record payload,
+  and source-local suffix. Do not reuse the raw record UID for multiple
+  normalized events.
+- `event_kind`, `payload_type`, and `actor_kind` must use the canonical domain.
+- Links must distinguish normalized event links (`linked_event_uid`) from
+  source external ids (`linked_external_id`).
+- Tool request/response rows must reference an emitted event UID and preserve
+  `tool_call_id`, `tool_name`, `tool_phase`, `tool_error`, input JSON, output
+  JSON, and output text.
+- Token usage must populate both legacy scalar columns and
+  `token_usage_buckets`. Bucket names are schema-controlled and tested against
+  SQL migrations.
+- `model`, `inference_provider`, and `session_id` must preserve source-specific
+  semantics. Hermes model strings are split from provider/model input and are
+  not blindly canonicalized through generic helpers.
+- Synthetic timestamp sequencing should only advance for rows that are actually
+  emitted. This matters for Hermes trajectory segment parsing.
+
+## Fixtures And Contracts
+
+Deterministic fixtures live under `fixtures/`; golden snapshots live under
+`crates/moraine-ingest-core/tests/goldens/source_normalization/`.
+`crates/moraine-ingest-core/tests/golden_fixtures.rs` runs the same public
+normalization entry point that ingest uses and asserts row shape across all
+source families.
+
+Fixture tests should verify both adapter output and generic wrapper output:
+
+- `raw_row.harness`, `raw_row.inference_provider`, `raw_row.top_type`,
+  `raw_row.session_id`, and raw JSON hashing.
+- Event row `event_kind`, `payload_type`, `actor_kind`, timestamps, model,
+  token fields, content types, and text previews.
+- Link row target columns and canonical link type.
+- Tool row request/response phases, tool ids, previews, and error flags.
+- `session_hint` and `model_hint` continuity across sequential records.
+- Ingest error rows for invalid timestamps or malformed source records.
+
+When behavior changes intentionally, update fixtures and goldens together.
+Otherwise, golden stability failures are regressions.
+
+## Config Boundary
+
+`moraine-config` is lower-level than `moraine-ingest-core`; it cannot call the
+ingest registry without creating a dependency cycle. Adding a harness therefore
+requires updates on both sides:
+
+- `crates/moraine-ingest-core/src/sources/mod.rs` registry.
+- `moraine_config::KNOWN_INGEST_HARNESSES`.
+- Default source examples in `crates/moraine-config/src/lib.rs` and
+  `config/moraine.toml` when the source should be enabled by default.
+- Documentation in `docs/configuration.md`.
+- Registry/config sync tests and fixture contract tests.
+
+The ingest-core registry test and golden fixture contract test are the guardrails
+that keep these lists aligned.
+
+## Validation
+
+For source adapter changes, run focused tests first and expand based on blast
+radius:
+
+```bash
+cargo fmt --all -- --check
+cargo test -p moraine-ingest-core --locked
+cargo test --workspace --locked
+```
+
+For ingest, monitor, MCP, ClickHouse schema, or source format changes, also run
+the functional stack and sandbox QA described in
+[Harness Author Workflow](harness-author-workflow.md):
+
+```bash
+bash scripts/ci/e2e-stack.sh
+id=$(scripts/dev/sandbox/moraine-sandbox up --quiet)
+scripts/dev/sandbox/moraine-sandbox down "$id"
+```

--- a/zensical.toml
+++ b/zensical.toml
@@ -15,6 +15,7 @@ nav = [
   { "Configuration" = "configuration.md" },
   { "Development" = [
     { "Ingest Sources" = "development/ingest-sources.md" },
+    { "Harness Author Workflow" = "development/harness-author-workflow.md" },
   ] },
 ]
 


### PR DESCRIPTION
## Summary
- Expanded the ingest source development contract with adapter responsibilities, shared helpers, handler patterns, row invariants, fixture contracts, and validation guidance.
- Added a dedicated harness author workflow page covering registration, config boundaries, fixtures, e2e coverage, sandbox QA, and PR checklist.
- Updated configuration docs with source format behavior, a source matrix, examples for Codex/Claude/Kimi/Hermes formats, and harness addition steps.
- Added the new workflow page to the docs navigation.

## Operational Impact
- Documentation-only change. No runtime, schema, or config behavior changes.

## Validation
- make docs-build
- cargo test -p moraine-config --locked
- cargo test -p moraine-ingest-core --locked
- pre-commit skipped Rust checks because only docs/nav files were staged

Closes #336