### PR TITLE
fix(clickhouse): compute turn_seq over deduplicated events (#388)

### DIFF
--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -594,6 +594,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             name: "018_checkpoint_host.sql",
             sql: include_str!("../../../sql/018_checkpoint_host.sql"),
         },
+        Migration {
+            version: "019",
+            name: "019_dedup_conversation_trace_final.sql",
+            sql: include_str!("../../../sql/019_dedup_conversation_trace_final.sql"),
+        },
     ]
 }
 

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -862,6 +862,26 @@ PY
   printf '%s' "$sessions_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; ok=any(s.get("id")==sid and s.get("harness",{}).get("id")=="cursor" for s in data.get("sessions", [])); sys.exit(0 if ok else 1)' "$cursor_session_id"
   printf '%s' "$sessions_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; ok=any(s.get("id")==sid and s.get("harness",{}).get("id")=="pi-coding-agent" for s in data.get("sessions", [])); sys.exit(0 if ok else 1)' "$pi_session_id"
 
+  # Regression for #388: turn_seq is computed by a running user-message window
+  # over the events ReplacingMergeTree. Re-ingestion can briefly leave a
+  # duplicate physical row live (same sort key, higher event_version) before a
+  # background merge collapses it. v_all_events now reads `events FINAL`, so the
+  # turn counter must not over-count that duplicate; otherwise search_sessions
+  # mints a turn:<session>:<seq> handle that open() cannot resolve once the
+  # merge fires (the original flake). We plant the duplicate ourselves and prove
+  # the turn count is unchanged while the duplicate is demonstrably still live.
+  echo "[e2e] checking turn_seq is stable against an un-merged duplicate event (#388)"
+  local codex_turns_before
+  codex_turns_before="$(clickhouse_scalar "$clickhouse_url" "SELECT max(turn_seq) FROM ${clickhouse_database}.v_conversation_trace WHERE session_id = '${codex_session_id}'")"
+  # Plant a duplicate of the codex user message in a fresh, un-merged part:
+  # SELECT * preserves ingested_at (so it lands in the same partition and shares
+  # the sort key), REPLACE bumps event_version so FINAL keeps exactly one row.
+  clickhouse_scalar "$clickhouse_url" "INSERT INTO ${clickhouse_database}.events SELECT * REPLACE (event_version + 1 AS event_version) FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND session_id = '${codex_session_id}' AND actor_kind = 'user' AND event_kind = 'message'" >/dev/null
+  assert_clickhouse_count "$clickhouse_url" "codex duplicate user-message row is live (un-merged)" "SELECT count() FROM ${clickhouse_database}.events WHERE source_name = 'ci-codex' AND session_id = '${codex_session_id}' AND actor_kind = 'user' AND event_kind = 'message'" "2"
+  assert_clickhouse_count "$clickhouse_url" "codex duplicate collapses under FINAL" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND session_id = '${codex_session_id}' AND actor_kind = 'user' AND event_kind = 'message'" "1"
+  assert_clickhouse_scalar "$clickhouse_url" "codex turn_seq unchanged by un-merged duplicate" "SELECT max(turn_seq) FROM ${clickhouse_database}.v_conversation_trace WHERE session_id = '${codex_session_id}'" "$codex_turns_before"
+  assert_clickhouse_scalar "$clickhouse_url" "codex session summary turn count unchanged by un-merged duplicate" "SELECT total_turns FROM ${clickhouse_database}.v_session_summary WHERE session_id = '${codex_session_id}'" "$codex_turns_before"
+
   echo "[e2e] checking MCP initialize/tools/search_sessions/open/list_sessions (codex)"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
     --moraine "$moraine_bin" \

--- a/sql/019_dedup_conversation_trace_final.sql
+++ b/sql/019_dedup_conversation_trace_final.sql
@@ -1,0 +1,133 @@
+-- Issue #388: turn_seq was computed over a non-deduplicated view of the
+-- `events` ReplacingMergeTree. While a re-ingested duplicate row is live
+-- (before a background merge collapses it), the running user-message window
+-- sum in `v_conversation_trace` over-counts, inflating turn ordinals that
+-- vanish on the next merge. That made `search_sessions` -> `open` on a
+-- `turn:<session>:<seq>` handle non-deterministic.
+--
+-- Fix: read `moraine.events FINAL` in `v_all_events`, the single base view
+-- every trace/summary view derives from. FINAL applies the engine's own
+-- ReplacingMergeTree collapse (same sort key, keep max `event_version`) at
+-- query time, so the turn-counting window always sees deduplicated rows
+-- regardless of merge timing. The downstream views are recreated verbatim so
+-- the chain is rebuilt as a unit (ClickHouse resolves view references at query
+-- time; recreating the base is what changes their behavior).
+--
+-- Note: a re-ingest gets a fresh `ingested_at` (the table DEFAULT) and so can
+-- land in a different monthly partition than the original, where background
+-- merges — which never cross partitions — would never collapse it. FINAL still
+-- dedups it because `events`' partition column (`ingested_at`) is NOT in the
+-- sort key, so ClickHouse merges across partitions for FINAL. Keep
+-- `ingested_at` out of the `events` ORDER BY or this dedup silently regresses.
+
+DROP VIEW IF EXISTS moraine.v_session_summary;
+DROP VIEW IF EXISTS moraine.v_turn_summary;
+DROP VIEW IF EXISTS moraine.v_conversation_trace;
+DROP VIEW IF EXISTS moraine.v_all_events;
+
+CREATE VIEW moraine.v_all_events AS
+SELECT
+  ingested_at,
+  event_uid,
+  origin_event_id AS compacted_parent_uid,
+  session_id,
+  session_date,
+  source_file,
+  source_inode,
+  source_generation,
+  source_line_no,
+  source_offset,
+  source_ref,
+  record_ts,
+  event_kind AS event_class,
+  payload_type,
+  actor_kind AS actor_role,
+  toString(turn_index) AS turn_id,
+  item_id,
+  tool_call_id AS call_id,
+  tool_name AS name,
+  if(tool_phase != '', tool_phase, op_status) AS phase,
+  text_content,
+  payload_json,
+  token_usage_json,
+  endpoint_kind,
+  token_usage_buckets,
+  token_usage_native_units,
+  event_version
+FROM moraine.events FINAL;
+
+CREATE VIEW moraine.v_conversation_trace AS
+SELECT
+  session_id,
+  session_date,
+  event_uid,
+  compacted_parent_uid,
+  source_file,
+  source_generation,
+  source_line_no,
+  source_offset,
+  source_ref,
+  ifNull(parseDateTime64BestEffortOrNull(record_ts), ingested_at) AS event_time,
+  row_number() OVER (
+    PARTITION BY session_id
+    ORDER BY ifNull(parseDateTime64BestEffortOrNull(record_ts), ingested_at), source_file, source_generation, source_offset, source_line_no, event_uid
+  ) AS event_order,
+  if(
+    toUInt32OrZero(turn_id) > 0,
+    toUInt32OrZero(turn_id),
+    greatest(
+      toUInt32(1),
+      toUInt32(
+        sum(if(actor_role = 'user' AND event_class = 'message', 1, 0)) OVER (
+          PARTITION BY session_id
+          ORDER BY ifNull(parseDateTime64BestEffortOrNull(record_ts), ingested_at), source_file, source_generation, source_offset, source_line_no, event_uid
+          ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        )
+      )
+    )
+  ) AS turn_seq,
+  turn_id,
+  actor_role,
+  event_class,
+  payload_type,
+  call_id,
+  name,
+  phase,
+  item_id,
+  text_content,
+  payload_json,
+  token_usage_json,
+  endpoint_kind,
+  token_usage_buckets,
+  token_usage_native_units
+FROM moraine.v_all_events;
+
+CREATE VIEW moraine.v_turn_summary AS
+SELECT
+  session_id,
+  turn_seq,
+  anyIf(turn_id, turn_id != '') AS turn_id,
+  min(event_time) AS started_at,
+  max(event_time) AS ended_at,
+  count() AS total_events,
+  countIf(actor_role = 'user' AND event_class = 'message') AS user_messages,
+  countIf(actor_role = 'assistant' AND event_class = 'message') AS assistant_messages,
+  countIf(event_class = 'tool_call') AS tool_calls,
+  countIf(event_class = 'tool_result') AS tool_results,
+  countIf(event_class = 'reasoning') AS reasoning_items
+FROM moraine.v_conversation_trace
+GROUP BY session_id, turn_seq;
+
+CREATE VIEW moraine.v_session_summary AS
+SELECT
+  session_id,
+  min(event_time) AS first_event_time,
+  max(event_time) AS last_event_time,
+  max(turn_seq) AS total_turns,
+  count() AS total_events,
+  countIf(event_class = 'tool_call') AS tool_calls,
+  countIf(event_class = 'tool_result') AS tool_results,
+  countIf(actor_role = 'user' AND event_class = 'message') AS user_messages,
+  countIf(actor_role = 'assistant' AND event_class = 'message') AS assistant_messages
+FROM moraine.v_conversation_trace
+GROUP BY session_id;


### PR DESCRIPTION
## What & why

`turn_seq` — the conversation turn ordinal exposed as the MCP `turn:<session>:<seq>` handle — was computed by a running user-message window over `moraine.v_conversation_trace`, which derives from `v_all_events`: a plain `SELECT … FROM moraine.events` with **no dedup**. `events` is a `ReplacingMergeTree(event_version)`, so a re-ingested row coexists with its predecessor (same sort key) until a background merge collapses it. While that duplicate user-message row is live, the running `sum(if(actor_role='user' AND event_class='message', …))` counts it twice, inflating `turn_seq` for every later event by one.

Because the count is transient, `search_sessions` and `open` disagree across a merge boundary:

1. `search` runs with the duplicate present → mints `turn:<session>:2`.
2. a background merge collapses the duplicate.
3. `open(turn:<session>:2)` runs → max `turn_seq` is now `1` → `not_found`.

This is the intermittent `pr-fast-linux` failure in #388 (`open returned error envelope … 'turn not found'`), and in production it means `turn:` handles minted right after (re-)ingest can briefly dangle.

## Fix

New migration `sql/019_dedup_conversation_trace_final.sql` recreates the view chain so `v_all_events` reads **`FROM moraine.events FINAL`**. `FINAL` applies the engine's own ReplacingMergeTree collapse (same sort key, keep max `event_version`) at query time, so the turn-counting window always sees deduplicated rows regardless of merge timing. `v_all_events` is the single base every trace/summary view derives from, so the fix propagates to `v_conversation_trace`, `v_turn_summary`, and `v_session_summary` (the latter two also stop transiently over-counting `total_events`/turn counts). The downstream views are recreated verbatim so the chain rebuilds as a unit.

`bundled_migrations()` registers the new file (enforced by the existing `bundled_migrations_matches_sql_directory` test).

## Operational impact

- One new ordered, idempotent migration (`019`). Applied automatically by `run_migrations()` on the default backend; non-default backends must apply it server-side (existing skew policy). No table rewrite — only the `events`-derived views are dropped and recreated.
- `FINAL` adds merge-on-read cost to the trace/summary views. At moraine's single-user scale, and because the hot queries filter by `session_id` (the sort-key prefix), this is negligible.

## Validation

- `cargo test -p moraine-clickhouse` — green, incl. `bundled_migrations_matches_sql_directory` (confirms 019 is registered and ordered).
- Hermetic ClickHouse integration test (real `clickhouse/clickhouse-server` image, full `sql/001..019` chain applied): seed a single-turn session, plant a transient un-merged duplicate of the user message (`version+1`, fresh part), then assert:
  - duplicate is physically live (`count()` raw = 2, `count() … FINAL` = 1),
  - `max(turn_seq)` over the shipped `v_conversation_trace` stays `1` (the fix),
  - a parallel **non-FINAL** trace over the identical data returns `2` (negative control — proves the test reproduces the bug and that `FINAL` is what fixes it).
- `scripts/ci/e2e-stack.sh` gains a permanent regression guard (mirrors the codex flake): it plants the same un-merged duplicate of the codex fixture's user message and asserts `turn_seq`/`total_turns` are unchanged while the duplicate is demonstrably live, immediately before the codex MCP smoke. Ran the full `e2e-stack.sh` locally (ClickHouse v25.12.5.44) — the new guard and all 10 MCP smokes pass green, with the codex smoke now running deterministically while a duplicate is live.

A high-effort multi-agent review of the branch surfaced no correctness bugs. It confirmed a subtlety worth recording: a re-ingest gets a fresh `ingested_at` and can land in a different monthly partition, where background merges (which never cross partitions) would never collapse it — but `FINAL` still dedups it because `events`' partition column is not in the sort key, so ClickHouse merges across partitions for `FINAL`. That dependency is now documented in the migration.

Closes #388.
