### PR TITLE
fix(ci): remove live backticks from e2e config heredoc

### DIFF
--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -499,7 +499,8 @@ glob = "${fixtures_root}/hermes/sessions/*.json"
 watch_root = "${fixtures_root}/hermes/sessions"
 
 [mcp]
-# Exercise the shared central server end to end: `moraine up` starts the
+# Exercise the shared central server end to end: 'moraine up' starts the
+# (n.b. no backticks in this heredoc: it is unquoted, so they would execute)
 # daemon and the mcp_smoke.py runs below proxy through it (falling back to an
 # embedded server if the socket is not yet up). Both are the defaults; pinned
 # here so the e2e's coverage of the proxy path is explicit, not incidental.


### PR DESCRIPTION
## What changed and why

`ci-functional` has been red on `main` since #375 merged. The `[mcp]` comment block added to the `moraine-ci.toml` heredoc in `scripts/ci/e2e-stack.sh` wrote `moraine up` in backticks. The heredoc delimiter is unquoted (intentionally, so `${fixtures_root}` etc. expand), which makes backticks **live command substitution**: bash executed `moraine up` while writing the config and spliced its multi-line "Startup Results" table into the TOML. The next config load failed:

```
TOML parse error at line 69, column 9
   69 | service | result | pid
```

This PR replaces the backticks with single quotes and adds a warning comment in the heredoc, since it is an easy place to reintroduce the bug. Scanned the rest of the script (and the other CI scripts): no other backticks or `$(...)` inside heredoc bodies.

### Why only main broke

The substitution invokes bare `moraine` from `PATH`, not `$moraine_bin`:

- **ci-pr-fast** (PR runs) executes `e2e-stack.sh` from the source tree — no `moraine` on `PATH`, the substitution quietly resolved to an empty string, config stayed valid, PR stayed green.
- **ci-functional** (push to main) goes through `e2e-install-artifact.sh`, which installs moraine into `$HOME/.local/bin` and prepends it to `PATH` first — so the backtick found a real binary.

## Operational impact

CI-only; no service/config/migration changes. Also stops a rogue `moraine up` against the installed default config in CI, which was triggering an unwanted ~175 MiB ClickHouse auto-install before the e2e even started.

## Validation

- `bash -n scripts/ci/e2e-stack.sh` — syntax OK.
- Rendered the exact config heredoc from old and fixed scripts with a stub `moraine` on `PATH`, then parsed with `tomllib`:
  - old: `TOML parse: FAILED (Expected '=' after a key in a key/value pair (at line 69, column 9))` — byte-for-byte the CI failure.
  - fixed: `TOML parse: OK`.
- `grep` audit of `scripts/ci/*.sh` heredoc bodies for backticks / `$(` — only shell-comment occurrences outside heredocs remain.

Fixes the `ci-functional` failure on run [27388208683](https://github.com/eric-tramel/moraine/actions/runs/27388208683).

🤖 Generated with [Claude Code](https://claude.com/claude-code)