### PR TITLE
feat(mcp): normalize file attention paths

### DIFF
--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -656,6 +656,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             name: "020_purge_empty_session_claude_code.sql",
             sql: include_str!("../../../sql/020_purge_empty_session_claude_code.sql"),
         },
+        Migration {
+            version: "021",
+            name: "021_file_attention_normalization.sql",
+            sql: include_str!("../../../sql/021_file_attention_normalization.sql"),
+        },
     ]
 }
 
@@ -1195,6 +1200,50 @@ mod tests {
                 "020 statement must not reference a bare `moraine.` after rewrite: {statement}"
             );
         }
+    }
+
+    #[test]
+    fn migration_021_adds_file_attention_columns_without_reordering_tables() {
+        let migration = bundled_migrations()
+            .into_iter()
+            .find(|m| m.version == "021")
+            .expect("migration 021 must be registered");
+
+        let materialized =
+            materialize_migration_sql(migration.sql, "other_db").expect("materialize 021");
+        let statements = split_sql_statements(&materialized);
+
+        assert_eq!(
+            statements.len(),
+            6,
+            "021 should only add three columns to events and tool_io"
+        );
+
+        for table in ["events", "tool_io"] {
+            for column in ["project_id", "repo_rel_path", "worktree_root"] {
+                let expected =
+                    format!("ALTER TABLE other_db.{table}\n  ADD COLUMN IF NOT EXISTS {column}");
+                assert!(
+                    statements
+                        .iter()
+                        .any(|statement| statement.contains(&expected)),
+                    "021 missing {column} on {table}: {statements:#?}"
+                );
+            }
+        }
+
+        assert!(
+            statements
+                .iter()
+                .all(|statement| !statement.contains("ORDER BY")),
+            "021 must not rewrite ReplacingMergeTree sort keys"
+        );
+        assert!(
+            statements
+                .iter()
+                .all(|statement| !statement.contains("Nullable")),
+            "021 should use non-null defaults for lookup fields"
+        );
     }
 
     #[test]

--- a/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
@@ -23,12 +23,151 @@ impl ClickHouseConversationRepository {
         &self,
         query: FileAttentionQuery,
     ) -> RepoResult<Vec<FileAttentionTouch>> {
-        let rel = query.rel.as_str();
-        if rel.is_empty() {
+        if query.rel.is_empty() {
             return Err(RepoError::invalid_argument(
                 "file_attention requires a non-empty path tail",
             ));
         }
+
+        let mut touches = Vec::<FileAttentionTouch>::new();
+        if !query.apply_project_scope
+            || query
+                .normalized_project_id
+                .as_deref()
+                .is_some_and(|project_id| !project_id.is_empty())
+        {
+            match self.file_attention_exact_impl(&query).await {
+                Ok(rows) => touches.extend(rows),
+                Err(RepoError::Backend(message)) if is_file_attention_schema_skew(&message) => {
+                    warn!(
+                        error = %message,
+                        "file_attention normalized lookup unavailable; falling back to Tier-0 suffix scan"
+                    );
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        touches.extend(self.file_attention_suffix_impl(&query).await?);
+        Ok(merge_file_attention_touches(
+            touches,
+            query.max_rows.saturating_add(1),
+        ))
+    }
+
+    async fn file_attention_exact_impl(
+        &self,
+        query: &FileAttentionQuery,
+    ) -> RepoResult<Vec<FileAttentionTouch>> {
+        let rel = query.rel.as_str();
+
+        let tool_io = self.table_ref("tool_io");
+        let events = self.table_ref("events");
+        let trace = self.table_ref("v_conversation_trace");
+        let rel_sql = sql_quote(rel);
+        let project_predicate = if query.apply_project_scope {
+            let project_id = query
+                .normalized_project_id
+                .as_deref()
+                .filter(|project_id| !project_id.is_empty())
+                .ok_or_else(|| {
+                    RepoError::invalid_argument("file_attention exact lookup requires project_id")
+                })?;
+            format!("project_id = {}", sql_quote(project_id))
+        } else {
+            "project_id != ''".to_string()
+        };
+
+        let mut inner_clauses = vec![format!(
+            "tool_phase = 'request'
+      AND NOT (lowerUTF8(tool_name) = 'file_attention' OR endsWith(lowerUTF8(tool_name), '_file_attention'))
+      AND {project_predicate}
+      AND repo_rel_path = {rel_sql}"
+        )];
+        if let Some(tool) = query.tool.as_deref() {
+            inner_clauses.push(format!("lower(tool_name) = lower({})", sql_quote(tool)));
+        }
+        if query.mutations_only {
+            inner_clauses.push(format!(
+                "lowerUTF8(tool_name) NOT IN ({FILE_ATTENTION_READ_TOOL_NAMES_SQL})"
+            ));
+        }
+        if query.apply_project_scope {
+            if let Some(scope_clause) = self.session_scope_clause("session_id") {
+                inner_clauses.push(scope_clause);
+            }
+        }
+        let match_predicate = inner_clauses.join("\n      AND ");
+
+        let mut outer_clauses: Vec<String> = Vec::new();
+        if let Some(start) = query.start_unix_ms {
+            outer_clauses.push(format!("toUnixTimestamp64Milli(tr.event_time) >= {start}"));
+        }
+        if let Some(end) = query.end_unix_ms {
+            outer_clauses.push(format!("toUnixTimestamp64Milli(tr.event_time) < {end}"));
+        }
+        let outer_where = if outer_clauses.is_empty() {
+            "1".to_string()
+        } else {
+            outer_clauses.join("\n    AND ")
+        };
+
+        let limit_plus = query.max_rows.saturating_add(1);
+        let max_execution_time = query.max_execution_time_secs.max(1).to_string();
+        let params = [
+            ("query_id", query.query_id.as_str()),
+            ("max_execution_time", max_execution_time.as_str()),
+            ("join_use_nulls", "1"),
+        ];
+
+        let sql = format!(
+            "WITH matched AS (
+    SELECT session_id, event_uid, tool_call_id, harness, tool_name, tool_phase, input_preview, output_preview, repo_rel_path, worktree_root
+    FROM {tool_io} FINAL
+    WHERE {match_predicate}
+  )
+  SELECT
+    ti.session_id AS session_id,
+    ti.event_uid AS event_uid,
+    ti.tool_call_id AS tool_call_id,
+    ti.harness AS harness,
+    ti.tool_name AS tool_name,
+    ti.tool_phase AS tool_phase,
+    if(ti.worktree_root != '', concat(ti.worktree_root, '/', ti.repo_rel_path), ti.repo_rel_path) AS matched_path,
+    'path_suffix' AS match_kind,
+    ti.worktree_root AS worktree_root,
+    ifNull(e.cwd, '') AS cwd,
+    toInt64(toUnixTimestamp64Milli(tr.event_time)) AS event_unix_ms,
+    toUInt64(ifNull(tr.event_order, toUInt64(0))) AS event_order,
+    tr.turn_seq AS turn_seq,
+    ti.input_preview AS input_preview,
+    ti.output_preview AS output_preview
+  FROM matched AS ti
+  ANY LEFT JOIN (
+    SELECT session_id, event_uid, event_time, toUInt64(event_order) AS event_order, toUInt32(turn_seq) AS turn_seq
+    FROM {trace}
+    WHERE (session_id, event_uid) IN (SELECT session_id, event_uid FROM matched)
+  ) AS tr ON tr.session_id = ti.session_id AND tr.event_uid = ti.event_uid
+  ANY LEFT JOIN (
+    SELECT session_id, event_uid, any(cwd) AS cwd
+    FROM {events} FINAL
+    WHERE (session_id, event_uid) IN (SELECT session_id, event_uid FROM matched)
+    GROUP BY session_id, event_uid
+  ) AS e ON e.session_id = ti.session_id AND e.event_uid = ti.event_uid
+  WHERE {outer_where}
+  ORDER BY isNull(event_unix_ms) ASC, event_unix_ms DESC, event_order DESC, ti.event_uid DESC
+  LIMIT {limit_plus}
+  FORMAT JSONEachRow",
+        );
+
+        self.map_backend(self.ch.query_rows_with_params(&sql, None, &params).await)
+    }
+
+    async fn file_attention_suffix_impl(
+        &self,
+        query: &FileAttentionQuery,
+    ) -> RepoResult<Vec<FileAttentionTouch>> {
+        let rel = query.rel.as_str();
 
         let tool_io = self.table_ref("tool_io");
         let events = self.table_ref("events");
@@ -160,13 +299,14 @@ impl ClickHouseConversationRepository {
 
         let sql = format!(
             "WITH matched AS (
-    SELECT session_id, event_uid, harness, tool_name, tool_phase, input_json, input_preview, output_preview
+    SELECT session_id, event_uid, tool_call_id, harness, tool_name, tool_phase, input_json, input_preview, output_preview
     FROM {tool_io} FINAL
     WHERE {match_predicate}
   )
   SELECT
     ti.session_id AS session_id,
     ti.event_uid AS event_uid,
+    ti.tool_call_id AS tool_call_id,
     ti.harness AS harness,
     ti.tool_name AS tool_name,
     ti.tool_phase AS tool_phase,
@@ -209,4 +349,47 @@ impl ClickHouseConversationRepository {
         self.map_backend(self.ch.request_text(&sql, None, None, false, None).await)
             .map(|_| ())
     }
+}
+
+fn is_file_attention_schema_skew(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("project_id")
+        || lower.contains("repo_rel_path")
+        || lower.contains("worktree_root")
+}
+
+pub(super) fn merge_file_attention_touches(
+    touches: Vec<FileAttentionTouch>,
+    limit: usize,
+) -> Vec<FileAttentionTouch> {
+    let mut seen = std::collections::HashSet::<(String, String, String)>::new();
+    let mut merged = Vec::with_capacity(touches.len().min(limit));
+    for touch in touches {
+        let key = (
+            touch.session_id.clone(),
+            touch.tool_call_id.clone(),
+            touch.event_uid.clone(),
+        );
+        if seen.insert(key) {
+            merged.push(touch);
+        }
+    }
+
+    merged.sort_by(compare_file_attention_touches);
+    merged.truncate(limit);
+    merged
+}
+
+fn compare_file_attention_touches(
+    a: &FileAttentionTouch,
+    b: &FileAttentionTouch,
+) -> std::cmp::Ordering {
+    match (a.event_unix_ms, b.event_unix_ms) {
+        (Some(a_ms), Some(b_ms)) => b_ms.cmp(&a_ms),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    }
+    .then_with(|| b.event_order.cmp(&a.event_order))
+    .then_with(|| b.event_uid.cmp(&a.event_uid))
 }

--- a/crates/moraine-conversations/src/clickhouse_repo/tests.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/tests.rs
@@ -1,3 +1,4 @@
+use super::file_attention::merge_file_attention_touches;
 use super::*;
 
 fn sample_search_doc() -> SearchDocExtraCacheEntry {
@@ -83,6 +84,32 @@ fn sample_mcp_search_row(event_uid: &str, raw_score: f64, event_unix_ms: i64) ->
     }
 }
 
+fn sample_file_attention_touch(
+    session_id: &str,
+    tool_call_id: &str,
+    event_uid: &str,
+    event_unix_ms: Option<i64>,
+    event_order: u64,
+) -> FileAttentionTouch {
+    FileAttentionTouch {
+        session_id: session_id.to_string(),
+        event_uid: event_uid.to_string(),
+        tool_call_id: tool_call_id.to_string(),
+        harness: "codex".to_string(),
+        tool_name: "Edit".to_string(),
+        tool_phase: "request".to_string(),
+        match_kind: "path_suffix".to_string(),
+        matched_path: "/repo/src/lib.rs".to_string(),
+        worktree_root: "/repo".to_string(),
+        cwd: "/repo".to_string(),
+        event_unix_ms,
+        event_order,
+        turn_seq: Some(1),
+        input_preview: String::new(),
+        output_preview: String::new(),
+    }
+}
+
 #[test]
 fn tokenize_query_enforces_limits_and_counts() {
     let terms = tokenize_query("Hello hello world tool_use", 3);
@@ -137,6 +164,36 @@ fn sort_mcp_search_rows_uses_timestamp_before_event_uid_tiebreaker() {
         .map(|row| row.event_uid.as_str())
         .collect::<Vec<_>>();
     assert_eq!(ids, vec!["evt-c", "evt-b", "evt-d", "evt-a"]);
+}
+
+#[test]
+fn file_attention_merge_dedupes_by_tool_row_identity_and_sorts_once() {
+    let exact = sample_file_attention_touch("s1", "call-1", "event-a", Some(100), 1);
+    let duplicate_fallback = sample_file_attention_touch("s1", "call-1", "event-a", Some(100), 1);
+    let newer_fallback = sample_file_attention_touch("s2", "call-2", "event-b", Some(200), 1);
+    let untimed = sample_file_attention_touch("s3", "call-3", "event-c", None, 0);
+
+    let merged =
+        merge_file_attention_touches(vec![exact, duplicate_fallback, untimed, newer_fallback], 10);
+    let ids = merged
+        .iter()
+        .map(|touch| touch.event_uid.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(ids, vec!["event-b", "event-a", "event-c"]);
+}
+
+#[test]
+fn file_attention_merge_preserves_exact_row_when_fallback_duplicates_it() {
+    let mut exact = sample_file_attention_touch("s1", "call-1", "event-a", Some(100), 1);
+    exact.matched_path = "/normalized/src/lib.rs".to_string();
+    let mut fallback = sample_file_attention_touch("s1", "call-1", "event-a", Some(100), 1);
+    fallback.matched_path = "/fallback/src/lib.rs".to_string();
+
+    let merged = merge_file_attention_touches(vec![exact, fallback], 10);
+
+    assert_eq!(merged.len(), 1);
+    assert_eq!(merged[0].matched_path, "/normalized/src/lib.rs");
 }
 
 #[test]

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -70,6 +70,11 @@ pub struct FileAttentionQuery {
     /// Repo-relative tail to suffix-match against captured file paths. The tail
     /// is what unifies the same logical file across worktree roots.
     pub rel: String,
+    /// Best-effort project identity for exact Phase-1 normalized lookup. This
+    /// is a repo `.moraine.toml` backend name when the request path can be
+    /// resolved to one. `None` disables the exact branch and leaves Tier 0
+    /// suffix matching as the only source of results.
+    pub normalized_project_id: Option<String>,
     /// Whether a structured matched path should be stripped by `rel` to report
     /// a worktree root. Disabled for arbitrary suffixes that could otherwise
     /// mislabel a source/package directory as a repository root.
@@ -99,6 +104,8 @@ pub struct FileAttentionQuery {
 pub struct FileAttentionTouch {
     pub session_id: String,
     pub event_uid: String,
+    #[serde(default)]
+    pub tool_call_id: String,
     #[serde(default)]
     pub harness: String,
     #[serde(default)]

--- a/crates/moraine-conversations/tests/repository_integration.rs
+++ b/crates/moraine-conversations/tests/repository_integration.rs
@@ -14,10 +14,10 @@ use moraine_clickhouse::ClickHouseClient;
 use moraine_config::ClickHouseConfig;
 use moraine_conversations::{
     ClickHouseConversationRepository, ConversationListFilter, ConversationListSort,
-    ConversationMode, ConversationRepository, ConversationSearchQuery, McpEventType,
-    McpSessionListFilter, PageRequest, RepoConfig, RepoError, SearchEventKind, SearchEventsQuery,
-    SearchMcpEventsQuery, SessionEventsDirection, SessionEventsQuery, SessionMetadataSearchQuery,
-    SessionOriginScope,
+    ConversationMode, ConversationRepository, ConversationSearchQuery, FileAttentionQuery,
+    McpEventType, McpSessionListFilter, PageRequest, RepoConfig, RepoError, SearchEventKind,
+    SearchEventsQuery, SearchMcpEventsQuery, SessionEventsDirection, SessionEventsQuery,
+    SessionMetadataSearchQuery, SessionOriginScope,
 };
 use serde_json::json;
 
@@ -170,6 +170,79 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
             return (
                 StatusCode::OK,
                 json_each_row(json!([{ "session_id": "sess-out-of-scope" }])),
+            );
+        }
+
+        if query.contains("FROM `moraine`.`tool_io` FINAL")
+            && query.contains("repo_rel_path = 'crates/foo.rs'")
+            && query.contains("project_id = 'project-a'")
+        {
+            return (
+                StatusCode::OK,
+                json_each_row(json!([
+                    {
+                        "session_id": "sess-normalized",
+                        "event_uid": "evt-normalized",
+                        "tool_call_id": "call-normalized",
+                        "harness": "codex",
+                        "tool_name": "edit",
+                        "tool_phase": "request",
+                        "matched_path": "/worktree-a/crates/foo.rs",
+                        "match_kind": "path_suffix",
+                        "worktree_root": "/worktree-a",
+                        "cwd": "/worktree-a",
+                        "event_unix_ms": 1769940100000_i64,
+                        "event_order": 20_u64,
+                        "turn_seq": 2_u32,
+                        "input_preview": "{\"not_the_path\":\"hidden\"}",
+                        "output_preview": ""
+                    }
+                ])),
+            );
+        }
+
+        if query.contains("FROM `moraine`.`tool_io` FINAL")
+            && query.contains("JSONExtractString(input_json, 'path')")
+            && query.contains("crates/foo.rs")
+        {
+            return (
+                StatusCode::OK,
+                json_each_row(json!([
+                    {
+                        "session_id": "sess-normalized",
+                        "event_uid": "evt-normalized",
+                        "tool_call_id": "call-normalized",
+                        "harness": "codex",
+                        "tool_name": "edit",
+                        "tool_phase": "request",
+                        "matched_path": "/legacy-would-have-won/crates/foo.rs",
+                        "match_kind": "path_suffix",
+                        "worktree_root": "/legacy-would-have-won",
+                        "cwd": "/legacy-would-have-won",
+                        "event_unix_ms": 1769940100000_i64,
+                        "event_order": 20_u64,
+                        "turn_seq": 2_u32,
+                        "input_preview": "{\"path\":\"/legacy-would-have-won/crates/foo.rs\"}",
+                        "output_preview": ""
+                    },
+                    {
+                        "session_id": "sess-legacy",
+                        "event_uid": "evt-legacy",
+                        "tool_call_id": "call-legacy",
+                        "harness": "codex",
+                        "tool_name": "bash",
+                        "tool_phase": "request",
+                        "matched_path": "",
+                        "match_kind": "shell_path",
+                        "worktree_root": "",
+                        "cwd": "/legacy",
+                        "event_unix_ms": 1769940000000_i64,
+                        "event_order": 10_u64,
+                        "turn_seq": 1_u32,
+                        "input_preview": "{\"command\":\"rg crates/foo.rs\"}",
+                        "output_preview": ""
+                    }
+                ])),
             );
         }
 
@@ -1704,6 +1777,57 @@ fn sql_self_aliases_aggregate(sql: &str, column: &str) -> bool {
         let tail_word = matches!(tail, Some(ch) if ch.is_ascii_alphanumeric() || ch == '_');
         !head_word && !tail_word
     })
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn file_attention_merges_normalized_exact_lookup_with_suffix_fallback() {
+    let (repo, state) = build_repo().await;
+
+    let touches = repo
+        .file_attention(FileAttentionQuery {
+            query_id: "test-file-attention-normalized".to_string(),
+            rel: "crates/foo.rs".to_string(),
+            normalized_project_id: Some("project-a".to_string()),
+            derive_worktree_roots: true,
+            apply_project_scope: true,
+            start_unix_ms: None,
+            end_unix_ms: None,
+            tool: None,
+            mutations_only: false,
+            max_rows: 10,
+            max_execution_time_secs: 3,
+        })
+        .await
+        .expect("file_attention query succeeds");
+
+    assert_eq!(touches.len(), 2);
+    assert_eq!(touches[0].session_id, "sess-normalized");
+    assert_eq!(touches[0].event_uid, "evt-normalized");
+    assert_eq!(touches[0].tool_call_id, "call-normalized");
+    assert_eq!(touches[0].matched_path, "/worktree-a/crates/foo.rs");
+    assert_eq!(touches[0].worktree_root, "/worktree-a");
+    assert_eq!(touches[0].match_kind, "path_suffix");
+    assert_eq!(touches[1].session_id, "sess-legacy");
+    assert_eq!(touches[1].event_uid, "evt-legacy");
+    assert_eq!(touches[1].match_kind, "shell_path");
+
+    let queries = state.queries.lock().expect("queries lock").clone();
+    let exact_query = queries
+        .iter()
+        .find(|query| query.contains("repo_rel_path = 'crates/foo.rs'"))
+        .expect("normalized exact file_attention query should be captured");
+    assert!(exact_query.contains("project_id = 'project-a'"));
+    assert!(exact_query.contains("tool_phase = 'request'"));
+    assert!(
+        !exact_query.contains("JSONExtractString(input_json"),
+        "exact lookup should not depend on legacy JSON suffix extraction: {exact_query}"
+    );
+
+    let fallback_query = queries
+        .iter()
+        .find(|query| query.contains("JSONExtractString(input_json, 'path')"))
+        .expect("Tier-0 suffix file_attention query should be captured");
+    assert!(fallback_query.contains("crates/foo.rs"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/moraine-ingest-core/src/sources/shared.rs
+++ b/crates/moraine-ingest-core/src/sources/shared.rs
@@ -2,12 +2,31 @@ use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
 use regex::Regex;
 use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(crate) const TEXT_LIMIT: usize = 200_000;
 pub(crate) const PREVIEW_LIMIT: usize = 320;
 pub(crate) const UNPARSEABLE_EVENT_TS: &str = "1970-01-01 00:00:00.000";
+const FILE_ATTENTION_PATH_KEYS: [&str; 9] = [
+    "file_path",
+    "notebook_path",
+    "path",
+    "target_file",
+    "relativeWorkspacePath",
+    "relative_workspace_path",
+    "filepath",
+    "file",
+    "filename",
+];
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct FileAttentionFields {
+    project_id: String,
+    repo_rel_path: String,
+    worktree_root: String,
+}
 
 fn session_id_re() -> &'static Regex {
     static SESSION_ID_RE: OnceLock<Regex> = OnceLock::new();
@@ -854,6 +873,193 @@ fn io_hash(input_json: &str, output_json: &str) -> u64 {
     raw_hash(&format!("{}\n{}", input_json, output_json))
 }
 
+fn event_file_attention_fields(cwd: &str) -> FileAttentionFields {
+    let cwd = normalize_path_text(cwd.trim());
+    if cwd.is_empty() || !cwd.starts_with('/') {
+        return FileAttentionFields::default();
+    }
+
+    let Some(root) = find_file_attention_root(Path::new(&cwd)) else {
+        return FileAttentionFields::default();
+    };
+    let Some(project_id) = project_id_for_root(&root) else {
+        return FileAttentionFields::default();
+    };
+
+    FileAttentionFields {
+        project_id,
+        repo_rel_path: String::new(),
+        worktree_root: root,
+    }
+}
+
+fn tool_file_attention_fields(
+    cwd: &str,
+    tool_phase: &str,
+    input_json: &str,
+) -> FileAttentionFields {
+    if tool_phase != "request" {
+        return FileAttentionFields::default();
+    }
+
+    let Ok(input) = serde_json::from_str::<Value>(input_json) else {
+        return FileAttentionFields::default();
+    };
+
+    let mut candidates = Vec::<String>::new();
+    collect_structured_path_candidates(&input, &mut candidates);
+    for candidate in candidates {
+        if let Some(fields) = resolve_tool_path_fields(cwd, &candidate) {
+            return fields;
+        }
+    }
+
+    FileAttentionFields::default()
+}
+
+fn resolve_tool_path_fields(cwd: &str, raw_path: &str) -> Option<FileAttentionFields> {
+    let raw_path = raw_path.trim();
+    if raw_path.is_empty() || raw_path.contains('\0') {
+        return None;
+    }
+
+    let normalized = normalize_path_text(raw_path);
+    if normalized.is_empty() {
+        return None;
+    }
+
+    let absolute = if normalized.starts_with('/') {
+        normalized
+    } else {
+        let cwd = normalize_path_text(cwd.trim());
+        if cwd.is_empty() || !cwd.starts_with('/') {
+            return None;
+        }
+        normalize_path_text(&format!("{}/{}", cwd.trim_end_matches('/'), normalized))
+    };
+
+    let root = find_file_attention_root(Path::new(&absolute))?;
+    let project_id = project_id_for_root(&root)?;
+    let repo_rel_path = strip_root(&absolute, &root)?;
+    if repo_rel_path.is_empty() {
+        return None;
+    }
+
+    Some(FileAttentionFields {
+        project_id,
+        repo_rel_path,
+        worktree_root: root,
+    })
+}
+
+fn collect_structured_path_candidates(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            for (key, item) in map {
+                if FILE_ATTENTION_PATH_KEYS.contains(&key.as_str()) {
+                    collect_path_values(item, out);
+                }
+                collect_structured_path_candidates(item, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_structured_path_candidates(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_path_values(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::String(path) if !path.trim().is_empty() => out.push(path.clone()),
+        Value::Array(items) => {
+            for item in items {
+                if let Value::String(path) = item {
+                    if !path.trim().is_empty() {
+                        out.push(path.clone());
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn normalize_path_text(path: &str) -> String {
+    let absolute = path.starts_with('/');
+    let mut parts: Vec<&str> = Vec::new();
+    for part in path.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                if let Some(last) = parts.last() {
+                    if *last != ".." {
+                        parts.pop();
+                        continue;
+                    }
+                }
+                if !absolute {
+                    parts.push(part);
+                }
+            }
+            _ => parts.push(part),
+        }
+    }
+
+    let body = parts.join("/");
+    if absolute {
+        if body.is_empty() {
+            "/".to_string()
+        } else {
+            format!("/{body}")
+        }
+    } else {
+        body
+    }
+}
+
+fn find_file_attention_root(path: &Path) -> Option<String> {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let mut dir = if path.is_dir() {
+        Some(path)
+    } else {
+        path.parent()
+    };
+    let mut git_fallback = None::<String>;
+    while let Some(current) = dir {
+        if current.join(moraine_config::REPO_BACKEND_FILE).exists() {
+            return Some(current.to_string_lossy().to_string());
+        }
+        if current.join(".git").exists() && git_fallback.is_none() {
+            git_fallback = Some(current.to_string_lossy().to_string());
+        }
+        if home.as_deref() == Some(current) {
+            break;
+        }
+        dir = current.parent();
+    }
+    git_fallback
+}
+
+fn project_id_for_root(root: &str) -> Option<String> {
+    let root = Path::new(root);
+    if root.join(moraine_config::REPO_BACKEND_FILE).is_file() {
+        return moraine_config::find_repo_backend_ref(root);
+    }
+    None
+}
+
+fn strip_root(path: &str, root: &str) -> Option<String> {
+    let root = root.trim_end_matches('/');
+    if root.is_empty() {
+        return None;
+    }
+    path.strip_prefix(&format!("{root}/"))
+        .map(|tail| tail.to_string())
+}
+
 pub(crate) struct RecordContext<'a> {
     pub(crate) source_name: &'a str,
     pub(crate) harness: &'a str,
@@ -882,6 +1088,7 @@ pub(crate) fn base_event_obj(
     let text_content = truncate_chars(text_content, TEXT_LIMIT);
     let event_kind = canonicalize_event_kind(event_kind);
     let payload_type = canonicalize_payload_type(payload_type);
+    let file_attention = event_file_attention_fields(ctx.cwd);
     let mut obj = Map::<String, Value>::new();
     obj.insert(
         "event_uid".to_string(),
@@ -1002,6 +1209,18 @@ pub(crate) fn base_event_obj(
         "token_usage_native_units".to_string(),
         token_native_units(&[]),
     );
+    obj.insert(
+        "project_id".to_string(),
+        Value::String(file_attention.project_id),
+    );
+    obj.insert(
+        "repo_rel_path".to_string(),
+        Value::String(file_attention.repo_rel_path),
+    );
+    obj.insert(
+        "worktree_root".to_string(),
+        Value::String(file_attention.worktree_root),
+    );
     obj.insert("event_version".to_string(), json!(event_version()));
     obj
 }
@@ -1075,6 +1294,7 @@ pub(crate) fn build_tool_row(
     output_json: &str,
     output_text: &str,
 ) -> Value {
+    let file_attention = tool_file_attention_fields(ctx.cwd, tool_phase, input_json);
     let input_json = truncate_chars(input_json, TEXT_LIMIT);
     let output_json = truncate_chars(output_json, TEXT_LIMIT);
     let output_text = truncate_chars(output_text, TEXT_LIMIT);
@@ -1098,6 +1318,9 @@ pub(crate) fn build_tool_row(
         "input_preview": truncate_chars(&input_json, PREVIEW_LIMIT),
         "output_preview": truncate_chars(&output_text, PREVIEW_LIMIT),
         "io_hash": io_hash(&input_json, &output_json),
+        "project_id": file_attention.project_id,
+        "repo_rel_path": file_attention.repo_rel_path,
+        "worktree_root": file_attention.worktree_root,
         "source_ref": format!("{}:{}:{}", ctx.source_file, ctx.source_generation, ctx.source_line_no),
         "event_version": event_version(),
     })
@@ -1126,15 +1349,14 @@ mod tests {
             .unwrap_or_default()
     }
 
-    #[test]
-    fn link_type_is_canonicalized_to_domain() {
-        let ctx = RecordContext {
+    fn test_record_context<'a>(cwd: &'a str) -> RecordContext<'a> {
+        RecordContext {
             source_name: "codex",
             harness: "codex",
             inference_provider: "openai",
             session_id: "s1",
             session_date: "2026-02-15",
-            cwd: "/repo",
+            cwd,
             source_file: "/tmp/s1.jsonl",
             source_inode: 1,
             source_generation: 1,
@@ -1142,7 +1364,30 @@ mod tests {
             source_offset: 1,
             record_ts: "2026-02-15T03:50:50.838Z",
             event_ts: "2026-02-15 03:50:50.838",
-        };
+        }
+    }
+
+    fn make_repo(name: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "moraine-file-attention-{name}-{}-{stamp}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(root.join("src")).expect("create repo dirs");
+        std::fs::write(
+            root.join(moraine_config::REPO_BACKEND_FILE),
+            "backend = \"team\"\n",
+        )
+        .expect("write repo backend marker");
+        root
+    }
+
+    #[test]
+    fn link_type_is_canonicalized_to_domain() {
+        let ctx = test_record_context("/repo");
 
         let link = build_link_row(&ctx, "e1", "e2", "", "new_link_type", "{}");
         let link_obj = link.as_object().unwrap();
@@ -1150,6 +1395,192 @@ mod tests {
             link_obj.get("link_type").unwrap().as_str().unwrap(),
             "unknown"
         );
+    }
+
+    #[test]
+    fn event_rows_capture_project_and_worktree_from_cwd() {
+        let root = make_repo("event-cwd");
+        let cwd = root.join("src");
+        let cwd_text = cwd.to_string_lossy().to_string();
+        let ctx = test_record_context(&cwd_text);
+
+        let row = Value::Object(base_event_obj(
+            &ctx,
+            "e1",
+            "message",
+            "message",
+            "assistant",
+            "hello",
+            "{}",
+        ));
+
+        assert_eq!(row["project_id"], "team");
+        assert_eq!(row["worktree_root"], root.to_string_lossy().as_ref());
+        assert_eq!(row["repo_rel_path"], "");
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn event_rows_ignore_git_only_root_without_project_id() {
+        let root = std::env::temp_dir().join(format!(
+            "moraine-file-attention-git-only-{}",
+            std::process::id()
+        ));
+        let cwd = root.join("src");
+        std::fs::create_dir_all(root.join(".git")).expect("create git marker");
+        std::fs::create_dir_all(&cwd).expect("create cwd");
+        let cwd_text = cwd.to_string_lossy().to_string();
+        let ctx = test_record_context(&cwd_text);
+
+        let row = Value::Object(base_event_obj(
+            &ctx,
+            "e1",
+            "message",
+            "message",
+            "assistant",
+            "hello",
+            "{}",
+        ));
+
+        assert_eq!(row["project_id"], "");
+        assert_eq!(row["worktree_root"], "");
+        assert_eq!(row["repo_rel_path"], "");
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn tool_rows_capture_absolute_and_relative_structured_paths() {
+        let root = make_repo("tool-paths");
+        let cwd_text = root.to_string_lossy().to_string();
+        let ctx = test_record_context(&cwd_text);
+        let absolute = root.join("src/lib.rs").to_string_lossy().to_string();
+
+        let absolute_row = build_tool_row(
+            &ctx,
+            "e1",
+            "call-1",
+            "",
+            "Edit",
+            "request",
+            0,
+            &json!({"file_path": absolute}).to_string(),
+            "",
+            "",
+        );
+        assert_eq!(absolute_row["project_id"], "team");
+        assert_eq!(
+            absolute_row["worktree_root"],
+            root.to_string_lossy().as_ref()
+        );
+        assert_eq!(absolute_row["repo_rel_path"], "src/lib.rs");
+
+        let relative_row = build_tool_row(
+            &ctx,
+            "e2",
+            "call-2",
+            "",
+            "Read",
+            "request",
+            0,
+            r#"{"path":"./src/../src/lib.rs"}"#,
+            "",
+            "",
+        );
+        assert_eq!(relative_row["project_id"], "team");
+        assert_eq!(
+            relative_row["worktree_root"],
+            root.to_string_lossy().as_ref()
+        );
+        assert_eq!(relative_row["repo_rel_path"], "src/lib.rs");
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn tool_rows_support_phase_zero_structured_path_keys() {
+        let root = make_repo("path-keys");
+        let cwd_text = root.to_string_lossy().to_string();
+        let ctx = test_record_context(&cwd_text);
+
+        for key in FILE_ATTENTION_PATH_KEYS {
+            let input = json!({ key: "src/lib.rs" }).to_string();
+            let row = build_tool_row(
+                &ctx, "e1", "call-1", "", "Edit", "request", 0, &input, "", "",
+            );
+            assert_eq!(row["project_id"], "team", "key {key}");
+            assert_eq!(row["repo_rel_path"], "src/lib.rs", "key {key}");
+        }
+
+        let nested = build_tool_row(
+            &ctx,
+            "e2",
+            "call-2",
+            "",
+            "MultiEdit",
+            "request",
+            0,
+            r#"{"edits":[{"target_file":["src/lib.rs"]}]}"#,
+            "",
+            "",
+        );
+        assert_eq!(nested["project_id"], "team");
+        assert_eq!(nested["repo_rel_path"], "src/lib.rs");
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn tool_rows_leave_shell_and_unproven_paths_unnormalized() {
+        let root = make_repo("negative-paths");
+        let cwd_text = root.to_string_lossy().to_string();
+        let ctx = test_record_context(&cwd_text);
+
+        let shell = build_tool_row(
+            &ctx,
+            "e1",
+            "call-1",
+            "",
+            "Bash",
+            "request",
+            0,
+            r#"{"command":"cat src/lib.rs"}"#,
+            "",
+            "",
+        );
+        assert_eq!(shell["project_id"], "");
+        assert_eq!(shell["repo_rel_path"], "");
+        assert_eq!(shell["worktree_root"], "");
+
+        let outside = build_tool_row(
+            &ctx,
+            "e2",
+            "call-2",
+            "",
+            "Read",
+            "request",
+            0,
+            r#"{"file_path":"/tmp/outside.rs"}"#,
+            "",
+            "",
+        );
+        assert_eq!(outside["project_id"], "");
+        assert_eq!(outside["repo_rel_path"], "");
+        assert_eq!(outside["worktree_root"], "");
+
+        let response = build_tool_row(
+            &ctx,
+            "e3",
+            "call-3",
+            "",
+            "Read",
+            "response",
+            0,
+            r#"{"file_path":"src/lib.rs"}"#,
+            "",
+            "",
+        );
+        assert_eq!(response["project_id"], "");
+        assert_eq!(response["repo_rel_path"], "");
+        assert_eq!(response["worktree_root"], "");
+        std::fs::remove_dir_all(root).ok();
     }
 
     #[test]

--- a/crates/moraine-ingest-core/tests/golden_fixtures.rs
+++ b/crates/moraine-ingest-core/tests/golden_fixtures.rs
@@ -67,6 +67,9 @@ const EVENT_REQUIRED_STRING_FIELDS: &[&str] = &[
     "text_preview",
     "payload_json",
     "token_usage_json",
+    "project_id",
+    "repo_rel_path",
+    "worktree_root",
 ];
 
 const EVENT_REQUIRED_U64_FIELDS: &[&str] = &[
@@ -791,6 +794,9 @@ fn assert_tool_row_shape(row: &Value, context: &str, event_uids: &HashSet<String
         "output_text",
         "input_preview",
         "output_preview",
+        "project_id",
+        "repo_rel_path",
+        "worktree_root",
         "source_ref",
     ] {
         assert_string(row, field, context);

--- a/crates/moraine-ingest-core/tests/goldens/source_normalization/claude_code.json
+++ b/crates/moraine-ingest-core/tests/goldens/source_normalization/claude_code.json
@@ -37,7 +37,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"cwd\":\"/work/claude-demo\",\"message\":{\"content\":\"Please inspect the sample project.\",\"role\":\"user\"},\"sessionId\":\"7c666c01-d38e-4658-8650-854ffb5b626e\",\"timestamp\":\"2026-01-19T15:58:40.000Z\",\"type\":\"user\",\"uuid\":\"user-1\"}",
           "payload_type": "message",
+          "project_id": "",
           "record_ts": "2026-01-19T15:58:40.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -81,7 +83,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -145,7 +148,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"thinking\":\"I should inspect files first.\",\"type\":\"thinking\"}",
           "payload_type": "reasoning",
+          "project_id": "",
           "record_ts": "2026-01-19T15:58:41.421Z",
+          "repo_rel_path": "",
           "request_id": "req-1",
           "retry_count": 0,
           "service_tier": "standard",
@@ -189,7 +194,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "req-1",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "assistant",
@@ -224,7 +230,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"id\":\"toolu_1\",\"input\":{\"path\":\"Cargo.toml\"},\"name\":\"Read\",\"type\":\"tool_use\"}",
           "payload_type": "tool_use",
+          "project_id": "",
           "record_ts": "2026-01-19T15:58:41.421Z",
+          "repo_rel_path": "",
           "request_id": "req-1",
           "retry_count": 0,
           "service_tier": "standard",
@@ -268,7 +276,8 @@
           "tool_name": "Read",
           "tool_phase": "",
           "trace_id": "req-1",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "assistant",
@@ -303,7 +312,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"text\":\"I will read the manifest.\",\"type\":\"text\"}",
           "payload_type": "text",
+          "project_id": "",
           "record_ts": "2026-01-19T15:58:41.421Z",
+          "repo_rel_path": "",
           "request_id": "req-1",
           "retry_count": 0,
           "service_tier": "standard",
@@ -347,7 +358,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "req-1",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -424,13 +436,16 @@
           "output_preview": "",
           "output_text": "",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "7c666c01-d38e-4658-8650-854ffb5b626e",
           "source_name": "golden-claude-code",
           "source_ref": "/fixtures/claude-code/session.jsonl:1:2",
           "tool_call_id": "toolu_1",
           "tool_error": 0,
           "tool_name": "Read",
-          "tool_phase": "request"
+          "tool_phase": "request",
+          "worktree_root": ""
         }
       ]
     },
@@ -471,7 +486,9 @@
           "parent_tool_call_id": "toolu_1",
           "payload_json": "{\"content\":[{\"text\":\"workspace = true\",\"type\":\"text\"}],\"is_error\":false,\"tool_use_id\":\"toolu_1\",\"type\":\"tool_result\"}",
           "payload_type": "tool_result",
+          "project_id": "",
           "record_ts": "2026-01-19T15:58:42.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -515,7 +532,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -592,13 +610,16 @@
           "output_preview": "workspace = true",
           "output_text": "workspace = true",
           "parent_tool_call_id": "toolu_1",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "7c666c01-d38e-4658-8650-854ffb5b626e",
           "source_name": "golden-claude-code",
           "source_ref": "/fixtures/claude-code/session.jsonl:1:3",
           "tool_call_id": "toolu_1",
           "tool_error": 0,
           "tool_name": "",
-          "tool_phase": "response"
+          "tool_phase": "response",
+          "worktree_root": ""
         }
       ]
     },
@@ -637,7 +658,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"cwd\":\"/work/claude-demo\",\"data\":{\"query\":\"moraine\",\"type\":\"search_results_received\"},\"durationMs\":12,\"parentUuid\":\"user-2\",\"retryAttempt\":1,\"sessionId\":\"7c666c01-d38e-4658-8650-854ffb5b626e\",\"status\":\"ok\",\"timestamp\":\"2026-01-19T15:58:43.000Z\",\"type\":\"progress\",\"uuid\":\"progress-1\"}",
           "payload_type": "search_results_received",
+          "project_id": "",
           "record_ts": "2026-01-19T15:58:43.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 1,
           "service_tier": "",
@@ -681,7 +704,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [

--- a/crates/moraine-ingest-core/tests/goldens/source_normalization/codex.json
+++ b/crates/moraine-ingest-core/tests/goldens/source_normalization/codex.json
@@ -37,7 +37,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"cli_version\":\"0.5.3\",\"cwd\":\"/repo\",\"id\":\"019c5f6a-49bd-7920-ac67-1dd8e33b0e95\"}",
           "payload_type": "session_meta",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:40.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -81,7 +83,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -143,7 +146,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"model\":\"gpt-5.3-codex\",\"turn_id\":\"019c5f6a-49bd-7920-ac67-1dd8e33b0e95\"}",
           "payload_type": "turn_context",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:42.191Z",
+          "repo_rel_path": "",
           "request_id": "019c5f6a-49bd-7920-ac67-1dd8e33b0e95",
           "retry_count": 0,
           "service_tier": "",
@@ -187,7 +192,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -251,7 +257,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"content\":[{\"text\":\"I will inspect the project.\",\"type\":\"output_text\"}],\"id\":\"msg_1\",\"phase\":\"completed\",\"role\":\"assistant\",\"type\":\"message\"}",
           "payload_type": "message",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:43.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -295,7 +303,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -370,7 +379,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"arguments\":\"{\\\"path\\\":\\\"Cargo.toml\\\"}\",\"call_id\":\"call_read\",\"name\":\"Read\",\"type\":\"function_call\"}",
           "payload_type": "function_call",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:44.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -414,7 +425,8 @@
           "tool_name": "Read",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -454,13 +466,16 @@
           "output_preview": "",
           "output_text": "",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "019c5f6a-49bd-7920-ac67-1dd8e33b0e95",
           "source_name": "golden-codex",
           "source_ref": "/fixtures/codex/session.jsonl:1:4",
           "tool_call_id": "call_read",
           "tool_error": 0,
           "tool_name": "Read",
-          "tool_phase": "request"
+          "tool_phase": "request",
+          "worktree_root": ""
         }
       ]
     },
@@ -499,7 +514,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"call_id\":\"call_read\",\"output\":\"workspace = true\",\"type\":\"function_call_output\"}",
           "payload_type": "function_call_output",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:45.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -543,7 +560,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -583,13 +601,16 @@
           "output_preview": "workspace = true",
           "output_text": "workspace = true",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "019c5f6a-49bd-7920-ac67-1dd8e33b0e95",
           "source_name": "golden-codex",
           "source_ref": "/fixtures/codex/session.jsonl:1:5",
           "tool_call_id": "call_read",
           "tool_error": 0,
           "tool_name": "",
-          "tool_phase": "response"
+          "tool_phase": "response",
+          "worktree_root": ""
         }
       ]
     },
@@ -628,7 +649,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"call_id\":\"call_patch\",\"input\":\"*** Begin Patch\\n*** End Patch\\n\",\"name\":\"apply_patch\",\"status\":\"completed\",\"type\":\"custom_tool_call\"}",
           "payload_type": "custom_tool_call",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:46.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -672,7 +695,8 @@
           "tool_name": "apply_patch",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -712,13 +736,16 @@
           "output_preview": "",
           "output_text": "",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "019c5f6a-49bd-7920-ac67-1dd8e33b0e95",
           "source_name": "golden-codex",
           "source_ref": "/fixtures/codex/session.jsonl:1:6",
           "tool_call_id": "call_patch",
           "tool_error": 0,
           "tool_name": "apply_patch",
-          "tool_phase": "request"
+          "tool_phase": "request",
+          "worktree_root": ""
         }
       ]
     },
@@ -757,7 +784,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"call_id\":\"call_patch\",\"output\":\"{\\\"ok\\\":true}\",\"status\":\"completed\",\"type\":\"custom_tool_call_output\"}",
           "payload_type": "custom_tool_call_output",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:47.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -801,7 +830,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -841,13 +871,16 @@
           "output_preview": "{\"ok\":true}",
           "output_text": "{\"ok\":true}",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "019c5f6a-49bd-7920-ac67-1dd8e33b0e95",
           "source_name": "golden-codex",
           "source_ref": "/fixtures/codex/session.jsonl:1:7",
           "tool_call_id": "call_patch",
           "tool_error": 0,
           "tool_name": "",
-          "tool_phase": "response"
+          "tool_phase": "response",
+          "worktree_root": ""
         }
       ]
     },
@@ -886,7 +919,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"action\":{\"query\":\"moraine ingest\",\"type\":\"search\"},\"status\":\"completed\",\"type\":\"web_search_call\"}",
           "payload_type": "web_search_call",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:48.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -930,7 +965,8 @@
           "tool_name": "web_search",
           "tool_phase": "completed",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -994,7 +1030,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"id\":\"rs_1\",\"summary\":[{\"text\":\"Need to preserve token accounting and tool rows.\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"}",
           "payload_type": "reasoning",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:49.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1038,7 +1076,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -1100,7 +1139,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"info\":{\"last_token_usage\":{\"cached_input_tokens\":58624,\"input_tokens\":65323,\"input_tokens_details\":{\"audio_tokens\":3,\"image_tokens\":20},\"output_tokens\":445,\"output_tokens_details\":{\"reasoning_tokens\":100}}},\"rate_limits\":{\"limit_id\":\"codex_bengalfox\",\"limit_name\":\"GPT-5.3-Codex-Spark\",\"plan_type\":\"pro\"},\"turn_id\":\"019c5f6a-49bd-7920-ac67-1dd8e33b0e95\",\"type\":\"token_count\"}",
           "payload_type": "token_count",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:50.838Z",
+          "repo_rel_path": "",
           "request_id": "019c5f6a-49bd-7920-ac67-1dd8e33b0e95",
           "retry_count": 0,
           "service_tier": "pro",
@@ -1144,7 +1185,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -1206,7 +1248,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"replacement_history\":[{\"content\":\"Please summarize this session.\",\"role\":\"user\",\"type\":\"message\"},{\"summary\":[{\"text\":\"Compacted reasoning survives.\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"},{\"arguments\":\"{\\\"path\\\":\\\"src\\\"}\",\"call_id\":\"call_compact\",\"name\":\"List\",\"type\":\"function_call\"},{\"call_id\":\"call_compact\",\"output\":\"normalize.rs\",\"type\":\"function_call_output\"}]}",
           "payload_type": "compacted",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:51.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1250,7 +1294,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "user",
@@ -1283,7 +1328,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"content\":\"Please summarize this session.\",\"role\":\"user\",\"type\":\"message\"}",
           "payload_type": "message",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:51.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1327,7 +1374,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "assistant",
@@ -1362,7 +1410,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"summary\":[{\"text\":\"Compacted reasoning survives.\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"}",
           "payload_type": "reasoning",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:51.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1406,7 +1456,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "assistant",
@@ -1439,7 +1490,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"arguments\":\"{\\\"path\\\":\\\"src\\\"}\",\"call_id\":\"call_compact\",\"name\":\"List\",\"type\":\"function_call\"}",
           "payload_type": "function_call",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:51.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1483,7 +1536,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "tool",
@@ -1516,7 +1570,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"call_id\":\"call_compact\",\"output\":\"normalize.rs\",\"type\":\"function_call_output\"}",
           "payload_type": "function_call_output",
+          "project_id": "",
           "record_ts": "2026-02-15T03:50:51.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1560,7 +1616,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [

--- a/crates/moraine-ingest-core/tests/goldens/source_normalization/cursor.json
+++ b/crates/moraine-ingest-core/tests/goldens/source_normalization/cursor.json
@@ -39,7 +39,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"text\":\"local fixture cursor user prompt cursor_fixture_keyword\",\"type\":\"text\"}",
           "payload_type": "user_message",
+          "project_id": "",
           "record_ts": "2026-02-16T12:00:10.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -83,7 +85,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -147,7 +150,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"text\":\"I will inspect the target file.\",\"type\":\"text\"}",
           "payload_type": "agent_message",
+          "project_id": "",
           "record_ts": "2026-02-16T12:00:11.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -191,7 +196,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "assistant",
@@ -226,7 +232,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"id\":\"cursor-tool-fixture\",\"input\":{\"path\":\"/workspace/src/main.rs\",\"range\":\"1:1-20:1\",\"symbol\":\"main\"},\"name\":\"Read\",\"type\":\"tool_use\"}",
           "payload_type": "tool_use",
+          "project_id": "",
           "record_ts": "2026-02-16T12:00:11.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -270,7 +278,8 @@
           "tool_name": "Read",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -323,13 +332,16 @@
           "output_preview": "",
           "output_text": "",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "11111111-2222-4333-8444-555555555555",
           "source_name": "golden-cursor",
           "source_ref": "/fixtures/cursor/projects/demo/agent-transcripts/11111111-2222-4333-8444-555555555555/11111111-2222-4333-8444-555555555555.jsonl:1:2",
           "tool_call_id": "cursor-tool-fixture",
           "tool_error": 0,
           "tool_name": "Read",
-          "tool_phase": "request"
+          "tool_phase": "request",
+          "worktree_root": ""
         }
       ]
     },
@@ -370,7 +382,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"content\":[{\"text\":\"fn main() { println!(\\\"cursor fixture\\\"); }\",\"type\":\"text\"}],\"is_error\":false,\"tool_use_id\":\"cursor-tool-fixture\",\"type\":\"tool_result\"}",
           "payload_type": "tool_result",
+          "project_id": "",
           "record_ts": "2026-02-16T12:00:12.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -414,7 +428,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -454,13 +469,16 @@
           "output_preview": "fn main() { println!(\"cursor fixture\"); }",
           "output_text": "fn main() { println!(\"cursor fixture\"); }",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "11111111-2222-4333-8444-555555555555",
           "source_name": "golden-cursor",
           "source_ref": "/fixtures/cursor/projects/demo/agent-transcripts/11111111-2222-4333-8444-555555555555/11111111-2222-4333-8444-555555555555.jsonl:1:3",
           "tool_call_id": "cursor-tool-fixture",
           "tool_error": 0,
           "tool_name": "",
-          "tool_phase": "response"
+          "tool_phase": "response",
+          "worktree_root": ""
         }
       ]
     },
@@ -501,7 +519,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"text\":\"The file contains a small main function.\",\"type\":\"reasoning\"}",
           "payload_type": "reasoning",
+          "project_id": "",
           "record_ts": "2026-02-16T12:00:13.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -545,7 +565,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "assistant",
@@ -580,7 +601,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"text\":\"local fixture cursor assistant reply cursor_fixture_keyword cursor_fixture_trace\",\"type\":\"text\"}",
           "payload_type": "agent_message",
+          "project_id": "",
           "record_ts": "2026-02-16T12:00:13.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -624,7 +647,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -686,7 +710,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"content\":[]}",
           "payload_type": "agent_message",
+          "project_id": "",
           "record_ts": "2026-02-16T12:00:14.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -730,7 +756,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],

--- a/crates/moraine-ingest-core/tests/goldens/source_normalization/cursor_sqlite.json
+++ b/crates/moraine-ingest-core/tests/goldens/source_normalization/cursor_sqlite.json
@@ -37,7 +37,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"agentBackend\":\"cursor-agent\",\"contextUsagePercent\":7.76,\"createdAt\":1778205877751,\"forceMode\":\"edit\",\"lastUpdatedAt\":1778205947428,\"messageCount\":5,\"name\":\"Demo refactor session\",\"promptTokensMax\":272000,\"promptTokensUsed\":21121,\"sessionId\":\"11111111-2222-4333-8444-555555555555\",\"status\":\"completed\",\"subtitle\":\"Edited game.js\",\"timestamp\":\"2026-05-08T02:04:37.751000Z\",\"title\":\"Demo refactor session\",\"totalLinesAdded\":37,\"totalLinesRemoved\":2,\"type\":\"cursor_composer\",\"unifiedMode\":\"agent\",\"workspaceId\":\"demo-window\",\"workspacePath\":\"/Users/demo/project\"}",
           "payload_type": "session_meta",
+          "project_id": "",
           "record_ts": "2026-05-08T02:04:37.751000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -81,7 +83,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -155,7 +158,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"text\":\"Please rename the helper and fix the loop bounds.\"}",
           "payload_type": "user_message",
+          "project_id": "",
           "record_ts": "2026-05-08T02:04:37.835Z",
+          "repo_rel_path": "",
           "request_id": "badfdd27-0a9a-497a-b959-79a5caac5fe0",
           "retry_count": 0,
           "service_tier": "",
@@ -199,7 +204,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "badfdd27-0a9a-497a-b959-79a5caac5fe0",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -263,7 +269,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"text\":\"**Planning the rename**\\n\\nThe helper is referenced in three places; I should update the call sites too.\"}",
           "payload_type": "reasoning",
+          "project_id": "",
           "record_ts": "2026-05-08T02:04:39.829Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -307,7 +315,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -371,7 +380,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"additionalData\":{\"startedAtMs\":1778205934000,\"status\":\"completed\"},\"modelCallId\":\"\",\"name\":\"edit_file_v2\",\"params\":{\"noCodeblock\":true,\"relativeWorkspacePath\":\"/Users/demo/project/game.js\"},\"rawArgs\":{},\"result\":{\"afterContentId\":\"composer.content.abcdef\"},\"status\":\"completed\",\"tool\":38,\"toolCallId\":\"call_bPJLcsryFL2Hllevss\\nctc_0cc5dfa4b63d4821\",\"toolIndex\":0,\"userDecision\":\"accepted\"}",
           "payload_type": "tool_use",
+          "project_id": "",
           "record_ts": "2026-05-08T02:05:34.020Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -415,7 +426,8 @@
           "tool_name": "edit_file_v2",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "tool",
@@ -450,7 +462,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"afterContentId\":\"composer.content.abcdef\"}",
           "payload_type": "tool_result",
+          "project_id": "",
           "record_ts": "2026-05-08T02:05:34.020Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -494,7 +508,8 @@
           "tool_name": "edit_file_v2",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -534,13 +549,16 @@
           "output_preview": "",
           "output_text": "",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "11111111-2222-4333-8444-555555555555",
           "source_name": "golden-cursor-sqlite",
           "source_ref": "/fixtures/cursor/User/globalStorage/state.vscdb:1:6628439650972450124",
           "tool_call_id": "call_bPJLcsryFL2Hllevss",
           "tool_error": 0,
           "tool_name": "edit_file_v2",
-          "tool_phase": "request"
+          "tool_phase": "request",
+          "worktree_root": ""
         },
         {
           "event_uid": "a4b803c7a9e0f29a4e71f0f607ea8620ed3ec62a41bc5cd4aaeb9effc23164a4",
@@ -556,13 +574,16 @@
           "output_preview": "{\"afterContentId\":\"composer.content.abcdef\"}",
           "output_text": "{\"afterContentId\":\"composer.content.abcdef\"}",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "11111111-2222-4333-8444-555555555555",
           "source_name": "golden-cursor-sqlite",
           "source_ref": "/fixtures/cursor/User/globalStorage/state.vscdb:1:6628439650972450124",
           "tool_call_id": "call_bPJLcsryFL2Hllevss",
           "tool_error": 0,
           "tool_name": "edit_file_v2",
-          "tool_phase": "response"
+          "tool_phase": "response",
+          "worktree_root": ""
         }
       ]
     },
@@ -603,7 +624,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"error\":{\"clientVisibleErrorMessage\":\"Command failed with exit code 1\",\"modelVisibleErrorMessage\":\"npm test exited 1\"},\"name\":\"run_terminal_command_v2\",\"params\":{\"command\":\"npm test\",\"workingDirectory\":\"/Users/demo/project\"},\"status\":\"error\",\"tool\":15,\"toolCallId\":\"call_FLtYI8rhT3xQ\\nfc_01cebed9\",\"toolIndex\":0}",
           "payload_type": "tool_use",
+          "project_id": "",
           "record_ts": "2026-05-08T02:05:41.812Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -647,7 +670,8 @@
           "tool_name": "run_terminal_command_v2",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "tool",
@@ -682,7 +706,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"clientVisibleErrorMessage\":\"Command failed with exit code 1\",\"modelVisibleErrorMessage\":\"npm test exited 1\"}",
           "payload_type": "tool_result",
+          "project_id": "",
           "record_ts": "2026-05-08T02:05:41.812Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -726,7 +752,8 @@
           "tool_name": "run_terminal_command_v2",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -766,13 +793,16 @@
           "output_preview": "",
           "output_text": "",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "11111111-2222-4333-8444-555555555555",
           "source_name": "golden-cursor-sqlite",
           "source_ref": "/fixtures/cursor/User/globalStorage/state.vscdb:1:4750020261448207567",
           "tool_call_id": "call_FLtYI8rhT3xQ",
           "tool_error": 0,
           "tool_name": "run_terminal_command_v2",
-          "tool_phase": "request"
+          "tool_phase": "request",
+          "worktree_root": ""
         },
         {
           "event_uid": "be3b3bf48edfc6d5f530d0f8e0197c1c9eccb05722ee1fbfe10a181661ddd734",
@@ -788,13 +818,16 @@
           "output_preview": "{\"clientVisibleErrorMessage\":\"Command failed with exit code 1\",\"modelVisibleErrorMessage\":\"npm test exited 1\"}",
           "output_text": "{\"clientVisibleErrorMessage\":\"Command failed with exit code 1\",\"modelVisibleErrorMessage\":\"npm test exited 1\"}",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "11111111-2222-4333-8444-555555555555",
           "source_name": "golden-cursor-sqlite",
           "source_ref": "/fixtures/cursor/User/globalStorage/state.vscdb:1:4750020261448207567",
           "tool_call_id": "call_FLtYI8rhT3xQ",
           "tool_error": 1,
           "tool_name": "run_terminal_command_v2",
-          "tool_phase": "response"
+          "tool_phase": "response",
+          "worktree_root": ""
         }
       ]
     },
@@ -835,7 +868,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"text\":\"Renamed the helper to `spawnGoblinWave` and fixed the off-by-one in the loop. The failing test is pre-existing.\"}",
           "payload_type": "agent_message",
+          "project_id": "",
           "record_ts": "2026-05-08T02:05:58.404Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -879,7 +914,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],

--- a/crates/moraine-ingest-core/tests/goldens/source_normalization/hermes_session_json.json
+++ b/crates/moraine-ingest-core/tests/goldens/source_normalization/hermes_session_json.json
@@ -37,7 +37,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"base_url\":\"https://api.anthropic.com\",\"last_updated\":\"2026-04-18T14:23:05.000000\",\"message_count\":4,\"model\":\"claude-opus-4-6\",\"platform\":\"cli\",\"session_id\":\"20260418_142200_live01\",\"session_start\":\"2026-04-18T14:22:00.000000\",\"system_prompt\":\"You are Hermes, a helpful CLI agent.\",\"tools\":[{\"function\":{\"description\":\"Run a shell command\",\"name\":\"shell\",\"parameters\":{\"properties\":{\"cmd\":{\"type\":\"string\"}},\"required\":[\"cmd\"],\"type\":\"object\"}},\"type\":\"function\"}]}",
           "payload_type": "session_meta",
+          "project_id": "",
           "record_ts": "2026-04-18T14:22:00.000000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -81,7 +83,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -143,7 +146,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"content\":\"What's today's date?\",\"role\":\"user\"}",
           "payload_type": "user_message",
+          "project_id": "",
           "record_ts": "2026-04-18T14:23:05.000000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -187,7 +192,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 1
+          "turn_index": 1,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -251,7 +257,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"reasoning\":\"I should run `date` to be accurate.\",\"role\":\"assistant\"}",
           "payload_type": "reasoning",
+          "project_id": "",
           "record_ts": "2026-04-18T14:23:05.000000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -295,7 +303,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 2
+          "turn_index": 2,
+          "worktree_root": ""
         },
         {
           "actor_kind": "assistant",
@@ -330,7 +339,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"function\":{\"arguments\":\"{\\\"cmd\\\":\\\"date\\\"}\",\"name\":\"shell\"},\"id\":\"call_date_001\",\"type\":\"function\"}",
           "payload_type": "tool_use",
+          "project_id": "",
           "record_ts": "2026-04-18T14:23:05.000001Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -374,7 +385,8 @@
           "tool_name": "shell",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 2
+          "turn_index": 2,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -414,13 +426,16 @@
           "output_preview": "",
           "output_text": "",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "hermes:20260418_142200_live01",
           "source_name": "golden-hermes-session",
           "source_ref": "/fixtures/hermes/sessions/session_20260418_142200_live01.json:1:2",
           "tool_call_id": "call_date_001",
           "tool_error": 0,
           "tool_name": "shell",
-          "tool_phase": "request"
+          "tool_phase": "request",
+          "worktree_root": ""
         }
       ]
     },
@@ -461,7 +476,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"content\":\"Sat Apr 18 14:23:03 EDT 2026\",\"name\":\"shell\",\"role\":\"tool\",\"tool_call_id\":\"call_date_001\"}",
           "payload_type": "tool_result",
+          "project_id": "",
           "record_ts": "2026-04-18T14:23:05.000000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -505,7 +522,8 @@
           "tool_name": "shell",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 3
+          "turn_index": 3,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -545,13 +563,16 @@
           "output_preview": "Sat Apr 18 14:23:03 EDT 2026",
           "output_text": "Sat Apr 18 14:23:03 EDT 2026",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "hermes:20260418_142200_live01",
           "source_name": "golden-hermes-session",
           "source_ref": "/fixtures/hermes/sessions/session_20260418_142200_live01.json:1:3",
           "tool_call_id": "call_date_001",
           "tool_error": 0,
           "tool_name": "shell",
-          "tool_phase": "response"
+          "tool_phase": "response",
+          "worktree_root": ""
         }
       ]
     },
@@ -590,7 +611,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"content\":\"Today is Saturday, April 18, 2026.\",\"role\":\"assistant\"}",
           "payload_type": "agent_message",
+          "project_id": "",
           "record_ts": "2026-04-18T14:23:05.000000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -634,7 +657,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 4
+          "turn_index": 4,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],

--- a/crates/moraine-ingest-core/tests/goldens/source_normalization/hermes_trajectory.json
+++ b/crates/moraine-ingest-core/tests/goldens/source_normalization/hermes_trajectory.json
@@ -37,7 +37,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"api_calls\":1,\"completed\":true,\"model\":\"anthropic/claude-sonnet-4.6\",\"partial\":false,\"prompt_index\":7,\"timestamp\":\"2026-03-30T14:22:31.456789\"}",
           "payload_type": "session_meta",
+          "project_id": "",
           "record_ts": "2026-03-30T14:22:31.456789Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -81,7 +83,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "system",
@@ -114,7 +117,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"from\":\"system\",\"value\":\"You are a careful coding assistant.\"}",
           "payload_type": "system",
+          "project_id": "",
           "record_ts": "2026-03-30T14:22:31.456790Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -158,7 +163,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "user",
@@ -193,7 +199,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"from\":\"human\",\"value\":\"What is the weather in Boston right now?\"}",
           "payload_type": "message",
+          "project_id": "",
           "record_ts": "2026-03-30T14:22:31.456791Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -237,7 +245,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 1
+          "turn_index": 1,
+          "worktree_root": ""
         },
         {
           "actor_kind": "assistant",
@@ -272,7 +281,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"from\":\"gpt\",\"type\":\"thinking\",\"value\":\"I should query the weather tool before answering.\"}",
           "payload_type": "reasoning",
+          "project_id": "",
           "record_ts": "2026-03-30T14:22:31.456792Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -316,7 +327,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 1
+          "turn_index": 1,
+          "worktree_root": ""
         },
         {
           "actor_kind": "assistant",
@@ -351,7 +363,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"arguments\":{\"location\":\"Boston, MA\"},\"name\":\"weather\"}",
           "payload_type": "tool_use",
+          "project_id": "",
           "record_ts": "2026-03-30T14:22:31.456793Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -395,7 +409,8 @@
           "tool_name": "weather",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 1
+          "turn_index": 1,
+          "worktree_root": ""
         },
         {
           "actor_kind": "tool",
@@ -430,7 +445,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"content\":{\"forecast\":\"rain\",\"temperature_c\":12},\"name\":\"weather\",\"tool_call_id\":\"call_abc123\"}",
           "payload_type": "tool_result",
+          "project_id": "",
           "record_ts": "2026-03-30T14:22:31.456794Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -474,7 +491,8 @@
           "tool_name": "weather",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 1
+          "turn_index": 1,
+          "worktree_root": ""
         },
         {
           "actor_kind": "assistant",
@@ -509,7 +527,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"from\":\"gpt\",\"type\":\"text\",\"value\":\"It looks rainy in Boston, around 12 degrees Celsius.\"}",
           "payload_type": "message",
+          "project_id": "",
           "record_ts": "2026-03-30T14:22:31.456795Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -553,7 +573,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 1
+          "turn_index": 1,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -593,13 +614,16 @@
           "output_preview": "",
           "output_text": "",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "hermes:0ca05e01889824d1362c36fb5987aaaf3f860e6321d0ffd07c4856db062d593f",
           "source_name": "golden-hermes-trajectory",
           "source_ref": "/fixtures/hermes/trajectories/001.jsonl:1:1",
           "tool_call_id": "call_abc123",
           "tool_error": 0,
           "tool_name": "weather",
-          "tool_phase": "request"
+          "tool_phase": "request",
+          "worktree_root": ""
         },
         {
           "event_uid": "f584a0bc63209a8f44dd4717e70884bc2e89a0fc6f125e0350bb3b69fd025dcc",
@@ -615,13 +639,16 @@
           "output_preview": "{\"forecast\":\"rain\",\"temperature_c\":12}",
           "output_text": "{\"forecast\":\"rain\",\"temperature_c\":12}",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "hermes:0ca05e01889824d1362c36fb5987aaaf3f860e6321d0ffd07c4856db062d593f",
           "source_name": "golden-hermes-trajectory",
           "source_ref": "/fixtures/hermes/trajectories/001.jsonl:1:1",
           "tool_call_id": "call_abc123",
           "tool_error": 0,
           "tool_name": "weather",
-          "tool_phase": "response"
+          "tool_phase": "response",
+          "worktree_root": ""
         }
       ]
     }

--- a/crates/moraine-ingest-core/tests/goldens/source_normalization/kimi_cli.json
+++ b/crates/moraine-ingest-core/tests/goldens/source_normalization/kimi_cli.json
@@ -47,7 +47,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"user_input\":\"Please inspect the sample project.\"}",
           "payload_type": "user_message",
+          "project_id": "",
           "record_ts": "2026-04-12T00:32:24.549974Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -91,7 +93,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -153,7 +156,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"n\":1}",
           "payload_type": "progress",
+          "project_id": "",
           "record_ts": "2026-04-12T00:32:24.550842Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -197,7 +202,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 1
+          "turn_index": 1,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -261,7 +267,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"think\":\"Need to inspect files first.\",\"type\":\"think\"}",
           "payload_type": "reasoning",
+          "project_id": "",
           "record_ts": "2026-04-12T00:32:25.100000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -305,7 +313,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -369,7 +378,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"text\":\"I will read the manifest.\",\"type\":\"text\"}",
           "payload_type": "agent_message",
+          "project_id": "",
           "record_ts": "2026-04-12T00:32:26.200000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -413,7 +424,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -477,7 +489,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"extras\":null,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"manifest.json\\\"}\",\"name\":\"ReadFile\"},\"id\":\"tool_abc\",\"type\":\"function\"}",
           "payload_type": "tool_use",
+          "project_id": "",
           "record_ts": "2026-04-12T00:32:27.300000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -521,7 +535,8 @@
           "tool_name": "ReadFile",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -561,13 +576,16 @@
           "output_preview": "",
           "output_text": "",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "kimi-cli:kimi-cli",
           "source_name": "golden-kimi-cli",
           "source_ref": "/fixtures/kimi-cli/wire.jsonl:1:6",
           "tool_call_id": "tool_abc",
           "tool_error": 0,
           "tool_name": "ReadFile",
-          "tool_phase": "request"
+          "tool_phase": "request",
+          "worktree_root": ""
         }
       ]
     },
@@ -608,7 +626,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"return_value\":{\"display\":[],\"extras\":null,\"is_error\":false,\"message\":\"Read file\",\"output\":\"{\\\"ok\\\":true}\"},\"tool_call_id\":\"tool_abc\"}",
           "payload_type": "tool_result",
+          "project_id": "",
           "record_ts": "2026-04-12T00:32:28.400000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -652,7 +672,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -692,13 +713,16 @@
           "output_preview": "{\"ok\":true}",
           "output_text": "{\"ok\":true}",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "kimi-cli:kimi-cli",
           "source_name": "golden-kimi-cli",
           "source_ref": "/fixtures/kimi-cli/wire.jsonl:1:7",
           "tool_call_id": "tool_abc",
           "tool_error": 0,
           "tool_name": "",
-          "tool_phase": "response"
+          "tool_phase": "response",
+          "worktree_root": ""
         }
       ]
     },
@@ -737,7 +761,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"context_tokens\":100,\"context_usage\":0.1,\"max_context_tokens\":1000,\"mcp_status\":null,\"message_id\":\"chatcmpl_test\",\"plan_mode\":false,\"token_usage\":{\"input_cache_creation\":1,\"input_cache_read\":2,\"input_other\":10,\"output\":5}}",
           "payload_type": "token_count",
+          "project_id": "",
           "record_ts": "2026-04-12T00:32:29.500000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -781,7 +807,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],

--- a/crates/moraine-ingest-core/tests/goldens/source_normalization/opencode.json
+++ b/crates/moraine-ingest-core/tests/goldens/source_normalization/opencode.json
@@ -37,7 +37,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"agent\":\"build\",\"directory\":\"/work/opencode-demo\",\"id\":\"ses_demo\",\"model\":{\"id\":\"glm-5.2\",\"providerID\":\"zai-coding-plan\"},\"project_id\":\"proj_demo\",\"share_url\":\"https://opencode.example/share/ses_demo\",\"time_created\":1780000000000,\"title\":\"OpenCode fixture session\",\"tokens_cache_read\":3,\"tokens_cache_write\":1,\"tokens_input\":10,\"tokens_output\":4,\"tokens_reasoning\":2,\"type\":\"opencode_session\"}",
           "payload_type": "session_meta",
+          "project_id": "",
           "record_ts": "2026-05-28T20:26:40.000000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -81,7 +83,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -201,7 +204,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"data\":{\"text\":\"Check the package metadata.\",\"time\":{\"start\":1780000001100},\"type\":\"text\"},\"directory\":\"/work/opencode-demo\",\"id\":\"part_user_text\",\"message_id\":\"msg_user\",\"message_model_id\":\"glm-5.2\",\"message_provider_id\":\"zai-coding-plan\",\"message_role\":\"user\",\"session_id\":\"ses_demo\",\"time_created\":1780000001100,\"type\":\"opencode_part\"}",
           "payload_type": "text",
+          "project_id": "",
           "record_ts": "2026-05-28T20:26:41.100000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -245,7 +250,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -309,7 +315,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"data\":{\"text\":\"I can inspect that.\",\"time\":{\"start\":1780000002000},\"type\":\"text\"},\"directory\":\"/work/opencode-demo\",\"id\":\"part_text\",\"message_id\":\"msg_assistant\",\"message_model_id\":\"glm-5.2\",\"message_provider_id\":\"zai-coding-plan\",\"message_role\":\"assistant\",\"session_id\":\"ses_demo\",\"time_created\":1780000002000,\"type\":\"opencode_part\"}",
           "payload_type": "text",
+          "project_id": "",
           "record_ts": "2026-05-28T20:26:42.000000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -353,7 +361,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -417,7 +426,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"data\":{\"text\":\"Need to list files.\",\"time\":{\"start\":1780000002100},\"type\":\"reasoning\"},\"directory\":\"/work/opencode-demo\",\"id\":\"part_reasoning\",\"message_id\":\"msg_assistant\",\"message_model_id\":\"glm-5.2\",\"message_provider_id\":\"zai-coding-plan\",\"message_role\":\"assistant\",\"session_id\":\"ses_demo\",\"time_created\":1780000002100,\"type\":\"opencode_part\"}",
           "payload_type": "reasoning",
+          "project_id": "",
           "record_ts": "2026-05-28T20:26:42.100000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -461,7 +472,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -525,7 +537,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"callID\":\"tool_done\",\"state\":{\"input\":{\"cmd\":\"pwd\"},\"output\":\"/work/opencode-demo\",\"status\":\"completed\"},\"tool\":\"bash\",\"type\":\"tool\"}",
           "payload_type": "tool_use",
+          "project_id": "",
           "record_ts": "2026-05-28T20:26:42.200000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -569,7 +583,8 @@
           "tool_name": "bash",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "tool",
@@ -604,7 +619,9 @@
           "parent_tool_call_id": "",
           "payload_json": "\"/work/opencode-demo\"",
           "payload_type": "tool_result",
+          "project_id": "",
           "record_ts": "2026-05-28T20:26:42.200000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -648,7 +665,8 @@
           "tool_name": "bash",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -688,13 +706,16 @@
           "output_preview": "",
           "output_text": "",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "ses_demo",
           "source_name": "golden-opencode",
           "source_ref": "/fixtures/opencode/session.jsonl:1:7",
           "tool_call_id": "tool_done",
           "tool_error": 0,
           "tool_name": "bash",
-          "tool_phase": "request"
+          "tool_phase": "request",
+          "worktree_root": ""
         },
         {
           "event_uid": "fb90886a0832006dba8d565b8635706846e4228133a09077e569f82bbcd28d3a",
@@ -710,13 +731,16 @@
           "output_preview": "/work/opencode-demo",
           "output_text": "/work/opencode-demo",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "ses_demo",
           "source_name": "golden-opencode",
           "source_ref": "/fixtures/opencode/session.jsonl:1:7",
           "tool_call_id": "tool_done",
           "tool_error": 0,
           "tool_name": "bash",
-          "tool_phase": "response"
+          "tool_phase": "response",
+          "worktree_root": ""
         }
       ]
     },
@@ -757,7 +781,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"callID\":\"tool_error\",\"state\":{\"error\":\"No such file or directory\",\"input\":{\"cmd\":\"cat missing.txt\"},\"status\":\"error\"},\"tool\":\"bash\",\"type\":\"tool\"}",
           "payload_type": "tool_use",
+          "project_id": "",
           "record_ts": "2026-05-28T20:26:42.300000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -801,7 +827,8 @@
           "tool_name": "bash",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "tool",
@@ -836,7 +863,9 @@
           "parent_tool_call_id": "",
           "payload_json": "\"No such file or directory\"",
           "payload_type": "tool_result",
+          "project_id": "",
           "record_ts": "2026-05-28T20:26:42.300000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -880,7 +909,8 @@
           "tool_name": "bash",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -920,13 +950,16 @@
           "output_preview": "",
           "output_text": "",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "ses_demo",
           "source_name": "golden-opencode",
           "source_ref": "/fixtures/opencode/session.jsonl:1:8",
           "tool_call_id": "tool_error",
           "tool_error": 0,
           "tool_name": "bash",
-          "tool_phase": "request"
+          "tool_phase": "request",
+          "worktree_root": ""
         },
         {
           "event_uid": "52e0078743d92344184e1f537384dc6e3cc0a85803c2173d07e0a1c876304188",
@@ -942,13 +975,16 @@
           "output_preview": "No such file or directory",
           "output_text": "No such file or directory",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "ses_demo",
           "source_name": "golden-opencode",
           "source_ref": "/fixtures/opencode/session.jsonl:1:8",
           "tool_call_id": "tool_error",
           "tool_error": 1,
           "tool_name": "bash",
-          "tool_phase": "response"
+          "tool_phase": "response",
+          "worktree_root": ""
         }
       ]
     },
@@ -989,7 +1025,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"data\":{\"cost\":0.001,\"reason\":\"stop\",\"tokens\":{\"cache\":{\"read\":7,\"write\":0},\"input\":20,\"output\":5,\"reasoning\":1},\"type\":\"step-finish\"},\"directory\":\"/work/opencode-demo\",\"id\":\"part_step_finish\",\"message_id\":\"msg_assistant\",\"message_model_id\":\"glm-5.2\",\"message_provider_id\":\"zai-coding-plan\",\"message_role\":\"assistant\",\"session_id\":\"ses_demo\",\"time_created\":1780000002400,\"type\":\"opencode_part\"}",
           "payload_type": "progress",
+          "project_id": "",
           "record_ts": "2026-05-28T20:26:42.400000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1033,7 +1071,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -1095,7 +1134,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"data\":{\"model\":{\"id\":\"glm-5.2\",\"providerID\":\"zai-coding-plan\"}},\"id\":\"sm_model\",\"message_type\":\"model-switched\",\"session_id\":\"ses_demo\",\"time_created\":1780000003000,\"type\":\"opencode_session_message\"}",
           "payload_type": "system",
+          "project_id": "",
           "record_ts": "2026-05-28T20:26:43.000000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1139,7 +1180,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],

--- a/crates/moraine-ingest-core/tests/goldens/source_normalization/pi_coding_agent.json
+++ b/crates/moraine-ingest-core/tests/goldens/source_normalization/pi_coding_agent.json
@@ -37,7 +37,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"cwd\":\"/work/pi-demo\",\"id\":\"11111111-2222-4333-8444-555555555555\",\"timestamp\":\"2026-05-08T02:00:00.000Z\",\"type\":\"session\",\"version\":3}",
           "payload_type": "session_meta",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:00.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -81,7 +83,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -143,7 +146,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"id\":\"pi-model-1\",\"modelId\":\"Arcee AI/Trinity Large Thinking\",\"parentId\":null,\"provider\":\"openrouter\",\"timestamp\":\"2026-05-08T02:00:00.100Z\",\"type\":\"model_change\"}",
           "payload_type": "system",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:00.100Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -187,7 +192,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [],
@@ -249,7 +255,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"id\":\"pi-thinking-1\",\"parentId\":\"pi-model-1\",\"thinkingLevel\":\"high\",\"timestamp\":\"2026-05-08T02:00:00.200Z\",\"type\":\"thinking_level_change\"}",
           "payload_type": "thinking",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:00.200Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -293,7 +301,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -370,7 +379,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"content\":[{\"text\":\"Please inspect the manifest and summarize the package.\",\"type\":\"text\"}],\"role\":\"user\",\"timestamp\":1778205601000}",
           "payload_type": "user_message",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:01.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -414,7 +425,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -491,7 +503,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"thinking\":\"I should read the manifest before answering.\",\"type\":\"thinking\"}",
           "payload_type": "thinking",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:02.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -535,7 +549,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "assistant",
@@ -570,7 +585,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"text\":\"I will inspect Cargo.toml first.\",\"type\":\"text\"}",
           "payload_type": "text",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:02.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -614,7 +631,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         },
         {
           "actor_kind": "assistant",
@@ -649,7 +667,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"arguments\":{\"path\":\"Cargo.toml\"},\"id\":\"pi-tool-1\",\"name\":\"read\",\"type\":\"toolCall\"}",
           "payload_type": "tool_use",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:02.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -693,7 +713,8 @@
           "tool_name": "read",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -770,13 +791,16 @@
           "output_preview": "",
           "output_text": "",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "11111111-2222-4333-8444-555555555555",
           "source_name": "golden-pi",
           "source_ref": "/fixtures/pi/session.jsonl:1:5",
           "tool_call_id": "pi-tool-1",
           "tool_error": 0,
           "tool_name": "read",
-          "tool_phase": "request"
+          "tool_phase": "request",
+          "worktree_root": ""
         }
       ]
     },
@@ -817,7 +841,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"content\":[{\"text\":\"[package]\\nname = \\\"moraine\\\"\",\"type\":\"text\"}],\"details\":{\"bytes\":25},\"isError\":false,\"role\":\"toolResult\",\"timestamp\":1778205603000,\"toolCallId\":\"pi-tool-1\",\"toolName\":\"read\"}",
           "payload_type": "tool_result",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:03.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -861,7 +887,8 @@
           "tool_name": "read",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -914,13 +941,16 @@
           "output_preview": "[package]\nname = \"moraine\"",
           "output_text": "[package]\nname = \"moraine\"",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "11111111-2222-4333-8444-555555555555",
           "source_name": "golden-pi",
           "source_ref": "/fixtures/pi/session.jsonl:1:6",
           "tool_call_id": "pi-tool-1",
           "tool_error": 0,
           "tool_name": "read",
-          "tool_phase": "response"
+          "tool_phase": "response",
+          "worktree_root": ""
         }
       ]
     },
@@ -961,7 +991,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"cancelled\":false,\"command\":\"cargo metadata --no-deps\",\"exitCode\":0,\"output\":\"{\\\"packages\\\":[]}\",\"role\":\"bashExecution\",\"timestamp\":1778205604000,\"truncated\":false}",
           "payload_type": "tool_result",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:04.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1005,7 +1037,8 @@
           "tool_name": "bash",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -1058,13 +1091,16 @@
           "output_preview": "",
           "output_text": "",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "11111111-2222-4333-8444-555555555555",
           "source_name": "golden-pi",
           "source_ref": "/fixtures/pi/session.jsonl:1:7",
           "tool_call_id": "pi-bash-1",
           "tool_error": 0,
           "tool_name": "bash",
-          "tool_phase": "request"
+          "tool_phase": "request",
+          "worktree_root": ""
         },
         {
           "event_uid": "b973ebf61f6db383539ef8d23f219662932b4cda5a03ce4645888ff481132a2a",
@@ -1080,13 +1116,16 @@
           "output_preview": "{\"packages\":[]}",
           "output_text": "{\"packages\":[]}",
           "parent_tool_call_id": "",
+          "project_id": "",
+          "repo_rel_path": "",
           "session_id": "11111111-2222-4333-8444-555555555555",
           "source_name": "golden-pi",
           "source_ref": "/fixtures/pi/session.jsonl:1:7",
           "tool_call_id": "pi-bash-1",
           "tool_error": 0,
           "tool_name": "bash",
-          "tool_phase": "response"
+          "tool_phase": "response",
+          "worktree_root": ""
         }
       ]
     },
@@ -1125,7 +1164,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"firstKeptEntryId\":\"pi-user-1\",\"id\":\"pi-compact-1\",\"parentId\":\"pi-bash-1\",\"summary\":\"Earlier manifest inspection was summarized.\",\"timestamp\":\"2026-05-08T02:00:05.000Z\",\"tokensBefore\":1234,\"type\":\"compaction\"}",
           "payload_type": "compacted",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:05.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1169,7 +1210,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -1244,7 +1286,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"fromId\":\"pi-bash-1\",\"id\":\"pi-branch-1\",\"parentId\":\"pi-compact-1\",\"summary\":\"A side branch checked package metadata.\",\"timestamp\":\"2026-05-08T02:00:06.000Z\",\"type\":\"branch_summary\"}",
           "payload_type": "summary",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:06.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1288,7 +1332,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -1363,7 +1408,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"customType\":\"demo-state\",\"data\":{\"status\":\"ok\"},\"id\":\"pi-custom-1\",\"parentId\":\"pi-branch-1\",\"timestamp\":\"2026-05-08T02:00:07.000Z\",\"type\":\"custom\"}",
           "payload_type": "system",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:07.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1407,7 +1454,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -1484,7 +1532,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"content\":\"Injected package context.\",\"customType\":\"demo-context\",\"display\":true,\"id\":\"pi-custom-message-1\",\"parentId\":\"pi-custom-1\",\"timestamp\":\"2026-05-08T02:00:08.000Z\",\"type\":\"custom_message\"}",
           "payload_type": "message",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:08.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1528,7 +1578,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -1603,7 +1654,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"id\":\"pi-label-1\",\"label\":\"manifest-checkpoint\",\"parentId\":\"pi-custom-message-1\",\"targetId\":\"pi-user-1\",\"timestamp\":\"2026-05-08T02:00:09.000Z\",\"type\":\"label\"}",
           "payload_type": "system",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:09.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1647,7 +1700,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [
@@ -1722,7 +1776,9 @@
           "parent_tool_call_id": "",
           "payload_json": "{\"id\":\"pi-info-1\",\"name\":\"Pi fixture manifest review\",\"parentId\":\"pi-label-1\",\"timestamp\":\"2026-05-08T02:00:10.000Z\",\"type\":\"session_info\"}",
           "payload_type": "session_meta",
+          "project_id": "",
           "record_ts": "2026-05-08T02:00:10.000Z",
+          "repo_rel_path": "",
           "request_id": "",
           "retry_count": 0,
           "service_tier": "",
@@ -1766,7 +1822,8 @@
           "tool_name": "",
           "tool_phase": "",
           "trace_id": "",
-          "turn_index": 0
+          "turn_index": 0,
+          "worktree_root": ""
         }
       ],
       "link_rows": [

--- a/crates/moraine-mcp-core/src/file_attention_v1.rs
+++ b/crates/moraine-mcp-core/src/file_attention_v1.rs
@@ -102,6 +102,7 @@ impl AppState {
         let repo_query = FileAttentionQuery {
             query_id: query_id.clone(),
             rel: tail.rel.clone(),
+            normalized_project_id: tail.project_id.clone(),
             derive_worktree_roots: tail.derive_worktree_roots,
             apply_project_scope: args.scope == FileAttentionScope::Project || project_scoped_server,
             start_unix_ms: args.start_unix_ms,
@@ -200,6 +201,7 @@ fn canonical_request_json(args: &CanonicalFileAttentionArgs) -> Value {
 struct TailResolution {
     rel: String,
     root: Option<String>,
+    project_id: Option<String>,
     /// The path was absolute and could not be reduced to a repo-relative tail,
     /// so `rel` is the absolute path matched literally.
     tail_is_absolute: bool,
@@ -231,6 +233,7 @@ fn resolve_tail(path: &str) -> TailResolution {
                         if !rel.is_empty() {
                             return TailResolution {
                                 rel,
+                                project_id: project_id_for_root(&root),
                                 root: Some(root),
                                 tail_is_absolute: false,
                                 normalized: normalized_changed,
@@ -244,6 +247,7 @@ fn resolve_tail(path: &str) -> TailResolution {
         return TailResolution {
             rel: normalized.trim_start_matches('/').to_string(),
             root: None,
+            project_id: None,
             tail_is_absolute: false,
             normalized: normalized_changed,
             derive_worktree_roots: false,
@@ -255,6 +259,7 @@ fn resolve_tail(path: &str) -> TailResolution {
             if !rel.is_empty() {
                 return TailResolution {
                     rel,
+                    project_id: project_id_for_root(&root),
                     root: Some(root),
                     tail_is_absolute: false,
                     normalized: normalized_changed,
@@ -267,6 +272,7 @@ fn resolve_tail(path: &str) -> TailResolution {
     TailResolution {
         rel: normalized,
         root: None,
+        project_id: None,
         tail_is_absolute: true,
         normalized: normalized_changed,
         derive_worktree_roots: false,
@@ -333,6 +339,14 @@ fn find_project_root(file_path: &Path) -> Option<String> {
             break;
         }
         dir = current.parent();
+    }
+    None
+}
+
+fn project_id_for_root(root: &str) -> Option<String> {
+    let root = Path::new(root);
+    if root.join(moraine_config::REPO_BACKEND_FILE).is_file() {
+        return moraine_config::find_repo_backend_ref(root);
     }
     None
 }
@@ -862,6 +876,7 @@ mod tests {
         FileAttentionTouch {
             session_id: session.to_string(),
             event_uid: event.to_string(),
+            tool_call_id: format!("call-{event}"),
             harness: "claude-code".to_string(),
             tool_name: tool.to_string(),
             tool_phase: "request".to_string(),
@@ -922,6 +937,7 @@ mod tests {
         assert_eq!(resolved.rel, "crates/foo/tee.rs");
         assert!(!resolved.tail_is_absolute);
         assert_eq!(resolved.root.as_deref(), root.to_str());
+        assert_eq!(resolved.project_id.as_deref(), Some("x"));
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/sql/001_schema.sql
+++ b/sql/001_schema.sql
@@ -96,6 +96,9 @@ CREATE TABLE IF NOT EXISTS moraine.events (
     'input_images', toFloat64(0),
     'output_images', toFloat64(0)
   ),
+  project_id LowCardinality(String) DEFAULT '',
+  repo_rel_path String DEFAULT '',
+  worktree_root String DEFAULT '',
   event_version UInt64,
   CONSTRAINT events_endpoint_kind_domain CHECK endpoint_kind IN (
     'generation', 'embedding', 'rerank', 'moderation', 'image_generation',
@@ -160,6 +163,9 @@ CREATE TABLE IF NOT EXISTS moraine.tool_io (
   input_preview String,
   output_preview String,
   io_hash UInt64,
+  project_id LowCardinality(String) DEFAULT '',
+  repo_rel_path String DEFAULT '',
+  worktree_root String DEFAULT '',
   source_ref String,
   event_version UInt64
 )

--- a/sql/021_file_attention_normalization.sql
+++ b/sql/021_file_attention_normalization.sql
@@ -1,0 +1,23 @@
+-- Forward-only normalization columns for file_attention Phase 1.
+--
+-- Existing rows read these as defaults. New ingest rows fill them only when a
+-- repo/worktree root and project backend marker can be proven; Tier 0 suffix
+-- matching remains the permanent fallback for legacy and unnormalizable rows.
+
+ALTER TABLE moraine.events
+  ADD COLUMN IF NOT EXISTS project_id LowCardinality(String) DEFAULT '';
+
+ALTER TABLE moraine.events
+  ADD COLUMN IF NOT EXISTS repo_rel_path String DEFAULT '';
+
+ALTER TABLE moraine.events
+  ADD COLUMN IF NOT EXISTS worktree_root String DEFAULT '';
+
+ALTER TABLE moraine.tool_io
+  ADD COLUMN IF NOT EXISTS project_id LowCardinality(String) DEFAULT '';
+
+ALTER TABLE moraine.tool_io
+  ADD COLUMN IF NOT EXISTS repo_rel_path String DEFAULT '';
+
+ALTER TABLE moraine.tool_io
+  ADD COLUMN IF NOT EXISTS worktree_root String DEFAULT '';


### PR DESCRIPTION
## Description

**What.** Adds Phase 1 normalized file-attention fields and query support for `file_attention`.

**Why.** Phase 0 suffix matching works for historical data, but new ingest rows can now carry project-relative path identity so `file_attention` can use exact `project_id` + `repo_rel_path` matches while keeping Tier 0 as the fallback for legacy and unnormalizable rows.

This PR adds forward-only normalization columns to `events` and `tool_io`, stamps structured tool request paths during ingest when the worktree root and `.moraine.toml` backend can be proven, and teaches the repository layer to merge normalized exact hits with the existing suffix fallback. The MCP layer now passes the resolved project id into the query path, preserving the existing `file_attention` response shape and match kinds.

Refs #389.

## Usage

No new user-facing command is required. Existing `file_attention` calls continue to work, and newly ingested structured tool request rows can be matched through normalized path fields when available.

Operationally, migration `021_file_attention_normalization.sql` adds these non-null/defaulted columns to both `events` and `tool_io`:

```sql
project_id LowCardinality(String) DEFAULT ''
repo_rel_path String DEFAULT ''
worktree_root String DEFAULT ''
```

## Changelog

- Adds forward-only file-attention normalization columns to ClickHouse schema and migrations.
- Captures normalized `project_id`, `repo_rel_path`, and `worktree_root` for structured tool request paths at ingest time.
- Merges normalized exact `file_attention` hits with Tier 0 suffix fallback results, deduped by tool-row identity.
- Extends fixture and repository tests for normalized exact lookup plus fallback behavior.

## Validation

Validated locally:

```bash
cargo fmt --all -- --check
cargo test --workspace --locked
```

The commit hook also ran the repo-managed format check and strict clippy baseline successfully during commit.

Sandbox QA used `sb-47cdba` and was torn down successfully with `scripts/dev/sandbox/moraine-sandbox down sb-47cdba`.

Sandbox checks:

```bash
cargo fmt --all -- --check
cargo test -p moraine-clickhouse -p moraine-ingest-core -p moraine-conversations -p moraine-mcp-core --locked
curl -fsS http://127.0.0.1:50637/api/health
```

Live sandbox ClickHouse/MCP checks verified:

- `events` and `tool_io` both expose `project_id`, `repo_rel_path`, and `worktree_root` with defaults.
- A synthetic normalized row whose `input_json` did not contain the path was returned by the real MCP `file_attention(path="crates/foo.rs", scope="all")` call as `path_suffix`.
- A synthetic legacy shell-command row was returned by the same MCP call as `shell_path`.
- The sandbox MCP call returned both expected sessions and `total_touches = 2`.

One additional sandbox clippy command was attempted:

```bash
cargo clippy --workspace --all-targets -- -D warnings
```

That command failed on existing lint debt outside this change path (`too_many_arguments` in ingest helper APIs and `field_reassign_with_default` in tee tests). The repo-managed pre-commit clippy baseline passed on the host.
