### PR TITLE
docs: forbid draft PRs in authoring skill

### DIFF
--- a/plugins/moraine-dev/.codex-plugin/plugin.json
+++ b/plugins/moraine-dev/.codex-plugin/plugin.json
@@ -35,7 +35,7 @@
       "Use $moraine-dev:moraine-start-work to begin a Moraine change safely.",
       "Use $moraine-dev:crystallize to turn a rough idea into a ready-to-implement plan.",
       "Use $moraine-dev:code-review to launch delegated subagents for all review personas on this PR.",
-      "Use $moraine-dev:moraine-author-pr to draft a PR title and description.",
+      "Use $moraine-dev:moraine-author-pr to create a ready-for-review PR.",
       "Use $moraine-dev:release to cut a Moraine release from a target version."
     ]
   }

--- a/plugins/moraine-dev/skills/moraine-author-pr/SKILL.md
+++ b/plugins/moraine-dev/skills/moraine-author-pr/SKILL.md
@@ -9,6 +9,8 @@ description: Create Moraine pull requests on GitHub. Use when the branch is read
 
 The goal is to **create the PR on GitHub**, not just draft title and body text in chat. The skill is complete when the PR exists on GitHub and you return its URL.
 
+Always create a ready-for-review PR. Never create a GitHub Draft PR, never pass `--draft`, never set `draft: true`, and never emit an `isDraft=true` PR directive. If the branch is not ready for reviewer attention, stop and explain what remains instead of opening a Draft PR.
+
 Write PR titles and descriptions that are reviewable, evidence-backed, and consistent across agents. Default bodies use `Description`, `Usage`, `Changelog`, and `Validation` sections. Base the summary on all commits in the branch, not only the latest one.
 
 If the branch is not ready — uncommitted work, failing tests the user expects fixed first, or the user asked only to revise an existing PR description — say what is blocking creation and what remains. Do not pretend a PR was opened.

--- a/plugins/moraine-dev/skills/moraine-author-pr/agents/openai.yaml
+++ b/plugins/moraine-dev/skills/moraine-author-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Moraine Author PR"
   short_description: "Author consistent Moraine pull requests"
-  default_prompt: "Use $moraine-dev:moraine-author-pr to draft a Moraine pull request title and description."
+  default_prompt: "Use $moraine-dev:moraine-author-pr to create a ready-for-review Moraine pull request."


### PR DESCRIPTION
## Description

**What.** Updates the Moraine developer PR authoring skill to require ready-for-review pull requests.

**Why.** Agents should stop when a branch is not ready instead of opening GitHub Draft PRs.

This adds an explicit no-Draft rule to `moraine-author-pr` and updates the plugin prompts from draft-title/body wording to ready-for-review PR creation.

## Usage

Moraine contributor agents invoking `$moraine-dev:moraine-author-pr` are now instructed to create ready-for-review PRs only and never use `--draft`, `draft: true`, or `isDraft=true`.

## Changelog

- Adds developer-only PR authoring guidance that forbids GitHub Draft PR creation.
- No end-user runtime behavior change.

## Validation

Validated plugin metadata with `python3 -m json.tool plugins/moraine-dev/.codex-plugin/plugin.json`, parsed the agent YAML with `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('plugins/moraine-dev/skills/moraine-author-pr/agents/openai.yaml').read_text()); print('yaml ok')"`, and ran `git diff --check` successfully. A targeted `rg` check confirmed the remaining draft-related hits are the new prohibition or unrelated non-authoring wording. The full Moraine code-review wave ran across elegance, idiom, correctness, completeness, security, YAGNI, and scope personas with no actionable findings. Sandbox QA was not run because this is a plugin instruction/metadata-only change.