### PR TITLE
[codex] docs: list supported agent harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ change across minor releases.
 - [Configuration](https://eric-tramel.github.io/moraine/configuration.html)
 - [MCP Search Interface Specification](https://eric-tramel.github.io/moraine/mcp-search-interface-spec.html)
 
+## Supported Agent Harnesses
+
+Moraine ships session trace ingestion adapters for these agent harnesses:
+
+| Harness | Config value | Session traces ingested |
+| --- | --- | --- |
+| [Codex](https://developers.openai.com/codex) | `codex` | JSONL session files under `~/.codex/sessions` |
+| [Claude Code](https://code.claude.com/docs/en/overview) | `claude-code` | JSONL project session files under `~/.claude/projects` |
+| [Kimi CLI](https://moonshotai.github.io/kimi-cli/en/) | `kimi-cli` | `wire.jsonl` session traces under `~/.kimi/sessions` |
+| [Hermes](https://hermes-agent.nousresearch.com/docs/) | `hermes` | Live session JSON and trajectory JSONL traces |
+| [Pi Coding Agent](https://pi.dev/docs/latest) | `pi-coding-agent` | JSONL session trees under `~/.pi/agent/sessions` |
+
 ## Quickstart
 
 Install from PyPI with `uv`:

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,18 @@ Agent. The default setup runs on your machine and writes runtime state under
 Moraine is under active development. Config keys, schemas, and MCP tool names
 can change across minor releases.
 
+## Supported Agent Harnesses
+
+Moraine ships session trace ingestion adapters for these agent harnesses:
+
+| Harness | Config value | Session traces ingested |
+| --- | --- | --- |
+| [Codex](https://developers.openai.com/codex) | `codex` | JSONL session files under `~/.codex/sessions` |
+| [Claude Code](https://code.claude.com/docs/en/overview) | `claude-code` | JSONL project session files under `~/.claude/projects` |
+| [Kimi CLI](https://moonshotai.github.io/kimi-cli/en/) | `kimi-cli` | `wire.jsonl` session traces under `~/.kimi/sessions` |
+| [Hermes](https://hermes-agent.nousresearch.com/docs/) | `hermes` | Live session JSON and trajectory JSONL traces |
+| [Pi Coding Agent](https://pi.dev/docs/latest) | `pi-coding-agent` | JSONL session trees under `~/.pi/agent/sessions` |
+
 ## Where To Start
 
 Read [Quickstart and Installation](quickstart.md) to install Moraine and start a


### PR DESCRIPTION
## What changed

- Added a supported agent harnesses table to the README.
- Added the same table to the docs landing page.
- Linked each harness name to its upstream documentation and included the Moraine `harness` config value plus the default trace source.

## Why

This makes it easier for users to see which agent session trace formats Moraine can ingest and where to find the relevant harness documentation.

## Impact

Docs-only change. No runtime, schema, or configuration behavior changed.

## Validation

- `make docs-build`