### PR TITLE
docs: clarify delegated code review skill consent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ This repo vendors developer-only agent workflows as a local Codex plugin:
 - Plugin: `plugins/moraine-dev/.codex-plugin/plugin.json`
 - Skills: `plugins/moraine-dev/skills/`
 
-Use `$moraine-dev:moraine-start-work` when beginning contributor work, `$moraine-dev:crystallize` when turning rough input into an ignored ready-to-implement plan under `plans/`, `$moraine-dev:moraine-author-pr` when drafting a PR title or description, `$moraine-dev:moraine-sandbox-qa` for ingest/MCP/monitor/schema/stack-facing validation, `$moraine-dev:code-review` for a full multi-persona review wave, and the `$moraine-dev:code-review-*` persona skills for focused PR review. When prior or active agent context matters, use the Moraine MCP tools directly. These skills are for repository contributors and automation agents, not end-user Moraine behavior.
+Use `$moraine-dev:moraine-start-work` when beginning contributor work, `$moraine-dev:crystallize` when turning rough input into an ignored ready-to-implement plan under `plans/`, `$moraine-dev:moraine-author-pr` when drafting a PR title or description, `$moraine-dev:moraine-sandbox-qa` for ingest/MCP/monitor/schema/stack-facing validation, `$moraine-dev:code-review` for a full multi-persona review wave, and the `$moraine-dev:code-review-*` persona skills for focused PR review. Using `$moraine-dev:code-review` is an explicit request for its delegated reviewer subagents. When prior or active agent context matters, use the Moraine MCP tools directly. These skills are for repository contributors and automation agents, not end-user Moraine behavior.
 Use `$moraine-dev:release` when cutting and publishing a Moraine release from a target version.
 
 ## Writing PRs

--- a/docs/development/agent-contributor-workflows.md
+++ b/docs/development/agent-contributor-workflows.md
@@ -78,11 +78,15 @@ be versioned.
 
 ## Review Personas
 
-Use `$moraine-dev:code-review` when you want the whole review set. It launches one subagent
-per persona, tracks those sessions, integrates their feedback, and follows up
-only with the sessions that need another look. Each review persona is a focused
-skill that should report findings only for its facet unless another issue is a
-direct blocker.
+Use `$moraine-dev:code-review` when you want the whole review set. Invoking the
+skill is an explicit request for delegated multi-agent review; agents should not
+ask for separate permission to spawn reviewer subagents, and should not replace
+the review wave with a local single-agent review. If subagent tooling is
+unavailable, report the delegated review as blocked. The coordinator launches
+one subagent per persona, tracks those sessions, integrates their feedback, and
+follows up only with the sessions that need another look. Each review persona is
+a focused skill that should report findings only for its facet unless another
+issue is a direct blocker.
 
 | Persona | Skill | Review facet |
 | --- | --- | --- |

--- a/plugins/moraine-dev/.codex-plugin/plugin.json
+++ b/plugins/moraine-dev/.codex-plugin/plugin.json
@@ -34,7 +34,7 @@
     "defaultPrompt": [
       "Use $moraine-dev:moraine-start-work to begin a Moraine change safely.",
       "Use $moraine-dev:crystallize to turn a rough idea into a ready-to-implement plan.",
-      "Use $moraine-dev:code-review to run all review personas on this PR.",
+      "Use $moraine-dev:code-review to launch delegated subagents for all review personas on this PR.",
       "Use $moraine-dev:moraine-author-pr to draft a PR title and description.",
       "Use $moraine-dev:release to cut a Moraine release from a target version."
     ]

--- a/plugins/moraine-dev/skills/code-review/SKILL.md
+++ b/plugins/moraine-dev/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: "Coordinate a full multi-persona code review for a Moraine PR or local change. Use when asked to review a PR, run the review agents, get code review feedback, or iterate on review feedback using all CodeReview personas: elegance, idiom, correctness, completeness, security, YAGNI, and scope."
+description: "Coordinate a delegated full multi-persona code review for a Moraine PR or local change. Use when asked to review a PR, run review agents, get code review feedback, or iterate on review feedback using all CodeReview personas: elegance, idiom, correctness, completeness, security, YAGNI, and scope. Invoking this skill is an explicit request to launch reviewer subagents."
 ---
 
 # Code Review
@@ -9,9 +9,11 @@ description: "Coordinate a full multi-persona code review for a Moraine PR or lo
 
 Use this skill to run one coordinated review wave across all focused review personas, merge their feedback, apply accepted fixes, and follow up only with the reviewer sessions that need another look.
 
+Invoking this skill is an explicit user request for delegated multi-agent review. Do not ask for separate permission to spawn reviewer subagents, and do not collapse the personas into a single local review. If subagent tooling is unavailable, report the delegated review as blocked.
+
 ## Review Wave
 
-Launch exactly one subagent for each persona:
+Launch exactly one delegated subagent for each persona:
 
 - `$moraine-dev:code-review-elegance`
 - `$moraine-dev:code-review-idomatic`
@@ -35,6 +37,8 @@ Review packet:
 ```
 
 Keep a mapping of persona to subagent session id. This mapping is part of the work product until review follow-up is complete.
+
+If the current harness has no callable subagent mechanism, stop before reviewing and report that the required delegated review wave is blocked by missing tooling. Do not silently substitute a manual single-agent review for this skill.
 
 ## Triage
 

--- a/plugins/moraine-dev/skills/code-review/agents/openai.yaml
+++ b/plugins/moraine-dev/skills/code-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Review"
   short_description: "Coordinate multi-persona PR review"
-  default_prompt: "Use $moraine-dev:code-review to run all code review personas on this PR."
+  default_prompt: "Use $moraine-dev:code-review to launch delegated subagents for all code review personas on this PR."

--- a/plugins/moraine-dev/skills/moraine-start-work/SKILL.md
+++ b/plugins/moraine-dev/skills/moraine-start-work/SKILL.md
@@ -9,7 +9,7 @@ description: Start Moraine repository development work safely. Use when an agent
 
 Use this workflow to start a Moraine contributor task with the same orientation every time: verify the checkout, isolate the branch, read governing instructions, and choose the right validation path before editing.
 
-You have explicit permission to spawn subagents from this session.
+Using `$moraine-dev:code-review` in this workflow is an explicit user request for that skill's delegated reviewer subagents. You have explicit permission to spawn the `$moraine-dev:code-review` review wave when the follow-on workflow reaches that step.
 
 ## Follow-On Workflow
 


### PR DESCRIPTION
## Description

**What.** Clarifies that `$moraine-dev:code-review` invocation is explicit consent for delegated reviewer subagents.

**Why.** Agents were treating the review wave as unauthorized unless the user separately asked for delegated agents.

This updates the code-review skill trigger text, body instructions, UI prompt metadata, contributor docs, and adjacent start-work guidance so the review coordinator owns the delegated-agent contract. The skill now says not to ask for separate permission, not to collapse personas into a local single-agent review, and to report the review as blocked if subagent tooling is unavailable.

## Usage

Use the review coordinator as before:

```text
Use $moraine-dev:code-review to review this PR.
```

That skill invocation now explicitly authorizes the delegated reviewer subagent wave.

## Changelog

- Clarifies delegated-review consent for the developer-only `$moraine-dev:code-review` skill.
- Updates Moraine contributor workflow docs and plugin prompt metadata.
- No end-user runtime behavior change.

## Validation

Validated JSON metadata with `python3 -m json.tool` for the plugin manifest and marketplace file. Parsed every `plugins/moraine-dev/skills/*/agents/openai.yaml` with PyYAML. Ran Codex skill validation for `plugins/moraine-dev/skills/code-review` and `plugins/moraine-dev/skills/moraine-start-work`, both successfully. Ran `git diff --check` successfully.

Installed the unmerged plugin from the final branch with `make agent-plugins-install AGENT_PLUGINS_SOURCE=current`; it installed `moraine-dev@moraine-dev (0.1.0)` successfully.

Ran the full delegated `$moraine-dev:code-review` persona wave. Elegance, idiom, correctness, completeness, security, and scope reported no findings. YAGNI raised an over-broad consent wording concern in `AGENTS.md` and `moraine-start-work`; that wording was narrowed to `$moraine-dev:code-review`, and the YAGNI follow-up reported no remaining findings.
