### PR TITLE
fix(ci): de-flake the un-merged-duplicate turn_seq e2e check

### DIFF
--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -873,6 +873,15 @@ PY
   echo "[e2e] checking turn_seq is stable against an un-merged duplicate event (#388)"
   local codex_turns_before
   codex_turns_before="$(clickhouse_scalar "$clickhouse_url" "SELECT max(turn_seq) FROM ${clickhouse_database}.v_conversation_trace WHERE session_id = '${codex_session_id}'")"
+  # Stop background merges on `events` before planting the duplicate so the two
+  # parts stay physically un-merged for the duration of these assertions. A
+  # background ReplacingMergeTree merge is the only thing that collapses the
+  # non-FINAL row count, and it fires nondeterministically — without this, the
+  # "live (un-merged)" assertion below races the merge and flakes (it has been
+  # observed to read 1 instead of 2). Observing the pre-merge state is the whole
+  # point: it is exactly what #388 guards against. FINAL still dedups at read
+  # time, so the FINAL / turn-count assertions are unaffected by the freeze.
+  clickhouse_scalar "$clickhouse_url" "SYSTEM STOP MERGES ${clickhouse_database}.events" >/dev/null
   # Plant a duplicate of the codex user message in a fresh, un-merged part:
   # SELECT * preserves ingested_at (so it lands in the same partition and shares
   # the sort key), REPLACE bumps event_version so FINAL keeps exactly one row.
@@ -881,6 +890,8 @@ PY
   assert_clickhouse_count "$clickhouse_url" "codex duplicate collapses under FINAL" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND session_id = '${codex_session_id}' AND actor_kind = 'user' AND event_kind = 'message'" "1"
   assert_clickhouse_scalar "$clickhouse_url" "codex turn_seq unchanged by un-merged duplicate" "SELECT max(turn_seq) FROM ${clickhouse_database}.v_conversation_trace WHERE session_id = '${codex_session_id}'" "$codex_turns_before"
   assert_clickhouse_scalar "$clickhouse_url" "codex session summary turn count unchanged by un-merged duplicate" "SELECT total_turns FROM ${clickhouse_database}.v_session_summary WHERE session_id = '${codex_session_id}'" "$codex_turns_before"
+  # Re-enable merges now that the pre-merge assertions have passed.
+  clickhouse_scalar "$clickhouse_url" "SYSTEM START MERGES ${clickhouse_database}.events" >/dev/null
 
   echo "[e2e] checking MCP initialize/tools/search_sessions/open/list_sessions (codex)"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \


### PR DESCRIPTION
## What & why

The #388 regression check in `scripts/ci/e2e-stack.sh` (added in #390) plants a
duplicate codex user-message row and asserts it is still physically live —
`count()` without `FINAL` must equal `2` — before verifying that `turn_seq` and
the session turn count are computed over **deduplicated** events.

That `codex duplicate user-message row is live (un-merged)` assertion races a
background `ReplacingMergeTree` merge: the merge can collapse the two parts
between the `INSERT` and the assertion, so it intermittently reads `1` and the
job fails. It surfaced on an unrelated PR's `pr-fast-linux` run (expected `2`,
actual `1`); a re-run passed, confirming the flake.

## Fix

Wrap the plant + assertions in `SYSTEM STOP MERGES`/`SYSTEM START MERGES` on
`events`. Background merges are the only thing that collapses the non-`FINAL`
row count, so freezing them makes the pre-merge state deterministic. Observing
that pre-merge state is the whole point of the test — it is exactly what #388
guards against — so this keeps the test's intent intact rather than weakening
the assertion. `FINAL` still dedups at read time, so the `FINAL` and turn-count
assertions are unchanged.

## Validation

- `bash -n scripts/ci/e2e-stack.sh` — clean (no other code touched; the full
  `e2e-stack.sh` requires `bun` + a managed-ClickHouse install, so it runs in CI
  rather than the dev sandbox).
- **Mechanism proof against ClickHouse 25.12.5.44** (the pinned CI version), on a
  `ReplacingMergeTree(version) ORDER BY key` table mirroring `events`:
  - `SYSTEM STOP MERGES <db>.<table>` is accepted.
  - With merges frozen, two same-key parts stay at `count() == 2` (and remain 2
    after a wait) — the assertion is now deterministic.
  - `count() FINAL == 1` throughout — the `FINAL`/turn-count assertions are
    unaffected by the freeze.
  - After `SYSTEM START MERGES` + `OPTIMIZE`, `count()` collapses to `1`,
    confirming a merge *does* collapse the duplicate (i.e. the freeze is what
    removes the race).
- CI `pr-fast-linux` on this PR exercises the full functional stack end-to-end.

## Related

Follow-up to #390 (which introduced the assertion). No runtime/schema/config
changes — CI-only.