### PR TITLE
[codex] fix ingest sqlite toolchain failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,21 +591,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "foldhash 0.2.0",
-]
-
-[[package]]
 name = "hashlink"
-version = "0.12.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1020,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1596,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator",

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -20,7 +20,10 @@ walkdir = "2.5"
 same-file = "1.0"
 moraine-config = { path = "../moraine-config" }
 moraine-clickhouse = { path = "../moraine-clickhouse" }
-rusqlite = { version = "0.40.1", features = ["bundled"] }
+# rusqlite 0.40.x pulls libsqlite3-sys 0.38.x, whose build script currently
+# uses unstable cfg_select! and fails on stable Rust. Stay on 0.39.x until the
+# upstream stable build is fixed.
+rusqlite = { version = "0.39.0", features = ["bundled"] }
 
 [dev-dependencies]
 axum = "0.7"


### PR DESCRIPTION
## What changed

- Pinned `moraine-ingest-core` to `rusqlite` 0.39.x.
- Updated `Cargo.lock` so the workspace uses `libsqlite3-sys` 0.37.0 instead of 0.38.1.
- Added a short dependency comment explaining why we should not float back to the 0.40.x line until the upstream stable build is fixed.

## Why

Past sessions kept failing before project tests when compiling `libsqlite3-sys` 0.38.1. I reproduced it both with the host Nix `cargo 1.94.0` and with rustup stable `cargo 1.96.0`; the upstream build script uses unstable `cfg_select!`, so simply routing developers through rustup stable is not enough.

`rusqlite` 0.39.0 depends on `libsqlite3-sys` 0.37.0, which avoids that unstable build script and lets the existing Cursor SQLite ingest tests run normally.

## Operational impact

No schema, config, or service behavior changes. This only adjusts the SQLite Rust dependency used by the ingest crate.

## Validation

- `cargo test -p moraine-ingest-core --locked` failed before the change with `error[E0658]: use of unstable library feature cfg_select` in `libsqlite3-sys-0.38.1/build.rs`.
- `cargo test -p moraine-ingest-core --locked` passed after the change under the host Nix `cargo 1.94.0`.
- `cargo fmt --all -- --check` passed.
- `cargo test --workspace --locked` passed.
- `make clippy` passed.
- Sandbox `sb-b37f8b`: `cargo test -p moraine-ingest-core --locked` passed inside Linux; sandbox was torn down afterward.