### PR TITLE
feat(agents): add release skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ This repo vendors developer-only agent workflows as a local Codex plugin:
 - Skills: `plugins/moraine-dev/skills/`
 
 Use `$moraine-dev:moraine-start-work` when beginning contributor work, `$moraine-dev:crystallize` when turning rough input into an ignored ready-to-implement plan under `plans/`, `$moraine-dev:moraine-author-pr` when drafting a PR title or description, `$moraine-dev:moraine-sandbox-qa` for ingest/MCP/monitor/schema/stack-facing validation, `$moraine-dev:code-review` for a full multi-persona review wave, and the `$moraine-dev:code-review-*` persona skills for focused PR review. When prior or active agent context matters, use the Moraine MCP tools directly. These skills are for repository contributors and automation agents, not end-user Moraine behavior.
+Use `$moraine-dev:release` when cutting and publishing a Moraine release from a target version.
 
 ## Writing PRs
 History uses concise, Conventional-Commit-like subjects such as:

--- a/docs/development/agent-contributor-workflows.md
+++ b/docs/development/agent-contributor-workflows.md
@@ -21,6 +21,7 @@ plugins/moraine-dev/
     code-review-security-review/
     code-review-yagni/
     moraine-author-pr/
+    release/
     moraine-start-work/
     moraine-sandbox-qa/
 ```
@@ -50,6 +51,7 @@ Codex exposes plugin skills with the plugin namespace, so use the
 | `$moraine-dev:crystallize` | Turn rough input into an ignored, ready-to-implement plan under `plans/`. |
 | `$moraine-dev:code-review` | Coordinate one review wave across all code-review personas and targeted follow-up. |
 | `$moraine-dev:moraine-author-pr` | Draft PR titles and descriptions with standard evidence and validation sections. |
+| `$moraine-dev:release` | Cut and publish a Moraine release from a target version. |
 | `$moraine-dev:moraine-start-work` | Start development work with branch/worktree, instruction, and validation checks. |
 | `$moraine-dev:moraine-sandbox-qa` | Run stack-facing QA in the isolated dev sandbox and tear it down afterward. |
 
@@ -83,6 +85,12 @@ direct blocker.
 Historical and active session lookup does not need a skill. Use the Moraine MCP
 tools directly: `search_sessions`, `list_sessions`, `open`, and
 `file_attention`.
+
+## Releases
+
+Use `$moraine-dev:release` for `/release X.Y.Z` work. It owns the release goal,
+version bump, release PR, annotated tag, GitHub release notes, tag-triggered
+workflow verification, and PyPI verification.
 
 ## Maintenance
 

--- a/plugins/moraine-dev/.codex-plugin/plugin.json
+++ b/plugins/moraine-dev/.codex-plugin/plugin.json
@@ -17,13 +17,14 @@
     "skills",
     "sandbox",
     "code-review",
-    "pull-requests"
+    "pull-requests",
+    "release"
   ],
   "skills": "./skills/",
   "interface": {
     "displayName": "Moraine Dev",
     "shortDescription": "Developer skills for Moraine contributors.",
-    "longDescription": "Project-local, developer-only skills that help agents contribute to Moraine consistently: start isolated work, crystallize rough ideas into implementation plans, author reviewable pull requests, run facet-specific code review personas, and validate behavior in the dev sandbox.",
+    "longDescription": "Project-local, developer-only skills that help agents contribute to Moraine consistently: start isolated work, crystallize rough ideas into implementation plans, author reviewable pull requests, run facet-specific code review personas, validate behavior in the dev sandbox, and cut releases.",
     "developerName": "Moraine maintainers",
     "category": "Productivity",
     "capabilities": [
@@ -34,7 +35,8 @@
       "Use $moraine-dev:moraine-start-work to begin a Moraine change safely.",
       "Use $moraine-dev:crystallize to turn a rough idea into a ready-to-implement plan.",
       "Use $moraine-dev:code-review to run all review personas on this PR.",
-      "Use $moraine-dev:moraine-author-pr to draft a PR title and description."
+      "Use $moraine-dev:moraine-author-pr to draft a PR title and description.",
+      "Use $moraine-dev:release to cut a Moraine release from a target version."
     ]
   }
 }

--- a/plugins/moraine-dev/skills/release/SKILL.md
+++ b/plugins/moraine-dev/skills/release/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: release
+description: Cut and publish Moraine releases from a version argument such as /release X.Y.Z or a request to use $moraine-dev:release. Use when Codex is asked to run Moraine's release process, bump release-managed versions, create and merge the release PR, push the vX.Y.Z tag, update GitHub release notes for a general audience, verify the release-moraine workflow, and confirm the PyPI moraine-cli package. Start or continue a Codex goal for the release.
+---
+
+# Release
+
+Run Moraine releases end to end from the repo-local `moraine-dev` developer
+plugin. A `/release X.Y.Z` invocation means: publish `vX.Y.Z`, not just
+prepare a plan.
+
+## Goal Contract
+
+Make the release a Codex goal before doing release work.
+
+- If `create_goal` is available and there is no active goal, call it with:
+  `Cut Moraine vX.Y.Z, including version bump PR, merged code, annotated repo tag, GitHub release notes, release workflow verification, and PyPI package verification.`
+- If a goal already exists, continue inside it and keep it current with
+  `update_plan`.
+- Do not call `update_goal(status="complete")` until all public release
+  evidence exists: merged PR, pushed tag, successful workflow, GitHub release
+  body/assets, and PyPI `moraine-cli` artifacts.
+
+## Preconditions
+
+Normalize the argument first:
+
+- `X.Y.Z` and `vX.Y.Z` both mean `VERSION=X.Y.Z` and `TAG=vX.Y.Z`.
+- Refuse ambiguous input, missing versions, or a target older than the latest
+  stable GitHub release.
+
+Before editing:
+
+1. Read the active `AGENTS.md`.
+2. Use Moraine session search if available. Start broad, then narrow:
+   - `release process Moraine PyPI GitHub tag`
+   - `v0.5.4 release workflow pypi release notes`
+   - `package-moraine-release release-moraine gh release edit`
+3. Inspect `.github/workflows/release-moraine.yml`.
+4. Read `.claude/skills/release-notes/SKILL.md` only as the house-format
+   reference for the GitHub release body.
+5. Verify tooling:
+   - `gh auth status`
+   - `git fetch origin --prune --tags`
+   - `gh repo view --json nameWithOwner,defaultBranchRef,url`
+6. Prove the target is unused:
+   - `git tag --list "$TAG"` returns nothing.
+   - `gh release view "$TAG"` fails with not found.
+   - `curl -fsSL "https://pypi.org/pypi/moraine-cli/$VERSION/json"` fails.
+
+## Branch And Context
+
+Do release edits in a dedicated worktree from fresh `origin/main` unless the
+user explicitly says otherwise:
+
+```bash
+git worktree add -b "codex/release-$TAG" \
+  "/Users/eric/src/moraine-worktrees/release-$TAG" origin/main
+```
+
+Gather the changes since the previous stable release:
+
+```bash
+prev_tag="$(gh release list --limit 20 --json tagName,isDraft,isPrerelease -q \
+  '[.[] | select(.isDraft==false and .isPrerelease==false) | .tagName] | .[0]')"
+git log --oneline --decorate "$prev_tag"..origin/main
+gh pr list --state merged --base main --limit 50 \
+  --json number,title,url,mergedAt,body
+```
+
+Read PR bodies for user-visible changes. Release notes should explain what a
+user can do or what is fixed, not just repeat commit titles.
+
+## Version Bump
+
+Run the bundled bump script from the release worktree root:
+
+```bash
+python3 plugins/moraine-dev/skills/release/scripts/bump-version.py "$VERSION"
+```
+
+Then inspect the diff. Expected version-only files are normally:
+
+- `Cargo.lock`
+- release-managed `apps/*/Cargo.toml`
+- release-managed `crates/*/Cargo.toml`
+- `.github/workflows/release-moraine.yml` example tag, if it still contains
+  the old tag
+- install docs only if they contain an explicit `MORAINE_INSTALL_VERSION`
+  example for the old tag
+
+Do not bump `bindings/python/moraine_conversations`; it is a separate internal
+Python extension package.
+
+## Validation
+
+Always run:
+
+```bash
+git diff --check
+cargo fmt --all -- --check
+cargo test --workspace --locked
+```
+
+Use `$moraine-dev:moraine-sandbox-qa` when the release includes ingest, MCP,
+monitor, ClickHouse schema, source-format, or stack-behavior changes since the
+previous tag. If that developer skill is unavailable, follow the dev sandbox
+commands required by `AGENTS.md`: capture the sandbox id with `--quiet`, run
+focused checks inside it, and tear it down before reporting completion.
+
+Typical sandbox checks:
+
+```bash
+id="$(scripts/dev/sandbox/moraine-sandbox up --quiet)"
+scripts/dev/sandbox/moraine-sandbox status "$id"
+# Run cargo/test commands inside the sandbox per AGENTS.md, then:
+scripts/dev/sandbox/moraine-sandbox down "$id"
+```
+
+If `moraine-mcp-core` or the MCP tool surface changed, run the strongest
+available MCP smoke test. Prefer `scripts/dev/sandbox/agent-smoke-e2e` when its
+API key prerequisites are present; otherwise run focused MCP crate tests and
+the project smoke tests that are available.
+
+## Release PR
+
+Create a focused release commit:
+
+```bash
+git add Cargo.lock apps crates .github README.md docs
+git commit -m "chore(release): cut $TAG"
+git push -u origin "codex/release-$TAG"
+```
+
+Open a PR to `main` titled `chore(release): cut $TAG`. The PR body must include:
+
+- what version was bumped,
+- a concise user-facing summary of changes since `prev_tag`,
+- validation commands and outcomes,
+- operational impact: tag push will run `release-moraine` and publish PyPI.
+
+Wait for required checks. Merge only when checks pass. Use the repo's normal
+merge style, then fetch `origin/main` and verify the merge commit:
+
+```bash
+gh pr view <number> --json state,mergedAt,mergeCommit,url
+git fetch origin main --tags
+git log --oneline -1 origin/main
+```
+
+Stop before tagging if the PR is not merged into `main`.
+
+## Tag And Workflow
+
+Tag the merge commit on `origin/main` with an annotated tag:
+
+```bash
+merge_sha="$(gh pr view <number> --json mergeCommit -q .mergeCommit.oid)"
+git tag -a "$TAG" "$merge_sha" -m "$TAG"
+git push origin "$TAG"
+```
+
+Then wait for the tag-triggered workflow:
+
+```bash
+run_id="$(gh run list --workflow release-moraine.yml --event push \
+  --branch "$TAG" --limit 1 --json databaseId -q '.[0].databaseId')"
+gh run watch "$run_id" --exit-status
+gh run view "$run_id" --json status,conclusion,url,name,event,headBranch,headSha
+```
+
+The tag-triggered `publish-pypi` job publishes `moraine-cli` to PyPI
+automatically. Manual dispatches default to `skip` and are not the normal
+release path.
+
+## GitHub Release Notes
+
+Edit the GitHub release body only after the workflow has completed. Matrix jobs
+can rewrite generated notes while they upload assets.
+
+Use the house format from `.claude/skills/release-notes/SKILL.md`, adapted to
+the release size:
+
+- Patch release: concise headline, what was fixed, upgrade note only if needed,
+  changelog at the bottom.
+- Feature release: install block, "What's new", "Under the hood", platform
+  support only if it changed, upgrade notes if needed, changelog at the bottom.
+- Always dedupe generated changelog blocks. Keep exactly one `Full Changelog`
+  compare link.
+
+Write for a general Moraine user. Prefer "Moraine now..." and "You can..." over
+implementation-first phrasing. Link PRs the first time they are mentioned.
+
+Publish with:
+
+```bash
+gh release edit "$TAG" --notes-file /tmp/moraine-release-notes.md
+```
+
+Verify:
+
+```bash
+gh release view "$TAG" --json tagName,name,url,body,assets,publishedAt,targetCommitish
+```
+
+Expect six GitHub release assets: three platform bundles and three checksum
+files, unless the workflow has intentionally changed.
+
+## PyPI Verification
+
+Verify the version-specific endpoint, the simple index, aggregate metadata, and
+an install smoke:
+
+```bash
+curl -fsSL -H 'Cache-Control: no-cache' \
+  "https://pypi.org/pypi/moraine-cli/$VERSION/json" | \
+  python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["info"]["version"], len(d["urls"])); print("\n".join(sorted(f["filename"] for f in d["urls"])))'
+
+curl -fsSL -H 'Cache-Control: no-cache' https://pypi.org/simple/moraine-cli/ |
+  rg "moraine_cli-$VERSION"
+
+curl -fsSL -H 'Cache-Control: no-cache' https://pypi.org/pypi/moraine-cli/json |
+  python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["info"]["version"]); print(len(d["releases"].get("'"$VERSION"'", [])))'
+
+uvx --refresh-package moraine-cli --from "moraine-cli==$VERSION" moraine --version
+```
+
+Expected PyPI files are three wheels plus the stub sdist. PyPI metadata can lag
+for a short time; retry with no-cache headers before declaring failure.
+
+## Stop Conditions
+
+Stop and report clearly if:
+
+- target tag or PyPI version already exists,
+- `gh` is unavailable or unauthenticated,
+- version bump diff touches unexpected files,
+- validation fails,
+- the release PR cannot be merged,
+- the tag workflow fails,
+- the GitHub release is missing assets,
+- PyPI does not publish the expected files after reasonable retries.
+
+If a tag has already been pushed, do not delete or recreate it without explicit
+user instruction.
+
+## Final Report
+
+End with the concrete public evidence:
+
+- merged release PR URL,
+- tag and tagged commit,
+- release workflow run URL and conclusion,
+- GitHub release URL and asset count,
+- PyPI version URL and file count,
+- `uvx` smoke output,
+- the final general-audience release notes section or a concise excerpt plus
+  the release link.

--- a/plugins/moraine-dev/skills/release/agents/openai.yaml
+++ b/plugins/moraine-dev/skills/release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Release"
+  short_description: "Cut and publish Moraine releases"
+  default_prompt: "/goal Use $moraine-dev:release to cut Moraine X.Y.Z, including version bump, release PR, tag, GitHub release notes, and PyPI verification."

--- a/plugins/moraine-dev/skills/release/scripts/bump-version.py
+++ b/plugins/moraine-dev/skills/release/scripts/bump-version.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Bump Moraine release-managed versions for a release branch."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+MANAGED_CARGO_TOMLS = [
+    "apps/moraine/Cargo.toml",
+    "apps/moraine-ingest/Cargo.toml",
+    "apps/moraine-mcp/Cargo.toml",
+    "apps/moraine-monitor/Cargo.toml",
+    "crates/moraine-clickhouse/Cargo.toml",
+    "crates/moraine-config/Cargo.toml",
+    "crates/moraine-conversations/Cargo.toml",
+    "crates/moraine-ingest-core/Cargo.toml",
+    "crates/moraine-mcp-core/Cargo.toml",
+    "crates/moraine-monitor-core/Cargo.toml",
+]
+
+MANAGED_PACKAGE_NAMES = {
+    "moraine",
+    "moraine-clickhouse",
+    "moraine-config",
+    "moraine-conversations",
+    "moraine-ingest",
+    "moraine-ingest-core",
+    "moraine-mcp",
+    "moraine-mcp-core",
+    "moraine-monitor",
+    "moraine-monitor-core",
+}
+
+VERSION_RE = re.compile(r"^v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bump Moraine release-managed Cargo versions and release examples."
+    )
+    parser.add_argument("version", help="Target version, with or without v prefix.")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root. Defaults to the current working directory.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned changes without writing files.",
+    )
+    return parser.parse_args()
+
+
+def normalize_version(raw: str) -> str:
+    match = VERSION_RE.match(raw)
+    if not match:
+        raise SystemExit(f"invalid release version: {raw!r}")
+    return match.group(1)
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text()
+    except FileNotFoundError:
+        raise SystemExit(f"missing expected file: {path}") from None
+
+
+def write_text(path: Path, text: str, *, dry_run: bool) -> None:
+    if not dry_run:
+        path.write_text(text)
+
+
+def package_name(text: str, path: Path) -> str:
+    match = re.search(r'(?m)^name = "([^"]+)"$', text)
+    if not match:
+        raise SystemExit(f"could not find package name in {path}")
+    return match.group(1)
+
+
+def package_version(text: str, path: Path) -> str:
+    match = re.search(r'(?m)^version = "([^"]+)"$', text)
+    if not match:
+        raise SystemExit(f"could not find package version in {path}")
+    return match.group(1)
+
+
+def replace_single(pattern: str, repl: str, text: str, path: Path) -> tuple[str, int]:
+    new_text, count = re.subn(pattern, repl, text, count=1, flags=re.MULTILINE)
+    if count != 1:
+        raise SystemExit(f"expected exactly one version replacement in {path}")
+    return new_text, count
+
+
+def bump_cargo_tomls(repo_root: Path, target_version: str, *, dry_run: bool) -> str:
+    current_version: str | None = None
+    changed: list[str] = []
+
+    for relpath in MANAGED_CARGO_TOMLS:
+        path = repo_root / relpath
+        text = read_text(path)
+        name = package_name(text, path)
+        if name not in MANAGED_PACKAGE_NAMES:
+            raise SystemExit(f"unexpected managed package name in {path}: {name}")
+        version = package_version(text, path)
+        if current_version is None:
+            current_version = version
+        elif version != current_version:
+            raise SystemExit(
+                f"managed Cargo.toml versions are not in sync: "
+                f"{path} has {version}, expected {current_version}"
+            )
+
+        new_text, _ = replace_single(
+            rf'^version = "{re.escape(version)}"$',
+            f'version = "{target_version}"',
+            text,
+            path,
+        )
+        if new_text != text:
+            write_text(path, new_text, dry_run=dry_run)
+            changed.append(relpath)
+
+    if current_version is None:
+        raise SystemExit("no managed Cargo.toml files configured")
+    if current_version == target_version:
+        raise SystemExit(f"target version is already set: {target_version}")
+
+    print(f"Cargo.toml: {current_version} -> {target_version}")
+    for relpath in changed:
+        print(f"  {relpath}")
+    return current_version
+
+
+def bump_lockfile(
+    repo_root: Path, current_version: str, target_version: str, *, dry_run: bool
+) -> None:
+    path = repo_root / "Cargo.lock"
+    text = read_text(path)
+    blocks = re.split(r"(?=^\[\[package\]\]\n)", text, flags=re.MULTILINE)
+    changed_names: set[str] = set()
+    new_blocks: list[str] = []
+
+    for block in blocks:
+        name_match = re.search(r'(?m)^name = "([^"]+)"$', block)
+        if name_match and name_match.group(1) in MANAGED_PACKAGE_NAMES:
+            version_match = re.search(r'(?m)^version = "([^"]+)"$', block)
+            if not version_match:
+                raise SystemExit(f"lockfile package has no version: {name_match.group(1)}")
+            found = version_match.group(1)
+            if found != current_version:
+                raise SystemExit(
+                    f"lockfile {name_match.group(1)} has {found}, expected {current_version}"
+                )
+            block = re.sub(
+                rf'(?m)^version = "{re.escape(current_version)}"$',
+                f'version = "{target_version}"',
+                block,
+                count=1,
+            )
+            changed_names.add(name_match.group(1))
+        new_blocks.append(block)
+
+    missing = MANAGED_PACKAGE_NAMES - changed_names
+    if missing:
+        raise SystemExit(
+            "lockfile did not contain managed packages: " + ", ".join(sorted(missing))
+        )
+
+    new_text = "".join(new_blocks)
+    write_text(path, new_text, dry_run=dry_run)
+    print(f"Cargo.lock: updated {len(changed_names)} managed package entries")
+
+
+def replace_optional_file(
+    repo_root: Path,
+    relpath: str,
+    current_version: str,
+    target_version: str,
+    *,
+    dry_run: bool,
+) -> int:
+    path = repo_root / relpath
+    if not path.exists():
+        return 0
+    text = read_text(path)
+    replacements = {
+        f"v{current_version}": f"v{target_version}",
+        f"MORAINE_INSTALL_VERSION=v{current_version}": (
+            f"MORAINE_INSTALL_VERSION=v{target_version}"
+        ),
+    }
+    new_text = text
+    count = 0
+    for old, new in replacements.items():
+        occurrences = new_text.count(old)
+        if occurrences:
+            new_text = new_text.replace(old, new)
+            count += occurrences
+    if new_text != text:
+        write_text(path, new_text, dry_run=dry_run)
+        print(f"{relpath}: {count} replacement(s)")
+    return count
+
+
+def bump_release_examples(
+    repo_root: Path, current_version: str, target_version: str, *, dry_run: bool
+) -> None:
+    optional_files = [
+        ".github/workflows/release-moraine.yml",
+        "README.md",
+        "docs/quickstart.md",
+        "scripts/install.sh",
+    ]
+    total = 0
+    for relpath in optional_files:
+        total += replace_optional_file(
+            repo_root, relpath, current_version, target_version, dry_run=dry_run
+        )
+    print(f"release examples: {total} replacement(s)")
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    if not (repo_root / "Cargo.toml").is_file() or not (repo_root / ".git").exists():
+        raise SystemExit(f"not a Moraine repository root: {repo_root}")
+
+    target_version = normalize_version(args.version)
+    current_version = bump_cargo_tomls(
+        repo_root, target_version, dry_run=args.dry_run
+    )
+    bump_lockfile(
+        repo_root, current_version, target_version, dry_run=args.dry_run
+    )
+    bump_release_examples(
+        repo_root, current_version, target_version, dry_run=args.dry_run
+    )
+    if args.dry_run:
+        print("dry run: no files written")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add `$moraine-dev:release` as a developer-only skill inside the repo-local `moraine-dev` Codex plugin for `/release X.Y.Z` workflows.
- Register the release workflow in the plugin metadata, `AGENTS.md`, and contributor workflow docs so agents use the same namespaced skill form as the other developer skills.
- Keep the deterministic `bump-version.py` helper bundled with the release skill under `plugins/moraine-dev/skills/release/`.

## Validation

- `python3 /Users/eric/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/moraine-dev/skills/release`
- `python3 /Users/eric/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/moraine-dev`
- `python3 -m py_compile plugins/moraine-dev/skills/release/scripts/bump-version.py`
- `python3 plugins/moraine-dev/skills/release/scripts/bump-version.py 9.9.9 --dry-run`
- `git diff --check origin/main...HEAD`

## Operational impact

This only adds developer Codex plugin files and documentation for Moraine contributors. It does not change Moraine runtime code, release workflow behavior, or end-user configuration.