### PR TITLE
chore(release): cut v0.6.1

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.6.0)"
+        description: "Tag to release (for example v0.6.1)"
         required: true
         type: string
       target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "moraine"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "glob",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/moraine-ingest/Cargo.toml
+++ b/apps/moraine-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Moraine ingest service binary"
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Moraine MCP stdio server"
 

--- a/apps/moraine-monitor/Cargo.toml
+++ b/apps/moraine-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Moraine monitor HTTP/UI service"
 

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Unified runtime control plane for Moraine services"
 

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-clickhouse"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Shared Moraine ClickHouse client and query helpers"
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-config"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Shared Moraine configuration schema and loaders"
 

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-conversations"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "High-level read/query APIs for Moraine conversations"
 

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest-core"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Core ingestion pipeline internals for Moraine"
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp-core"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "MCP protocol and tool routing core for Moraine"
 

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor-core"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Analytics and query logic for Moraine monitor service"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ install directory precedence:
 
 examples:
   scripts/install.sh
-  MORAINE_INSTALL_VERSION=v0.6.0 scripts/install.sh
+  MORAINE_INSTALL_VERSION=v0.6.1 scripts/install.sh
   MORAINE_INSTALL_ASSET_BASE_URL=http://127.0.0.1:8080 \
     MORAINE_INSTALL_VERSION=ci-e2e scripts/install.sh
   MORAINE_INSTALL_DIR="$HOME/bin" MORAINE_INSTALL_SKIP_CLICKHOUSE=1 scripts/install.sh


### PR DESCRIPTION
## Description

**What.** Bumps the release-managed Moraine crates, lockfile entries, and release/install examples from `0.6.0` to `0.6.1`.

**Why.** This prepares the `v0.6.1` tag so the release workflow can publish the next Moraine patch release to GitHub Releases and PyPI.

The user-facing release since `v0.6.0` includes OpenCode SQLite ingest, remote ClickHouse defaults, the new MCP `file_attention` retrieval tool, and clearer monitor trace labels for thinking rows. The range also includes CLI/conversations refactors and contributor-workflow updates that should not change end-user behavior.

## Usage

After this PR is merged, tag `main` with `v0.6.1`. The tag-triggered `release-moraine` workflow will build the platform bundles, publish the GitHub release assets, and publish `moraine-cli==0.6.1` to PyPI.

Users can then upgrade with:

```bash
uv tool upgrade moraine-cli
moraine up && moraine status
```

## Changelog

- Bumps release-managed workspace packages and `Cargo.lock` entries to `0.6.1`.
- Updates the release workflow manual-dispatch example and installer version example to `v0.6.1`.
- Release notes should cover OpenCode SQLite ingest, remote ClickHouse setup, MCP `file_attention`, monitor thinking-label fixes, SQLite toolchain stability, and contributor-only workflow changes since `v0.6.0`.

## Operational Impact

No schema migration or runtime config change is introduced by this version-bump PR itself. Pushing the `v0.6.1` tag after merge will run `.github/workflows/release-moraine.yml`, upload the three platform bundles plus checksum assets, and publish the `moraine-cli` wheels and stub sdist to PyPI.

## Validation

Validated the release bump with `git diff --check`, `cargo fmt --all -- --check`, and `cargo test --workspace --locked`; all passed locally. The release commit also passed the repo pre-commit hook: `make fmt` and the strict clippy baseline.

Ran isolated sandbox QA in `sb-abe04c`. After installing the missing sandbox `rustfmt`/`clippy` components, `cargo fmt --all -- --check` and `cargo test --workspace --locked` passed inside `/repo`. The functional stack smoke passed with `MORAINECTL_BIN=/home/moraine/target/debug/moraine bash scripts/ci/e2e-stack.sh`, including normalized ingest rows, monitor API routes, turn sequence duplicate handling, MCP smoke checks across codex/claude/kimi/cursor/cursor-sqlite/pi/hermes/session_json, and project-only scoping. The sandbox monitor health endpoint returned `ok: true` against ClickHouse `25.12.5.44`, and `scripts/dev/sandbox/moraine-sandbox down sb-abe04c` succeeded.

`ANTHROPIC_API_KEY` was not set, so the optional `scripts/dev/sandbox/agent-smoke-e2e` harness was not available; the project e2e MCP smoke suite was run instead.
