### PR TITLE
fix: wire Claude plugin MCP manifest

### DIFF
--- a/plugins/moraine/.claude-plugin/plugin.json
+++ b/plugins/moraine/.claude-plugin/plugin.json
@@ -17,5 +17,6 @@
     "agent-memory",
     "session-search",
     "realtime-agents"
-  ]
+  ],
+  "mcpServers": "./.mcp.json"
 }


### PR DESCRIPTION
## Description

**What.** Points the Moraine Claude plugin manifest at its MCP server config with `"mcpServers": "./.mcp.json"`.

**Why.** The plugin installed successfully and `claude mcp list` could health-check the root `.mcp.json`, but normal Claude sessions marked `plugin:moraine:moraine` as failed and did not expose the plugin MCP tools.

The original plugin relied on the root `.mcp.json` being discovered implicitly. Claude's plugin runtime loads MCP servers from the plugin manifest, either inline or through a manifest path reference. Keeping the existing `.mcp.json` and referencing it from `.claude-plugin/plugin.json` makes the normal session path start the plugin MCP server.

## Usage

After this is merged, refresh the installed plugin and restart Claude sessions:

```bash
claude plugin update moraine
```

If the update command keeps the stale cached `0.6.1` install, remove and reinstall:

```bash
claude plugin remove moraine
claude plugin install moraine@moraine
```

## Changelog

- Fixes the Claude plugin MCP server not being available in normal Claude sessions.
- No Moraine runtime behavior change.

## Validation

Reproduced the broken installed plugin state from the merged PR: `claude -p --output-format stream-json ...` reported `plugin:moraine:moraine` as `failed`; ToolSearch did not include `mcp__plugin_moraine_moraine__list_sessions`, and Claude fell back to the older manual `conversation-search` MCP server.

Validated the fix with:

```bash
python3 -m json.tool plugins/moraine/.claude-plugin/plugin.json
claude plugin validate ./plugins/moraine --strict
claude plugin validate . --strict
git diff --check
```

Installed the patched plugin into a temporary Claude HOME and confirmed session init reported `plugin:moraine:moraine` as `pending` instead of `failed`, with debug logs showing the plugin MCP server started and connected.

Ran an authenticated session with the patched plugin via `--plugin-dir`; session init reported `plugin:moraine:moraine` as `connected`, the initial tool set included `mcp__plugin_moraine_moraine__file_attention`, `list_sessions`, `open`, and `search_sessions`, ToolSearch selected `mcp__plugin_moraine_moraine__list_sessions`, and that MCP tool call completed successfully.

Rust tests and sandbox QA were not run because this is plugin metadata only and does not modify Rust code, ClickHouse schema, ingest, monitor, or the MCP runtime implementation.
