### PR TITLE
fix(mcp): make list_sessions resilient to blank-session_id rows (#386)

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo.rs
@@ -5166,6 +5166,13 @@ FORMAT JSONEachRow",
         let mode_subquery = self.mode_subquery();
 
         let mut where_clauses = vec![
+            // A blank session_id is never a real session (e.g. the orphan
+            // Workflow-journal events ingested before #386's exclusion). Drop
+            // them here so they never consume a LIMIT slot or anchor the keyset
+            // cursor. `notEmpty(trimBoth(...))` mirrors the MCP contract's
+            // `trim().is_empty()` rejection so the repo filter and the mcp-core
+            // skip agree on what counts as blank.
+            "notEmpty(trimBoth(s.session_id))".to_string(),
             format!(
                 "toUnixTimestamp64Milli(s.last_event_time) >= {}",
                 filter.start_unix_ms

--- a/crates/moraine-conversations/tests/repository_integration.rs
+++ b/crates/moraine-conversations/tests/repository_integration.rs
@@ -1926,6 +1926,9 @@ async fn list_mcp_sessions_uses_overlap_filter_and_cursor_pagination() {
     assert!(list_query.contains("ifNull(m.mode, 'chat') = 'web_search'"));
     assert!(list_query.contains("ORDER BY s.last_event_time DESC, s.session_id DESC"));
     assert!(list_query.contains("payload_type IN ('task_complete', 'turn_aborted')"));
+    // Blank session_id rows are filtered at the source so they never consume a
+    // LIMIT slot or anchor the keyset cursor (#386).
+    assert!(list_query.contains("notEmpty(trimBoth(s.session_id))"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/moraine-mcp-core/src/list_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/list_sessions_v1.rs
@@ -13,6 +13,7 @@ use moraine_conversations::{
 };
 use serde_json::{json, Value};
 use tokio::time::{timeout, Duration};
+use tracing::warn;
 
 const LIST_SESSIONS_BROAD_WINDOW_MS: i64 = 30 * 24 * 60 * 60 * 1_000;
 
@@ -139,12 +140,24 @@ fn list_sessions_data_json(
     args: &CanonicalListSessionsArgs,
     page: &Page<McpSessionListItem>,
 ) -> Result<Value, ContractError> {
-    let sessions = page
-        .items
-        .iter()
-        .enumerate()
-        .map(|(index, session)| session_json(index + 1, session))
-        .collect::<Result<Vec<_>, _>>()?;
+    // Skip (and warn about) rows whose identifier can't be encoded — e.g. the
+    // empty-`session_id` orphans left by Workflow journals ingested before the
+    // exclusion landed (#386). One malformed row must never fail the whole
+    // page. Rank advances only for kept rows so it stays contiguous (1..=N).
+    let mut sessions = Vec::with_capacity(page.items.len());
+    for session in &page.items {
+        // Rank is 1-based over KEPT rows so it stays contiguous when a row is
+        // skipped — `sessions.len()` only grows on a successful push.
+        let rank = sessions.len() + 1;
+        match session_json(rank, session) {
+            Ok(value) => sessions.push(value),
+            Err(error) => warn!(
+                session_id = %session.session_id,
+                error = %error,
+                "list_sessions: skipping session row with an invalid identifier"
+            ),
+        }
+    }
 
     Ok(json!({
         "result_count": sessions.len(),
@@ -441,6 +454,105 @@ mod tests {
         assert!(first.get("snippet").is_none());
         assert!(first.get("events").is_none());
         assert!(first.get("payload_json").is_none());
+    }
+
+    #[test]
+    fn skips_session_rows_with_empty_session_id() {
+        let args = parse_list_sessions_args(
+            json!({
+                "start_datetime": "2026-04-30T09:00:00-04:00",
+                "end_datetime": "2026-04-30T13:00:00-04:00",
+                "limit": 50
+            }),
+            50,
+        )
+        .expect("valid args");
+
+        let item = |session_id: &str| McpSessionListItem {
+            session_id: session_id.to_string(),
+            first_event_time: "2026-04-30 13:00:00".to_string(),
+            first_event_unix_ms: 1_777_554_000_000,
+            last_event_time: "2026-04-30 13:10:00".to_string(),
+            last_event_unix_ms: 1_777_554_600_000,
+            total_turns: 1,
+            total_events: 1,
+            mode: ConversationMode::ToolCalling,
+            completed: true,
+            title: None,
+            source: Some("claude-code".to_string()),
+            session_slug: None,
+            session_summary: None,
+        };
+
+        // A leading empty-session_id orphan (the #386 junk) must be dropped,
+        // not fail the whole page; the valid row survives with a contiguous
+        // rank of 1.
+        let page = Page {
+            items: vec![item(""), item("real-session")],
+            next_cursor: None,
+        };
+
+        let data = list_sessions_data_json(&args, &page).expect("page must not fail on a bad row");
+        assert_eq!(data["result_count"], json!(1));
+        assert_eq!(
+            data["sessions"].as_array().expect("sessions array").len(),
+            1
+        );
+        let kept = &data["sessions"][0];
+        assert_eq!(kept["rank"], json!(1));
+        assert_eq!(
+            kept["id"],
+            json!(McpSessionId::from_raw_session_id("real-session")
+                .expect("valid id")
+                .to_string())
+        );
+    }
+
+    #[test]
+    fn skips_trailing_and_whitespace_rows_and_preserves_cursor() {
+        let args = parse_list_sessions_args(
+            json!({
+                "start_datetime": "2026-04-30T09:00:00-04:00",
+                "end_datetime": "2026-04-30T13:00:00-04:00",
+                "limit": 50
+            }),
+            50,
+        )
+        .expect("valid args");
+
+        let item = |session_id: &str| McpSessionListItem {
+            session_id: session_id.to_string(),
+            first_event_time: "2026-04-30 13:00:00".to_string(),
+            first_event_unix_ms: 1_777_554_000_000,
+            last_event_time: "2026-04-30 13:10:00".to_string(),
+            last_event_unix_ms: 1_777_554_600_000,
+            total_turns: 1,
+            total_events: 1,
+            mode: ConversationMode::ToolCalling,
+            completed: true,
+            title: None,
+            source: Some("claude-code".to_string()),
+            session_slug: None,
+            session_summary: None,
+        };
+
+        // A whitespace-only id (rejected by the contract's trim check) and a
+        // TRAILING empty-id orphan are both dropped; the valid row keeps rank
+        // 1, and the repo-provided cursor is passed through untouched.
+        let page = Page {
+            items: vec![item("real-session"), item("   "), item("")],
+            next_cursor: Some("opaque-cursor".to_string()),
+        };
+
+        let data = list_sessions_data_json(&args, &page).expect("page must not fail on bad rows");
+        assert_eq!(data["result_count"], json!(1));
+        assert_eq!(
+            data["sessions"].as_array().expect("sessions array").len(),
+            1
+        );
+        assert_eq!(data["sessions"][0]["rank"], json!(1));
+        assert_eq!(data["truncated"], json!(true));
+        assert_eq!(data["next_cursor"], json!("opaque-cursor"));
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Blank-`session_id` event rows made `mcp__moraine__list_sessions` **hard-error**
for any time range that overlapped them:

```
internal_error: repository returned an invalid MCP identifier component:
invalid_id: session_id must be a non-empty string
```

The repository surfaced the blank row, and shaping it into the response failed
`McpSessionId` validation, which `collect::<Result<_>>()?` turned into a
full-page error. The Workflow-journal orphans from #386 are the source of these
rows; #387 stops new ones, but existing rows (and any future blank-id row) still
break the read path. This is the read-path resilience half of #386 (defense-in-depth, suggested fix #2).

## Approach — two layers

1. **Repo (`list_mcp_sessions`)** — add `notEmpty(trimBoth(s.session_id))` to the
   WHERE clause so blank ids never reach the result set. This is the load-bearing
   fix: blank rows no longer consume a `LIMIT` slot or anchor the keyset cursor
   (which is derived from the last row's raw `session_id`). `trimBoth` mirrors the
   contract's `trim().is_empty()` rejection, so the repo filter and the mcp-core
   skip agree on what "blank" means.
2. **mcp-core (`list_sessions_data_json`)** — skip and `warn!` any row whose
   identifier can't be encoded, instead of failing the whole page. Rank advances
   only for kept rows so it stays contiguous (1..=N). Defense-in-depth at the
   identifier-construction boundary.

## Operational impact

- No schema/config/migration changes. Read-path only.
- A blank-id row is now silently excluded from listings (logged at `warn!`),
  rather than taking out the whole page.

## Validation

- `cargo test -p moraine-mcp-core -p moraine-conversations` + full
  `cargo test --workspace` — green (dev sandbox, linux toolchain). New tests:
  - `skips_session_rows_with_empty_session_id` (leading blank row dropped, valid row keeps rank 1)
  - `skips_trailing_and_whitespace_rows_and_preserves_cursor` (whitespace-only + trailing blank dropped; `next_cursor`/`truncated` preserved)
  - repo integration assertion that the query carries `notEmpty(trimBoth(s.session_id))`
- `cargo fmt --check` + CI strict clippy — clean (pre-commit hook).
- **Live end-to-end (dev sandbox, real MCP server + ClickHouse):** ingested a
  blank-`session_id` orphan whose events fall in today's window (confirmed the
  orphan "session" is present in `v_session_summary` for the range), then called
  `list_sessions` over that range through the running `moraine run mcp`. Result:
  `result_count=1` (the legit session only), **no `internal_error`** — pre-fix
  this exact call errored. Also verified `notEmpty(trimBoth(...))` classifies
  `''`/`'   '`→excluded, real ids→kept in ClickHouse 25.12.

## Related

Follow-up to #387 (ingest exclusion). Companion PR purges the already-ingested
orphan rows via a migration.