### PR TITLE
chore(pages): bind moraine.sh custom domain to the site

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -39,13 +39,14 @@ jobs:
         run: |
           set -euo pipefail
           for f in site/index.html site/introduction.html site/quickstart.html \
-                   site/configuration.html site/assets/og.png site/assets/favicon.svg \
+                   site/configuration.html site/CNAME site/assets/og.png site/assets/favicon.svg \
                    site/assets/monitor-desktop.png site/assets/fonts/space-grotesk-700.woff2; do
             test -f "$f" || { echo "::error::missing $f"; exit 1; }
           done
           grep -q "Long-term memory" site/index.html || { echo "::error::hero headline missing from site/index.html"; exit 1; }
           grep -q "The traces are the truth" site/index.html || { echo "::error::landing page not overlaid onto site root"; exit 1; }
-          echo "verified: hero landing page + docs built into site/"
+          grep -qx "moraine.sh" site/CNAME || { echo "::error::CNAME must contain the custom domain (workflow Pages drops it otherwise)"; exit 1; }
+          echo "verified: hero landing page + docs + CNAME built into site/"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ docs-build:
 	$(UV) run --with zensical zensical build
 	@echo "[docs] overlaying landing page onto site root"
 	@cp web/landing/index.html site/index.html
+	@cp web/landing/CNAME site/CNAME
 	@mkdir -p site/assets
 	@cp -R web/landing/assets/. site/assets/
 

--- a/web/landing/CNAME
+++ b/web/landing/CNAME
@@ -1,0 +1,1 @@
+moraine.sh

--- a/web/landing/index.html
+++ b/web/landing/index.html
@@ -5,22 +5,22 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Moraine — long-term memory for your agents</title>
 <meta name="description" content="Moraine keeps the complete, lossless trace of every agent session — exactly what happened, not a summary — and makes it searchable, so your agents can recall everything they've ever done. Fully local.">
-<link rel="canonical" href="https://eric-tramel.github.io/moraine/">
+<link rel="canonical" href="https://moraine.sh/">
 <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
 <meta name="theme-color" content="#080b11">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Moraine">
 <meta property="og:title" content="Moraine — long-term memory for your agents">
 <meta property="og:description" content="The complete, lossless trace of every agent session — exactly what happened, not a summary — made searchable. The traces are the truth. Fully local.">
-<meta property="og:url" content="https://eric-tramel.github.io/moraine/">
-<meta property="og:image" content="https://eric-tramel.github.io/moraine/assets/og.png">
+<meta property="og:url" content="https://moraine.sh/">
+<meta property="og:image" content="https://moraine.sh/assets/og.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:alt" content="Moraine — long-term memory for your agents">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Moraine — long-term memory for your agents">
 <meta name="twitter:description" content="The complete, lossless trace of every agent session — exactly what happened, not a summary — made searchable. The traces are the truth. Fully local.">
-<meta name="twitter:image" content="https://eric-tramel.github.io/moraine/assets/og.png">
+<meta name="twitter:image" content="https://moraine.sh/assets/og.png">
 <link rel="preload" href="assets/fonts/space-grotesk-700.woff2" as="font" type="font/woff2" crossorigin>
 <style>
   /* ---------- self-hosted fonts (no external requests) ---------- */


### PR DESCRIPTION
## What & why

`moraine.sh` was serving GitHub's generic **404** even though Porkbun DNS was already correct (apex `A` → `185.199.108–111.153`, `AAAA` set, `www` CNAME → `eric-tramel.github.io`). Root cause: the repo's Pages **custom domain was unset** (`"cname": null`), so GitHub had no mapping from the `moraine.sh` host to this repo.

I set the custom domain on the repo (`cname=moraine.sh`) — `http://moraine.sh` now serves the hero. This PR makes that binding **durable** and tidies the canonical URLs:

- **Ship a `CNAME` file** (`moraine.sh`) in the published artifact via `make docs-build`. Workflow-built Pages can drop the custom domain on a redeploy if the artifact has no CNAME; this prevents regressions.
- **Repoint** `canonical` / `og:url` / `og:image` / `twitter:image` from `eric-tramel.github.io/moraine/` → `https://moraine.sh/`.
- **Verify in CI**: `docs-deploy` now fails if `site/CNAME` is missing or doesn't contain `moraine.sh`.

## Notes
- DNS is already correct; no Porkbun changes needed.
- HTTPS: GitHub auto-provisions a Let's Encrypt cert for `moraine.sh` within minutes–hour of the domain binding. Once issued, enable **Enforce HTTPS** (Settings → Pages) — or I can flip `https_enforced` via the API once the cert is ready.
- All internal links/assets are relative, so serving at the apex root (vs `/moraine/`) needs no path changes.

## Validation
- `make docs-build` emits `site/CNAME` = `moraine.sh` and repointed canonical/OG URLs; CI verify step simulated locally — passes.
- `http://moraine.sh/` returns 200 with the hero after setting the domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)