### PR TITLE
feat(mcp): shared central MCP server with per-session proxy (default on)

### DIFF
--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -6,7 +6,14 @@ description = "Moraine MCP stdio server"
 
 [dependencies]
 anyhow = "1.0"
-tokio = { version = "1.40", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.40", features = [
+    "rt",
+    "rt-multi-thread",
+    "io-std",
+    "io-util",
+    "net",
+    "time",
+] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 moraine-config = { path = "../../crates/moraine-config" }
 moraine-mcp-core = { path = "../../crates/moraine-mcp-core" }

--- a/apps/moraine-mcp/src/cli.rs
+++ b/apps/moraine-mcp/src/cli.rs
@@ -1,21 +1,44 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use std::path::PathBuf;
+
+/// How this `moraine-mcp` process should run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServeMode {
+    /// Default for `moraine run mcp`: proxy to the shared central server when
+    /// it is enabled and reachable, otherwise fall back to an embedded stdio
+    /// server. The decision is made at runtime in `run_mcp_entry`.
+    Stdio,
+    /// `moraine-mcp --serve socket`: become the shared central server,
+    /// listening on a Unix domain socket. Launched by `moraine up`.
+    Socket,
+}
 
 #[derive(Debug, Clone)]
 pub struct CliArgs {
     pub config_path: PathBuf,
+    pub serve_mode: ServeMode,
+    /// Optional `--socket <path>` override for the central socket path,
+    /// otherwise taken from `mcp.central_socket_path` in config.
+    pub socket_override: Option<PathBuf>,
 }
 
 fn usage() {
     eprintln!(
         "usage:
-  moraine-mcp [--config <path>]
+  moraine-mcp [--config <path>] [--serve <stdio|socket>] [--socket <path>]
+
+  --serve stdio   (default) serve over stdio: proxy to the central MCP
+                  server if enabled and reachable, else run embedded.
+  --serve socket  run the shared central MCP server on a Unix socket.
+  --socket <path> override the central socket path.
 "
     );
 }
 
 fn parse_args_from(mut args: impl Iterator<Item = String>) -> Result<CliArgs> {
     let mut config_path: Option<PathBuf> = None;
+    let mut serve_mode = ServeMode::Stdio;
+    let mut socket_override: Option<PathBuf> = None;
 
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -24,6 +47,24 @@ fn parse_args_from(mut args: impl Iterator<Item = String>) -> Result<CliArgs> {
                     .next()
                     .ok_or_else(|| anyhow!("--config requires a path"))?;
                 config_path = Some(PathBuf::from(value));
+            }
+            "--serve" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| anyhow!("--serve requires a mode (stdio|socket)"))?;
+                serve_mode = match value.as_str() {
+                    "stdio" => ServeMode::Stdio,
+                    "socket" => ServeMode::Socket,
+                    // Reject unknown modes loudly rather than silently ignoring
+                    // them, so a partial/mismatched upgrade fails visibly.
+                    other => bail!("unknown --serve mode `{other}` (expected stdio or socket)"),
+                };
+            }
+            "--socket" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| anyhow!("--socket requires a path"))?;
+                socket_override = Some(PathBuf::from(value));
             }
             "-h" | "--help" | "help" => {
                 usage();
@@ -35,6 +76,8 @@ fn parse_args_from(mut args: impl Iterator<Item = String>) -> Result<CliArgs> {
 
     Ok(CliArgs {
         config_path: moraine_config::resolve_mcp_config_path(config_path),
+        serve_mode,
+        socket_override,
     })
 }
 
@@ -44,7 +87,7 @@ pub fn parse_args() -> Result<CliArgs> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_args_from;
+    use super::{parse_args_from, ServeMode};
     use std::path::PathBuf;
 
     #[test]
@@ -60,5 +103,41 @@ mod tests {
             parse_args_from(vec!["--config".to_string(), "/tmp/mcp.toml".to_string()].into_iter())
                 .expect("valid config path should parse");
         assert_eq!(parsed.config_path, PathBuf::from("/tmp/mcp.toml"));
+    }
+
+    #[test]
+    fn parse_args_defaults_to_stdio_mode() {
+        let parsed = parse_args_from(std::iter::empty()).expect("empty args should parse");
+        assert_eq!(parsed.serve_mode, ServeMode::Stdio);
+        assert!(parsed.socket_override.is_none());
+    }
+
+    #[test]
+    fn parse_args_accepts_serve_socket_and_socket_override() {
+        let parsed = parse_args_from(
+            vec![
+                "--serve".to_string(),
+                "socket".to_string(),
+                "--socket".to_string(),
+                "/tmp/custom.sock".to_string(),
+            ]
+            .into_iter(),
+        )
+        .expect("serve socket should parse");
+        assert_eq!(parsed.serve_mode, ServeMode::Socket);
+        assert_eq!(
+            parsed.socket_override,
+            Some(PathBuf::from("/tmp/custom.sock"))
+        );
+    }
+
+    #[test]
+    fn parse_args_rejects_unknown_serve_mode() {
+        let err = parse_args_from(vec!["--serve".to_string(), "http".to_string()].into_iter())
+            .expect_err("unknown serve mode should error");
+        assert!(
+            err.to_string().contains("unknown --serve mode `http`"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/apps/moraine-mcp/src/main.rs
+++ b/apps/moraine-mcp/src/main.rs
@@ -26,6 +26,10 @@ fn main() -> Result<()> {
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
         )
         .with_target(false)
+        // Logs MUST go to stderr: stdout is the MCP JSON-RPC stream (for the
+        // embedded server and the proxy), and any log line written there would
+        // corrupt the protocol for the connected agent.
+        .with_writer(std::io::stderr)
         .init();
 
     let args = cli::parse_args()?;

--- a/apps/moraine-mcp/src/main.rs
+++ b/apps/moraine-mcp/src/main.rs
@@ -16,8 +16,11 @@ mod tools {
 use anyhow::{Context, Result};
 use tracing_subscriber::EnvFilter;
 
-#[tokio::main(flavor = "multi_thread")]
-async fn main() -> Result<()> {
+// No `#[tokio::main]`: the runtime flavor depends on the mode. The central
+// server wants a multi-threaded runtime, but a thin per-session proxy only
+// needs a single thread — that single-thread choice is what keeps the
+// per-agent footprint small at scale. `rpc::run` builds the right runtime.
+fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
@@ -26,8 +29,14 @@ async fn main() -> Result<()> {
         .init();
 
     let args = cli::parse_args()?;
-    let cfg = moraine_config::load_config(&args.config_path)
+    let mut cfg = moraine_config::load_config(&args.config_path)
         .with_context(|| format!("failed to load config {}", args.config_path.display()))?;
 
-    rpc::run(cfg).await
+    // An explicit --socket overrides the configured central socket path, so the
+    // daemon and its clients can be pointed at the same path from the launcher.
+    if let Some(socket) = &args.socket_override {
+        cfg.mcp.central_socket_path = socket.to_string_lossy().to_string();
+    }
+
+    rpc::run(cfg, args.serve_mode)
 }

--- a/apps/moraine-mcp/src/rpc.rs
+++ b/apps/moraine-mcp/src/rpc.rs
@@ -1,6 +1,42 @@
-use anyhow::Result;
+use crate::cli::ServeMode;
+use anyhow::{Context, Result};
 use moraine_config::AppConfig;
+use std::path::PathBuf;
+use tokio::runtime::Builder;
 
-pub async fn run(cfg: AppConfig) -> Result<()> {
-    moraine_mcp_core::run_stdio(cfg).await
+/// Build the appropriate tokio runtime for the chosen mode and drive it.
+///
+/// - `--serve socket`: the shared central server. Multi-threaded runtime so it
+///   can fan many concurrent connections across cores.
+/// - default (stdio) with central enabled: a thin proxy (or embedded fallback)
+///   for one agent session. A current-thread runtime is sufficient — the agent
+///   issues one RPC at a time — and keeps the per-session footprint to ~1
+///   thread, which is the whole point at hundreds of sessions.
+/// - default (stdio) with central disabled: the legacy embedded server on a
+///   multi-threaded runtime (byte-for-byte the pre-central behavior).
+pub fn run(cfg: AppConfig, serve_mode: ServeMode) -> Result<()> {
+    match serve_mode {
+        ServeMode::Socket => {
+            let socket = PathBuf::from(&cfg.mcp.central_socket_path);
+            let rt = Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .context("failed to build multi-threaded runtime")?;
+            rt.block_on(moraine_mcp_core::run_socket(cfg, socket))
+        }
+        ServeMode::Stdio if cfg.mcp.use_central_server => {
+            let rt = Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("failed to build current-thread runtime")?;
+            rt.block_on(moraine_mcp_core::run_mcp_entry(cfg))
+        }
+        ServeMode::Stdio => {
+            let rt = Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .context("failed to build multi-threaded runtime")?;
+            rt.block_on(moraine_mcp_core::run_stdio(cfg))
+        }
+    }
 }

--- a/apps/moraine/src/main.rs
+++ b/apps/moraine/src/main.rs
@@ -1487,6 +1487,10 @@ fn start_background_service(
 
     let child = Command::new(&binary)
         .args(args)
+        // Background services never read stdin; closing it avoids inheriting the
+        // launcher's terminal/pipe fd (and a SIGHUP/blocking-read footgun for the
+        // central MCP server, which would otherwise hold an unused stdin handle).
+        .stdin(Stdio::null())
         .stdout(Stdio::from(logfile))
         .stderr(Stdio::from(logfile_err))
         .spawn()
@@ -1828,7 +1832,10 @@ fn selected_up_services(args: &UpArgs, cfg: &AppConfig) -> Vec<Service> {
     if args.monitor || cfg.runtime.start_monitor_on_up {
         services.push(Service::Monitor);
     }
-    if args.mcp || cfg.runtime.start_mcp_on_up {
+    // The Mcp service now runs the shared central MCP server (`--serve socket`)
+    // when start_central_on_up is set (the default). The legacy
+    // runtime.start_mcp_on_up flag and the --mcp CLI flag still force it on too.
+    if args.mcp || cfg.runtime.start_mcp_on_up || cfg.mcp.start_central_on_up {
         services.push(Service::Mcp);
     }
     services
@@ -2266,12 +2273,23 @@ async fn main() -> Result<ExitCode> {
 
             let mut started_services = Vec::new();
             for service in services_to_start {
+                // Launch the Mcp service as the shared central server. The
+                // `--serve socket` flag is injected here (NOT in the shared
+                // service_args_with_defaults helper) so the foreground
+                // `moraine run mcp` path that agents register stays a stdio
+                // client and never accidentally becomes a server.
+                let extra_args: Vec<String> =
+                    if service == Service::Mcp && cfg.mcp.start_central_on_up {
+                        vec!["--serve".to_string(), "socket".to_string()]
+                    } else {
+                        Vec::new()
+                    };
                 started_services.push(start_background_service(
                     service,
                     &config_path,
                     &cfg,
                     &paths,
-                    &[],
+                    &extra_args,
                 )?);
             }
 
@@ -2299,6 +2317,9 @@ async fn main() -> Result<ExitCode> {
                     stopped.push(service);
                 }
             }
+            // Defensively remove the central MCP socket so a stopped stack never
+            // leaves a stale socket that a client would connect to and hang on.
+            let _ = fs::remove_file(&cfg.mcp.central_socket_path);
             render_down(&output, &DownSnapshot { stopped })?;
             Ok(ExitCode::SUCCESS)
         }

--- a/apps/moraine/src/main.rs
+++ b/apps/moraine/src/main.rs
@@ -2277,10 +2277,18 @@ async fn main() -> Result<ExitCode> {
                 // `--serve socket` flag is injected here (NOT in the shared
                 // service_args_with_defaults helper) so the foreground
                 // `moraine run mcp` path that agents register stays a stdio
-                // client and never accidentally becomes a server.
+                // client and never accidentally becomes a server. The explicit
+                // `--socket` pins the daemon to the launcher-resolved path so it
+                // binds exactly where clients (which resolve from the same
+                // config) connect.
                 let extra_args: Vec<String> =
                     if service == Service::Mcp && cfg.mcp.start_central_on_up {
-                        vec!["--serve".to_string(), "socket".to_string()]
+                        vec![
+                            "--serve".to_string(),
+                            "socket".to_string(),
+                            "--socket".to_string(),
+                            cfg.mcp.central_socket_path.clone(),
+                        ]
                     } else {
                         Vec::new()
                     };

--- a/apps/moraine/src/main.rs
+++ b/apps/moraine/src/main.rs
@@ -330,13 +330,20 @@ struct ClickhouseStatusSnapshot {
 enum StartState {
     Started,
     AlreadyRunning,
+    /// A live central MCP server already owns the socket but no fresh PID file
+    /// tracks it (e.g. the file was deleted while the daemon survived). Nothing
+    /// was spawned: a second daemon would no-op-exit, and recording its PID
+    /// would clobber the file with a dead PID, breaking `status` and `down`.
+    AlreadyServing,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
 struct StartOutcome {
     service: Service,
     state: StartState,
-    pid: u32,
+    /// `None` when the service is alive but not launcher-tracked
+    /// (`StartState::AlreadyServing`).
+    pid: Option<u32>,
     log_path: Option<String>,
 }
 
@@ -351,6 +358,8 @@ struct UpSnapshot {
 #[derive(Debug, Clone, serde::Serialize)]
 struct DownSnapshot {
     stopped: Vec<Service>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    warning: Option<String>,
 }
 
 struct CliOutput {
@@ -621,6 +630,23 @@ fn service_running(paths: &RuntimePaths, service: Service) -> Option<u32> {
         Some(pid)
     } else {
         None
+    }
+}
+
+/// True when something is currently accepting connections on the central MCP
+/// socket. Used alongside (not instead of) the PID file: the daemon can
+/// outlive a deleted or stale PID file, and acting on the file alone either
+/// spawns a useless second daemon (`up`) or unlinks a live server's socket,
+/// orphaning it unreachably (`down`).
+fn central_socket_live(socket_path: &str) -> bool {
+    #[cfg(unix)]
+    {
+        std::os::unix::net::UnixStream::connect(socket_path).is_ok()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = socket_path;
+        false
     }
 }
 
@@ -1182,7 +1208,7 @@ async fn start_clickhouse(cfg: &AppConfig, paths: &RuntimePaths) -> Result<Start
         return Ok(StartOutcome {
             service: Service::ClickHouse,
             state: StartState::AlreadyRunning,
-            pid,
+            pid: Some(pid),
             log_path: Some(log_path(paths, Service::ClickHouse).display().to_string()),
         });
     }
@@ -1207,7 +1233,7 @@ async fn start_clickhouse(cfg: &AppConfig, paths: &RuntimePaths) -> Result<Start
     Ok(StartOutcome {
         service: Service::ClickHouse,
         state: StartState::Started,
-        pid: child.id(),
+        pid: Some(child.id()),
         log_path: Some(log_path(paths, Service::ClickHouse).display().to_string()),
     })
 }
@@ -1467,7 +1493,21 @@ fn start_background_service(
         return Ok(StartOutcome {
             service,
             state: StartState::AlreadyRunning,
-            pid,
+            pid: Some(pid),
+            log_path: Some(log_path(paths, service).display().to_string()),
+        });
+    }
+
+    // The central MCP server can outlive its PID file (e.g. the file was
+    // deleted while the daemon survived). Probe the socket before spawning:
+    // a second daemon would just no-op-exit, and the write_pid below would
+    // then record that dead PID, breaking `status` and `down` for the live
+    // server.
+    if service == Service::Mcp && central_socket_live(&cfg.mcp.central_socket_path) {
+        return Ok(StartOutcome {
+            service,
+            state: StartState::AlreadyServing,
+            pid: None,
             log_path: Some(log_path(paths, service).display().to_string()),
         });
     }
@@ -1500,7 +1540,7 @@ fn start_background_service(
     Ok(StartOutcome {
         service,
         state: StartState::Started,
-        pid: child.id(),
+        pid: Some(child.id()),
         log_path: Some(log_path(paths, service).display().to_string()),
     })
 }
@@ -1832,9 +1872,10 @@ fn selected_up_services(args: &UpArgs, cfg: &AppConfig) -> Vec<Service> {
     if args.monitor || cfg.runtime.start_monitor_on_up {
         services.push(Service::Monitor);
     }
-    // The Mcp service now runs the shared central MCP server (`--serve socket`)
-    // when start_central_on_up is set (the default). The legacy
-    // runtime.start_mcp_on_up flag and the --mcp CLI flag still force it on too.
+    // The up-managed Mcp service is always the shared central MCP server
+    // (`--serve socket`); the legacy stdio daemon variant is gone. `--mcp` and
+    // the deprecated runtime.start_mcp_on_up alias force it on even when
+    // mcp.start_central_on_up is disabled.
     if args.mcp || cfg.runtime.start_mcp_on_up || cfg.mcp.start_central_on_up {
         services.push(Service::Mcp);
     }
@@ -1927,6 +1968,14 @@ fn format_start_state(outcome: &StartOutcome) -> String {
     match outcome.state {
         StartState::Started => "started".to_string(),
         StartState::AlreadyRunning => "already running".to_string(),
+        StartState::AlreadyServing => "already serving (unmanaged)".to_string(),
+    }
+}
+
+fn format_start_pid(outcome: &StartOutcome) -> String {
+    match outcome.pid {
+        Some(pid) => pid.to_string(),
+        None => "-".to_string(),
     }
 }
 
@@ -2222,13 +2271,13 @@ fn render_up(output: &CliOutput, snapshot: &UpSnapshot) -> Result<()> {
     let mut rows = vec![vec![
         snapshot.clickhouse.service.name().to_string(),
         format_start_state(&snapshot.clickhouse),
-        snapshot.clickhouse.pid.to_string(),
+        format_start_pid(&snapshot.clickhouse),
     ]];
     rows.extend(snapshot.services.iter().map(|outcome| {
         vec![
             outcome.service.name().to_string(),
             format_start_state(outcome),
-            outcome.pid.to_string(),
+            format_start_pid(outcome),
         ]
     }));
     output.table("Startup Results", &["service", "result", "pid"], &rows);
@@ -2244,6 +2293,9 @@ fn render_down(output: &CliOutput, snapshot: &DownSnapshot) -> Result<()> {
     }
     if snapshot.stopped.is_empty() {
         output.section("Shutdown", &["no running services found".to_string()]);
+        if let Some(warning) = &snapshot.warning {
+            output.section("Warning", std::slice::from_ref(warning));
+        }
         return Ok(());
     }
     let rows = snapshot
@@ -2252,6 +2304,9 @@ fn render_down(output: &CliOutput, snapshot: &DownSnapshot) -> Result<()> {
         .map(|service| vec![service.name().to_string(), "stopped".to_string()])
         .collect::<Vec<_>>();
     output.table("Shutdown", &["service", "result"], &rows);
+    if let Some(warning) = &snapshot.warning {
+        output.section("Warning", std::slice::from_ref(warning));
+    }
     Ok(())
 }
 
@@ -2273,25 +2328,25 @@ async fn main() -> Result<ExitCode> {
 
             let mut started_services = Vec::new();
             for service in services_to_start {
-                // Launch the Mcp service as the shared central server. The
-                // `--serve socket` flag is injected here (NOT in the shared
+                // The up-managed Mcp service IS the shared central server;
+                // there is no up-managed stdio variant. The `--serve socket`
+                // flag is injected here (NOT in the shared
                 // service_args_with_defaults helper) so the foreground
                 // `moraine run mcp` path that agents register stays a stdio
                 // client and never accidentally becomes a server. The explicit
                 // `--socket` pins the daemon to the launcher-resolved path so it
                 // binds exactly where clients (which resolve from the same
                 // config) connect.
-                let extra_args: Vec<String> =
-                    if service == Service::Mcp && cfg.mcp.start_central_on_up {
-                        vec![
-                            "--serve".to_string(),
-                            "socket".to_string(),
-                            "--socket".to_string(),
-                            cfg.mcp.central_socket_path.clone(),
-                        ]
-                    } else {
-                        Vec::new()
-                    };
+                let extra_args: Vec<String> = if service == Service::Mcp {
+                    vec![
+                        "--serve".to_string(),
+                        "socket".to_string(),
+                        "--socket".to_string(),
+                        cfg.mcp.central_socket_path.clone(),
+                    ]
+                } else {
+                    Vec::new()
+                };
                 started_services.push(start_background_service(
                     service,
                     &config_path,
@@ -2325,10 +2380,25 @@ async fn main() -> Result<ExitCode> {
                     stopped.push(service);
                 }
             }
-            // Defensively remove the central MCP socket so a stopped stack never
-            // leaves a stale socket that a client would connect to and hang on.
-            let _ = fs::remove_file(&cfg.mcp.central_socket_path);
-            render_down(&output, &DownSnapshot { stopped })?;
+            // Remove the central MCP socket only when nothing is listening on
+            // it: a dead socket would make clients connect-then-stall before
+            // falling back to embedded, but unlinking a *live* server's socket
+            // (possible when its PID file was lost, so stop_service had nothing
+            // to kill) would orphan that server unreachably while it keeps
+            // running. A daemon stopped by stop_service above has already
+            // removed its own socket via its signal handler.
+            let warning = if central_socket_live(&cfg.mcp.central_socket_path) {
+                Some(format!(
+                    "an MCP server is still listening on {} but is not tracked by a \
+                     PID file, so it was not stopped and its socket was left in place; \
+                     stop that process manually and re-run `moraine down`",
+                    cfg.mcp.central_socket_path
+                ))
+            } else {
+                let _ = fs::remove_file(&cfg.mcp.central_socket_path);
+                None
+            };
+            render_down(&output, &DownSnapshot { stopped, warning })?;
             Ok(ExitCode::SUCCESS)
         }
         CliCommand::Status => {
@@ -2912,5 +2982,34 @@ mod tests {
 
         assert_eq!(managed_clickhouse_checksum_state(&cfg, &paths), "verified");
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn central_socket_live_detects_listener_vs_dead_socket() {
+        // Keep the path short: macOS temp_dir() exceeds the ~104-byte sun_path
+        // limit for Unix socket addresses.
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let sock = PathBuf::from(format!(
+            "/tmp/moraine-csl-{}-{stamp}.sock",
+            std::process::id()
+        ));
+        let sock_str = sock.to_string_lossy().to_string();
+
+        // No socket file at all.
+        assert!(!central_socket_live(&sock_str));
+
+        // A live listener is detected even with no PID file anywhere.
+        let listener = std::os::unix::net::UnixListener::bind(&sock).expect("bind socket");
+        assert!(central_socket_live(&sock_str));
+
+        // A dead socket file (listener gone) is not treated as live.
+        drop(listener);
+        assert!(!central_socket_live(&sock_str));
+
+        let _ = fs::remove_file(&sock);
     }
 }

--- a/config/moraine.toml
+++ b/config/moraine.toml
@@ -124,4 +124,3 @@ healthcheck_interval_ms = 500
 clickhouse_auto_install = true
 clickhouse_version = "v25.12.5.44-stable"
 start_monitor_on_up = true
-start_mcp_on_up = false

--- a/config/moraine.toml
+++ b/config/moraine.toml
@@ -91,6 +91,16 @@ default_exclude_codex_mcp = true
 prewarm_on_initialize = false
 async_log_writes = true
 protocol_version = "2024-11-05"
+# Shared central MCP server (default ON). One `moraine up`-managed server owns
+# the ClickHouse client, caches, and runtime; every `moraine run mcp` becomes a
+# thin stdio<->socket proxy to it, instead of booting a full server per agent
+# session. If the socket is absent/unreachable, `moraine run mcp` transparently
+# falls back to an embedded server, so unconfigured setups keep working.
+use_central_server = true
+start_central_on_up = true
+# Bare filename resolves under the runtime pids dir -> ~/.moraine/run/mcp.sock.
+central_socket_path = "mcp.sock"
+central_connect_timeout_ms = 250
 
 [bm25]
 k1 = 1.2

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -100,6 +100,28 @@ pub struct McpConfig {
     pub async_log_writes: bool,
     #[serde(default = "default_protocol_version")]
     pub protocol_version: String,
+    /// When true, `moraine run mcp` first tries to reach the shared central
+    /// MCP server over its Unix socket and proxies to it; if the socket is
+    /// absent or unreachable it transparently falls back to an embedded
+    /// stdio server. When false, `moraine run mcp` always runs embedded
+    /// (pre-central behavior).
+    #[serde(default = "default_true")]
+    pub use_central_server: bool,
+    /// Filesystem path of the central MCP server's Unix domain socket. A
+    /// bare filename is resolved relative to the runtime pids dir
+    /// (`~/.moraine/run`), so the default lands at `~/.moraine/run/mcp.sock`.
+    /// An absolute path is used verbatim.
+    #[serde(default = "default_mcp_socket")]
+    pub central_socket_path: String,
+    /// When true, `moraine up` launches the shared central MCP server as a
+    /// background daemon (Service::Mcp in `--serve socket` mode).
+    #[serde(default = "default_true")]
+    pub start_central_on_up: bool,
+    /// Upper bound, in milliseconds, on how long a proxy client waits to
+    /// connect to the central socket before giving up and falling back to
+    /// an embedded server. Keeps startup fast when the daemon is absent.
+    #[serde(default = "default_central_connect_timeout_ms")]
+    pub central_connect_timeout_ms: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -214,6 +236,10 @@ impl Default for McpConfig {
             prewarm_on_initialize: false,
             async_log_writes: true,
             protocol_version: default_protocol_version(),
+            use_central_server: true,
+            central_socket_path: default_mcp_socket(),
+            start_central_on_up: true,
+            central_connect_timeout_ms: default_central_connect_timeout_ms(),
         }
     }
 }
@@ -432,6 +458,14 @@ fn default_context_after() -> u16 {
 
 fn default_protocol_version() -> String {
     "2024-11-05".to_string()
+}
+
+fn default_mcp_socket() -> String {
+    "mcp.sock".to_string()
+}
+
+fn default_central_connect_timeout_ms() -> u64 {
+    250
 }
 
 fn default_k1() -> f64 {
@@ -693,6 +727,14 @@ fn normalize_config(mut cfg: AppConfig) -> Result<AppConfig> {
     cfg.runtime.service_bin_dir = expand_path(&cfg.runtime.service_bin_dir);
     cfg.runtime.managed_clickhouse_dir = expand_path(&cfg.runtime.managed_clickhouse_dir);
 
+    // Resolve the central MCP socket path against the (already-normalized)
+    // pids dir so a bare filename lands at `~/.moraine/run/mcp.sock` while an
+    // absolute path is preserved. The daemon (`moraine up`) and proxy clients
+    // (`moraine run mcp`) both read this resolved value, so they agree on the
+    // socket as long as they load the same config.
+    cfg.mcp.central_socket_path =
+        resolve_runtime_subdir(&cfg.runtime.pids_dir, &cfg.mcp.central_socket_path);
+
     Ok(cfg)
 }
 
@@ -932,6 +974,68 @@ prewarm_on_initialize = true
         let cfg = load_config(&path).expect("mcp prewarm toggle should load");
         std::fs::remove_file(&path).ok();
         assert!(cfg.mcp.prewarm_on_initialize);
+    }
+
+    #[test]
+    fn central_mcp_defaults_are_on() {
+        let cfg = McpConfig::default();
+        assert!(cfg.use_central_server);
+        assert!(cfg.start_central_on_up);
+        assert_eq!(cfg.central_connect_timeout_ms, 250);
+        assert_eq!(cfg.central_socket_path, "mcp.sock");
+    }
+
+    #[test]
+    fn central_socket_path_resolves_relative_to_pids_dir() {
+        let path = write_temp_config(
+            r#"
+[runtime]
+root_dir = "/tmp/moraine-central-test"
+"#,
+            "central-socket-relative",
+        );
+        let cfg = load_config(&path).expect("config should load");
+        std::fs::remove_file(&path).ok();
+        // Bare "mcp.sock" default resolves under <root>/run.
+        assert_eq!(
+            cfg.mcp.central_socket_path,
+            "/tmp/moraine-central-test/run/mcp.sock"
+        );
+    }
+
+    #[test]
+    fn central_socket_path_absolute_is_preserved() {
+        let path = write_temp_config(
+            r#"
+[runtime]
+root_dir = "/tmp/moraine-central-test"
+
+[mcp]
+central_socket_path = "/var/run/moraine/custom.sock"
+"#,
+            "central-socket-absolute",
+        );
+        let cfg = load_config(&path).expect("config should load");
+        std::fs::remove_file(&path).ok();
+        assert_eq!(cfg.mcp.central_socket_path, "/var/run/moraine/custom.sock");
+    }
+
+    #[test]
+    fn central_mcp_toggles_are_optional_in_toml() {
+        // A config that predates the central-server feature (no central keys)
+        // must still parse, picking up the new defaults.
+        let path = write_temp_config(
+            r#"
+[mcp]
+max_results = 25
+"#,
+            "central-omitted-keys",
+        );
+        let cfg = load_config(&path).expect("legacy mcp config should load");
+        std::fs::remove_file(&path).ok();
+        assert_eq!(cfg.mcp.max_results, 25);
+        assert!(cfg.mcp.use_central_server);
+        assert!(cfg.mcp.start_central_on_up);
     }
 
     #[test]

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -171,6 +171,11 @@ pub struct RuntimeConfig {
     pub clickhouse_version: String,
     #[serde(default = "default_true")]
     pub start_monitor_on_up: bool,
+    /// Deprecated (v0.6.0): the up-managed MCP service is always the shared
+    /// central server now, controlled by `mcp.start_central_on_up`. This key
+    /// is still parsed (existing configs must keep loading under
+    /// `deny_unknown_fields`) and acts as a force-on alias, like
+    /// `moraine up --mcp`.
     #[serde(default = "default_false")]
     pub start_mcp_on_up: bool,
 }

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -9,7 +9,15 @@ anyhow = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.40", features = ["io-std", "io-util", "rt", "sync", "time"] }
+tokio = { version = "1.40", features = [
+    "io-std",
+    "io-util",
+    "net",
+    "rt",
+    "signal",
+    "sync",
+    "time",
+] }
 tracing = "0.1"
 moraine-config = { path = "../moraine-config" }
 moraine-clickhouse = { path = "../moraine-clickhouse" }

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -22,3 +22,10 @@ tracing = "0.1"
 moraine-config = { path = "../moraine-config" }
 moraine-clickhouse = { path = "../moraine-clickhouse" }
 moraine-conversations = { path = "../moraine-conversations" }
+
+[dev-dependencies]
+# `#[tokio::test]` needs the macros feature explicitly; without this it only
+# compiles via feature unification from moraine-conversations' tokio features,
+# which would break `cargo test -p moraine-mcp-core` if that crate ever
+# dropped "macros".
+tokio = { version = "1.40", features = ["macros"] }

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -11,11 +11,13 @@ use moraine_config::AppConfig;
 use moraine_conversations::{ClickHouseConversationRepository, RepoConfig};
 use serde::Deserialize;
 use serde_json::{json, Value};
+#[cfg(unix)]
+use std::path::PathBuf;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tracing::{debug, warn};
 
 #[derive(Debug, Deserialize)]
@@ -326,34 +328,51 @@ fn tool_error_result(message: String) -> Value {
     })
 }
 
-pub async fn run_stdio(cfg: AppConfig) -> Result<()> {
-    let ch = ClickHouseClient::new(cfg.clickhouse.clone())?;
+impl AppState {
+    /// Build the shared MCP application state: one ClickHouse client (and its
+    /// reqwest connection pool) and one conversation repository (and its
+    /// caches). A single instance is shared across every connection a central
+    /// server handles, so the heavy state is allocated once per host rather
+    /// than once per agent session.
+    pub fn build(cfg: AppConfig) -> Result<Arc<AppState>> {
+        let ch = ClickHouseClient::new(cfg.clickhouse.clone())?;
 
-    let repo_cfg = RepoConfig {
-        max_results: cfg.mcp.max_results,
-        preview_chars: cfg.mcp.preview_chars,
-        default_context_before: cfg.mcp.default_context_before,
-        default_context_after: cfg.mcp.default_context_after,
-        default_include_tool_events: cfg.mcp.default_include_tool_events,
-        default_exclude_codex_mcp: cfg.mcp.default_exclude_codex_mcp,
-        async_log_writes: cfg.mcp.async_log_writes,
-        bm25_k1: cfg.bm25.k1,
-        bm25_b: cfg.bm25.b,
-        bm25_default_min_score: cfg.bm25.default_min_score,
-        bm25_default_min_should_match: cfg.bm25.default_min_should_match,
-        bm25_max_query_terms: cfg.bm25.max_query_terms,
-    };
+        let repo_cfg = RepoConfig {
+            max_results: cfg.mcp.max_results,
+            preview_chars: cfg.mcp.preview_chars,
+            default_context_before: cfg.mcp.default_context_before,
+            default_context_after: cfg.mcp.default_context_after,
+            default_include_tool_events: cfg.mcp.default_include_tool_events,
+            default_exclude_codex_mcp: cfg.mcp.default_exclude_codex_mcp,
+            async_log_writes: cfg.mcp.async_log_writes,
+            bm25_k1: cfg.bm25.k1,
+            bm25_b: cfg.bm25.b,
+            bm25_default_min_score: cfg.bm25.default_min_score,
+            bm25_default_min_should_match: cfg.bm25.default_min_should_match,
+            bm25_max_query_terms: cfg.bm25.max_query_terms,
+        };
 
-    let repo = ClickHouseConversationRepository::new(ch, repo_cfg);
-    let state = Arc::new(AppState {
-        cfg,
-        repo,
-        prewarm_started: Arc::new(AtomicBool::new(false)),
-    });
+        let repo = ClickHouseConversationRepository::new(ch, repo_cfg);
+        Ok(Arc::new(AppState {
+            cfg,
+            repo,
+            prewarm_started: Arc::new(AtomicBool::new(false)),
+        }))
+    }
+}
 
-    let stdin = BufReader::new(tokio::io::stdin());
-    let mut lines = stdin.lines();
-    let mut stdout = tokio::io::stdout();
+/// Drive a single newline-delimited JSON-RPC connection to completion.
+///
+/// This is the one source of truth for the MCP wire framing: one JSON object
+/// per line in, one JSON object + `\n` per response out, blank lines skipped.
+/// `run_stdio` drives it over stdin/stdout; the central server drives one of
+/// these per accepted socket connection, all sharing a single `Arc<AppState>`.
+async fn serve_connection<R, W>(state: Arc<AppState>, reader: R, mut writer: W) -> Result<()>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut lines = reader.lines();
 
     while let Some(line) = lines.next_line().await? {
         let line = line.trim();
@@ -374,13 +393,246 @@ pub async fn run_stdio(cfg: AppConfig) -> Result<()> {
 
         if let Some(resp) = state.handle_request(req).await {
             let payload = serde_json::to_vec(&resp)?;
-            stdout.write_all(&payload).await?;
-            stdout.write_all(b"\n").await?;
-            stdout.flush().await?;
+            writer.write_all(&payload).await?;
+            writer.write_all(b"\n").await?;
+            writer.flush().await?;
         }
     }
 
     Ok(())
+}
+
+/// Run an embedded MCP server over stdin/stdout. This is the pre-central
+/// behavior: one full server (ClickHouse client + caches) per process, owned
+/// by the agent session that spawned it. Used directly when the central server
+/// is disabled, and as the transparent fallback when it is unreachable.
+pub async fn run_stdio(cfg: AppConfig) -> Result<()> {
+    let state = AppState::build(cfg)?;
+    serve_connection(
+        state,
+        BufReader::new(tokio::io::stdin()),
+        tokio::io::stdout(),
+    )
+    .await
+}
+
+/// Run the shared central MCP server, listening on a Unix domain socket.
+///
+/// Builds the heavy `AppState` exactly once, then accepts connections and
+/// serves each on its own task sharing that single state. One bad client never
+/// takes down the server; transient `accept` errors back off and retry. A
+/// SIGTERM/SIGINT handler unlinks the socket so a clean `moraine down` leaves
+/// no stale socket behind.
+#[cfg(unix)]
+pub async fn run_socket(cfg: AppConfig, socket_path: PathBuf) -> Result<()> {
+    use tokio::net::{UnixListener, UnixStream};
+
+    let state = AppState::build(cfg)?;
+
+    if let Some(parent) = socket_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create socket directory {}", parent.display()))?;
+    }
+
+    // Stale-socket dance: if a live server already owns the path, this start is
+    // a no-op (idempotent `moraine up`). Otherwise remove the dead socket file
+    // so bind() can succeed.
+    if socket_path.exists() {
+        match UnixStream::connect(&socket_path).await {
+            Ok(_) => {
+                warn!(
+                    "central MCP server already listening at {}; nothing to do",
+                    socket_path.display()
+                );
+                return Ok(());
+            }
+            Err(_) => {
+                let _ = std::fs::remove_file(&socket_path);
+            }
+        }
+    }
+
+    let listener = UnixListener::bind(&socket_path)
+        .with_context(|| format!("failed to bind MCP socket {}", socket_path.display()))?;
+
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(err) =
+            std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))
+        {
+            warn!(
+                "failed to set 0o600 permissions on {}: {}",
+                socket_path.display(),
+                err
+            );
+        }
+    }
+
+    spawn_socket_cleanup_on_signal(socket_path.clone());
+
+    debug!("central MCP server listening on {}", socket_path.display());
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, _addr)) => {
+                let conn_state = state.clone();
+                tokio::spawn(async move {
+                    if let Err(err) = serve_socket_connection(conn_state, stream).await {
+                        debug!("mcp connection ended: {}", err);
+                    }
+                });
+            }
+            Err(err) => {
+                // e.g. EMFILE under fd pressure: log and keep serving rather
+                // than tearing down every other session's connection.
+                warn!("mcp accept error: {}", err);
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn serve_socket_connection(
+    state: Arc<AppState>,
+    stream: tokio::net::UnixStream,
+) -> Result<()> {
+    let (read_half, write_half) = stream.into_split();
+    serve_connection(state, BufReader::new(read_half), write_half).await
+}
+
+#[cfg(unix)]
+fn spawn_socket_cleanup_on_signal(socket_path: PathBuf) {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    tokio::spawn(async move {
+        let mut term = match signal(SignalKind::terminate()) {
+            Ok(sig) => sig,
+            Err(err) => {
+                warn!("failed to install SIGTERM handler: {}", err);
+                return;
+            }
+        };
+        let mut int = match signal(SignalKind::interrupt()) {
+            Ok(sig) => sig,
+            Err(err) => {
+                warn!("failed to install SIGINT handler: {}", err);
+                return;
+            }
+        };
+
+        tokio::select! {
+            _ = term.recv() => {}
+            _ = int.recv() => {}
+        }
+
+        let _ = std::fs::remove_file(&socket_path);
+        std::process::exit(0);
+    });
+}
+
+/// Run a near-zero-cost stdio<->socket proxy for a single agent session.
+///
+/// No ClickHouse client, no caches, no multi-threaded runtime: just two byte
+/// pumps. Because it never parses the JSON, it cannot perturb the framing
+/// (id presence, compact spacing, etc.) — it forwards bytes verbatim.
+///
+/// Half-close semantics matter: when the agent closes stdin we must *not* abort
+/// the downstream copy, or a large in-flight `tools/call` response would be
+/// truncated. So the downstream pump (server -> stdout) is authoritative for
+/// exit; on stdin EOF we shut down the socket write half (signalling EOF to the
+/// server) and keep draining downstream until the server closes its side.
+#[cfg(unix)]
+pub async fn run_proxy(stream: tokio::net::UnixStream) -> Result<()> {
+    proxy_streams(tokio::io::stdin(), tokio::io::stdout(), stream).await
+}
+
+/// Core of [`run_proxy`], generic over the client side so it can be exercised
+/// with in-memory streams in tests. `client_in`/`client_out` are stdin/stdout
+/// in production; `stream` is the connection to the central server.
+#[cfg(unix)]
+async fn proxy_streams<I, O>(
+    mut client_in: I,
+    mut client_out: O,
+    stream: tokio::net::UnixStream,
+) -> Result<()>
+where
+    I: AsyncRead + Unpin,
+    O: AsyncWrite + Unpin,
+{
+    let (mut sock_read, mut sock_write) = stream.into_split();
+
+    let upstream = async {
+        let _ = tokio::io::copy(&mut client_in, &mut sock_write).await;
+        // Signal EOF to the server so it can finish any in-flight response and
+        // close its write half. Ignore errors (server may already be gone).
+        let _ = sock_write.shutdown().await;
+    };
+
+    let downstream = async {
+        let _ = tokio::io::copy(&mut sock_read, &mut client_out).await;
+        let _ = client_out.flush().await;
+    };
+
+    tokio::pin!(upstream);
+    tokio::pin!(downstream);
+
+    tokio::select! {
+        // Server closed its write half (normal end, or crash/EOF): we are done.
+        _ = &mut downstream => {}
+        // Agent finished sending and we half-closed upstream: keep draining the
+        // server's response stream to completion before exiting.
+        _ = &mut upstream => {
+            downstream.await;
+        }
+    }
+
+    Ok(())
+}
+
+/// Entry point used by `moraine run mcp` (the command agents register).
+///
+/// When the central server is enabled (the default), connect to its socket and
+/// proxy; if the socket is missing, refused, or slow to answer, fall back to an
+/// embedded stdio server so correctness never depends on the daemon being up.
+/// When central mode is disabled, run embedded directly (pre-central behavior).
+pub async fn run_mcp_entry(cfg: AppConfig) -> Result<()> {
+    #[cfg(unix)]
+    if cfg.mcp.use_central_server {
+        use tokio::net::UnixStream;
+
+        let socket_path = PathBuf::from(&cfg.mcp.central_socket_path);
+        let dur = std::time::Duration::from_millis(cfg.mcp.central_connect_timeout_ms);
+        match tokio::time::timeout(dur, UnixStream::connect(&socket_path)).await {
+            Ok(Ok(stream)) => {
+                debug!(
+                    "proxying stdio to central MCP server at {}",
+                    socket_path.display()
+                );
+                return run_proxy(stream).await;
+            }
+            Ok(Err(err)) => warn!(
+                "central MCP server unreachable at {} ({}); using embedded server",
+                socket_path.display(),
+                err
+            ),
+            Err(_) => warn!(
+                "central MCP server connect timed out at {} after {}ms; using embedded server",
+                socket_path.display(),
+                cfg.mcp.central_connect_timeout_ms
+            ),
+        }
+    }
+
+    run_stdio(cfg).await
+}
+
+/// Non-Unix platforms do not support the Unix-socket central server. The
+/// `moraine run mcp` entry point still works (embedded only) via the
+/// `run_mcp_entry` fallback above.
+#[cfg(not(unix))]
+pub async fn run_socket(_cfg: AppConfig, _socket_path: std::path::PathBuf) -> Result<()> {
+    anyhow::bail!("the central MCP socket server is only supported on Unix platforms")
 }
 
 #[cfg(test)]
@@ -534,6 +786,149 @@ mod tests {
                 "sessions",
                 "next_cursor"
             ])
+        );
+    }
+
+    #[test]
+    fn app_state_build_succeeds_without_live_clickhouse() {
+        // Building state only constructs the HTTP client and caches; it must
+        // not require ClickHouse to be reachable.
+        let state = AppState::build(AppConfig::default()).expect("build state");
+        assert!(!state.prewarm_started.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn serve_connection_frames_one_response_per_request() {
+        let state = AppState::build(AppConfig::default()).expect("build state");
+
+        // Two requests separated by a blank line (which must be skipped).
+        let input = concat!(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}\n",
+            "\n",
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"ping\"}\n",
+        )
+        .as_bytes()
+        .to_vec();
+
+        let mut out: Vec<u8> = Vec::new();
+        serve_connection(state, BufReader::new(&input[..]), &mut out)
+            .await
+            .expect("serve connection");
+
+        let text = String::from_utf8(out).expect("utf8");
+        let lines: Vec<&str> = text.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines.len(), 2, "exactly one response per request: {text}");
+
+        let first: Value = serde_json::from_str(lines[0]).expect("json line 1");
+        assert_eq!(first["id"], json!(1));
+        assert_eq!(first["result"]["serverInfo"]["name"], json!("moraine-mcp"));
+
+        let second: Value = serde_json::from_str(lines[1]).expect("json line 2");
+        assert_eq!(second["id"], json!(2));
+        assert_eq!(second["result"], json!({}));
+    }
+
+    #[cfg(unix)]
+    fn unique_socket_path(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::AtomicU32;
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        // Keep the path short to stay well under the ~104-byte sun_path limit.
+        std::path::PathBuf::from(format!(
+            "/tmp/moraine-{tag}-{}-{nanos}-{n}.sock",
+            std::process::id()
+        ))
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_socket_serves_initialize_over_unix_socket() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+        use tokio::net::UnixStream;
+
+        let sock = unique_socket_path("serve");
+        let _ = std::fs::remove_file(&sock);
+
+        let server_sock = sock.clone();
+        let server = tokio::spawn(async move {
+            let _ = run_socket(AppConfig::default(), server_sock).await;
+        });
+
+        // Connect with a few retries while the listener comes up.
+        let mut stream = None;
+        for _ in 0..50 {
+            match UnixStream::connect(&sock).await {
+                Ok(s) => {
+                    stream = Some(s);
+                    break;
+                }
+                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+            }
+        }
+        let mut stream = stream.expect("connect to central socket");
+
+        stream
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"initialize\",\"params\":{}}\n")
+            .await
+            .expect("write request");
+
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        reader.read_line(&mut line).await.expect("read response");
+
+        let resp: Value = serde_json::from_str(line.trim()).expect("json response");
+        assert_eq!(resp["id"], json!(7));
+        assert_eq!(resp["result"]["serverInfo"]["name"], json!("moraine-mcp"));
+
+        server.abort();
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn proxy_streams_drains_downstream_after_client_eof() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+        use tokio::net::UnixStream;
+
+        let (client_side, server_side) = UnixStream::pair().expect("socket pair");
+
+        // Fake server: read the (small) request, then write a LARGE response and
+        // close its write half. If the proxy aborted downstream on client stdin
+        // EOF, this response would be truncated.
+        const BIG: usize = 1_000_000;
+        let server = tokio::spawn(async move {
+            let (read_half, mut write_half) = server_side.into_split();
+            let mut reader = BufReader::new(read_half);
+            let mut req = String::new();
+            reader
+                .read_line(&mut req)
+                .await
+                .expect("server read request");
+            write_half
+                .write_all(&vec![b'x'; BIG])
+                .await
+                .expect("server write big");
+            write_half.write_all(b"\n").await.expect("server write nl");
+            write_half.shutdown().await.expect("server shutdown");
+        });
+
+        // Client stdin is a tiny request that hits EOF immediately.
+        let client_in = std::io::Cursor::new(b"{\"id\":1}\n".to_vec());
+        let mut client_out: Vec<u8> = Vec::new();
+
+        proxy_streams(client_in, &mut client_out, client_side)
+            .await
+            .expect("proxy");
+        server.await.expect("server task");
+
+        assert_eq!(
+            client_out.len(),
+            BIG + 1,
+            "downstream response must not be truncated when stdin closes first"
         );
     }
 }

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -429,44 +429,64 @@ pub async fn run_socket(cfg: AppConfig, socket_path: PathBuf) -> Result<()> {
 
     let state = AppState::build(cfg)?;
 
-    if let Some(parent) = socket_path.parent() {
-        std::fs::create_dir_all(parent)
+    if let Some(parent) = socket_path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        use std::os::unix::fs::DirBuilderExt;
+        // 0o700 on directories we create, so the socket is never reachable
+        // through a fresh directory even before its own permissions are set.
+        // An existing directory's mode is left alone (it may be shared, e.g.
+        // /tmp for an absolute central_socket_path override).
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(parent)
             .with_context(|| format!("failed to create socket directory {}", parent.display()))?;
     }
 
     // Stale-socket dance: if a live server already owns the path, this start is
-    // a no-op (idempotent `moraine up`). Otherwise remove the dead socket file
-    // so bind() can succeed.
-    if socket_path.exists() {
-        match UnixStream::connect(&socket_path).await {
-            Ok(_) => {
-                warn!(
-                    "central MCP server already listening at {}; nothing to do",
-                    socket_path.display()
-                );
-                return Ok(());
-            }
-            Err(_) => {
-                let _ = std::fs::remove_file(&socket_path);
-            }
-        }
+    // a no-op (idempotent `moraine up`). A dead socket file needs no removal —
+    // the rename below atomically replaces it.
+    if socket_path.exists() && UnixStream::connect(&socket_path).await.is_ok() {
+        warn!(
+            "central MCP server already listening at {}; nothing to do",
+            socket_path.display()
+        );
+        return Ok(());
     }
 
-    let listener = UnixListener::bind(&socket_path)
-        .with_context(|| format!("failed to bind MCP socket {}", socket_path.display()))?;
+    // Bind on a private temp path, restrict it, then atomically rename into
+    // place. The socket is therefore never connectable at the public path with
+    // umask-derived (possibly world-connectable) permissions — there is no
+    // bind-then-chmod window. Unix sockets are bound to the inode, so the
+    // listener keeps accepting through the renamed path.
+    let tmp_path = socket_path.with_extension(format!("{}.tmp", std::process::id()));
+    let _ = std::fs::remove_file(&tmp_path);
+    let listener = UnixListener::bind(&tmp_path)
+        .with_context(|| format!("failed to bind MCP socket {}", tmp_path.display()))?;
 
     {
         use std::os::unix::fs::PermissionsExt;
-        if let Err(err) =
-            std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))
-        {
-            warn!(
-                "failed to set 0o600 permissions on {}: {}",
-                socket_path.display(),
-                err
-            );
-        }
+        std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
+            .inspect_err(|_| {
+                let _ = std::fs::remove_file(&tmp_path);
+            })
+            .with_context(|| {
+                format!(
+                    "failed to set 0o600 permissions on MCP socket {}",
+                    tmp_path.display()
+                )
+            })?;
     }
+
+    std::fs::rename(&tmp_path, &socket_path)
+        .inspect_err(|_| {
+            let _ = std::fs::remove_file(&tmp_path);
+        })
+        .with_context(|| {
+            format!(
+                "failed to move MCP socket into place at {}",
+                socket_path.display()
+            )
+        })?;
 
     spawn_socket_cleanup_on_signal(socket_path.clone());
 
@@ -870,6 +890,16 @@ mod tests {
             }
         }
         let mut stream = stream.expect("connect to central socket");
+
+        // The bind-restrict-rename dance must leave the public path user-only.
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&sock)
+                .expect("socket metadata")
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o600, "socket must be user-only (0o600)");
+        }
 
         stream
             .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"initialize\",\"params\":{}}\n")

--- a/docs/agent-mcp-search/install.md
+++ b/docs/agent-mcp-search/install.md
@@ -10,6 +10,33 @@ Run `moraine up` first so ClickHouse, ingest, and the monitor are available.
 If you use a non-default Moraine config, pass it through the harness's
 environment support as `MORAINE_MCP_CONFIG=/path/to/moraine.toml`.
 
+## Shared central server (default)
+
+By default `moraine up` starts a single shared MCP server for the whole host,
+and every `moraine run mcp` becomes a thin stdio↔socket proxy to it. This
+replaces the previous model of booting a full MCP server (its own ClickHouse
+client, caches, and runtime threads) inside every agent session, and is what
+keeps hundreds of concurrent sessions cheap.
+
+What this means for you:
+
+- **Registration is unchanged.** Keep registering `moraine run mcp` exactly as
+  shown below. The proxy-vs-embedded choice is made internally.
+- **`moraine up` is required** for the shared server. The daemon listens on a
+  Unix socket at `~/.moraine/run/mcp.sock` (mode `0o600`, so it is scoped to
+  your user). `moraine down` stops it and removes the socket.
+- **Automatic fallback.** If the central server is not running (you skipped
+  `moraine up`, or it crashed), `moraine run mcp` transparently falls back to an
+  embedded server after ~250&nbsp;ms, so retrieval keeps working either way.
+- **Crash blast radius.** A central-server crash drops all live sessions' MCP
+  connections at once; harnesses re-establish the connection on their next tool
+  use, and `moraine up` restarts the daemon. To opt out and return to a server
+  per session, set `use_central_server = false` (see
+  [Configuration → MCP](../configuration.md#shared-central-mcp-server)).
+
+The remaining sections register the unchanged `moraine run mcp` command with
+each harness.
+
 ## Global Codex
 
 Codex stores user-level configuration in `~/.codex/config.toml`, and the Codex

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,6 +243,10 @@ default_exclude_codex_mcp = true
 prewarm_on_initialize = false
 async_log_writes = true
 protocol_version = "2024-11-05"
+use_central_server = true
+start_central_on_up = true
+central_socket_path = "mcp.sock"
+central_connect_timeout_ms = 250
 ```
 
 Raise `max_results` only when clients need larger result windows. Increase
@@ -250,6 +254,28 @@ context defaults when retrieval snippets are too narrow.
 Leave `prewarm_on_initialize` disabled for harnesses that launch multiple MCP
 processes at once; enabling it trades startup CPU/database work for lower
 first-search latency.
+
+### Shared central MCP server
+
+By default Moraine runs a single shared MCP server per host instead of one
+full server per agent session, which sharply reduces CPU and memory when many
+sessions are active at once. The fields above control it:
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `use_central_server` | `true` | When set, `moraine run mcp` connects to the central server's socket and proxies to it; if the socket is missing or unreachable it transparently falls back to an embedded server. Set to `false` to always run embedded (pre-central behavior). |
+| `start_central_on_up` | `true` | When set, `moraine up` launches the central server as a background daemon. |
+| `central_socket_path` | `mcp.sock` | Unix socket path. A bare filename resolves under the runtime pids dir (`~/.moraine/run/mcp.sock`, mode `0o600`); an absolute path is used verbatim. |
+| `central_connect_timeout_ms` | `250` | How long a client waits to connect before falling back to embedded. |
+
+The MCP registration command is unchanged — agents still launch
+`moraine run mcp`. The proxy-vs-embedded decision is internal. The daemon and
+its clients must resolve the same `central_socket_path` (i.e. load the same
+config) to share a server; otherwise clients silently fall back to embedded.
+The `0o600` socket scopes the server to a single user, so on a shared host each
+user runs their own central server. See
+[Agent MCP Search → Install](agent-mcp-search/install.md#shared-central-server-default)
+for operational notes.
 
 ## Search Ranking
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,6 @@ port = 8080
 [runtime]
 root_dir = "~/.moraine"
 start_monitor_on_up = true
-start_mcp_on_up = false
 
 [[ingest.sources]]
 name = "codex"
@@ -277,6 +276,12 @@ user runs their own central server. See
 [Agent MCP Search → Install](agent-mcp-search/install.md#shared-central-server-default)
 for operational notes.
 
+The up-managed MCP service is always the central socket server; the legacy
+per-`up` stdio daemon is gone (v0.6.0). `runtime.start_mcp_on_up` is
+deprecated: it is still parsed so existing configs keep loading, and it now
+acts as a force-on alias for the central server (the same as `moraine up
+--mcp`). Use `mcp.start_central_on_up` instead.
+
 ## Search Ranking
 
 `[bm25]` tunes search behavior:
@@ -306,7 +311,6 @@ service_bin_dir = "~/.local/bin"
 managed_clickhouse_dir = "~/.local/lib/moraine/clickhouse/current"
 clickhouse_auto_install = true
 start_monitor_on_up = true
-start_mcp_on_up = false
 ```
 
 Relative `logs_dir` and `pids_dir` values are resolved under `root_dir`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -55,6 +55,13 @@ Moraine MCP search runs as a local stdio MCP server. Each agent harness starts
 `moraine run mcp` when it needs the tools, so keep the Moraine stack running
 with `moraine up`.
 
+By default `moraine up` also starts a single **shared** MCP server for the host,
+and each `moraine run mcp` proxies to it instead of booting a full server per
+session — this is what keeps many concurrent agents cheap. Registration is
+unchanged; if the shared server is not running, `moraine run mcp` falls back to
+an embedded server automatically. See
+[Agent MCP Search → Install](agent-mcp-search/install.md#shared-central-server-default).
+
 Add Moraine to Codex globally:
 
 ```bash
@@ -82,8 +89,8 @@ For Cursor, Kimi CLI, Pi, project-scoped Claude Code, and other clients, see
 
 | Command | Purpose |
 | --- | --- |
-| `moraine up` | Start ClickHouse, ingest, and the monitor UI. |
-| `moraine up --mcp` | Start the MCP server along with the default services. |
+| `moraine up` | Start ClickHouse, ingest, the monitor UI, and the shared MCP server. |
+| `moraine up --mcp` | Force-start the shared MCP server (also on by default). |
 | `moraine status` | Print service and ingest health. |
 | `moraine logs` | Show recent service logs. |
 | `moraine logs ingest --lines 500` | Show recent ingest logs. |

--- a/scripts/bench/central_mcp_resource.py
+++ b/scripts/bench/central_mcp_resource.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "psutil>=5.9,<8",
+# ]
+# ///
+"""Resource benchmark for the shared central MCP server vs per-session embedded servers.
+
+This quantifies the win behind `mcp.use_central_server`: instead of every agent
+session booting a full `moraine-mcp` server (its own multi-threaded tokio runtime,
+ClickHouse HTTP client + connection pool, and search caches), sessions share ONE
+central server and each become a thin stdio<->socket proxy.
+
+It spawns N simulated agent MCP clients, drives each through the realistic steady
+state (initialize -> tools/list -> one search_sessions tools/call -> idle resident),
+then measures aggregate RSS, OS thread count, and process count via psutil. Two arms:
+
+  embedded : mcp.use_central_server = false. Each client is a full embedded server.
+  central  : one `moraine-mcp --serve socket` daemon + N proxy clients.
+
+For a fair isolation of the variable this PR changes, clients are spawned as
+`moraine-mcp --config <cfg>` directly (the child process `moraine run mcp` execs);
+the `moraine` launcher-parent overhead is identical in both arms and excluded.
+
+Run it inside the dev sandbox (ClickHouse must be reachable for tools/call):
+
+  scripts/dev/sandbox/moraine-sandbox shell <id>
+  # inside:
+  python3 /repo/scripts/bench/central_mcp_resource.py \
+      --moraine-mcp /home/moraine/target/debug/moraine-mcp \
+      --clickhouse-url http://clickhouse:8123 \
+      --ns 1,10,50,100 --reps 3
+
+On macOS the numbers are directional (thread accounting differs); take authoritative
+figures from the Linux sandbox.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+try:
+    import psutil
+except Exception:  # pragma: no cover
+    psutil = None
+
+
+# ----------------------------------------------------------------------------- helpers
+
+
+def parse_ns(value: str) -> list[int]:
+    out: list[int] = []
+    for part in value.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        n = int(part)
+        if n <= 0:
+            raise argparse.ArgumentTypeError("N values must be > 0")
+        out.append(n)
+    if not out:
+        raise argparse.ArgumentTypeError("at least one N is required")
+    return out
+
+
+def raise_fd_limit(target: int = 8192) -> None:
+    try:
+        import resource
+
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        new_soft = min(hard, max(soft, target))
+        if new_soft > soft:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
+    except Exception:
+        pass
+
+
+def write_config(
+    path: Path,
+    *,
+    clickhouse_url: str,
+    database: str,
+    root_dir: Path,
+    use_central_server: bool,
+    central_socket_path: Path,
+) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "[clickhouse]",
+                f'url = "{clickhouse_url}"',
+                f'database = "{database}"',
+                "",
+                "[runtime]",
+                f'root_dir = "{root_dir}"',
+                "",
+                "[mcp]",
+                f"use_central_server = {str(use_central_server).lower()}",
+                "start_central_on_up = false",
+                f'central_socket_path = "{central_socket_path}"',
+                # Keep startup fast even when the socket is missing.
+                "central_connect_timeout_ms = 250",
+                "",
+            ]
+        )
+    )
+
+
+# ----------------------------------------------------------------------------- client
+
+
+@dataclass
+class McpClient:
+    proc: subprocess.Popen
+    tools_call_ms: Optional[float] = None
+
+    def _send(self, payload: dict) -> dict:
+        line = json.dumps(payload) + "\n"
+        assert self.proc.stdin is not None and self.proc.stdout is not None
+        self.proc.stdin.write(line)
+        self.proc.stdin.flush()
+        resp = self.proc.stdout.readline()
+        if not resp:
+            raise RuntimeError("MCP server closed stream unexpectedly")
+        return json.loads(resp)
+
+    def warm_up(self, query: str) -> None:
+        self._send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+        self._send({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+        t0 = time.time()
+        self._send(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "search_sessions", "arguments": {"query": query}},
+            }
+        )
+        self.tools_call_ms = (time.time() - t0) * 1000.0
+        # Leave stdin OPEN so the process stays resident (idle agent steady state).
+
+    def close(self) -> None:
+        try:
+            if self.proc.stdin:
+                self.proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self.proc.wait(timeout=5)
+        except Exception:
+            self.proc.kill()
+
+
+def spawn_client(moraine_mcp: str, config: Path) -> McpClient:
+    proc = subprocess.Popen(
+        [moraine_mcp, "--config", str(config)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        bufsize=1,
+    )
+    return McpClient(proc=proc)
+
+
+# ----------------------------------------------------------------------------- measure
+
+
+@dataclass
+class ResourceSample:
+    proc_count: int = 0
+    rss_bytes: int = 0
+    threads: int = 0
+
+
+def sample_pids(pids: list[int]) -> ResourceSample:
+    if psutil is None:
+        raise RuntimeError("psutil is required for measurement")
+    sample = ResourceSample()
+    for pid in pids:
+        try:
+            p = psutil.Process(pid)
+            with p.oneshot():
+                sample.rss_bytes += int(p.memory_info().rss)
+                sample.threads += int(p.num_threads())
+            sample.proc_count += 1
+        except Exception:
+            continue
+    return sample
+
+
+# ----------------------------------------------------------------------------- run arm
+
+
+@dataclass
+class ArmResult:
+    arm: str
+    n: int
+    client: ResourceSample
+    server: ResourceSample
+    tools_call_ms: list[float] = field(default_factory=list)
+
+    @property
+    def total_rss_mb(self) -> float:
+        return (self.client.rss_bytes + self.server.rss_bytes) / (1024 * 1024)
+
+    @property
+    def total_threads(self) -> int:
+        return self.client.threads + self.server.threads
+
+    @property
+    def total_procs(self) -> int:
+        return self.client.proc_count + self.server.proc_count
+
+    @property
+    def marginal_rss_mb(self) -> float:
+        if self.n == 0:
+            return 0.0
+        return (self.client.rss_bytes / self.n) / (1024 * 1024)
+
+
+def wait_for_socket(sock: Path, timeout_s: float = 10.0) -> None:
+    import socket as _socket
+
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if sock.exists():
+            s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+            try:
+                s.connect(str(sock))
+                s.close()
+                return
+            except OSError:
+                pass
+            finally:
+                try:
+                    s.close()
+                except Exception:
+                    pass
+        time.sleep(0.05)
+    raise RuntimeError(f"central server socket never came up at {sock}")
+
+
+def run_arm(
+    arm: str,
+    n: int,
+    *,
+    moraine_mcp: str,
+    clickhouse_url: str,
+    database: str,
+    query: str,
+    settle_s: float,
+    batch: int,
+) -> ArmResult:
+    central = arm == "central"
+    workdir = Path(tempfile.mkdtemp(prefix=f"moraine-bench-{arm}-{n}-"))
+    root_dir = workdir / "root"
+    root_dir.mkdir(parents=True, exist_ok=True)
+    (root_dir / "run").mkdir(parents=True, exist_ok=True)
+    sock = root_dir / "run" / "mcp.sock"
+    config = workdir / "config.toml"
+    write_config(
+        config,
+        clickhouse_url=clickhouse_url,
+        database=database,
+        root_dir=root_dir,
+        use_central_server=central,
+        central_socket_path=sock,
+    )
+
+    server_proc: Optional[subprocess.Popen] = None
+    clients: list[McpClient] = []
+    try:
+        if central:
+            server_proc = subprocess.Popen(
+                [moraine_mcp, "--config", str(config), "--serve", "socket"],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            wait_for_socket(sock)
+
+        # Spawn clients in batches to avoid fd/backlog spikes.
+        for start in range(0, n, batch):
+            group = []
+            for _ in range(start, min(start + batch, n)):
+                group.append(spawn_client(moraine_mcp, config))
+            for c in group:
+                c.warm_up(query)
+            clients.extend(group)
+            time.sleep(0.1)
+
+        time.sleep(settle_s)
+
+        client_sample = sample_pids([c.proc.pid for c in clients])
+        server_sample = ResourceSample()
+        if server_proc is not None:
+            server_sample = sample_pids([server_proc.pid])
+
+        return ArmResult(
+            arm=arm,
+            n=n,
+            client=client_sample,
+            server=server_sample,
+            tools_call_ms=[c.tools_call_ms for c in clients if c.tools_call_ms is not None],
+        )
+    finally:
+        for c in clients:
+            c.close()
+        if server_proc is not None:
+            server_proc.terminate()
+            try:
+                server_proc.wait(timeout=5)
+            except Exception:
+                server_proc.kill()
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+# ----------------------------------------------------------------------------- main
+
+
+def resolve_moraine_mcp(explicit: Optional[str]) -> str:
+    if explicit:
+        return explicit
+    for cand in ("moraine-mcp",):
+        found = shutil.which(cand)
+        if found:
+            return found
+    # Fall back to the repo debug build.
+    repo_root = Path(__file__).resolve().parents[2]
+    for rel in ("target/debug/moraine-mcp", "target/release/moraine-mcp"):
+        p = repo_root / rel
+        if p.exists():
+            return str(p)
+    raise SystemExit("could not resolve moraine-mcp; pass --moraine-mcp <path>")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--moraine-mcp", help="path to the moraine-mcp binary")
+    ap.add_argument("--clickhouse-url", default="http://127.0.0.1:8123")
+    ap.add_argument("--database", default="moraine")
+    ap.add_argument("--ns", type=parse_ns, default=[1, 10, 50, 100])
+    ap.add_argument("--reps", type=int, default=3)
+    ap.add_argument(
+        "--arms",
+        default="embedded,central",
+        help="comma list of arms to run (embedded, central)",
+    )
+    ap.add_argument("--query", default="error handling")
+    ap.add_argument("--settle-seconds", type=float, default=2.0)
+    ap.add_argument("--batch", type=int, default=25)
+    ap.add_argument("--json-out", help="write raw results to this JSON path")
+    args = ap.parse_args()
+
+    if psutil is None:
+        print("error: psutil is required (run via `uv run` or `pip install psutil`)", file=sys.stderr)
+        return 2
+
+    raise_fd_limit()
+    moraine_mcp = resolve_moraine_mcp(args.moraine_mcp)
+    arms = [a.strip() for a in args.arms.split(",") if a.strip()]
+
+    print(f"# central MCP resource benchmark")
+    print(f"# binary: {moraine_mcp}")
+    print(f"# clickhouse: {args.clickhouse_url} db={args.database}")
+    print(f"# platform: {sys.platform}  reps={args.reps}  Ns={args.ns}\n")
+
+    rows: list[dict] = []
+    # Aggregate by (arm, n): take mean across reps of each metric.
+    for n in args.ns:
+        for arm in arms:
+            reps: list[ArmResult] = []
+            for _ in range(args.reps):
+                reps.append(
+                    run_arm(
+                        arm,
+                        n,
+                        moraine_mcp=moraine_mcp,
+                        clickhouse_url=args.clickhouse_url,
+                        database=args.database,
+                        query=args.query,
+                        settle_s=args.settle_seconds,
+                        batch=args.batch,
+                    )
+                )
+            row = {
+                "arm": arm,
+                "n": n,
+                "procs": round(statistics.mean(r.total_procs for r in reps), 1),
+                "client_rss_mb": round(statistics.mean(r.client.rss_bytes for r in reps) / (1024 * 1024), 1),
+                "server_rss_mb": round(statistics.mean(r.server.rss_bytes for r in reps) / (1024 * 1024), 1),
+                "total_rss_mb": round(statistics.mean(r.total_rss_mb for r in reps), 1),
+                "marginal_rss_mb": round(statistics.mean(r.marginal_rss_mb for r in reps), 2),
+                "total_threads": round(statistics.mean(r.total_threads for r in reps), 1),
+                "tools_call_ms": round(
+                    statistics.mean(
+                        statistics.mean(r.tools_call_ms) if r.tools_call_ms else 0.0 for r in reps
+                    ),
+                    1,
+                ),
+            }
+            rows.append(row)
+
+    # Markdown table.
+    headers = [
+        "N",
+        "arm",
+        "procs",
+        "client RSS (MB)",
+        "server RSS (MB)",
+        "total RSS (MB)",
+        "marginal/session (MB)",
+        "total threads",
+        "tools/call (ms)",
+    ]
+    print("| " + " | ".join(headers) + " |")
+    print("|" + "|".join("---" for _ in headers) + "|")
+    for row in rows:
+        print(
+            "| "
+            + " | ".join(
+                str(x)
+                for x in [
+                    row["n"],
+                    row["arm"],
+                    row["procs"],
+                    row["client_rss_mb"],
+                    row["server_rss_mb"],
+                    row["total_rss_mb"],
+                    row["marginal_rss_mb"],
+                    row["total_threads"],
+                    row["tools_call_ms"],
+                ]
+            )
+            + " |"
+        )
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(rows, indent=2))
+        print(f"\nwrote {args.json_out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/central_mcp_resource.py
+++ b/scripts/bench/central_mcp_resource.py
@@ -184,19 +184,50 @@ class ResourceSample:
     threads: int = 0
 
 
-def sample_pids(pids: list[int]) -> ResourceSample:
-    if psutil is None:
-        raise RuntimeError("psutil is required for measurement")
-    sample = ResourceSample()
-    for pid in pids:
+_PAGE_SIZE = os.sysconf("SC_PAGE_SIZE") if hasattr(os, "sysconf") else 4096
+
+
+def _read_proc(pid: int) -> Optional[tuple[int, int]]:
+    """Return (rss_bytes, threads) from Linux /proc, or None if unavailable."""
+    try:
+        rss_bytes = 0
+        threads = 0
+        with open(f"/proc/{pid}/status", "r") as fh:
+            for line in fh:
+                if line.startswith("VmRSS:"):
+                    rss_bytes = int(line.split()[1]) * 1024  # kB -> bytes
+                elif line.startswith("Threads:"):
+                    threads = int(line.split()[1])
+        return rss_bytes, threads
+    except Exception:
+        return None
+
+
+def _read_pid(pid: int) -> Optional[tuple[int, int]]:
+    """Return (rss_bytes, threads) via psutil, falling back to /proc on Linux."""
+    if psutil is not None:
         try:
             p = psutil.Process(pid)
             with p.oneshot():
-                sample.rss_bytes += int(p.memory_info().rss)
-                sample.threads += int(p.num_threads())
-            sample.proc_count += 1
+                return int(p.memory_info().rss), int(p.num_threads())
         except Exception:
+            return None
+    return _read_proc(pid)
+
+
+def measurement_available() -> bool:
+    return psutil is not None or sys.platform.startswith("linux")
+
+
+def sample_pids(pids: list[int]) -> ResourceSample:
+    sample = ResourceSample()
+    for pid in pids:
+        got = _read_pid(pid)
+        if got is None:
             continue
+        sample.rss_bytes += got[0]
+        sample.threads += got[1]
+        sample.proc_count += 1
     return sample
 
 
@@ -364,8 +395,11 @@ def main() -> int:
     ap.add_argument("--json-out", help="write raw results to this JSON path")
     args = ap.parse_args()
 
-    if psutil is None:
-        print("error: psutil is required (run via `uv run` or `pip install psutil`)", file=sys.stderr)
+    if not measurement_available():
+        print(
+            "error: need psutil or a Linux /proc filesystem for measurement",
+            file=sys.stderr,
+        )
         return 2
 
     raise_fd_limit()

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -498,6 +498,14 @@ enabled = true
 glob = "${fixtures_root}/hermes/sessions/*.json"
 watch_root = "${fixtures_root}/hermes/sessions"
 
+[mcp]
+# Exercise the shared central server end to end: `moraine up` starts the
+# daemon and the mcp_smoke.py runs below proxy through it (falling back to an
+# embedded server if the socket is not yet up). Both are the defaults; pinned
+# here so the e2e's coverage of the proxy path is explicit, not incidental.
+use_central_server = true
+start_central_on_up = true
+
 [runtime]
 root_dir = "${runtime_root}"
 logs_dir = "logs"

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -515,7 +515,6 @@ managed_clickhouse_dir = "${runtime_root}/managed-clickhouse"
 clickhouse_auto_install = true
 clickhouse_start_timeout_seconds = 90.0
 start_monitor_on_up = true
-start_mcp_on_up = false
 EOF
 
   trap "cleanup_e2e \"$moraine_bin\" \"$config_path\" \"$runtime_root\" \"$tmp_root\"" EXIT

--- a/scripts/dev/sandbox/moraine-sandbox
+++ b/scripts/dev/sandbox/moraine-sandbox
@@ -448,7 +448,6 @@ managed_clickhouse_dir = "/home/moraine/.moraine/clickhouse"
 clickhouse_auto_install = false
 clickhouse_version = "${ch_version}"
 start_monitor_on_up = true
-start_mcp_on_up = false
 EOF
     log "wrote config ${toml_path}"
 }


### PR DESCRIPTION
## Summary

Make the default operation of `moraine up` and `moraine run mcp` use a **single shared, system-central MCP server** per host instead of booting one full MCP server inside every agent session. At hundreds of concurrent sessions this collapses N redundant runtimes, ClickHouse clients, and caches into one.

Before, every harness that registered `moraine run mcp` (Codex, Claude Code, Hermes, Kimi, Cursor, Pi) spawned a full `moraine-mcp`: its own multi-threaded tokio runtime (one worker thread **per core**), its own ClickHouse HTTP client + connection pool, and its own search caches — all held resident for the life of the session. That state is identical and read-only across sessions, so N sessions multiplied it N times.

Now:

- **`moraine up`** launches one `moraine-mcp --serve socket` daemon that owns the heavy state once and listens on a Unix domain socket (`~/.moraine/run/mcp.sock`, mode `0o600`). It reuses the existing `Service::Mcp` PID / `down` / `status` machinery (the previously vestigial up-managed mcp daemon, which read a dead stdin, is repurposed into the listener).
- **`moraine run mcp`** (registration unchanged) connects to that socket and runs a near-zero-cost stdio↔socket **proxy** on a current-thread runtime — no ClickHouse client, no caches, ~1–3 threads. If the socket is missing/unreachable it **transparently falls back** to an embedded server after a short timeout, so unconfigured setups and a crashed daemon keep working.

**No re-registration required** — the proxy-vs-embedded choice is internal.

## Measured gains

Benchmark (`scripts/bench/central_mcp_resource.py`) in the Linux dev sandbox against the sibling ClickHouse, debug builds, ~10-core aarch64, 3 reps. Each simulated session does `initialize → tools/list → search_sessions` then idles resident.

| N sessions | mode | procs | total RSS (MB) | total OS threads | tools/call (ms) |
|---|---|---|---|---|---|
| 1 | embedded (old) | 1 | 13.9 | 12 | 12.1 |
| 1 | **central (new)** | 2 | 21.3 | 15 | 12.7 |
| 10 | embedded (old) | 10 | 138.8 | 121 | 5.4 |
| 10 | **central (new)** | 11 | **85.5** | **42** | 1.4 |
| 50 | embedded (old) | 50 | 696.1 | 603 | 3.8 |
| 50 | **central (new)** | 51 | **375.1** | **163** | 0.5 |
| 100 | embedded (old) | 100 | 1391.0 | 1206 | 5.2 |
| 100 | **central (new)** | 101 | **736.7** | **316** | 0.4 |

**At 100 concurrent sessions: RSS −47% (1391 → 737 MB), OS threads −74% (1206 → 316).**

- **Per-session marginal cost** drops from ~13.9 MB / ~12 threads (a full embedded server) to ~7.2 MB / ~3 threads (a proxy), plus one fixed ~15 MB server.
- **Threads are the headline and the win grows with core count**: the old embedded server spawns one tokio worker thread *per core*, so on a 32-core host each session is ~34 threads (→ ~3400 at N=100) versus a flat ~3/proxy + the server.
- **No latency regression** — the shared server is actually faster at scale because its cache and ClickHouse connection stay warm across all sessions (0.4 ms vs 5.2 ms at N=100). (Absolute values are small here because the sandbox DB is empty; the comparison is apples-to-apples.)
- **Crossover is ~2–3 sessions**: at N=1 the central mode is slightly heavier (the fixed server), which is the expected and intended trade for the linear savings beyond that.

Honest framing: the RSS win comes from eliminating per-session **runtimes + ClickHouse clients + thread pools**, not from cache deduplication (caches start empty and are small here). Release builds lower the absolute numbers; the ratios hold.

## Operational impact

- New `[mcp]` config (all backwards-compatible; old TOML without the keys still parses):
  - `use_central_server` (default `true`) — proxy to central, else embedded.
  - `start_central_on_up` (default `true`) — `moraine up` starts the daemon.
  - `central_socket_path` (default `mcp.sock`, resolved under `~/.moraine/run`).
  - `central_connect_timeout_ms` (default `250`).
  - Set `use_central_server = false` to restore the per-session embedded behavior.
- `moraine down` stops the daemon (existing PID machinery) and removes the socket.
- No migrations. No schema changes. Registration commands unchanged across all harnesses.

## Backwards compatibility & failure modes

- **No central server running** (skipped `moraine up`): clients fall back to embedded after a ~250 ms (instant on ENOENT) connect attempt.
- **Server crash mid-session**: all live MCP connections drop at once (the central trade-off vs per-session isolation); harnesses re-establish on next tool use, and `moraine up` restarts the daemon.
- **Stale socket**: `--serve` does a connect-probe-then-rebind dance; a second daemon while one is live is an idempotent no-op (verified).
- **Half-close**: the proxy is a pure byte pump with downstream-authoritative drain, so a large in-flight `tools/call` response is never truncated when the agent closes stdin first (unit-tested).
- **Single-user**: the `0o600` socket scopes the server per user; on a shared host each user runs their own (cross-user agents fall back to embedded).

## Validation

- `cargo test --workspace --locked` — all green (new tests: JSON-RPC framing, socket round-trip, proxy half-close no-truncation, config resolution + backwards-compat, CLI parsing).
- `cargo clippy --workspace --all-targets -- -Dwarnings` (CI strict baseline) and `cargo fmt --all -- --check` — clean (also enforced by pre-commit hook).
- `zensical build` (docs) — no issues.
- **Dev sandbox functional E2E** (Linux, real ClickHouse):
  - Embedded fallback (no daemon) → `initialize` + `tools/list`(3) + `tools/call` return clean JSON-RPC.
  - Explicit-socket daemon + 3 proxy clients → all OK; socket mode `0o600`; second daemon is an idempotent no-op; clean stop.
  - Resource benchmark above (100 concurrent clients per arm).
- `scripts/ci/e2e-stack.sh` config now sets `use_central_server`/`start_central_on_up = true`, so CI exercises the central + proxy path end to end (with embedded fallback as the safety net).

A bug caught during sandbox validation and fixed here: `moraine-mcp` logged to **stdout** (the JSON-RPC stream); logs now go to **stderr** so a fallback `warn!` can't corrupt the protocol.

## Out of scope / follow-ups

- `moraine run mcp` still spawns a launcher parent that `wait()`s on the proxy child; exec-replacing it would shave one more process per session (the savings above already exclude that identical-in-both-arms parent).
- Long-lived shared caches evict only by TTL; a size bound on the central daemon is a possible follow-up.
- Raising the shared ClickHouse pool size if `tools/call` latency regresses at very high concurrency (it did not in this benchmark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review follow-ups (d4a56fc)

- **Unified `up` semantics.** The up-managed MCP service is now *always* the shared central server; the legacy up-managed stdio daemon (which exited immediately on its nulled stdin) is gone. `moraine up --mcp` and the deprecated `runtime.start_mcp_on_up` force-start the central server even when `mcp.start_central_on_up = false`, matching the quickstart table.
- **Stale-PID hardening.** `moraine up` probes the socket before spawning: a daemon that outlived its PID file now reports `already serving (unmanaged)` (pid `-`/`null`) instead of spawning a no-op second daemon whose recorded PID clobbered the file. `moraine down` unlinks the socket only when nothing is listening; a live unmanaged server produces a warning instead of being orphaned unreachably.
- **Socket permission race closed.** The daemon binds at a private temp path, chmods to `0600`, then atomically renames into place — the public path is never connectable with umask-derived permissions. Socket parent directories created by the daemon are `0700`.
- **`moraine-mcp-core` declares its own tokio `macros` dev-dependency** rather than compiling via feature unification from `moraine-conversations`.

Additional validation for the follow-ups: dev-sandbox functional checks (idempotent `up`; `rm mcp.pid` + `up` → `already serving (unmanaged)` with no PID clobber and no second daemon; `down` with unmanaged live server → warning + socket left + daemon alive; SIGTERM → daemon unlinks socket and exits; fresh `up` → socket `srw-------`; `RUST_LOG=debug` confirms the proxy path) plus an in-sandbox `scripts/ci/e2e-stack.sh` run (all seven harness MCP smokes green through the central + proxy path), workspace tests, clippy strict baseline, fmt, and `make docs-build`.

## Behavior changes — release-note for v0.6.0

- `moraine up` now starts the shared central MCP server by default (`mcp.start_central_on_up = true`). An explicit `runtime.start_mcp_on_up = false` no longer prevents this — opt out with `mcp.start_central_on_up = false`.
- `runtime.start_mcp_on_up` is **deprecated**: still parsed (old configs keep loading), now a force-on alias for the central server, removed from the template config and docs. Use `mcp.start_central_on_up`.
- `moraine up --mcp` force-starts the **central** server; there is no per-`up` stdio MCP daemon anymore.
- `moraine run mcp` defaults to proxying to the central server (`mcp.use_central_server = true`), with transparent embedded fallback; set it to `false` for the pre-0.6 per-session embedded behavior.
- JSON output: `up`'s `pid` field is now nullable (`null` for `already_serving`); `down` gains an optional `warning` field.
- A central-server crash drops all live MCP connections at once (vs per-session isolation before); harnesses reconnect on next tool use.
