### PR TITLE
fix(mcp): split nullable enum schemas

### DIFF
--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -231,13 +231,23 @@ impl AppState {
                                 "description": "Opaque cursor from a previous list_sessions response with the same filter and sort values."
                             },
                             "mode": {
-                                "type": ["string", "null"],
-                                "enum": ["web_search", "mcp_internal", "tool_calling", "chat", null],
+                                "anyOf": [
+                                    {
+                                        "type": "string",
+                                        "enum": ["web_search", "mcp_internal", "tool_calling", "chat"]
+                                    },
+                                    { "type": "null" }
+                                ],
                                 "description": "Optional session mode filter."
                             },
                             "sort": {
-                                "type": ["string", "null"],
-                                "enum": ["desc", "asc", null],
+                                "anyOf": [
+                                    {
+                                        "type": "string",
+                                        "enum": ["desc", "asc"]
+                                    },
+                                    { "type": "null" }
+                                ],
                                 "default": "desc",
                                 "description": "Sort order by session updated_at and session ID."
                             }
@@ -464,6 +474,43 @@ mod tests {
             list_sessions["inputSchema"]["properties"]["sort"]["default"],
             json!("desc")
         );
+        assert_eq!(
+            list_sessions["inputSchema"]["properties"]["mode"]["anyOf"],
+            json!([
+                {
+                    "type": "string",
+                    "enum": ["web_search", "mcp_internal", "tool_calling", "chat"]
+                },
+                { "type": "null" }
+            ])
+        );
+        assert_eq!(
+            list_sessions["inputSchema"]["properties"]["sort"]["anyOf"],
+            json!([
+                {
+                    "type": "string",
+                    "enum": ["desc", "asc"]
+                },
+                { "type": "null" }
+            ])
+        );
+        for field in ["mode", "sort"] {
+            let variants = list_sessions["inputSchema"]["properties"][field]["anyOf"]
+                .as_array()
+                .expect("nullable enum anyOf");
+            for variant in variants {
+                if variant["type"] == json!("string") {
+                    assert!(
+                        !variant["enum"]
+                            .as_array()
+                            .expect("string enum")
+                            .iter()
+                            .any(Value::is_null),
+                        "{field} string enum branch must not include null"
+                    );
+                }
+            }
+        }
         assert_eq!(
             list_sessions["outputSchema"]["properties"]["data"]["required"],
             json!([


### PR DESCRIPTION
## Summary

Split the `list_sessions` nullable enum schemas for `mode` and `sort` into explicit `anyOf` branches. The string branches now contain only string enum values, with null represented by a separate `{ "type": "null" }` branch.

## Why

OMP/OpenRouter converts Moraine MCP schemas into OpenAI function parameters. The previous mixed nullable enum shape could become a strict schema branch with `type: "string"` while still carrying `null` in `enum`, which OpenAI rejects before the model can call any tool.

## Impact

The accepted inputs remain unchanged: valid enum strings or null. This only changes the advertised JSON Schema shape to be more portable across strict OpenAI-style tool schema validators.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p moraine-mcp-core tools_list_publishes_mcp_search_surface_with_output_schemas --locked`
- `cargo test -p moraine-mcp-core --locked`
- pre-commit hook: fmt + strict clippy baseline
