### PR TITLE
feat: add Codex plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,9 +1,21 @@
 {
-  "name": "moraine-dev",
+  "name": "moraine",
   "interface": {
-    "displayName": "Moraine Developer Agent Workflows"
+    "displayName": "Moraine"
   },
   "plugins": [
+    {
+      "name": "moraine",
+      "source": {
+        "source": "local",
+        "path": "./plugins/moraine"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
     {
       "name": "moraine-dev",
       "source": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Prefer adding new runtime logic under `apps/` + `crates/` (not legacy `rust/` or
 - `make install`: build the current checkout for the host target and install it over the active `moraine` on your PATH (release bundle → the same `scripts/install.sh` path users get; ClickHouse skipped by default, `INSTALL_ARGS="--with-clickhouse"` to include it). Use this to test tip-of-branch on the host instead of waiting for a tagged release. See `scripts/dev/install-host.sh --help`.
 - `make docs-build` / `make docs-serve`: MkDocs build/serve.
 - `make hooks-install`: enable the repo-managed git hooks (`.githooks/pre-commit` runs `cargo fmt --check` and the same clippy strict baseline CI uses). One-time per clone; bypass a single commit with `SKIP_PRECOMMIT=1 git commit ...` or `git commit --no-verify`.
-- `make agent-plugins-install`: register the Codex developer plugin marketplace from the configured `main` branch and install/update its contributor plugins. Use `AGENT_PLUGINS_SOURCE=current` only when testing unmerged plugin changes from the current checkout.
+- `make agent-plugins-install`: register the Codex Moraine marketplace from the configured `main` branch and install/update the `moraine-dev` contributor workflow plugin. Use `AGENT_PLUGINS_SOURCE=current` only when testing unmerged plugin changes from the current checkout.
 
 ## Coding Style & Naming Conventions
 Use Rust 2021 idioms and keep code `rustfmt`-clean.
@@ -114,6 +114,9 @@ This repo vendors developer-only agent workflows as a local Codex plugin:
 - Marketplace: `.agents/plugins/marketplace.json`
 - Plugin: `plugins/moraine-dev/.codex-plugin/plugin.json`
 - Skills: `plugins/moraine-dev/skills/`
+
+The marketplace is named `moraine` and also exposes the end-user `moraine`
+runtime plugin; contributor automation should install only `moraine-dev`.
 
 Use `$moraine-dev:moraine-start-work` when beginning contributor work, `$moraine-dev:crystallize` when turning rough input into an ignored ready-to-implement plan under `plans/`, `$moraine-dev:moraine-author-pr` when drafting a PR title or description, `$moraine-dev:moraine-sandbox-qa` for ingest/MCP/monitor/schema/stack-facing validation, `$moraine-dev:code-review` for a full multi-persona review wave, and the `$moraine-dev:code-review-*` persona skills for focused PR review. Using `$moraine-dev:code-review` is an explicit request for its delegated reviewer subagents. When prior or active agent context matters, use the Moraine MCP tools directly. These skills are for repository contributors and automation agents, not end-user Moraine behavior.
 Use `$moraine-dev:release` when cutting and publishing a Moraine release from a target version.

--- a/README.md
+++ b/README.md
@@ -67,24 +67,48 @@ moraine status
 
 The monitor UI runs at `http://127.0.0.1:8080` by default.
 
-### Claude Code Setup
+## Connect Claude Code or Codex
 
-For Claude Code, install the Moraine plugin after `moraine up`:
+After `moraine up`, install the Moraine plugin for your agent harness. The
+plugins register the MCP search server and bundle guidance for searching prior
+sessions, but they still use the `moraine` CLI on your `PATH` and the running
+local stack.
+
+For Claude Code:
 
 ```bash
 claude plugin marketplace add eric-tramel/moraine --sparse .claude-plugin plugins
 claude plugin install moraine@moraine
 ```
 
-Restart Claude Code after installing. New sessions get the
-`moraine:session-search` and `moraine:realtime-peek` skills, and Moraine MCP
-tools are exposed as `mcp__plugin_moraine_moraine__*`.
+For Codex:
+
+```bash
+codex plugin marketplace add eric-tramel/moraine \
+  --sparse .agents/plugins \
+  --sparse plugins/moraine \
+  --sparse plugins/moraine-dev
+codex plugin add moraine@moraine
+```
+
+Start a new agent session after installing the plugin. Claude Code sessions get
+the `moraine:session-search` and `moraine:realtime-peek` skills, and Moraine MCP
+tools are exposed as `mcp__plugin_moraine_moraine__*`. Then ask:
+
+```text
+What are my agents doing right now?
+```
+
+The user-scoped plugins can search the host-wide Moraine history visible to your
+user. For project-scoped setup, duplicate MCP cleanup, and other clients, see
+[Agent MCP Search](https://eric-tramel.github.io/moraine/agent-mcp-search/index.html).
 
 ## Agent Harness Guidance
 
-Moraine is most useful when your agent harness knows that it can search prior
-sessions. Add the following guidance to your global harness instructions, such
-as `~/.codex/AGENTS.md` for Codex or `~/.claude/CLAUDE.md` for Claude Code:
+The Claude Code and Codex plugins already bundle Moraine search guidance. If you
+use manual MCP registration or another harness, add the following guidance to
+your global harness instructions, such as `~/.codex/AGENTS.md` for Codex or
+`~/.claude/CLAUDE.md` for Claude Code:
 
 ```markdown
 - You have access to all past agent sessions (whether codex, claude, hermes, etc., anything) via moraine search tools.

--- a/docs/agent-mcp-search/install.md
+++ b/docs/agent-mcp-search/install.md
@@ -59,6 +59,58 @@ claude mcp remove moraine --scope user
 Manual Claude MCP registration remains useful for project-scoped setup,
 `--project-only`, and custom environment wiring such as `MORAINE_MCP_CONFIG`.
 
+## Codex plugin marketplace (recommended)
+
+For Codex, the recommended user-scoped setup is the Moraine plugin. The plugin
+registers the MCP server and bundles Moraine search skills, but it does not
+install Moraine itself and it does not start ClickHouse, ingest, or the monitor.
+Install or upgrade the CLI first, then start the stack:
+
+```bash
+uv tool install moraine-cli
+```
+
+```bash
+uv tool upgrade moraine-cli
+```
+
+```bash
+moraine up
+```
+
+Add the marketplace from this repository and install the end-user plugin:
+
+```bash
+codex plugin marketplace add eric-tramel/moraine --sparse .agents/plugins --sparse plugins/moraine --sparse plugins/moraine-dev
+codex plugin add moraine@moraine
+```
+
+The same marketplace also exposes the contributor-only `moraine-dev` plugin for
+Moraine maintainers; end users should install `moraine@moraine`.
+
+The plugin MCP launcher looks for `moraine` on `PATH` and then runs
+`moraine run mcp`. If the CLI is missing, it reports a `binary_missing` message
+with install guidance instead of failing as a raw command-not-found error.
+
+Security note: the user-scoped plugin launches unscoped `moraine run mcp`, so
+Codex can search the host-wide Moraine history visible to your user. Enable the
+plugin only in trusted Codex environments. For untrusted repositories, or when
+you want retrieval limited to the current project, use the manual
+project-scoped `--project-only` registration below. Also start Codex from a
+trusted shell where `moraine` resolves to the installed CLI, not to a repo-local
+shim or relative `PATH` entry.
+
+If you previously registered Moraine manually with `codex mcp add`, remove that
+manual entry before relying on the plugin to avoid duplicate MCP servers:
+
+```bash
+codex mcp list
+codex mcp remove moraine
+```
+
+Manual Codex MCP registration remains useful for project-scoped setup,
+`--project-only`, and custom environment wiring such as `MORAINE_MCP_CONFIG`.
+
 ## Shared central server (default)
 
 By default `moraine up` starts a single shared MCP server for the whole host,
@@ -115,13 +167,15 @@ Details worth knowing:
   view.
 
 The remaining sections register the unchanged `moraine run mcp` command with
-each harness, including manual Claude Code registration for project-scoped or
-custom setups.
+each harness, including manual Codex and Claude Code registration for
+project-scoped or custom setups.
 
-## Global Codex
+## Manual Codex
 
 Codex stores user-level configuration in `~/.codex/config.toml`, and the Codex
-CLI can add MCP servers directly. OpenAI's Codex docs note that the CLI and IDE
+CLI can add MCP servers directly. The plugin is the recommended user-scoped path
+above. Use manual registration when you want project scope, `--project-only`, or
+custom environment handling. OpenAI's Codex docs note that the CLI and IDE
 extension share MCP configuration, so a CLI install is enough for both clients:
 [Codex MCP docs](https://developers.openai.com/codex/mcp) and
 [Codex configuration reference](https://developers.openai.com/codex/config-reference).

--- a/docs/development/agent-contributor-workflows.md
+++ b/docs/development/agent-contributor-workflows.md
@@ -26,9 +26,13 @@ plugins/moraine-dev/
     moraine-sandbox-qa/
 ```
 
-Both the Codex marketplace and plugin are named `moraine-dev`. The marketplace
-entry points to `./plugins/moraine-dev`, and the plugin manifest exposes
-`./skills/`.
+The Codex marketplace is named `moraine`. It exposes the end-user `moraine`
+runtime plugin and the contributor-only `moraine-dev` workflow plugin. The
+developer helper installs only `moraine-dev`; it does not automatically install
+the end-user runtime MCP plugin.
+
+The `moraine-dev` marketplace entry points to `./plugins/moraine-dev`, and the
+plugin manifest exposes `./skills/`.
 
 ## Install Locally
 
@@ -40,9 +44,9 @@ make agent-plugins-install
 
 This registers the Codex marketplace from the configured Git remote, replaces a
 stale marketplace entry, syncs the marketplace snapshot from `origin/main`, and
-installs or refreshes every plugin listed there. This intentionally uses the
-merged `main` branch as the source of truth so agents running from stale feature
-worktrees still pick up the latest developer workflows.
+installs or refreshes the `moraine-dev` plugin listed there. This intentionally
+uses the merged `main` branch as the source of truth so agents running from
+stale feature worktrees still pick up the latest developer workflows.
 
 When changing the plugin itself, test the unmerged checkout explicitly:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -83,7 +83,32 @@ claude mcp remove moraine --scope user
 ```
 
 Manual registration still works and is useful for project-scoped Claude Code
-setups or other harnesses. Add Moraine to Codex globally:
+setups or other harnesses.
+
+For Codex, install the Moraine plugin marketplace entry. It registers the MCP
+server and bundles the same Moraine search skills:
+
+```bash
+codex plugin marketplace add eric-tramel/moraine --sparse .agents/plugins --sparse plugins/moraine --sparse plugins/moraine-dev
+codex plugin add moraine@moraine
+```
+
+The same marketplace also contains the contributor-only `moraine-dev` plugin for
+Moraine maintainers; end users should install `moraine@moraine`.
+
+The user-scoped plugin can search the host-wide Moraine history visible to your
+user. Enable it only in trusted Codex environments. Use manual project-scoped
+setup when you need `--project-only`.
+
+If you already added Moraine manually to Codex, remove the manual server first
+to avoid duplicate MCP tools:
+
+```bash
+codex mcp remove moraine
+```
+
+Manual registration still works and is useful for project-scoped Codex setups or
+other harnesses. Add Moraine to Codex globally:
 
 ```bash
 codex mcp add moraine -- moraine run mcp

--- a/plugins/moraine-dev/skills/release/SKILL.md
+++ b/plugins/moraine-dev/skills/release/SKILL.md
@@ -87,6 +87,7 @@ Then inspect the diff. Expected version-only files are normally:
 - `.github/workflows/release-moraine.yml` example tag, if it still contains
   the old tag
 - `plugins/moraine/.claude-plugin/plugin.json`
+- `plugins/moraine/.codex-plugin/plugin.json`
 - install docs only if they contain an explicit `MORAINE_INSTALL_VERSION`
   example for the old tag
 

--- a/plugins/moraine-dev/skills/release/scripts/bump-version.py
+++ b/plugins/moraine-dev/skills/release/scripts/bump-version.py
@@ -36,7 +36,10 @@ MANAGED_PACKAGE_NAMES = {
     "moraine-monitor-core",
 }
 
-CLAUDE_PLUGIN_MANIFEST = "plugins/moraine/.claude-plugin/plugin.json"
+RUNTIME_PLUGIN_MANIFESTS = [
+    ("Claude", "plugins/moraine/.claude-plugin/plugin.json"),
+    ("Codex", "plugins/moraine/.codex-plugin/plugin.json"),
+]
 
 VERSION_RE = re.compile(r"^v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$")
 
@@ -228,21 +231,24 @@ def bump_release_examples(
     print(f"release examples: {total} replacement(s)")
 
 
-def bump_claude_plugin_manifest(
+def bump_runtime_plugin_manifests(
     repo_root: Path, current_version: str, target_version: str, *, dry_run: bool
 ) -> None:
-    path = repo_root / CLAUDE_PLUGIN_MANIFEST
-    data = json.loads(read_text(path))
-    if data.get("name") != "moraine":
-        raise SystemExit(f"unexpected Claude plugin name in {path}: {data.get('name')}")
-    version = data.get("version")
-    if version != current_version:
-        raise SystemExit(
-            f"Claude plugin manifest has {version}, expected {current_version}"
-        )
-    data["version"] = target_version
-    write_text(path, json.dumps(data, indent=2) + "\n", dry_run=dry_run)
-    print(f"{CLAUDE_PLUGIN_MANIFEST}: {current_version} -> {target_version}")
+    for label, relpath in RUNTIME_PLUGIN_MANIFESTS:
+        path = repo_root / relpath
+        data = json.loads(read_text(path))
+        if data.get("name") != "moraine":
+            raise SystemExit(
+                f"unexpected {label} plugin name in {path}: {data.get('name')}"
+            )
+        version = data.get("version")
+        if version != current_version:
+            raise SystemExit(
+                f"{label} plugin manifest has {version}, expected {current_version}"
+            )
+        data["version"] = target_version
+        write_text(path, json.dumps(data, indent=2) + "\n", dry_run=dry_run)
+        print(f"{relpath}: {current_version} -> {target_version}")
 
 
 def main() -> int:
@@ -261,7 +267,7 @@ def main() -> int:
     bump_release_examples(
         repo_root, current_version, target_version, dry_run=args.dry_run
     )
-    bump_claude_plugin_manifest(
+    bump_runtime_plugin_manifests(
         repo_root, current_version, target_version, dry_run=args.dry_run
     )
     if args.dry_run:

--- a/plugins/moraine/.codex-plugin/plugin.json
+++ b/plugins/moraine/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "moraine",
+  "version": "0.6.1",
+  "description": "Codex plugin for Moraine MCP session search and realtime agent awareness.",
+  "author": {
+    "name": "Moraine maintainers",
+    "email": "eric.tramel@gmail.com",
+    "url": "https://github.com/eric-tramel/moraine"
+  },
+  "homepage": "https://github.com/eric-tramel/moraine",
+  "repository": "https://github.com/eric-tramel/moraine",
+  "license": "Apache-2.0",
+  "keywords": [
+    "moraine",
+    "mcp",
+    "codex",
+    "agent-memory",
+    "session-search",
+    "realtime-agents"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Moraine",
+    "shortDescription": "Search local agent sessions from Codex.",
+    "longDescription": "Connects Codex to Moraine MCP session search, realtime agent awareness, and bundled guidance for recovering prior agent context.",
+    "developerName": "Moraine maintainers",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read"
+    ],
+    "defaultPrompt": [
+      "Search my past agent sessions with Moraine.",
+      "Check what another agent is doing now.",
+      "Find prior context for this issue."
+    ],
+    "brandColor": "#2F6F73"
+  }
+}

--- a/plugins/moraine/.mcp.json
+++ b/plugins/moraine/.mcp.json
@@ -1,8 +1,9 @@
 {
   "mcpServers": {
     "moraine": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch.sh",
-      "args": []
+      "command": "./scripts/launch.sh",
+      "args": [],
+      "cwd": "."
     }
   }
 }

--- a/plugins/moraine/scripts/launch.sh
+++ b/plugins/moraine/scripts/launch.sh
@@ -16,7 +16,7 @@ for path_dir in $PATH; do
         {
           printf '%s\n' 'moraine plugin launch error: binary_untrusted'
           printf '%s\n' 'Refusing to run a moraine executable resolved from a relative PATH entry.'
-          printf '%s\n' 'Restart Claude Code from a trusted shell where moraine resolves to an absolute installed path.'
+          printf '%s\n' 'Restart your agent harness from a trusted shell where moraine resolves to an absolute installed path.'
         } >&2
         exit 126
       fi
@@ -34,11 +34,11 @@ IFS="$old_ifs"
 if [ -z "$moraine_bin" ]; then
   {
     printf '%s\n' 'moraine plugin launch error: binary_missing'
-    printf '%s\n' 'The Moraine Claude plugin requires the moraine CLI on PATH.'
+    printf '%s\n' 'The Moraine plugin requires the moraine CLI on PATH.'
     printf '%s\n' 'Install: uv tool install moraine-cli'
     printf '%s\n' 'Upgrade: uv tool upgrade moraine-cli'
     printf '%s\n' 'Start the stack before using MCP search: moraine up'
-    printf '%s\n' 'If Moraine is already installed, restart Claude Code with its bin directory on PATH.'
+    printf '%s\n' 'If Moraine is already installed, restart your agent harness with its bin directory on PATH.'
   } >&2
   exit 127
 fi
@@ -48,12 +48,28 @@ moraine_name="${moraine_bin##*/}"
 moraine_parent="${moraine_bin%/*}"
 moraine_dir="$(CDPATH= cd -- "$moraine_parent" 2>/dev/null && pwd -P || printf '%s\n' "$moraine_parent")"
 moraine_bin="$moraine_dir/$moraine_name"
+scan_dir="$moraine_dir"
+while [ "$scan_dir" != "/" ]; do
+  if [ -e "$scan_dir/.git" ]; then
+    {
+      printf '%s\n' 'moraine plugin launch error: binary_untrusted'
+      printf '%s\n' 'Refusing to run a moraine executable from a Git worktree.'
+      printf '%s\n' 'Restart your agent harness with the installed moraine CLI earlier on a trusted PATH.'
+    } >&2
+    exit 126
+  fi
+  scan_dir="${scan_dir%/*}"
+  if [ -z "$scan_dir" ]; then
+    scan_dir="/"
+  fi
+done
+
 case "$moraine_bin" in
   "$cwd"/*)
     {
       printf '%s\n' 'moraine plugin launch error: binary_untrusted'
       printf '%s\n' 'Refusing to run a moraine executable from the current project directory.'
-      printf '%s\n' 'Restart Claude Code with the installed moraine CLI earlier on a trusted PATH.'
+      printf '%s\n' 'Restart your agent harness with the installed moraine CLI earlier on a trusted PATH.'
     } >&2
     exit 126
     ;;

--- a/plugins/moraine/skills/session-search/SKILL.md
+++ b/plugins/moraine/skills/session-search/SKILL.md
@@ -14,7 +14,7 @@ Use Moraine when the user assumes continuity that is not visible in current cont
 - Use `open` to expand any `session:`, `turn:`, or `event:` ID returned by Moraine.
 - Use `file_attention` when the clue is a file path or when you need to know which sessions read or changed a file across worktrees.
 
-In Claude Code plugin installs, the MCP tools may appear with names like `mcp__plugin_moraine_moraine__search_sessions`; use the corresponding Moraine tool available in the current harness.
+In plugin installs, the MCP tools may appear with names like `mcp__plugin_moraine_moraine__search_sessions`; use the corresponding Moraine tool available in the current harness.
 
 ## Query Shape
 

--- a/scripts/dev/install-agent-plugins.sh
+++ b/scripts/dev/install-agent-plugins.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 CODEX_CMD="${CODEX_CMD:-codex}"
 AGENT_PLUGINS_SOURCE="${AGENT_PLUGINS_SOURCE:-main}"
 AGENT_PLUGINS_REMOTE="${AGENT_PLUGINS_REMOTE:-origin}"
-LEGACY_MARKETPLACE_NAMES=("moraine-developer-agents")
+INSTALL_PLUGIN_NAMES=("moraine-dev")
+LEGACY_MARKETPLACE_NAMES=("moraine-developer-agents" "moraine-dev")
 
 die() {
     printf '[agent-plugins] error: %s\n' "$*" >&2
@@ -91,23 +92,36 @@ if [[ "$should_upgrade" == 1 ]]; then
 fi
 
 plugin_list_json="$("$CODEX_CMD" plugin list --marketplace "$marketplace_name" --available --json)"
-plugin_names="$(PLUGIN_LIST_JSON="$plugin_list_json" python3 - <<'PY'
+if ! plugin_names="$(PLUGIN_LIST_JSON="$plugin_list_json" INSTALL_PLUGIN_NAMES="${INSTALL_PLUGIN_NAMES[*]}" python3 - <<'PY'
 import json
 import os
 import sys
 
 data = json.loads(os.environ["PLUGIN_LIST_JSON"])
+wanted = os.environ["INSTALL_PLUGIN_NAMES"].split()
 seen = set()
 
 for section in ("installed", "available"):
     for plugin in data.get(section, []):
         name = plugin.get("name")
-        if name and name not in seen:
+        if name:
             seen.add(name)
-            print(name)
+
+missing = [name for name in wanted if name not in seen]
+if missing:
+    print(
+        "marketplace is missing developer workflow plugin(s): " + ", ".join(missing),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+for name in wanted:
+    print(name)
 PY
-)"
-[[ -n "$plugin_names" ]] || die "marketplace has no plugins: $marketplace_name"
+)"; then
+    die "marketplace is missing developer workflow plugin(s): ${INSTALL_PLUGIN_NAMES[*]}"
+fi
+[[ -n "$plugin_names" ]] || die "no developer workflow plugins selected for marketplace: $marketplace_name"
 
 while IFS= read -r plugin_name; do
     [[ -n "$plugin_name" ]] || continue


### PR DESCRIPTION
## Description

**What.** Adds the end-user Codex plugin surface for Moraine MCP session search.

**Why.** Issue #398 calls for replacing manual Codex MCP wiring with a marketplace plugin that reuses the existing Moraine plugin assets and bundles agent search guidance with the MCP registration.

This PR adds `plugins/moraine/.codex-plugin/plugin.json`, exposes the runtime `moraine` plugin from the Codex marketplace alongside the contributor-only `moraine-dev` plugin, and keeps the shared MCP launcher/scripts/skills reused across Claude and Codex. The launcher now starts directly as `./scripts/launch.sh` from the installed plugin directory and rejects untrusted `moraine` binaries from relative PATH entries, the current cwd, or Git worktrees.

Contributor install behavior stays scoped: `make agent-plugins-install` installs only `moraine-dev`, not the end-user runtime plugin.

Closes #398.

## Usage

Install or upgrade the Moraine CLI and start the stack first:

```bash
uv tool install moraine-cli
uv tool upgrade moraine-cli
moraine up
```

Then install the Codex plugin from this repository marketplace:

```bash
codex plugin marketplace add eric-tramel/moraine --sparse .agents/plugins --sparse plugins/moraine --sparse plugins/moraine-dev
codex plugin add moraine@moraine
```

The same marketplace also exposes `moraine-dev` for Moraine contributors; end users should install `moraine@moraine`.

## Changelog

- Adds the Codex `moraine` plugin manifest and marketplace entry.
- Documents Codex plugin install, duplicate MCP cleanup, and manual project-scoped fallback.
- Keeps contributor automation installing only `moraine-dev`.
- Updates release version bumping to keep Claude and Codex runtime plugin manifests in lockstep.

## Validation

Validated plugin metadata and docs with:

```bash
python3 /Users/eric/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/moraine
claude plugin validate plugins/moraine
python3 /Users/eric/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/moraine/skills/session-search
python3 /Users/eric/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/moraine/skills/realtime-peek
python3 /Users/eric/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/moraine-dev/skills/release
python3 -m json.tool .agents/plugins/marketplace.json
python3 -m json.tool plugins/moraine/.codex-plugin/plugin.json
python3 -m json.tool plugins/moraine/.mcp.json
bash -n scripts/dev/install-agent-plugins.sh
sh -n plugins/moraine/scripts/launch.sh
git diff --check
make docs-build
```

Ran an isolated Codex plugin install and confirmed `codex mcp get moraine` resolves to `./scripts/launch.sh` with the installed plugin directory as cwd. Ran a fake MCP launcher validation covering successful `moraine run mcp`, missing binary, relative PATH rejection, absolute Git-worktree PATH rejection, and current-cwd PATH rejection.

Also validated contributor and release flows:

```bash
make agent-plugins-install AGENT_PLUGINS_SOURCE=current
python3 plugins/moraine-dev/skills/release/scripts/bump-version.py 0.6.2 --dry-run
```

Ran a temp-home Claude plugin install smoke check and confirmed the shared plugin still exposes the Moraine skills and MCP server.

Cargo tests and sandbox QA were not run because this change does not modify Rust service code, ingest, monitor, MCP server implementation, or ClickHouse schema.
