### PR TITLE
fix(intel-macos): publish release artifacts

### DIFF
--- a/.github/workflows/ci-functional.yml
+++ b/.github/workflows/ci-functional.yml
@@ -21,6 +21,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - os: macos-14
             target: aarch64-apple-darwin
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-packaging.yml
+++ b/.github/workflows/ci-packaging.yml
@@ -43,11 +43,16 @@ jobs:
         with:
           filters: |
             packaging:
+              - '.github/workflows/release-moraine.yml'
               - '.github/workflows/ci-packaging.yml'
               - 'bindings/python/moraine-cli/**'
               - 'scripts/build-python-wheels.py'
               - 'scripts/build-python-sdist.py'
               - 'scripts/package-moraine-release.sh'
+              - 'scripts/ci/assert-release-targets.py'
+
+      - name: Assert release target coverage
+        run: python3 scripts/ci/assert-release-targets.py
 
       - name: Skip when no packaging changes
         if: github.event_name == 'pull_request' && steps.filter.outputs.packaging != 'true'

--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -43,6 +43,9 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             cargo_container: ""
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            cargo_container: ""
 
     steps:
       - name: Checkout
@@ -143,7 +146,7 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
           mkdir -p dist/wheels
-          for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu aarch64-apple-darwin; do
+          for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu aarch64-apple-darwin x86_64-apple-darwin; do
             python3 scripts/build-python-wheels.py \
               --target "$target" \
               --bundle "dist/moraine-bundle-$target.tar.gz" \

--- a/scripts/build-python-sdist.py
+++ b/scripts/build-python-sdist.py
@@ -90,10 +90,10 @@ prepare_metadata_for_build_wheel = _refuse
 README_TEMPLATE = """\
 # moraine (source distribution)
 
-This sdist is a stub. Moraine distributes prebuilt binary wheels only
-(macOS arm64, Linux x86_64, Linux aarch64). Installing this sdist with
-`pip install moraine --no-binary moraine` will fail with a pointer to
-the source-install instructions.
+This sdist is a stub. Moraine distributes prebuilt binary wheels only for
+macOS arm64, macOS x86_64, Linux x86_64, and Linux aarch64. Installing
+this sdist with `pip install moraine --no-binary moraine` will fail with a
+pointer to the source-install instructions.
 
 To install moraine:
 

--- a/scripts/build-python-wheels.py
+++ b/scripts/build-python-wheels.py
@@ -26,6 +26,7 @@ Design notes:
 Usage:
   python scripts/build-python-wheels.py \
       --target x86_64-unknown-linux-gnu  --bundle dist/moraine-bundle-x86_64-unknown-linux-gnu.tar.gz \
+      --target x86_64-apple-darwin      --bundle dist/moraine-bundle-x86_64-apple-darwin.tar.gz \
       --target aarch64-apple-darwin      --bundle dist/moraine-bundle-aarch64-apple-darwin.tar.gz \
       --out-dir dist/wheels \
       --version 0.4.1

--- a/scripts/ci/assert-release-targets.py
+++ b/scripts/ci/assert-release-targets.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-import importlib.util
+import ast
 import re
 import sys
 from pathlib import Path
@@ -70,13 +70,20 @@ def _publish_loop_targets() -> set[str]:
 
 def _wheel_builder_platforms() -> dict[str, str]:
     path = ROOT / "scripts" / "build-python-wheels.py"
-    spec = importlib.util.spec_from_file_location("moraine_build_python_wheels", path)
-    if spec is None or spec.loader is None:
-        raise AssertionError(f"could not load wheel builder from {path}")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return dict(module.TARGET_TO_WHEEL_PLATFORM)
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "TARGET_TO_WHEEL_PLATFORM"
+            for target in node.targets
+        ):
+            value = ast.literal_eval(node.value)
+            if not isinstance(value, dict) or not all(
+                isinstance(target, str) and isinstance(platform, str)
+                for target, platform in value.items()
+            ):
+                raise AssertionError("TARGET_TO_WHEEL_PLATFORM must be a string-to-string dict")
+            return dict(value)
+    raise AssertionError(f"could not find TARGET_TO_WHEEL_PLATFORM in {path}")
 
 
 def _assert_equal(name: str, actual: set[str]) -> None:

--- a/scripts/ci/assert-release-targets.py
+++ b/scripts/ci/assert-release-targets.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Assert release target coverage stays aligned across packaging entrypoints."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+
+EXPECTED_TARGETS = {
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+}
+
+EXPECTED_MATRIX = {
+    "x86_64-unknown-linux-gnu": "ubuntu-latest",
+    "aarch64-unknown-linux-gnu": "ubuntu-24.04-arm",
+    "aarch64-apple-darwin": "macos-14",
+    "x86_64-apple-darwin": "macos-15-intel",
+}
+
+EXPECTED_WHEEL_PLATFORMS = {
+    "x86_64-unknown-linux-gnu": "manylinux_2_28_x86_64",
+    "aarch64-unknown-linux-gnu": "manylinux_2_28_aarch64",
+    "aarch64-apple-darwin": "macosx_11_0_arm64",
+    "x86_64-apple-darwin": "macosx_11_0_x86_64",
+}
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(relpath: str) -> str:
+    return (ROOT / relpath).read_text(encoding="utf-8")
+
+
+def _matrix_targets(relpath: str) -> dict[str, str]:
+    text = _read(relpath)
+    matrix: dict[str, str] = {}
+    current_os = None
+
+    for line in text.splitlines():
+        os_match = re.match(r"^\s*-\s+os:\s*([A-Za-z0-9_.-]+)\s*$", line)
+        if os_match:
+            current_os = os_match.group(1)
+            continue
+
+        target_match = re.match(r"^\s*target:\s*([A-Za-z0-9_.-]+)\s*$", line)
+        if target_match and current_os is not None:
+            target = target_match.group(1)
+            if target in matrix:
+                raise AssertionError(f"{relpath} declares duplicate target {target}")
+            matrix[target] = current_os
+            current_os = None
+
+    return matrix
+
+
+def _publish_loop_targets() -> set[str]:
+    text = _read(".github/workflows/release-moraine.yml")
+    match = re.search(r"for target in ([^;]+);\s*do", text)
+    if not match:
+        raise AssertionError("release workflow is missing the PyPI wheel target loop")
+    return set(match.group(1).split())
+
+
+def _wheel_builder_platforms() -> dict[str, str]:
+    path = ROOT / "scripts" / "build-python-wheels.py"
+    spec = importlib.util.spec_from_file_location("moraine_build_python_wheels", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"could not load wheel builder from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return dict(module.TARGET_TO_WHEEL_PLATFORM)
+
+
+def _assert_equal(name: str, actual: set[str]) -> None:
+    if actual != EXPECTED_TARGETS:
+        missing = sorted(EXPECTED_TARGETS - actual)
+        extra = sorted(actual - EXPECTED_TARGETS)
+        raise AssertionError(f"{name} target drift; missing={missing} extra={extra}")
+
+
+def _assert_matrix(name: str, actual: dict[str, str]) -> None:
+    _assert_equal(name, set(actual))
+    wrong_runner = {
+        target: {"expected": expected_os, "actual": actual[target]}
+        for target, expected_os in EXPECTED_MATRIX.items()
+        if actual[target] != expected_os
+    }
+    if wrong_runner:
+        raise AssertionError(f"{name} runner drift: {wrong_runner}")
+
+
+def _assert_wheel_platforms(actual: dict[str, str]) -> None:
+    _assert_equal("wheel builder", set(actual))
+    if actual != EXPECTED_WHEEL_PLATFORMS:
+        raise AssertionError(
+            f"wheel platform drift; expected={EXPECTED_WHEEL_PLATFORMS} actual={actual}"
+        )
+
+
+def main() -> int:
+    matrices = {
+        "release matrix": _matrix_targets(".github/workflows/release-moraine.yml"),
+        "functional matrix": _matrix_targets(".github/workflows/ci-functional.yml"),
+    }
+    for name, matrix in matrices.items():
+        _assert_matrix(name, matrix)
+
+    target_checks = {
+        "PyPI publish loop": _publish_loop_targets(),
+    }
+    for name, targets in target_checks.items():
+        _assert_equal(name, targets)
+    _assert_wheel_platforms(_wheel_builder_platforms())
+    print("release target, runner, and wheel platform coverage ok:", " ".join(sorted(EXPECTED_TARGETS)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/e2e-install-artifact.sh
+++ b/scripts/ci/e2e-install-artifact.sh
@@ -11,6 +11,7 @@ usage() {
 usage: scripts/ci/e2e-install-artifact.sh <target-triple>
 
 example:
+  scripts/ci/e2e-install-artifact.sh x86_64-apple-darwin
   scripts/ci/e2e-install-artifact.sh aarch64-apple-darwin
 EOF
 }

--- a/scripts/package-moraine-release.sh
+++ b/scripts/package-moraine-release.sh
@@ -7,6 +7,7 @@ usage: scripts/package-moraine-release.sh <target-triple> [output-dir]
 
 examples:
   scripts/package-moraine-release.sh x86_64-unknown-linux-gnu dist
+  scripts/package-moraine-release.sh x86_64-apple-darwin dist
   scripts/package-moraine-release.sh aarch64-apple-darwin dist
 EOF
 }


### PR DESCRIPTION
## Context

While testing the install flow end to end, I noticed that Intel macOS support was already present in the installer and wheel builder, but the release workflow was not publishing Intel macOS artifacts. This PR closes that gap =)

## Summary

This fixes a release packaging gap for Intel macOS.

Moraine already recognized `x86_64-apple-darwin` in the installer and Python wheel builder, but the release workflow did not build or publish that target. Intel macOS users could therefore follow the official install path and still land on a missing bundle or wheel artifact.

> [!IMPORTANT]
> This PR also adds a release-target guardrail so future packaging changes cannot silently drop a supported target, move it to the wrong runner, or publish it with the wrong Python wheel platform tag.

## What Changed

- Added `x86_64-apple-darwin` to the release matrix on GitHub's Intel macOS runner.
- Included the Intel macOS target in the PyPI wheel publishing loop.
- Added functional install coverage for the same target.
- Added `scripts/ci/assert-release-targets.py` to keep release coverage aligned across:
  - release matrix targets and runner labels
  - functional matrix targets and runner labels
  - PyPI publish loop targets
  - wheel builder target-to-platform mappings
- Updated packaging examples so Intel macOS appears as a first-class release target.

## Validation

```text
python scripts/ci/assert-release-targets.py
python -m py_compile scripts/ci/assert-release-targets.py scripts/build-python-wheels.py scripts/build-python-sdist.py
bash -n scripts/package-moraine-release.sh scripts/ci/e2e-install-artifact.sh
git diff --check
python -c "import ast, pathlib; ast.parse(pathlib.Path('scripts/ci/assert-release-targets.py').read_text(), feature_version=(3, 9)); print('python 3.9 syntax ok')"
```