### PR TITLE
chore(release): cut v0.6.0

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.5.6)"
+        description: "Tag to release (for example v0.6.0)"
         required: true
         type: string
       target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "moraine"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "glob",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest-core"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp-core"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor-core"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/moraine-ingest/Cargo.toml
+++ b/apps/moraine-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2021"
 description = "Moraine ingest service binary"
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2021"
 description = "Moraine MCP stdio server"
 

--- a/apps/moraine-monitor/Cargo.toml
+++ b/apps/moraine-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2021"
 description = "Moraine monitor HTTP/UI service"
 

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2021"
 description = "Unified runtime control plane for Moraine services"
 

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-clickhouse"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2021"
 description = "Shared Moraine ClickHouse client and query helpers"
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-config"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2021"
 description = "Shared Moraine configuration schema and loaders"
 

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-conversations"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2021"
 description = "High-level read/query APIs for Moraine conversations"
 

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest-core"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2021"
 description = "Core ingestion pipeline internals for Moraine"
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp-core"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2021"
 description = "MCP protocol and tool routing core for Moraine"
 

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor-core"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2021"
 description = "Analytics and query logic for Moraine monitor service"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ install directory precedence:
 
 examples:
   scripts/install.sh
-  MORAINE_INSTALL_VERSION=v0.5.6 scripts/install.sh
+  MORAINE_INSTALL_VERSION=v0.6.0 scripts/install.sh
   MORAINE_INSTALL_ASSET_BASE_URL=http://127.0.0.1:8080 \
     MORAINE_INSTALL_VERSION=ci-e2e scripts/install.sh
   MORAINE_INSTALL_DIR="$HOME/bin" MORAINE_INSTALL_SKIP_CLICKHOUSE=1 scripts/install.sh


### PR DESCRIPTION
## Summary
- Minor version bump `0.5.6` → `0.6.0` (workspace packages, lockfile metadata, release workflow + installer examples).
- Feature-heavy release headlined by the shared central MCP server (default on), Cursor IDE chat ingestion (`cursor_sqlite`), named ClickHouse backends with per-project routing, and `moraine run mcp --project-only` launch-directory scoping.
- Rounded out by ingest/dedup correctness fixes (turn_seq over deduplicated events, blank-session_id resilience), six new auto-applying schema migrations on the default backend, and a `make install` dev path plus a new GitHub Pages landing page.

## Changes since v0.5.6
**feat**
- #375 `feat(mcp)`: shared central MCP server with per-session proxy (default on)
- #377 `feat(ingest)`: `cursor_sqlite` format — ingest Cursor IDE chat history from `state.vscdb` (RFC #361)
- #379 `feat`: named ClickHouse backends with per-project routing — mirror ingest tee, route-aware MCP
- #378 `feat(mcp)`: `moraine run mcp --project-only` scopes retrieval to the launch directory
- #380 `feat(dev)`: `make install` — build the current checkout and take over the host moraine
- #384 `feat(docs)`: iconic hero landing page for GitHub Pages

**fix**
- #387 `fix(ingest)`: exclude Claude Code Workflow journals from ingestion
- #390 `fix(clickhouse)`: compute turn_seq over deduplicated events (#388; migration 019, `v_all_events` reads `events FINAL`)
- #391 `fix(mcp)`: make `list_sessions` resilient to blank-session_id rows
- #392 `fix(db)`: purge empty-session_id Claude Code rows (migration 020)
- #393 `fix(ci)`: stop background merges around the un-merged-duplicate e2e check
- #376 `fix(ci)`: remove live backticks from e2e config heredoc

**chore**
- #385 `chore(pages)`: bind `moraine.sh` custom domain to the site

## Operational impact
- **Default-on central MCP server (#375).** `moraine up` now starts the shared central MCP server (`mcp.start_central_on_up=true` by default), and `moraine run mcp` proxies to it (`mcp.use_central_server=true`) with transparent embedded fallback. `runtime.start_mcp_on_up` is **DEPRECATED** and now behaves as a force-on alias. Opt out by setting `mcp.start_central_on_up=false` and/or `mcp.use_central_server=false`. Behavioral note: a central-server crash drops ALL live MCP connections at once, and `up.pid` in the JSON status is now nullable.
- **Schema migrations 015–020.** Six new migrations auto-apply on the **DEFAULT** backend on `moraine up` / `moraine db migrate`. Team/non-default backends are **NEVER** auto-migrated — operators apply `sql/` themselves, and clients hard-error on schema skew. Migrations 019 (turn_seq over deduplicated events) and 020 (purge empty-session_id rows) backfill existing data.
- **New config model (#379).** `[backends.<name>]` + `[[routes]]` introduce named backends and per-project routing. `[clickhouse]` is now a back-compat alias for `[backends.default]` — declaring **both** is a load error. Default-only installs are behaviorally unchanged.
- **`cursor_sqlite` source (#377) ships ENABLED BY DEFAULT.** It matches nothing unless Cursor is installed, so existing hosts without Cursor see no change; hosts with Cursor will begin ingesting `state.vscdb` chat history automatically.
- Release also prepares the annotated `v0.6.0` tag to publish GitHub release bundles and PyPI wheels.

## Known limitations (tracked, non-blocking)
- #394 — `search_sessions` quoted phrases are treated as bag-of-words; phrase matching is undocumented on the tool.
- #395 — monitor session-list aggregate double-counts cross-month `cursor_sqlite` duplicate rows.
- #273 — kimi sub-agent session linkage is not yet resolved.

## Validation
- `cargo fmt --all -- --check` ✅
- `cargo check --workspace --locked` ✅ (rustc 1.96; `RUSTC_BOOTSTRAP=1` needed locally for the third-party `libsqlite3-sys 0.38.1` `cfg_select` build script)
- Full `cargo build` / `cargo test --workspace --locked` + strict clippy run in CI (`ci-pr-fast`) on this PR.
- After merge: push the annotated `v0.6.0` tag on `main` to fire `.github/workflows/release-moraine.yml` (maintainer step — there is no auto-tag-on-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
