### PR TITLE
chore: clarify moraine-dev contributor skill workflows

### DIFF
--- a/plugins/moraine-dev/skills/moraine-author-pr/SKILL.md
+++ b/plugins/moraine-dev/skills/moraine-author-pr/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: moraine-author-pr
-description: Author Moraine pull request titles and descriptions. Use when drafting, revising, or reviewing a PR body for this repository; when preparing a PR summary after local changes; when documenting user-facing features, bug fixes, performance optimizations, validation, changelog impact, or operational impact; or when ensuring PR text follows repository conventions without AI attribution.
+description: Create Moraine pull requests on GitHub. Use when the branch is ready to open a PR; when the user asks to create, push, or open a PR; after local changes are committed; or when documenting user-facing features, bug fixes, performance optimizations, validation, changelog impact, or operational impact in a PR that follows repository conventions without AI attribution.
 ---
 
 # Moraine Author PR
 
 ## Overview
 
-Use this workflow to write PR titles and descriptions that are reviewable, evidence-backed, and consistent across agents. Default bodies use `Description`, `Usage`, `Changelog`, and `Validation` sections.
+The goal is to **create the PR on GitHub**, not just draft title and body text in chat. The skill is complete when the PR exists on GitHub and you return its URL.
+
+Write PR titles and descriptions that are reviewable, evidence-backed, and consistent across agents. Default bodies use `Description`, `Usage`, `Changelog`, and `Validation` sections. Base the summary on all commits in the branch, not only the latest one.
+
+If the branch is not ready — uncommitted work, failing tests the user expects fixed first, or the user asked only to revise an existing PR description — say what is blocking creation and what remains. Do not pretend a PR was opened.
 
 ## Title Rules
 
@@ -89,7 +93,7 @@ codex plugin marketplace add .
 Then enable `moraine-dev` and invoke:
 
 ```text
-Use $moraine-dev:moraine-author-pr to draft this PR.
+Use $moraine-dev:moraine-author-pr to create this PR on GitHub.
 ```
 ````
 

--- a/plugins/moraine-dev/skills/moraine-start-work/SKILL.md
+++ b/plugins/moraine-dev/skills/moraine-start-work/SKILL.md
@@ -9,6 +9,8 @@ description: Start Moraine repository development work safely. Use when an agent
 
 Use this workflow to start a Moraine contributor task with the same orientation every time: verify the checkout, isolate the branch, read governing instructions, and choose the right validation path before editing.
 
+You have explicit permission to spawn subagents from this session.
+
 ## Follow-On Workflow
 
 After the start checklist and branch/worktree setup, run the rest of the contributor workflow in this order:


### PR DESCRIPTION
## Description

**What.** Updates two `moraine-dev` contributor skills to set clearer agent expectations.

**Why.** Agents were treating `moraine-author-pr` as a drafting-only step instead of actually opening PRs on GitHub, and `moraine-start-work` did not explicitly authorize subagent use when parallel exploration helps.

- `moraine-author-pr`: description and overview now require creating the PR on GitHub, summarizing all branch commits, and reporting blockers when the branch is not ready.
- `moraine-start-work`: adds explicit permission to spawn subagents from the session.

No runtime, config, or schema changes.

## Changelog

- None. Developer-only agent skill guidance.

## Validation

Reviewed the edited `SKILL.md` files for wording and consistency with existing contributor workflow docs. No Rust tests or sandbox QA required; change is plugin skill metadata only.

Made with [Cursor](https://cursor.com)