### PR TITLE
fix(ingest): exclude Claude Code Workflow journals from ingestion (#386)

### DIFF
--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -577,6 +577,48 @@ pub fn map_tracked_path(format: &str, path: &str) -> Option<String> {
     None
 }
 
+/// True for Claude Code `Workflow` orchestration journals, which share the
+/// claude-code source glob/extension but are not user sessions and must never
+/// be ingested.
+///
+/// A `Workflow` run writes `<project>/<session-uuid>/subagents/workflows/<wf>/journal.jsonl`,
+/// a `started`/`result` event log with no `sessionId`. The recursive
+/// `~/.claude/projects/**/*.jsonl` glob predates this Claude Code feature and
+/// slurps these journals; lacking a `sessionId` they land as empty-`session_id`
+/// `unknown` events that break `list_sessions` for any time range overlapping
+/// them (issue #386).
+///
+/// The match is scoped deliberately tight — only a file literally named
+/// `journal.jsonl` beneath a `subagents/workflows/` directory. The sibling
+/// `agent-*.jsonl` transcripts in the same workflow directory (and the
+/// `subagents/agent-*.jsonl` Task-subagent transcripts) DO carry valid
+/// `sessionId`s and remain ingestible.
+pub fn is_workflow_journal_path(path: &str) -> bool {
+    let path = Path::new(path);
+    if path.file_name().and_then(|name| name.to_str()) != Some("journal.jsonl") {
+        return false;
+    }
+
+    // Single allocation-free pass over the path's named segments, looking for
+    // an adjacent `subagents/workflows` pair. Non-`Normal` components (root,
+    // prefix) and any non-UTF-8 segment are skipped without advancing the
+    // window, so they never bridge the pair we are matching.
+    let mut prev: Option<&str> = None;
+    for component in path.components() {
+        let Component::Normal(segment) = component else {
+            continue;
+        };
+        let Some(segment) = segment.to_str() else {
+            continue;
+        };
+        if prev == Some("subagents") && segment == "workflows" {
+            return true;
+        }
+        prev = Some(segment);
+    }
+    false
+}
+
 fn default_batch_size() -> usize {
     4000
 }
@@ -1648,6 +1690,41 @@ format = "sqlite"
             map_tracked_path(SOURCE_FORMAT_CURSOR_SQLITE, "/tmp/User/notes.jsonl"),
             None
         );
+    }
+
+    #[test]
+    fn workflow_journals_are_excluded_but_real_sessions_and_subagents_are_not() {
+        let project = "/Users/x/.claude/projects/-Users-x-src-moraine";
+        let session = "7e74512d-612b-4406-ae5e-069e73d7f2dc";
+
+        // The orphan journals: only these get excluded.
+        assert!(is_workflow_journal_path(&format!(
+            "{project}/{session}/subagents/workflows/wf_12dc2994-7e9/journal.jsonl"
+        )));
+        // Relative paths and trailing-component variants still match.
+        assert!(is_workflow_journal_path(
+            "subagents/workflows/wf_abc/journal.jsonl"
+        ));
+
+        // Workflow subagent transcripts carry a sessionId — keep them.
+        assert!(!is_workflow_journal_path(&format!(
+            "{project}/{session}/subagents/workflows/wf_8dc1b543-8da/agent-a38ca143465605620.jsonl"
+        )));
+        // Task-subagent transcripts (no `workflows` segment) — keep them.
+        assert!(!is_workflow_journal_path(&format!(
+            "{project}/{session}/subagents/agent-a5a524a7f876aa747.jsonl"
+        )));
+        // The real top-level session transcript — keep it.
+        assert!(!is_workflow_journal_path(&format!(
+            "{project}/{session}.jsonl"
+        )));
+        // A `journal.jsonl` that is NOT under `subagents/workflows/` must not
+        // be swept up by the filename alone.
+        assert!(!is_workflow_journal_path(&format!(
+            "{project}/{session}/journal.jsonl"
+        )));
+        assert!(!is_workflow_journal_path("/tmp/workflows/journal.jsonl"));
+        assert!(!is_workflow_journal_path("/tmp/subagents/journal.jsonl"));
     }
 
     fn make_temp_dir(label: &str) -> PathBuf {

--- a/crates/moraine-ingest-core/src/dispatch.rs
+++ b/crates/moraine-ingest-core/src/dispatch.rs
@@ -5,7 +5,8 @@ use crate::sources::shared::{format_record_ts, parse_record_ts};
 use crate::{DispatchState, Metrics, SinkMessage, WorkItem};
 use anyhow::{Context, Result};
 use moraine_config::{
-    map_tracked_path, AppConfig, SOURCE_FORMAT_CURSOR_SQLITE, SOURCE_FORMAT_SESSION_JSON,
+    is_workflow_journal_path, map_tracked_path, AppConfig, SOURCE_FORMAT_CURSOR_SQLITE,
+    SOURCE_FORMAT_SESSION_JSON,
 };
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -37,6 +38,39 @@ const SESSION_JSON_GENERATION: u32 = 1;
 /// watcher; anything else here is a stray event for an untracked file).
 fn work_path_is_canonical(work: &WorkItem) -> bool {
     map_tracked_path(&work.format, &work.path).as_deref() == Some(work.path.as_str())
+}
+
+/// The single gate before a path becomes ingest work: every entry point
+/// (backfill, reconcile, and the live watcher via the debounce task) funnels
+/// through `enqueue_work`, which calls this. A path is ingestable only when it
+/// is the canonical tracked path for its format AND it is not an
+/// orchestration-internal trace that merely shares a session source's
+/// glob/extension.
+///
+/// The only excluded class today is Claude Code `Workflow` journals (issue
+/// #386): the recursive `~/.claude/projects/**/*.jsonl` glob (and the
+/// recursive watcher) pick them up, but they carry no `sessionId` and would
+/// normalize to empty-`session_id` junk that breaks `list_sessions`. Filtering
+/// here — rather than tightening the glob — also catches live watcher writes,
+/// which never consult the glob. The exclusion is scoped to the `claude-code`
+/// harness so a same-named file under any other configured source is never
+/// silently dropped.
+fn work_item_is_ingestable(work: &WorkItem) -> bool {
+    if !work_path_is_canonical(work) {
+        debug!(
+            "dropping non-canonical work item {} (format {})",
+            work.path, work.format
+        );
+        return false;
+    }
+    if work.harness == "claude-code" && is_workflow_journal_path(&work.path) {
+        debug!(
+            "skipping workflow orchestration journal {} (no sessionId; issue #386)",
+            work.path
+        );
+        return false;
+    }
+    true
 }
 
 /// Best-effort mapping from a Hermes session `base_url` to an inference
@@ -286,14 +320,9 @@ pub(crate) fn spawn_debounce_task(
 
                     for key in ready {
                         if let Some((work, _)) = pending.remove(&key) {
-                            if !work_path_is_canonical(&work) {
-                                debug!(
-                                    "dropping non-canonical work item {} (format {})",
-                                    work.path, work.format
-                                );
-                                continue;
-                            }
-
+                            // `enqueue_work` is the single ingestability gate;
+                            // it early-returns on non-ingestable items, so no
+                            // pre-check is needed here.
                             enqueue_work(work, &process_tx, &dispatch, &metrics).await;
                         }
                     }
@@ -309,11 +338,7 @@ pub(crate) async fn enqueue_work(
     dispatch: &Arc<Mutex<DispatchState>>,
     metrics: &Arc<Metrics>,
 ) {
-    if !work_path_is_canonical(&work) {
-        debug!(
-            "dropping non-canonical work item {} (format {})",
-            work.path, work.format
-        );
+    if !work_item_is_ingestable(&work) {
         return;
     }
 
@@ -1019,10 +1044,10 @@ fn truncate(input: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        complete_work, compose_hermes_model, enrich_claude_model_latency,
+        complete_work, compose_hermes_model, enqueue_work, enrich_claude_model_latency,
         infer_vendor_from_base_url, process_file, process_session_json_file, run_work_item,
-        source_inode_for_file, work_path_is_canonical, SessionCursor, SESSION_JSON_GENERATION,
-        SESSION_JSON_INODE,
+        source_inode_for_file, work_item_is_ingestable, work_path_is_canonical, SessionCursor,
+        SESSION_JSON_GENERATION, SESSION_JSON_INODE,
     };
     use crate::model::Checkpoint;
     use crate::{DispatchState, Metrics, SinkMessage, WorkItem};
@@ -1030,6 +1055,7 @@ mod tests {
     use std::collections::HashMap;
     use std::fs;
     use std::path::PathBuf;
+    use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use tokio::sync::{mpsc, RwLock, Semaphore};
@@ -1265,6 +1291,96 @@ mod tests {
             ..sqlite.clone()
         };
         assert!(!work_path_is_canonical(&sidecar));
+    }
+
+    #[test]
+    fn workflow_journals_are_not_ingestable_but_sessions_and_subagents_are() {
+        let claude = |path: &str| WorkItem {
+            source_name: "claude".to_string(),
+            harness: "claude-code".to_string(),
+            format: "jsonl".to_string(),
+            path: path.to_string(),
+        };
+        let proj = "/Users/x/.claude/projects/-Users-x-src-moraine";
+        let sid = "7e74512d-612b-4406-ae5e-069e73d7f2dc";
+
+        // The orphan workflow journal is rejected even though it is the
+        // canonical path for the jsonl format (issue #386).
+        let journal = claude(&format!(
+            "{proj}/{sid}/subagents/workflows/wf_12dc2994-7e9/journal.jsonl"
+        ));
+        assert!(work_path_is_canonical(&journal));
+        assert!(!work_item_is_ingestable(&journal));
+
+        // Real sessions and both kinds of subagent transcripts stay ingestible.
+        assert!(work_item_is_ingestable(&claude(&format!(
+            "{proj}/{sid}.jsonl"
+        ))));
+        assert!(work_item_is_ingestable(&claude(&format!(
+            "{proj}/{sid}/subagents/workflows/wf_8dc1b543-8da/agent-a38ca143465605620.jsonl"
+        ))));
+        assert!(work_item_is_ingestable(&claude(&format!(
+            "{proj}/{sid}/subagents/agent-a5a524a7f876aa747.jsonl"
+        ))));
+
+        // The exclusion is scoped to claude-code: the same path under another
+        // harness/source must not be silently dropped.
+        let codex_journal = WorkItem {
+            source_name: "codex".to_string(),
+            harness: "codex".to_string(),
+            format: "jsonl".to_string(),
+            path: format!("{proj}/{sid}/subagents/workflows/wf_x/journal.jsonl"),
+        };
+        assert!(work_item_is_ingestable(&codex_journal));
+    }
+
+    /// End-to-end through the dispatch gate: a workflow journal enqueued from
+    /// any entry point (backfill/reconcile/watcher all call `enqueue_work`)
+    /// must never reach the processor channel or the dispatch state, while a
+    /// real session transcript does. This is the behavior that keeps the
+    /// empty-`session_id` junk out of ClickHouse.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enqueue_work_drops_workflow_journals_before_processing() {
+        let dispatch = Arc::new(Mutex::new(DispatchState::default()));
+        let metrics = Arc::new(Metrics::default());
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(8);
+
+        let proj = "/Users/x/.claude/projects/-Users-x-src-moraine";
+        let sid = "7e74512d-612b-4406-ae5e-069e73d7f2dc";
+        let journal = WorkItem {
+            source_name: "claude".to_string(),
+            harness: "claude-code".to_string(),
+            format: "jsonl".to_string(),
+            path: format!("{proj}/{sid}/subagents/workflows/wf_12dc2994-7e9/journal.jsonl"),
+        };
+
+        enqueue_work(journal.clone(), &process_tx, &dispatch, &metrics).await;
+
+        assert!(
+            process_rx.try_recv().is_err(),
+            "workflow journal must not be forwarded to the processor"
+        );
+        {
+            let state = dispatch.lock().expect("dispatch mutex poisoned");
+            assert!(state.pending.is_empty(), "no pending work for a journal");
+            assert!(
+                !state.item_by_key.contains_key(&journal.key()),
+                "journal must not be tracked in dispatch state"
+            );
+        }
+        assert_eq!(metrics.queue_depth.load(Ordering::Relaxed), 0);
+
+        // A real session transcript from the same source is forwarded.
+        let session = WorkItem {
+            path: format!("{proj}/{sid}.jsonl"),
+            ..journal.clone()
+        };
+        enqueue_work(session.clone(), &process_tx, &dispatch, &metrics).await;
+        let forwarded = process_rx
+            .try_recv()
+            .expect("real session transcript must be forwarded");
+        assert_eq!(forwarded.key(), session.key());
+        assert_eq!(metrics.queue_depth.load(Ordering::Relaxed), 1);
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Claude Code `Workflow` orchestration runs write
`<project>/<session-uuid>/subagents/workflows/<wf>/journal.jsonl` — a
`started`/`result` event log with **no `sessionId`**. The recursive
`~/.claude/projects/**/*.jsonl` claude-code glob (and the recursive watcher)
predate this Claude Code feature and slurp these journals. Lacking a
`sessionId`, they normalize to empty-`session_id` `unknown` events, and
`mcp__moraine__list_sessions` then hard-errors for any time range overlapping
them:

```
internal_error: repository returned an invalid MCP identifier component:
invalid_id: session_id must be a non-empty string
```

Fixes #386 (root ingest fix — suggested fix #1, exclusion).

## Approach

- New `moraine_config::is_workflow_journal_path(path)` — a pure path predicate
  matching **only** a file literally named `journal.jsonl` beneath a
  `subagents/workflows/` directory (allocation-free single pass over path
  segments).
- New `work_item_is_ingestable` gate in `dispatch.rs`, applied in
  `enqueue_work`. Backfill, reconcile, and the live watcher (via the debounce
  task) **all funnel through `enqueue_work`**, so filtering there — rather than
  tightening the glob — also catches live watcher writes, which never consult
  the glob.
- The exclusion is **scoped to the `claude-code` harness**, so a same-named
  file under any other configured source is never silently dropped.

### Scoped tight on purpose

Only `journal.jsonl` orchestration logs are excluded. The sibling
`agent-*.jsonl` workflow-subagent transcripts and the `subagents/agent-*.jsonl`
Task-subagent transcripts **carry valid `sessionId`s** (the parent session
UUID) and remain fully ingestible. On this host: 10 journals (all `sessionId`-less)
vs. 109 + 266 legitimate subagent transcripts — the matcher keeps the latter.

## Operational impact

- No config, schema, or migration changes. Pure go-forward ingest behavior.
- Existing installs: new journals are no longer ingested. Excluded paths log at
  `debug` (`skipping workflow orchestration journal …`).

## Validation

- `cargo test -p moraine-config -p moraine-ingest-core` and full
  `cargo test --workspace --locked` — green (run in the dev sandbox, linux
  toolchain). New tests:
  - `moraine-config`: `workflow_journals_are_excluded_but_real_sessions_and_subagents_are_not`
  - `moraine-ingest-core`: `workflow_journals_are_not_ingestable_but_sessions_and_subagents_are` (incl. a non-claude-harness case) and `enqueue_work_drops_workflow_journals_before_processing` (gate→processor channel).
- `cargo fmt --check` + CI strict clippy baseline — clean (pre-commit hook).
- **Live end-to-end in the dev sandbox**: wrote a real session transcript, a
  workflow `journal.jsonl`, and a workflow `agent-*.jsonl` into the watched
  claude fixtures dir. ClickHouse confirmed:
  - `journal.jsonl` → **0 events, 0 empty-`session_id`, no checkpoint**
  - real session transcript → 1 event ✓
  - workflow `agent-*.jsonl` → 1 event ✓

## Reviewed

Ran a multi-angle review of the branch and addressed the actionable findings:
allocation-free matcher, `claude-code` harness scoping (bounds blast radius to
the documented intent), and removed a redundant double-evaluation of the gate in
the debounce loop.

## Follow-ups (out of scope — issue #386 fixes #2 & #3)

This PR stops the bleed but is **forward-only**; it does not touch rows already
written on existing installs:

1. **Data cleanup (#3):** purge the already-ingested orphans, e.g.
   `ALTER TABLE events DELETE WHERE empty(session_id)` (plus `raw_events` and the
   search index). Intentionally not automated here — destructive, operator-gated.
2. **MCP defense-in-depth (#2):** `list_sessions` should skip/`warn!` rows with an
   empty `session_id` rather than failing the whole page, so a single malformed
   row can never take out a listing.