### PR TITLE
docs: add Claude plugin setup to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ moraine status
 
 The monitor UI runs at `http://127.0.0.1:8080` by default.
 
+### Claude Code Setup
+
+For Claude Code, install the Moraine plugin after `moraine up`:
+
+```bash
+claude plugin marketplace add eric-tramel/moraine --sparse .claude-plugin plugins
+claude plugin install moraine@moraine
+```
+
+Restart Claude Code after installing. New sessions get the
+`moraine:session-search` and `moraine:realtime-peek` skills, and Moraine MCP
+tools are exposed as `mcp__plugin_moraine_moraine__*`.
+
 ## Agent Harness Guidance
 
 Moraine is most useful when your agent harness knows that it can search prior


### PR DESCRIPTION
## Description

**What.** Adds a compact first-time Claude Code setup flow to the README quickstart.

**Why.** The README should show the direct happy path for new Claude users without mixing in migration, cache-refresh, or project-scoped alternatives.

The new section tells users to install the Moraine plugin after `moraine up`, restart Claude Code, and expect the bundled Moraine skills plus `mcp__plugin_moraine_moraine__*` MCP tools in new sessions.

## Usage

README users now see the primary Claude flow directly:

```bash
claude plugin marketplace add eric-tramel/moraine --sparse .claude-plugin plugins
claude plugin install moraine@moraine
```

## Changelog

- Documents the first-time Claude Code plugin install path in the README.
- No runtime behavior change.

## Validation

Ran `git diff --check` and `make docs-build`; both passed. Rust tests and sandbox QA were not run because this is a README-only documentation change.
