### PR TITLE
chore(agents): maintenance skill updates

### DIFF
--- a/plugins/moraine-dev/skills/moraine-author-pr/SKILL.md
+++ b/plugins/moraine-dev/skills/moraine-author-pr/SKILL.md
@@ -7,7 +7,7 @@ description: Author Moraine pull request titles and descriptions. Use when draft
 
 ## Overview
 
-Use this workflow to write PR titles and descriptions that are reviewable, evidence-backed, and consistent across agents.
+Use this workflow to write PR titles and descriptions that are reviewable, evidence-backed, and consistent across agents. Default bodies use `Description`, `Usage`, `Changelog`, and `Validation` sections.
 
 ## Title Rules
 
@@ -27,17 +27,17 @@ Do not include AI attribution in the title or body. Do not add generated-by foot
 Default to these sections:
 
 ```markdown
-## What
+## Description
 
-- ...
+**What.** [One sentence description].
 
-## Why
+**Why.** [One sentence description].
 
-- ...
+[Multi-paragraph description]
 
 ## Usage
 
-- ...
+[How users or developers will see this change]
 
 ## Changelog
 
@@ -45,43 +45,31 @@ Default to these sections:
 
 ## Validation
 
-- ...
+[Narrative description of how this was validated]
 ```
 
 Keep sections short when the PR is small. Add focused extra sections only when useful, such as `## Bug Evidence`, `## Performance`, `## Operational Impact`, or `## References`.
 
-## What
+## Description
 
-State the concrete change in reviewer-facing terms. Mention files or subsystems when that helps review scope.
+Open with bold one-line **What.** and **Why.** summaries, then expand in prose, bullets, or examples as needed.
+
+State the concrete change in reviewer-facing terms. Mention files or subsystems when that helps review scope. Explain the reason for the change, not only the implementation. Include code, commands, queries, or before/after examples when they make the motivation concrete.
 
 Good:
 
 ```markdown
-## What
+## Description
 
-- Adds a repo-local `moraine-dev` plugin.
+**What.** Adds a repo-local `moraine-dev` plugin with contributor agent skills.
+
+**Why.** Agents were repeating PR body structure differently across sessions; a shared skill gives each agent the same review contract.
+
 - Vendors `$moraine-dev:moraine-start-work`, `$moraine-dev:moraine-author-pr`, and `$moraine-dev:moraine-sandbox-qa` skills.
 - Documents local installation in `docs/development/agent-contributor-workflows.md`.
-```
-
-## Why
-
-Explain the reason for the change, not only the implementation. Include code, commands, queries, or before/after examples when they make the motivation concrete.
-
-Example:
-
-````markdown
-## Why
-
-Agents were repeating PR body structure differently across sessions. A shared
-skill gives each agent the same review contract:
-
-```text
-What -> Why -> Usage -> Changelog -> Validation
-```
 
 That makes it easier for reviewers to find behavior, impact, and test evidence.
-````
+```
 
 ## Usage
 
@@ -135,17 +123,14 @@ Good:
 
 ## Validation
 
-List exact commands and outcomes. Include skipped validation with a reason.
+Write a short narrative that names exact commands and outcomes. Include skipped validation with a reason.
 
 Example:
 
 ```markdown
 ## Validation
 
-- `python3 -m json.tool .agents/plugins/marketplace.json` passed.
-- `quick_validate.py plugins/moraine-dev/skills/moraine-author-pr` passed.
-- `make docs-build` passed.
-- Rust tests not run; docs/plugin metadata only.
+Validated plugin metadata with `python3 -m json.tool .agents/plugins/marketplace.json` and `quick_validate.py plugins/moraine-dev/skills/moraine-author-pr`. Ran `make docs-build` successfully. Rust tests were not run; change is docs and plugin metadata only.
 ```
 
 For stack-facing changes, include sandbox validation details or state why sandbox QA was not run.

--- a/plugins/moraine-dev/skills/moraine-start-work/SKILL.md
+++ b/plugins/moraine-dev/skills/moraine-start-work/SKILL.md
@@ -16,8 +16,8 @@ After the start checklist and branch/worktree setup, run the rest of the contrib
 1. Use `$moraine-dev:crystallize` to turn rough or ambiguous input into a ready-to-implement local plan.
 2. Implement the scoped change from that plan or, when the task is already concrete, from the user's explicit request.
 3. Use `$moraine-dev:code-review` and iterate fixes until the review is clean or every remaining item is explicitly rejected or deferred with rationale.
-4. Use `$moraine-dev:moraine-sandbox-qa` for stack-facing changes and iterate fixes until sandbox QA is clean. For changes that do not need sandbox QA, record why it was skipped.
-5. Use `$moraine-dev:moraine-author-pr` to draft the PR title and description from the final diff, evidence, and validation results.
+4. Use `$moraine-dev:moraine-sandbox-qa` for stack-facing changes and iterate fixes until sandbox QA is clean.
+5. Use `$moraine-dev:moraine-author-pr` to create a PR.
 
 ## Start Checklist
 
@@ -31,11 +31,11 @@ git worktree list --porcelain
 find .. -name AGENTS.md -print
 ```
 
-Read every `AGENTS.md` that governs the files you will edit. If the user refers to previous work, another agent, an unexplained decision, a branch you cannot see, or a failure from another session, use the Moraine MCP tools directly before making assumptions. Prefer `search_sessions` for keyword search, `list_sessions` for time or active-session browsing, `open` for expansion, and `file_attention` for file-specific history.
+If the user refers to previous work, another agent, an unexplained decision, a branch you cannot see, or a failure from another session, use the Moraine MCP tools directly before making assumptions.
 
 ## Branch And Worktree
 
-Use an isolated branch for development work. Prefer the branch prefix requested by the user; otherwise use `codex/`.
+Use an isolated branch for development work. Choose an appropriate branch prefix (e.g. `feat/`, `bug/`, etc.)
 
 If the harness already placed you in an isolated worktree, create or verify a branch there:
 
@@ -51,15 +51,6 @@ git worktree add ../moraine-worktrees/<short-task-name> -b codex/<short-task-nam
 
 When spawned into a temporary agent worktree, compare your `HEAD` with any sibling worktree whose branch name matches the task. If the sibling has newer in-progress code, treat that sibling as authoritative and run sandbox validation from that worktree.
 
-## Validation Choice
+## Validation Description
 
-Run focused local checks for narrow docs or metadata changes. For Rust changes, default to:
-
-```bash
-cargo fmt --all -- --check
-cargo test --workspace --locked
-```
-
-For ingest, MCP, monitor, ClickHouse schema, source-format, or stack-behavior changes, use `$moraine-dev:moraine-sandbox-qa` before reporting the task complete.
-
-End with the changed paths, validation commands, and any validation you intentionally skipped.
+Favor narrative description of what you tested instead of bullet points.


### PR DESCRIPTION
## Summary
- Refines `moraine-author-pr` to use a unified **Description** section with bold **What.** / **Why.** lead-ins, narrative Usage/Changelog/Validation guidance, and clearer examples.
- Simplifies `moraine-start-work`: streamlines the contributor workflow steps, relaxes branch-prefix guidance, trims MCP lookup boilerplate, and favors narrative validation descriptions over bullet lists.

## Test plan
- [ ] Review updated skill text in `plugins/moraine-dev/skills/moraine-author-pr/SKILL.md`
- [ ] Review updated skill text in `plugins/moraine-dev/skills/moraine-start-work/SKILL.md`
- [ ] Confirm plugin metadata still validates (`quick_validate.py` if available)


Made with [Cursor](https://cursor.com)