### PR TITLE
fix(db): purge empty-session_id Claude Code rows — migration 020 (#386)

### DIFF
--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -599,6 +599,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             name: "019_dedup_conversation_trace_final.sql",
             sql: include_str!("../../../sql/019_dedup_conversation_trace_final.sql"),
         },
+        Migration {
+            version: "020",
+            name: "020_purge_empty_session_claude_code.sql",
+            sql: include_str!("../../../sql/020_purge_empty_session_claude_code.sql"),
+        },
     ]
 }
 
@@ -1071,6 +1076,71 @@ mod tests {
                 !m.sql.is_empty(),
                 "migration {} has empty bundled sql — include_str! target may be missing",
                 m.name
+            );
+        }
+    }
+
+    #[test]
+    fn migration_020_purges_every_session_keyed_table() {
+        let migration = bundled_migrations()
+            .into_iter()
+            .find(|m| m.version == "020")
+            .expect("migration 020 must be registered");
+
+        // Materialize against a non-default database to also prove the
+        // `moraine.` prefix is rewritten everywhere (no bare table names leak).
+        let materialized =
+            materialize_migration_sql(migration.sql, "other_db").expect("materialize 020");
+        let statements = split_sql_statements(&materialized);
+
+        // Every table that can hold empty-session_id claude-code junk must be
+        // purged; a dropped table here would leave lingering junk (#386).
+        let harness_scoped = [
+            "events",
+            "raw_events",
+            "event_links",
+            "tool_io",
+            "search_documents",
+            "search_postings",
+            "search_hit_log",
+        ];
+        // No harness column on this aggregate — scoped on session_id alone.
+        let session_only = ["search_conversation_terms"];
+
+        assert_eq!(
+            statements.len(),
+            harness_scoped.len() + session_only.len(),
+            "unexpected statement count in 020: {statements:#?}"
+        );
+
+        for table in harness_scoped {
+            let expected =
+                format!("ALTER TABLE other_db.{table} DELETE WHERE session_id = '' AND harness = 'claude-code'");
+            assert!(
+                statements.iter().any(|s| s.contains(&expected)),
+                "020 missing harness-scoped purge for `{table}`"
+            );
+        }
+        for table in session_only {
+            let expected = format!("ALTER TABLE other_db.{table} DELETE WHERE session_id = ''");
+            assert!(
+                statements
+                    .iter()
+                    .any(|s| s.contains(&expected) && !s.contains("harness")),
+                "020 missing session-only purge for `{table}`"
+            );
+        }
+
+        // Every statement must complete synchronously so the migration is only
+        // recorded once the junk is actually gone.
+        for statement in &statements {
+            assert!(
+                statement.contains("mutations_sync = 1"),
+                "020 statement must run with mutations_sync = 1: {statement}"
+            );
+            assert!(
+                !statement.contains("moraine."),
+                "020 statement must not reference a bare `moraine.` after rewrite: {statement}"
             );
         }
     }

--- a/sql/020_purge_empty_session_claude_code.sql
+++ b/sql/020_purge_empty_session_claude_code.sql
@@ -1,0 +1,48 @@
+-- 020_purge_empty_session_claude_code.sql
+--
+-- One-time cleanup for issue #386. Before the ingest exclusion landed, the
+-- recursive `~/.claude/projects/**/*.jsonl` glob slurped Claude Code `Workflow`
+-- orchestration journals (`subagents/workflows/<wf>/journal.jsonl`). Those
+-- records carry no `sessionId`, so they normalized to events with an empty
+-- `session_id` (harness = 'claude-code'), which break `list_sessions` for any
+-- time range overlapping them and pollute search.
+--
+-- This migration deletes those orphan rows — and the search fan-out derived
+-- from them — from every table that keys on `session_id` (+ `harness`). The MV
+-- targets (search_documents, search_postings, search_conversation_terms) are
+-- physical tables populated at ingest, so deleting the base `events` rows does
+-- NOT remove them; each is purged explicitly. (search_interaction_log keys on
+-- event_uid only and has no writer in the codebase, so it holds no junk and is
+-- not touched.)
+--
+-- Predicate is scoped to the junk only: `session_id = '' AND harness =
+-- 'claude-code'` (the canonical harness value post-012). No legitimate row
+-- has an empty session_id, so `search_conversation_terms` — a SummingMergeTree
+-- aggregate with no harness column — is purged on `session_id = ''` alone.
+--
+-- Each `ALTER TABLE ... DELETE` runs with `SETTINGS mutations_sync = 1` so the
+-- statement only returns once the mutation has actually completed on the
+-- server: the migration is recorded as applied only after the junk is gone,
+-- and a mutation that fails surfaces as a migration error rather than being
+-- silently lost. The deletes are idempotent — the whole file re-runs if any
+-- statement fails, and a re-run matches zero rows once clean. Mutations operate
+-- on physical rows across all parts, so ReplacingMergeTree version columns and
+-- merge state are irrelevant here.
+
+-- Base event tables.
+ALTER TABLE moraine.events DELETE WHERE session_id = '' AND harness = 'claude-code' SETTINGS mutations_sync = 1;
+ALTER TABLE moraine.raw_events DELETE WHERE session_id = '' AND harness = 'claude-code' SETTINGS mutations_sync = 1;
+ALTER TABLE moraine.event_links DELETE WHERE session_id = '' AND harness = 'claude-code' SETTINGS mutations_sync = 1;
+ALTER TABLE moraine.tool_io DELETE WHERE session_id = '' AND harness = 'claude-code' SETTINGS mutations_sync = 1;
+
+-- Search fan-out (materialized-view target tables).
+ALTER TABLE moraine.search_documents DELETE WHERE session_id = '' AND harness = 'claude-code' SETTINGS mutations_sync = 1;
+ALTER TABLE moraine.search_postings DELETE WHERE session_id = '' AND harness = 'claude-code' SETTINGS mutations_sync = 1;
+
+-- Conversation-term aggregates have no harness column; an empty session_id can
+-- only originate from this junk, so scope on session_id alone.
+ALTER TABLE moraine.search_conversation_terms DELETE WHERE session_id = '' SETTINGS mutations_sync = 1;
+
+-- Search query telemetry (defensive; only populated if junk was ever returned
+-- as a search hit).
+ALTER TABLE moraine.search_hit_log DELETE WHERE session_id = '' AND harness = 'claude-code' SETTINGS mutations_sync = 1;


### PR DESCRIPTION
## What & why

Before #386's ingest exclusion (#387), the recursive `~/.claude/projects/**/*.jsonl`
glob ingested Claude Code `Workflow` journals (`subagents/workflows/<wf>/journal.jsonl`)
as events with an **empty `session_id`**. Those orphans break `list_sessions` and
pollute search, and they **persist on any DB that ran the old glob** — the
exclusion only stops new ones. This is the data-cleanup half of #386 (suggested fix #3).

## Approach

New migration `020_purge_empty_session_claude_code.sql` (registered in
`bundled_migrations()`). `ALTER TABLE … DELETE` the empty-`session_id`
claude-code rows from every table that keys on `session_id`:

| Table | Predicate |
|---|---|
| `events`, `raw_events`, `event_links`, `tool_io` | `session_id = '' AND harness = 'claude-code'` |
| `search_documents`, `search_postings`, `search_hit_log` | `session_id = '' AND harness = 'claude-code'` |
| `search_conversation_terms` | `session_id = ''` (SummingMergeTree, no harness column) |

The search tables are **materialized-view targets** — physical tables populated
at ingest — so deleting the base `events` rows would otherwise leave them
dangling; each is purged explicitly. (`search_interaction_log` keys on
`event_uid` only and has no writer in the codebase, so it holds no junk and is
left untouched.)

`harness = 'claude-code'` is the canonical value post-`012`. No legitimate row
has an empty `session_id`, so the harness-less `search_conversation_terms` is
safely scoped on `session_id = ''` alone.

> **Numbering:** this is `020`, not `019`, to avoid colliding with the open #390
> (which also adds an `sql/019_*` migration). Duplicate versions would make the
> later-applied migration skip silently, since the ledger keys on the 3-digit
> version.

## Operational impact

- Runs automatically on `moraine up` / `moraine db migrate` for any backend
  whose schema ledger is behind. moraine only migrates the **default** backend.
- Each `ALTER … DELETE` runs with **`SETTINGS mutations_sync = 1`**, so the
  migration is recorded as applied only after the deletes actually complete on
  the server, and a failed mutation surfaces as a migration error (the file
  re-runs) instead of being silently lost. The predicate is targeted, so the
  mutation only rewrites parts containing junk.
- Idempotent: re-running matches zero rows once clean.

## Validation

- `cargo test -p moraine-clickhouse` + full `cargo test --workspace` — green
  (dev sandbox, linux toolchain). New test `migration_020_purges_every_session_keyed_table`
  materializes the bundled migration against a non-default DB and asserts it
  splits into the expected 8 synchronous per-table deletes (and that the
  `moraine.` prefix is rewritten — no bare table names leak).
  `bundled_migrations_matches_sql_directory` enforces sql/ ↔ bundled parity.
- **Live end-to-end (dev sandbox, real `moraine db migrate` runner against a
  dirty ClickHouse):** ingested a Workflow journal + a real session, confirmed
  the junk landed, then dropped the migration's ledger row and re-ran
  `moraine db migrate`. After the mutations completed: **junk = 0 across all
  targeted tables, the legit session fully intact** (`events`,
  `search_documents`), ledger re-applied. Also verified
  `ALTER … DELETE … SETTINGS mutations_sync = 1` is accepted and synchronously
  purges in ClickHouse 25.12.

## Related

Companion to #387 (stops new orphans) and #391 (tolerates blank ids at read
time). Together these close #386.