### PR TITLE
feat: add guided setup command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,6 +991,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonc-parser"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840785e1a8b4fdb27be18440a35a81af64820dc185c3973ff8b012d4c6282512"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1142,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dialoguer",
+ "jsonc-parser",
  "moraine-clickhouse",
  "moraine-config",
  "ratatui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +393,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +429,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -1102,6 +1132,7 @@ version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
+ "dialoguer",
  "moraine-clickhouse",
  "moraine-config",
  "ratatui",
@@ -1150,7 +1181,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -1380,7 +1411,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1401,7 +1432,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1582,7 +1613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1764,6 +1795,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,11 +1929,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2492,6 +2549,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "toml_edit",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -46,50 +46,27 @@ Moraine ships session trace ingestion adapters for these agent harnesses:
 
 ## Quickstart
 
-Install from PyPI with `uv`:
-
 ```bash
 uv tool install moraine-cli
-```
-
-Or install the latest release bundle:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/eric-tramel/moraine/main/scripts/install.sh | sh
-```
-
-Start the local stack:
-
-```bash
+moraine setup
 moraine up
-moraine status
 ```
+
+`moraine setup` creates or repairs `~/.moraine/config.toml` and guides plugin or
+MCP registration for detected agent harnesses.
 
 The monitor UI runs at `http://127.0.0.1:8080` by default.
 
+For release bundles, upgrades, project-scoped setup, and other harnesses, see the
+[Quickstart and Installation](https://eric-tramel.github.io/moraine/quickstart.html).
+
 ## Connect Claude Code or Codex
 
-After `moraine up`, install the Moraine plugin for your agent harness. The
-plugins register the MCP search server and bundle guidance for searching prior
-sessions, but they still use the `moraine` CLI on your `PATH` and the running
-local stack.
-
-For Claude Code:
-
-```bash
-claude plugin marketplace add eric-tramel/moraine --sparse .claude-plugin plugins
-claude plugin install moraine@moraine
-```
-
-For Codex:
-
-```bash
-codex plugin marketplace add eric-tramel/moraine \
-  --sparse .agents/plugins \
-  --sparse plugins/moraine \
-  --sparse plugins/moraine-dev
-codex plugin add moraine@moraine
-```
+Use `moraine setup` to install or update the Moraine plugin for Claude Code and
+Codex. The same guided selector can also register Moraine MCP for other detected
+harnesses. The plugins register the MCP search server and bundle guidance for
+searching prior sessions, but they still use the `moraine` CLI on your `PATH`
+and the running local stack.
 
 Start a new agent session after installing the plugin. Claude Code sessions get
 the `moraine:session-search` and `moraine:realtime-peek` skills, and Moraine MCP

--- a/README.md
+++ b/README.md
@@ -60,17 +60,16 @@ The monitor UI runs at `http://127.0.0.1:8080` by default.
 For release bundles, upgrades, project-scoped setup, and other harnesses, see the
 [Quickstart and Installation](https://eric-tramel.github.io/moraine/quickstart.html).
 
-## Connect Claude Code or Codex
+## Connect Agent Harnesses
 
-Use `moraine setup` to install or update the Moraine plugin for Claude Code and
-Codex. The same guided selector can also register Moraine MCP for other detected
-harnesses. The plugins register the MCP search server and bundle guidance for
-searching prior sessions, but they still use the `moraine` CLI on your `PATH`
-and the running local stack.
+Use `moraine setup` to install or update the Moraine plugins for Claude Code and
+Codex, or to register Moraine MCP for supported harnesses such as OpenCode,
+Cursor, Hermes, Kimi CLI, and Pi Coding Agent. The integrations use the
+`moraine` CLI on your `PATH` and the running local stack.
 
-Start a new agent session after installing the plugin. Claude Code sessions get
-the `moraine:session-search` and `moraine:realtime-peek` skills, and Moraine MCP
-tools are exposed as `mcp__plugin_moraine_moraine__*`. Then ask:
+Start a new agent session after installing an integration. Claude Code sessions
+get the `moraine:session-search` and `moraine:realtime-peek` skills, and Moraine
+MCP tools are exposed as `mcp__plugin_moraine_moraine__*`. Then ask:
 
 ```text
 What are my agents doing right now?

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -11,6 +11,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 dialoguer = { version = "0.11", default-features = false }
+jsonc-parser = { version = "0.32", features = ["serde"] }
 ratatui = { version = "0.29", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 sha2 = "0.10"

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -14,5 +14,6 @@ dialoguer = { version = "0.11", default-features = false }
 ratatui = { version = "0.29", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 sha2 = "0.10"
+toml_edit = "0.22"
 moraine-config = { path = "../../crates/moraine-config" }
 moraine-clickhouse = { path = "../../crates/moraine-clickhouse" }

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -10,6 +10,7 @@ tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "time"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.5", features = ["derive"] }
+dialoguer = { version = "0.11", default-features = false }
 ratatui = { version = "0.29", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 sha2 = "0.10"

--- a/apps/moraine/src/cli.rs
+++ b/apps/moraine/src/cli.rs
@@ -139,6 +139,9 @@ pub(crate) enum SetupMcpTarget {
     Codex,
     Hermes,
     KimiCli,
+    #[serde(rename = "opencode")]
+    #[value(name = "opencode")]
+    OpenCode,
     Cursor,
     PiCodingAgent,
 }
@@ -201,6 +204,12 @@ mod tests {
             "--mcp-target",
             "codex",
             "--mcp-target",
+            "opencode",
+            "--mcp-target",
+            "cursor",
+            "--mcp-target",
+            "pi-coding-agent",
+            "--mcp-target",
             "claude-code",
         ]);
         match cli.command {
@@ -209,7 +218,13 @@ mod tests {
                 assert!(setup.dry_run);
                 assert_eq!(
                     setup.mcp_targets,
-                    vec![SetupMcpTarget::Codex, SetupMcpTarget::ClaudeCode]
+                    vec![
+                        SetupMcpTarget::Codex,
+                        SetupMcpTarget::OpenCode,
+                        SetupMcpTarget::Cursor,
+                        SetupMcpTarget::PiCodingAgent,
+                        SetupMcpTarget::ClaudeCode,
+                    ]
                 );
             }
             _ => panic!("expected setup command"),

--- a/apps/moraine/src/cli.rs
+++ b/apps/moraine/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use serde::Serialize;
 use std::path::PathBuf;
 
 use crate::service::Service;
@@ -37,6 +38,7 @@ pub(crate) enum CliCommand {
     Db(DbArgs),
     Clickhouse(ClickhouseArgs),
     Config(ConfigArgs),
+    Setup(SetupArgs),
     Run(RunArgs),
 }
 
@@ -109,6 +111,39 @@ pub(crate) struct ConfigGetArgs {
 }
 
 #[derive(Debug, Args)]
+pub(crate) struct SetupArgs {
+    /// Accept non-interactive defaults. Does not enable MCP targets by itself.
+    #[arg(long)]
+    pub(crate) yes: bool,
+    /// Show planned changes without writing files or running external commands.
+    #[arg(long)]
+    pub(crate) dry_run: bool,
+    /// Skip config file creation, validation, and repair.
+    #[arg(long, conflicts_with = "repair_config")]
+    pub(crate) skip_config: bool,
+    /// Skip MCP/plugin registration prompts and actions.
+    #[arg(long, conflicts_with = "mcp_targets")]
+    pub(crate) skip_mcp: bool,
+    /// Repair an invalid config by backing it up and writing the default template.
+    #[arg(long)]
+    pub(crate) repair_config: bool,
+    /// MCP/plugin target to configure. Repeat to select multiple targets.
+    #[arg(long = "mcp-target", value_enum, value_name = "TARGET")]
+    pub(crate) mcp_targets: Vec<SetupMcpTarget>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum SetupMcpTarget {
+    ClaudeCode,
+    Codex,
+    Hermes,
+    KimiCli,
+    Cursor,
+    PiCodingAgent,
+}
+
+#[derive(Debug, Args)]
 pub(crate) struct RunArgs {
     #[arg(value_enum)]
     pub(crate) service: Service,
@@ -154,6 +189,38 @@ mod tests {
             }) => assert_eq!(get.key, "clickhouse.url"),
             _ => panic!("expected config get command"),
         }
+    }
+
+    #[test]
+    fn clap_parses_setup_targets() {
+        let cli = Cli::parse_from([
+            "moraine",
+            "setup",
+            "--yes",
+            "--dry-run",
+            "--mcp-target",
+            "codex",
+            "--mcp-target",
+            "claude-code",
+        ]);
+        match cli.command {
+            CliCommand::Setup(setup) => {
+                assert!(setup.yes);
+                assert!(setup.dry_run);
+                assert_eq!(
+                    setup.mcp_targets,
+                    vec![SetupMcpTarget::Codex, SetupMcpTarget::ClaudeCode]
+                );
+            }
+            _ => panic!("expected setup command"),
+        }
+    }
+
+    #[test]
+    fn clap_rejects_setup_skip_mcp_with_target() {
+        let err = Cli::try_parse_from(["moraine", "setup", "--skip-mcp", "--mcp-target", "codex"])
+            .expect_err("conflicting setup mcp flags should fail");
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/apps/moraine/src/commands.rs
+++ b/apps/moraine/src/commands.rs
@@ -1,5 +1,6 @@
 mod down;
 mod logs;
+mod setup;
 mod status;
 mod up;
 
@@ -139,6 +140,7 @@ pub(crate) async fn dispatch(cli: Cli, output: CliOutput) -> Result<ExitCode> {
                 }
             }
         }
+        CliCommand::Setup(args) => setup::handle(&output, cli.config.clone(), args),
         CliCommand::Run(run) => run_service(cli.config.clone(), run).await,
     }
 }

--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -2599,7 +2599,9 @@ mod tests {
                 enabled_sources: 0,
                 disabled_sources: 3,
                 added_sources: 0,
-                updated_sources: 0,
+                // The bundled template carries macOS Cursor SQLite paths. On Linux,
+                // setup repairs that setup-owned source while disabling it.
+                updated_sources: if cfg!(target_os = "macos") { 0 } else { 1 },
             }
         );
         assert!(source_enabled(&document, "codex"));

--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -15,9 +15,14 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::cli::{SetupArgs, SetupMcpTarget};
 use crate::render::{CliOutput, OutputMode};
-use toml_edit::{value as toml_value, ArrayOfTables, DocumentMut, Item, Table};
+use toml_edit::{ArrayOfTables, DocumentMut, Item, Table};
+
+mod harnesses;
+use harnesses::{McpConfigFormat, McpConfigWrite};
 
 const DEFAULT_CONFIG_TEMPLATE: &str = include_str!("../../../../config/moraine.toml");
+const HOST_WIDE_ACCESS_WARNING: &str =
+    "Selected harness integrations get host-wide Moraine session history access visible to your user.";
 
 pub(super) fn handle(
     output: &CliOutput,
@@ -468,11 +473,12 @@ struct IngestSelectionUpdate {
     enabled_sources: usize,
     disabled_sources: usize,
     added_sources: usize,
+    updated_sources: usize,
 }
 
 impl IngestSelectionUpdate {
     fn changed_sources(self) -> usize {
-        self.enabled_sources + self.disabled_sources + self.added_sources
+        self.enabled_sources + self.disabled_sources + self.added_sources + self.updated_sources
     }
 
     fn has_changes(self) -> bool {
@@ -499,6 +505,11 @@ impl IngestSelectionUpdate {
             parts.push("1 disabled".to_string());
         } else if self.disabled_sources > 1 {
             parts.push(format!("{} disabled", self.disabled_sources));
+        }
+        if self.updated_sources == 1 {
+            parts.push("1 repaired".to_string());
+        } else if self.updated_sources > 1 {
+            parts.push(format!("{} repaired", self.updated_sources));
         }
         format!("ingest sources updated: {}", parts.join(", "))
     }
@@ -527,37 +538,35 @@ fn apply_ingest_selections_to_document(
     let mut update = IngestSelectionUpdate::default();
 
     for selection in selections {
-        let harness = selection.target.harness_name();
         let enabled = selection.mode.configures_ingest();
-        let source_indexes = ingest_source_indexes_for_harness(document, harness)?;
 
-        if source_indexes.is_empty() {
-            if enabled {
-                let sources = ensure_ingest_sources_mut(document)?;
-                for source in default_ingest_sources_for_target(selection.target) {
-                    sources.push(source.to_table(enabled));
+        for setup_source in harnesses::default_ingest_sources(selection.target) {
+            let source_index = ingest_source_index(document, *setup_source)?;
+
+            match source_index {
+                Some(source_idx) => {
+                    let sources = ensure_ingest_sources_mut(document)?;
+                    let source_table = sources
+                        .get_mut(source_idx)
+                        .expect("source index came from the same array");
+                    let source_update = setup_source.reconcile_table(source_table, enabled);
+                    if source_update.enabled_changed {
+                        if enabled {
+                            update.enabled_sources += 1;
+                        } else {
+                            update.disabled_sources += 1;
+                        }
+                    }
+                    if source_update.metadata_changed {
+                        update.updated_sources += 1;
+                    }
+                }
+                None if enabled => {
+                    let sources = ensure_ingest_sources_mut(document)?;
+                    sources.push(setup_source.to_table(enabled));
                     update.added_sources += 1;
                 }
-            }
-            continue;
-        }
-
-        let sources = ensure_ingest_sources_mut(document)?;
-        for source_idx in source_indexes {
-            let source = sources
-                .get_mut(source_idx)
-                .expect("source index came from the same array");
-            let current_enabled = source
-                .get("enabled")
-                .and_then(Item::as_bool)
-                .unwrap_or(true);
-            if current_enabled != enabled {
-                source["enabled"] = toml_value(enabled);
-                if enabled {
-                    update.enabled_sources += 1;
-                } else {
-                    update.disabled_sources += 1;
-                }
+                None => {}
             }
         }
     }
@@ -565,20 +574,17 @@ fn apply_ingest_selections_to_document(
     Ok(update)
 }
 
-fn ingest_source_indexes_for_harness(
+fn ingest_source_index(
     document: &mut DocumentMut,
-    harness: &str,
-) -> Result<Vec<usize>> {
+    setup_source: harnesses::DefaultIngestSource,
+) -> Result<Option<usize>> {
     let Some(sources) = ingest_sources_mut(document)? else {
-        return Ok(Vec::new());
+        return Ok(None);
     };
-    Ok(sources
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, source)| {
-            (source.get("harness").and_then(Item::as_str) == Some(harness)).then_some(idx)
-        })
-        .collect())
+    Ok(sources.iter().position(|source| {
+        source.get("name").and_then(Item::as_str) == Some(setup_source.name())
+            && source.get("harness").and_then(Item::as_str) == Some(setup_source.harness())
+    }))
 }
 
 fn ensure_ingest_sources_mut(document: &mut DocumentMut) -> Result<&mut ArrayOfTables> {
@@ -611,104 +617,6 @@ fn ingest_sources_mut(document: &mut DocumentMut) -> Result<Option<&mut ArrayOfT
     Ok(Some(sources.as_array_of_tables_mut().ok_or_else(|| {
         anyhow::anyhow!("ingest.sources must be an array of tables")
     })?))
-}
-
-#[derive(Debug, Clone, Copy)]
-struct DefaultIngestSource {
-    name: &'static str,
-    harness: &'static str,
-    glob: &'static str,
-    watch_root: &'static str,
-    format: Option<&'static str>,
-}
-
-impl DefaultIngestSource {
-    fn to_table(self, enabled: bool) -> Table {
-        let mut table = Table::new();
-        table["name"] = toml_value(self.name);
-        table["harness"] = toml_value(self.harness);
-        table["enabled"] = toml_value(enabled);
-        table["glob"] = toml_value(self.glob);
-        table["watch_root"] = toml_value(self.watch_root);
-        if let Some(format) = self.format {
-            table["format"] = toml_value(format);
-        }
-        table
-    }
-}
-
-fn default_ingest_sources_for_target(target: SetupMcpTarget) -> Vec<DefaultIngestSource> {
-    match target {
-        SetupMcpTarget::ClaudeCode => vec![DefaultIngestSource {
-            name: "claude",
-            harness: "claude-code",
-            glob: "~/.claude/projects/**/*.jsonl",
-            watch_root: "~/.claude/projects",
-            format: None,
-        }],
-        SetupMcpTarget::Codex => vec![DefaultIngestSource {
-            name: "codex",
-            harness: "codex",
-            glob: "~/.codex/sessions/**/*.jsonl",
-            watch_root: "~/.codex/sessions",
-            format: None,
-        }],
-        SetupMcpTarget::Hermes => vec![DefaultIngestSource {
-            name: "hermes",
-            harness: "hermes",
-            glob: "~/.hermes/sessions/session_*.json",
-            watch_root: "~/.hermes/sessions",
-            format: Some("session_json"),
-        }],
-        SetupMcpTarget::KimiCli => vec![DefaultIngestSource {
-            name: "kimi-cli",
-            harness: "kimi-cli",
-            glob: "~/.kimi/sessions/**/wire.jsonl",
-            watch_root: "~/.kimi/sessions",
-            format: Some("jsonl"),
-        }],
-        SetupMcpTarget::OpenCode => vec![DefaultIngestSource {
-            name: "opencode",
-            harness: "opencode",
-            glob: "~/.local/share/opencode/opencode*.db",
-            watch_root: "~/.local/share/opencode",
-            format: Some("opencode_sqlite"),
-        }],
-        SetupMcpTarget::Cursor => {
-            let cursor_state_root = if cfg!(target_os = "macos") {
-                "~/Library/Application Support/Cursor/User"
-            } else {
-                "~/.config/Cursor/User"
-            };
-            vec![
-                DefaultIngestSource {
-                    name: "cursor",
-                    harness: "cursor",
-                    glob: "~/.cursor/projects/*/agent-transcripts/**/*.jsonl",
-                    watch_root: "~/.cursor/projects",
-                    format: Some("jsonl"),
-                },
-                DefaultIngestSource {
-                    name: "cursor-sqlite",
-                    harness: "cursor",
-                    glob: if cfg!(target_os = "macos") {
-                        "~/Library/Application Support/Cursor/User/**/state.vscdb"
-                    } else {
-                        "~/.config/Cursor/User/**/state.vscdb"
-                    },
-                    watch_root: cursor_state_root,
-                    format: Some("cursor_sqlite"),
-                },
-            ]
-        }
-        SetupMcpTarget::PiCodingAgent => vec![DefaultIngestSource {
-            name: "pi",
-            harness: "pi-coding-agent",
-            glob: "~/.pi/agent/sessions/**/*.jsonl",
-            watch_root: "~/.pi/agent/sessions",
-            format: Some("jsonl"),
-        }],
-    }
 }
 
 fn write_toml_atomic(path: &Path, content: &str) -> Result<()> {
@@ -873,7 +781,8 @@ fn setup_target_selections(
         });
     }
 
-    prompt_setup_target_selector(&setup_targets(), runner)
+    let targets = harnesses::setup_targets();
+    prompt_setup_target_selector(&targets, runner)
 }
 
 fn dedup_targets(targets: &[SetupMcpTarget]) -> Vec<SetupMcpTarget> {
@@ -883,18 +792,6 @@ fn dedup_targets(targets: &[SetupMcpTarget]) -> Vec<SetupMcpTarget> {
         .copied()
         .filter(|target| seen.insert(*target))
         .collect()
-}
-
-fn setup_targets() -> [SetupMcpTarget; 7] {
-    [
-        SetupMcpTarget::ClaudeCode,
-        SetupMcpTarget::Codex,
-        SetupMcpTarget::Hermes,
-        SetupMcpTarget::KimiCli,
-        SetupMcpTarget::OpenCode,
-        SetupMcpTarget::Cursor,
-        SetupMcpTarget::PiCodingAgent,
-    ]
 }
 
 fn prompt_setup_target_selector(
@@ -992,6 +889,13 @@ fn render_setup_selector(
             .black()
             .apply_to("Space cycles none → ingest + harness → ingest only → harness only. Enter applies. Esc skips.")
     ))?;
+    term.write_line(&format!(
+        "  {}",
+        Style::new()
+            .for_stderr()
+            .yellow()
+            .apply_to(HOST_WIDE_ACCESS_WARNING)
+    ))?;
 
     for (idx, selection) in selections.iter().enumerate() {
         term.write_line(&format_setup_selector_row(
@@ -1001,7 +905,7 @@ fn render_setup_selector(
         ))?;
     }
     term.flush()?;
-    Ok(selections.len() + 2)
+    Ok(selections.len() + 3)
 }
 
 fn format_setup_selector_row(
@@ -1244,7 +1148,7 @@ impl SetupProgress {
             self.mark("→", ">", Style::new().cyan()),
             self.label(&format!(
                 "Updating {} config at {}",
-                write.kind.label(),
+                write.label(),
                 write.path().display()
             ))
         );
@@ -1567,206 +1471,7 @@ impl McpPlan {
         config_target: &ConfigTarget,
         home: Option<PathBuf>,
     ) -> Self {
-        match target {
-            SetupMcpTarget::ClaudeCode if config_target.requires_explicit_mcp_config() => {
-                let mut args = vec![
-                    "mcp".to_string(),
-                    "add".to_string(),
-                    "--transport".to_string(),
-                    "stdio".to_string(),
-                    "--scope".to_string(),
-                    "user".to_string(),
-                    "moraine".to_string(),
-                    "--".to_string(),
-                    "moraine".to_string(),
-                    "run".to_string(),
-                    "mcp".to_string(),
-                    "--config".to_string(),
-                ];
-                args.push(config_target.path.display().to_string());
-                let command = CommandSpec::new("claude", args);
-                Self::manual(
-                    target,
-                    format!(
-                        "Claude Code plugin installs use the default Moraine config. For this custom config target, use manual MCP registration:\n{}",
-                        command.display()
-                    ),
-                )
-            }
-            SetupMcpTarget::ClaudeCode => Self {
-                target,
-                action: McpAction::Execute,
-                steps: vec![
-                    McpPlanStep::warn_and_continue(
-                        CommandSpec::new(
-                            "claude",
-                            [
-                                "plugin",
-                                "marketplace",
-                                "add",
-                                "eric-tramel/moraine",
-                                "--sparse",
-                                ".claude-plugin",
-                                "plugins",
-                            ],
-                        ),
-                        "Claude marketplace add failed; continuing because the marketplace may already exist",
-                    )
-                    .with_progress(
-                        "Adding Claude Code plugin marketplace",
-                        "Claude Code marketplace ready",
-                        "Claude Code marketplace already present or unavailable",
-                        "Claude Code marketplace add failed",
-                    ),
-                    McpPlanStep::required(CommandSpec::new(
-                        "claude",
-                        ["plugin", "install", "moraine@moraine"],
-                    ))
-                    .with_progress(
-                        "Installing Claude Code Moraine plugin",
-                        "Claude Code plugin installed",
-                        "Claude Code plugin install warning",
-                        "Claude Code plugin install failed",
-                    ),
-                    McpPlanStep::warn_and_continue(
-                        CommandSpec::new(
-                            "claude",
-                            ["mcp", "remove", "moraine", "--scope", "user"],
-                        ),
-                        "Existing manual Claude Code MCP registration could not be removed; continuing in case it was absent",
-                    )
-                    .with_progress(
-                        "Cleaning up old Claude Code MCP registration",
-                        "Old Claude Code MCP registration removed or absent",
-                        "Old Claude Code MCP registration left unchanged",
-                        "Old Claude Code MCP cleanup failed",
-                    ),
-                ],
-                config_writes: Vec::new(),
-                manual_snippet: None,
-            },
-            SetupMcpTarget::Codex if config_target.requires_explicit_mcp_config() => {
-                let command = CommandSpec::new("codex", codex_args(config_target));
-                Self::manual(
-                    target,
-                    format!(
-                        "Codex plugin installs use the default Moraine config. For this custom config target, use manual MCP registration:\n{}",
-                        command.display()
-                    ),
-                )
-            }
-            SetupMcpTarget::Codex => Self {
-                target,
-                action: McpAction::Execute,
-                steps: vec![
-                    McpPlanStep::warn_and_continue(
-                        CommandSpec::new(
-                            "codex",
-                            [
-                                "plugin",
-                                "marketplace",
-                                "add",
-                                "eric-tramel/moraine",
-                                "--sparse",
-                                ".agents/plugins",
-                                "--sparse",
-                                "plugins/moraine",
-                                "--sparse",
-                                "plugins/moraine-dev",
-                            ],
-                        ),
-                        "Codex marketplace add failed; continuing because the marketplace may already exist",
-                    )
-                    .with_progress(
-                        "Adding Codex plugin marketplace",
-                        "Codex marketplace ready",
-                        "Codex marketplace already present or unavailable",
-                        "Codex marketplace add failed",
-                    ),
-                    McpPlanStep::required(CommandSpec::new(
-                        "codex",
-                        ["plugin", "add", "moraine@moraine"],
-                    ))
-                    .with_progress(
-                        "Installing Codex Moraine plugin",
-                        "Codex plugin installed",
-                        "Codex plugin install warning",
-                        "Codex plugin install failed",
-                    ),
-                    McpPlanStep::warn_and_continue(
-                        CommandSpec::new("codex", ["mcp", "remove", "moraine"]),
-                        "Existing manual Codex MCP registration could not be removed; continuing in case it was absent",
-                    )
-                    .with_progress(
-                        "Cleaning up old Codex MCP registration",
-                        "Old Codex MCP registration removed or absent",
-                        "Old Codex MCP registration left unchanged",
-                        "Old Codex MCP cleanup failed",
-                    ),
-                ],
-                config_writes: Vec::new(),
-                manual_snippet: None,
-            },
-            SetupMcpTarget::Hermes => Self::replace_registration(
-                target,
-                CommandSpec::new("hermes", ["mcp", "remove", "moraine"]),
-                McpPlanStep::required_stdout(
-                    CommandSpec::new("hermes", hermes_args(config_target)).with_stdin("\n"),
-                    "tools enabled",
-                )
-                .with_progress(
-                    "Registering Moraine MCP in Hermes",
-                    "Hermes MCP tools enabled",
-                    "Hermes MCP registration warning",
-                    "Hermes MCP registration failed",
-                ),
-            ),
-            SetupMcpTarget::KimiCli => Self::replace_registration(
-                target,
-                CommandSpec::new("kimi", ["mcp", "remove", "moraine"]),
-                McpPlanStep::required(CommandSpec::new("kimi", kimi_args(config_target)))
-                    .with_progress(
-                        "Registering Moraine MCP in Kimi CLI",
-                        "Kimi CLI MCP registered",
-                        "Kimi CLI MCP registration warning",
-                        "Kimi CLI MCP registration failed",
-                    ),
-            ),
-            SetupMcpTarget::OpenCode => Self::write_config(
-                target,
-                home
-                    .as_ref()
-                    .map(|home| McpConfigWrite::opencode(home, config_target)),
-                opencode_snippet(config_target),
-            ),
-            SetupMcpTarget::Cursor => Self::write_config(
-                target,
-                home.as_ref()
-                    .map(|home| McpConfigWrite::cursor(home, config_target)),
-                cursor_snippet(config_target),
-            ),
-            SetupMcpTarget::PiCodingAgent => {
-                let mut plan = Self::write_config(
-                    target,
-                    home.as_ref()
-                        .map(|home| McpConfigWrite::pi(home, config_target)),
-                    pi_snippet(config_target),
-                );
-                if !plan.config_writes.is_empty() {
-                    plan.steps.push(McpPlanStep::required(CommandSpec::new(
-                        "pi",
-                        ["install", "npm:pi-mcp-extension"],
-                    ))
-                    .with_progress(
-                        "Installing Pi MCP extension",
-                        "Pi MCP extension installed",
-                        "Pi MCP extension install warning",
-                        "Pi MCP extension install failed",
-                    ));
-                }
-                plan
-            }
-        }
+        harnesses::mcp_plan(target, config_target, home)
     }
 
     fn replace_registration(
@@ -1931,206 +1636,6 @@ enum CommandFailurePolicy {
     WarnAndContinue(&'static str),
 }
 
-fn mcp_run_args(config_target: &ConfigTarget) -> Vec<String> {
-    let mut args = vec!["run".to_string(), "mcp".to_string()];
-    if config_target.requires_explicit_mcp_config() {
-        args.push("--config".to_string());
-        args.push(config_target.path.display().to_string());
-    }
-    args
-}
-
-fn codex_args(config_target: &ConfigTarget) -> Vec<String> {
-    let mut args = vec![
-        "mcp".to_string(),
-        "add".to_string(),
-        "moraine".to_string(),
-        "--".to_string(),
-        "moraine".to_string(),
-    ];
-    args.extend(mcp_run_args(config_target));
-    args
-}
-
-fn hermes_args(config_target: &ConfigTarget) -> Vec<String> {
-    let mut args = vec![
-        "mcp".to_string(),
-        "add".to_string(),
-        "moraine".to_string(),
-        "--command".to_string(),
-        "moraine".to_string(),
-        "--args".to_string(),
-    ];
-    args.extend(mcp_run_args(config_target));
-    args
-}
-
-fn kimi_args(config_target: &ConfigTarget) -> Vec<String> {
-    let mut args = vec![
-        "mcp".to_string(),
-        "add".to_string(),
-        "--transport".to_string(),
-        "stdio".to_string(),
-        "moraine".to_string(),
-        "--".to_string(),
-        "moraine".to_string(),
-    ];
-    args.extend(mcp_run_args(config_target));
-    args
-}
-
-fn cursor_snippet(config_target: &ConfigTarget) -> String {
-    let snippet = serde_json::json!({
-        "mcpServers": {
-            "moraine": {
-                "type": "stdio",
-                "command": "moraine",
-                "args": mcp_run_args(config_target),
-            }
-        }
-    });
-    format!(
-        "Add this server to ~/.cursor/mcp.json for global Cursor use or .cursor/mcp.json for a project:\n{}",
-        serde_json::to_string_pretty(&snippet).unwrap_or_else(|_| snippet.to_string())
-    )
-}
-
-fn opencode_snippet(config_target: &ConfigTarget) -> String {
-    let snippet = serde_json::json!({
-        "$schema": "https://opencode.ai/config.json",
-        "mcp": {
-            "moraine": {
-                "type": "local",
-                "command": opencode_command(config_target),
-                "enabled": true,
-            }
-        }
-    });
-    format!(
-        "Add this server to ~/.config/opencode/opencode.json:\n{}",
-        serde_json::to_string_pretty(&snippet).unwrap_or_else(|_| snippet.to_string())
-    )
-}
-
-fn pi_snippet(config_target: &ConfigTarget) -> String {
-    let snippet = serde_json::json!({
-        "mcpServers": {
-            "moraine": {
-                "transport": "stdio",
-                "command": "moraine",
-                "args": mcp_run_args(config_target),
-                "lifecycle": "eager",
-            }
-        }
-    });
-    format!(
-        "Install the Pi MCP extension first:\npi install npm:pi-mcp-extension\n\nThen add this server to ~/.pi/agent/mcp.json:\n{}",
-        serde_json::to_string_pretty(&snippet).unwrap_or_else(|_| snippet.to_string())
-    )
-}
-
-fn opencode_command(config_target: &ConfigTarget) -> Vec<String> {
-    std::iter::once("moraine".to_string())
-        .chain(mcp_run_args(config_target))
-        .collect()
-}
-
-#[derive(Debug, Clone)]
-struct McpConfigWrite {
-    path: PathBuf,
-    kind: McpConfigKind,
-    command: Vec<String>,
-}
-
-impl McpConfigWrite {
-    fn cursor(home: &Path, config_target: &ConfigTarget) -> Self {
-        Self {
-            path: home.join(".cursor").join("mcp.json"),
-            kind: McpConfigKind::Cursor,
-            command: mcp_run_args(config_target),
-        }
-    }
-
-    fn pi(home: &Path, config_target: &ConfigTarget) -> Self {
-        Self {
-            path: home.join(".pi").join("agent").join("mcp.json"),
-            kind: McpConfigKind::Pi,
-            command: mcp_run_args(config_target),
-        }
-    }
-
-    fn opencode(home: &Path, config_target: &ConfigTarget) -> Self {
-        Self {
-            path: home.join(".config").join("opencode").join("opencode.json"),
-            kind: McpConfigKind::OpenCode,
-            command: opencode_command(config_target),
-        }
-    }
-
-    fn path(&self) -> &Path {
-        &self.path
-    }
-
-    fn merge_into(&self, root: &mut Map<String, Value>) -> Result<()> {
-        match self.kind {
-            McpConfigKind::Cursor => {
-                let servers = object_entry_mut(root, "mcpServers")?;
-                servers.insert(
-                    "moraine".to_string(),
-                    serde_json::json!({
-                        "type": "stdio",
-                        "command": "moraine",
-                        "args": self.command.clone(),
-                    }),
-                );
-            }
-            McpConfigKind::Pi => {
-                let servers = object_entry_mut(root, "mcpServers")?;
-                servers.insert(
-                    "moraine".to_string(),
-                    serde_json::json!({
-                        "transport": "stdio",
-                        "command": "moraine",
-                        "args": self.command.clone(),
-                        "lifecycle": "eager",
-                    }),
-                );
-            }
-            McpConfigKind::OpenCode => {
-                root.entry("$schema".to_string())
-                    .or_insert_with(|| serde_json::json!("https://opencode.ai/config.json"));
-                let servers = object_entry_mut(root, "mcp")?;
-                servers.insert(
-                    "moraine".to_string(),
-                    serde_json::json!({
-                        "type": "local",
-                        "command": self.command.clone(),
-                        "enabled": true,
-                    }),
-                );
-            }
-        }
-        Ok(())
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum McpConfigKind {
-    Cursor,
-    Pi,
-    OpenCode,
-}
-
-impl McpConfigKind {
-    fn label(self) -> &'static str {
-        match self {
-            McpConfigKind::Cursor => "Cursor",
-            McpConfigKind::Pi => "Pi",
-            McpConfigKind::OpenCode => "OpenCode",
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize)]
 struct McpConfigFileReport {
     path: String,
@@ -2166,13 +1671,13 @@ impl McpConfigFileReport {
 }
 
 fn apply_mcp_config_write(write: &McpConfigWrite) -> Result<McpConfigFileReport> {
-    let mut root = read_json_object_or_default(write.path())?;
+    let mut root = read_json_object_or_default(write.path(), write.format())?;
     write.merge_into(&mut root)?;
     write_json_atomic(write.path(), &Value::Object(root))?;
     Ok(McpConfigFileReport::written(write))
 }
 
-fn read_json_object_or_default(path: &Path) -> Result<Map<String, Value>> {
+fn read_json_object_or_default(path: &Path, format: McpConfigFormat) -> Result<Map<String, Value>> {
     let content = match fs::read_to_string(path) {
         Ok(content) => content,
         Err(exc) if exc.kind() == ErrorKind::NotFound => return Ok(Map::new()),
@@ -2185,27 +1690,20 @@ fn read_json_object_or_default(path: &Path) -> Result<Map<String, Value>> {
         return Ok(Map::new());
     }
 
-    let value: Value = serde_json::from_str(&content)
-        .with_context(|| format!("{} is not valid JSON", path.display()))?;
+    let value = match format {
+        McpConfigFormat::Jsonc => read_jsonc_value(path, &content)?,
+        McpConfigFormat::Json => serde_json::from_str(&content)
+            .with_context(|| format!("{} is not valid JSON", path.display()))?,
+    };
     match value {
         Value::Object(object) => Ok(object),
         _ => bail!("{} must contain a JSON object", path.display()),
     }
 }
 
-fn object_entry_mut<'a>(
-    root: &'a mut Map<String, Value>,
-    key: &str,
-) -> Result<&'a mut Map<String, Value>> {
-    let value = root
-        .entry(key.to_string())
-        .or_insert_with(|| Value::Object(Map::new()));
-    if !value.is_object() {
-        bail!("{key} must be a JSON object");
-    }
-    Ok(value
-        .as_object_mut()
-        .expect("value was checked as a JSON object"))
+fn read_jsonc_value(path: &Path, content: &str) -> Result<Value> {
+    jsonc_parser::parse_to_serde_value::<Value>(content, &Default::default())
+        .with_context(|| format!("{} is not valid JSONC", path.display()))
 }
 
 fn write_json_atomic(path: &Path, value: &Value) -> Result<()> {
@@ -2814,36 +2312,11 @@ fn append_target_details(target: &McpTargetReport, output: &CliOutput, lines: &m
 
 impl SetupMcpTarget {
     fn label(self) -> &'static str {
-        match self {
-            SetupMcpTarget::ClaudeCode => "Claude Code",
-            SetupMcpTarget::Codex => "Codex",
-            SetupMcpTarget::Hermes => "Hermes",
-            SetupMcpTarget::KimiCli => "Kimi CLI",
-            SetupMcpTarget::OpenCode => "OpenCode",
-            SetupMcpTarget::Cursor => "Cursor",
-            SetupMcpTarget::PiCodingAgent => "Pi Coding Agent",
-        }
+        harnesses::spec(self).label()
     }
 
     fn setup_kind(self) -> &'static str {
-        match self {
-            SetupMcpTarget::ClaudeCode | SetupMcpTarget::Codex => "plugin",
-            SetupMcpTarget::Hermes | SetupMcpTarget::KimiCli => "MCP",
-            SetupMcpTarget::OpenCode | SetupMcpTarget::Cursor => "MCP config",
-            SetupMcpTarget::PiCodingAgent => "MCP extension",
-        }
-    }
-
-    fn harness_name(self) -> &'static str {
-        match self {
-            SetupMcpTarget::ClaudeCode => "claude-code",
-            SetupMcpTarget::Codex => "codex",
-            SetupMcpTarget::Hermes => "hermes",
-            SetupMcpTarget::KimiCli => "kimi-cli",
-            SetupMcpTarget::OpenCode => "opencode",
-            SetupMcpTarget::Cursor => "cursor",
-            SetupMcpTarget::PiCodingAgent => "pi-coding-agent",
-        }
+        harnesses::spec(self).setup_kind()
     }
 
     fn is_available_for_setup(self, runner: &dyn CommandRunner) -> bool {
@@ -2858,36 +2331,14 @@ impl SetupMcpTarget {
     }
 
     fn program_candidates(self) -> &'static [&'static str] {
-        match self {
-            SetupMcpTarget::ClaudeCode => &["claude"],
-            SetupMcpTarget::Codex => &["codex"],
-            SetupMcpTarget::Hermes => &["hermes"],
-            SetupMcpTarget::KimiCli => &["kimi"],
-            SetupMcpTarget::OpenCode => &["opencode"],
-            SetupMcpTarget::Cursor => &["cursor", "cursor-agent"],
-            SetupMcpTarget::PiCodingAgent => &["pi"],
-        }
+        harnesses::spec(self).program_candidates()
     }
 
     fn default_probe_paths(self) -> Vec<PathBuf> {
         let Some(home) = env::var_os("HOME").map(PathBuf::from) else {
             return Vec::new();
         };
-        match self {
-            SetupMcpTarget::OpenCode => vec![
-                home.join(".config").join("opencode"),
-                home.join(".local").join("share").join("opencode"),
-            ],
-            SetupMcpTarget::Cursor => vec![
-                home.join(".cursor"),
-                home.join("Library")
-                    .join("Application Support")
-                    .join("Cursor"),
-                home.join(".config").join("Cursor"),
-            ],
-            SetupMcpTarget::PiCodingAgent => vec![home.join(".pi").join("agent")],
-            _ => Vec::new(),
-        }
+        harnesses::spec(self).default_probe_paths(&home)
     }
 }
 
@@ -2896,6 +2347,7 @@ mod tests {
     use super::*;
     use crate::render::OutputMode;
     use std::collections::{BTreeMap, BTreeSet};
+    use toml_edit::value as toml_value;
 
     #[derive(Default)]
     struct FakeRunner {
@@ -2987,6 +2439,37 @@ mod tests {
             .unwrap_or(true)
     }
 
+    fn source_value<'a>(document: &'a DocumentMut, name: &str, key: &str) -> Option<&'a str> {
+        document["ingest"]["sources"]
+            .as_array_of_tables()
+            .expect("ingest sources")
+            .iter()
+            .find(|source| source.get("name").and_then(Item::as_str) == Some(name))
+            .expect("source exists")
+            .get(key)
+            .and_then(Item::as_str)
+    }
+
+    fn push_source(
+        document: &mut DocumentMut,
+        name: &str,
+        harness: &str,
+        enabled: bool,
+        glob: &str,
+        watch_root: &str,
+    ) {
+        let mut table = Table::new();
+        table["name"] = toml_value(name);
+        table["harness"] = toml_value(harness);
+        table["enabled"] = toml_value(enabled);
+        table["glob"] = toml_value(glob);
+        table["watch_root"] = toml_value(watch_root);
+        document["ingest"]["sources"]
+            .as_array_of_tables_mut()
+            .expect("ingest sources")
+            .push(table);
+    }
+
     #[test]
     fn setup_config_target_prefers_cli_then_home() {
         let cli = resolve_setup_config_target_with(
@@ -3042,6 +2525,11 @@ mod tests {
     }
 
     #[test]
+    fn setup_selector_warning_discloses_host_wide_history_access() {
+        assert!(HOST_WIDE_ACCESS_WARNING.contains("host-wide Moraine session history access"));
+    }
+
+    #[test]
     fn harness_targets_include_only_modes_that_configure_harnesses() {
         let selections = SetupSelectionSet {
             targets: vec![
@@ -3077,6 +2565,14 @@ mod tests {
         let mut document = DEFAULT_CONFIG_TEMPLATE
             .parse::<DocumentMut>()
             .expect("template parses");
+        push_source(
+            &mut document,
+            "cursor-custom",
+            "cursor",
+            true,
+            "~/custom/**/*.jsonl",
+            "~/custom",
+        );
 
         let update = apply_ingest_selections_to_document(
             &mut document,
@@ -3103,11 +2599,13 @@ mod tests {
                 enabled_sources: 0,
                 disabled_sources: 3,
                 added_sources: 0,
+                updated_sources: 0,
             }
         );
         assert!(source_enabled(&document, "codex"));
         assert!(!source_enabled(&document, "cursor"));
         assert!(!source_enabled(&document, "cursor-sqlite"));
+        assert!(source_enabled(&document, "cursor-custom"));
         assert!(!source_enabled(&document, "hermes"));
     }
 
@@ -3138,6 +2636,7 @@ mod tests {
                 enabled_sources: 0,
                 disabled_sources: 0,
                 added_sources: 2,
+                updated_sources: 0,
             }
         );
         assert_eq!(sources_for_harness(&document, "cursor").len(), 2);
@@ -3149,6 +2648,65 @@ mod tests {
         fs::write(&path, document.to_string()).expect("write updated config");
         moraine_config::load_config(&path).expect("updated config loads");
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn ingest_selection_reconciles_missing_setup_owned_sources() {
+        let mut document = r#"
+[ingest]
+
+[[ingest.sources]]
+name = "cursor"
+harness = "cursor"
+enabled = false
+glob = "~/stale/**/*.jsonl"
+watch_root = "~/stale"
+format = "stale"
+
+[[ingest.sources]]
+name = "cursor-custom"
+harness = "cursor"
+enabled = false
+glob = "~/custom/**/*.jsonl"
+watch_root = "~/custom"
+"#
+        .parse::<DocumentMut>()
+        .expect("partial cursor config parses");
+
+        let update = apply_ingest_selections_to_document(
+            &mut document,
+            &[SetupTargetSelection {
+                target: SetupMcpTarget::Cursor,
+                mode: SetupSelectionMode::IngestOnly,
+            }],
+        )
+        .expect("apply ingest selections");
+
+        assert_eq!(
+            update,
+            IngestSelectionUpdate {
+                enabled_sources: 1,
+                disabled_sources: 0,
+                added_sources: 1,
+                updated_sources: 1,
+            }
+        );
+        assert!(source_enabled(&document, "cursor"));
+        assert!(source_enabled(&document, "cursor-sqlite"));
+        assert!(!source_enabled(&document, "cursor-custom"));
+        assert_eq!(
+            source_value(&document, "cursor", "glob"),
+            Some("~/.cursor/projects/*/agent-transcripts/**/*.jsonl")
+        );
+        assert_eq!(
+            source_value(&document, "cursor", "watch_root"),
+            Some("~/.cursor/projects")
+        );
+        assert_eq!(source_value(&document, "cursor", "format"), Some("jsonl"));
+        assert_eq!(
+            source_value(&document, "cursor-custom", "glob"),
+            Some("~/custom/**/*.jsonl")
+        );
     }
 
     #[test]
@@ -3448,6 +3006,50 @@ mod tests {
         assert_eq!(
             value["mcp"]["moraine"]["command"],
             serde_json::json!(["moraine", "run", "mcp", "--config", "/tmp/custom.toml"])
+        );
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn opencode_config_write_accepts_jsonc_config() {
+        let home = temp_path("opencode-jsonc-home");
+        let opencode_dir = home.join(".config").join("opencode");
+        fs::create_dir_all(&opencode_dir).expect("create opencode dir");
+        let path = opencode_dir.join("opencode.json");
+        fs::write(
+            &path,
+            r#"{
+  // OpenCode config files are JSONC.
+  "theme": "system",
+  "mcp": {
+    "other": {
+      "type": "local",
+      "command": ["node", "server.js"],
+    },
+  },
+}"#,
+        )
+        .expect("write existing opencode config");
+
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let write = McpConfigWrite::opencode(&home, &target);
+        apply_mcp_config_write(&write).expect("write opencode config");
+
+        let value: Value =
+            serde_json::from_str(&fs::read_to_string(&path).expect("read opencode config"))
+                .expect("opencode config json");
+        assert_eq!(value["theme"], "system");
+        assert_eq!(
+            value["mcp"]["other"]["command"],
+            serde_json::json!(["node", "server.js"])
+        );
+        assert_eq!(value["mcp"]["moraine"]["type"], "local");
+        assert_eq!(
+            value["mcp"]["moraine"]["command"],
+            serde_json::json!(["moraine", "run", "mcp"])
         );
         let _ = fs::remove_dir_all(home);
     }

--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -1,9 +1,5 @@
 use anyhow::{bail, Context, Result};
-use dialoguer::{
-    console::{style, Style},
-    theme::Theme,
-    MultiSelect,
-};
+use dialoguer::console::{style, Key, Style, Term};
 use serde::Serialize;
 use serde_json::{Map, Value};
 use std::collections::BTreeSet;
@@ -19,6 +15,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::cli::{SetupArgs, SetupMcpTarget};
 use crate::render::{CliOutput, OutputMode};
+use toml_edit::{value as toml_value, ArrayOfTables, DocumentMut, Item, Table};
 
 const DEFAULT_CONFIG_TEMPLATE: &str = include_str!("../../../../config/moraine.toml");
 
@@ -55,7 +52,7 @@ fn run_setup(
         bail!("`moraine --output json setup` requires --yes or --dry-run");
     }
 
-    let config = if args.skip_config {
+    let mut config = if args.skip_config {
         ConfigReport::skipped(&target.path, "skipped by --skip-config")
     } else {
         setup_config(args, &target, interactive)?
@@ -66,23 +63,45 @@ fn run_setup(
         let config_allows_mcp =
             args.skip_config || args.dry_run || config.status == SetupStatus::Ok;
         if config_allows_mcp {
-            let selected = selected_mcp_targets(args, interactive, runner)?;
-            let targets_confirmed_by_selection =
-                args.mcp_targets.is_empty() && interactive && !args.yes && !args.dry_run;
-            let mut progress = SetupProgress::from_output(output);
-            for mcp_target in selected {
-                let report = setup_mcp_target_with_progress(
-                    args,
-                    &target,
-                    mcp_target,
-                    interactive,
-                    targets_confirmed_by_selection,
-                    &mut progress,
-                    runner,
-                )?;
-                mcp_targets.push(report);
+            let selections = setup_target_selections(args, interactive, runner)?;
+            if selections.apply_ingest && !args.skip_config && config.status == SetupStatus::Ok {
+                match apply_ingest_selections_to_config(&target.path, &selections.targets) {
+                    Ok(update) => config.apply_ingest_update(update),
+                    Err(exc) => {
+                        config = ConfigReport::error(
+                            &target.path,
+                            "ingest_update_failed",
+                            &format!("failed to update ingest source selections: {exc}"),
+                        );
+                    }
+                }
             }
-            progress.finish();
+
+            let harness_targets = selections.harness_targets();
+            if config.status == SetupStatus::Ok || args.skip_config || args.dry_run {
+                let targets_confirmed_by_selection = selections.confirmed_harness;
+                let mut progress = SetupProgress::from_output(output);
+                for mcp_target in harness_targets {
+                    let report = setup_mcp_target_with_progress(
+                        args,
+                        &target,
+                        mcp_target,
+                        interactive,
+                        targets_confirmed_by_selection,
+                        &mut progress,
+                        runner,
+                    )?;
+                    mcp_targets.push(report);
+                }
+                progress.finish();
+            } else {
+                for mcp_target in harness_targets {
+                    mcp_targets.push(McpTargetReport::skipped(
+                        mcp_target,
+                        "config setup did not complete; skipping MCP/plugin setup",
+                    ));
+                }
+            }
         } else {
             for mcp_target in dedup_targets(&args.mcp_targets) {
                 mcp_targets.push(McpTargetReport::skipped(
@@ -444,24 +463,417 @@ fn timestamp_suffix() -> String {
     format!("{}-{}", duration.as_secs(), duration.subsec_nanos())
 }
 
-fn selected_mcp_targets(
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct IngestSelectionUpdate {
+    enabled_sources: usize,
+    disabled_sources: usize,
+    added_sources: usize,
+}
+
+impl IngestSelectionUpdate {
+    fn changed_sources(self) -> usize {
+        self.enabled_sources + self.disabled_sources + self.added_sources
+    }
+
+    fn has_changes(self) -> bool {
+        self.changed_sources() > 0
+    }
+
+    fn summary(self) -> String {
+        if !self.has_changes() {
+            return "ingest sources already matched selection".to_string();
+        }
+
+        let mut parts = Vec::new();
+        if self.added_sources == 1 {
+            parts.push("1 added".to_string());
+        } else if self.added_sources > 1 {
+            parts.push(format!("{} added", self.added_sources));
+        }
+        if self.enabled_sources == 1 {
+            parts.push("1 enabled".to_string());
+        } else if self.enabled_sources > 1 {
+            parts.push(format!("{} enabled", self.enabled_sources));
+        }
+        if self.disabled_sources == 1 {
+            parts.push("1 disabled".to_string());
+        } else if self.disabled_sources > 1 {
+            parts.push(format!("{} disabled", self.disabled_sources));
+        }
+        format!("ingest sources updated: {}", parts.join(", "))
+    }
+}
+
+fn apply_ingest_selections_to_config(
+    path: &Path,
+    selections: &[SetupTargetSelection],
+) -> Result<IngestSelectionUpdate> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut document = content
+        .parse::<DocumentMut>()
+        .with_context(|| format!("{} is not valid TOML", path.display()))?;
+    let update = apply_ingest_selections_to_document(&mut document, selections)?;
+    if update.has_changes() {
+        write_toml_atomic(path, &document.to_string())?;
+    }
+    Ok(update)
+}
+
+fn apply_ingest_selections_to_document(
+    document: &mut DocumentMut,
+    selections: &[SetupTargetSelection],
+) -> Result<IngestSelectionUpdate> {
+    let mut update = IngestSelectionUpdate::default();
+
+    for selection in selections {
+        let harness = selection.target.harness_name();
+        let enabled = selection.mode.configures_ingest();
+        let source_indexes = ingest_source_indexes_for_harness(document, harness)?;
+
+        if source_indexes.is_empty() {
+            if enabled {
+                let sources = ensure_ingest_sources_mut(document)?;
+                for source in default_ingest_sources_for_target(selection.target) {
+                    sources.push(source.to_table(enabled));
+                    update.added_sources += 1;
+                }
+            }
+            continue;
+        }
+
+        let sources = ensure_ingest_sources_mut(document)?;
+        for source_idx in source_indexes {
+            let source = sources
+                .get_mut(source_idx)
+                .expect("source index came from the same array");
+            let current_enabled = source
+                .get("enabled")
+                .and_then(Item::as_bool)
+                .unwrap_or(true);
+            if current_enabled != enabled {
+                source["enabled"] = toml_value(enabled);
+                if enabled {
+                    update.enabled_sources += 1;
+                } else {
+                    update.disabled_sources += 1;
+                }
+            }
+        }
+    }
+
+    Ok(update)
+}
+
+fn ingest_source_indexes_for_harness(
+    document: &mut DocumentMut,
+    harness: &str,
+) -> Result<Vec<usize>> {
+    let Some(sources) = ingest_sources_mut(document)? else {
+        return Ok(Vec::new());
+    };
+    Ok(sources
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, source)| {
+            (source.get("harness").and_then(Item::as_str) == Some(harness)).then_some(idx)
+        })
+        .collect())
+}
+
+fn ensure_ingest_sources_mut(document: &mut DocumentMut) -> Result<&mut ArrayOfTables> {
+    if document.as_table().get("ingest").is_none() {
+        document["ingest"] = Item::Table(Table::new());
+    }
+
+    let ingest = document["ingest"]
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!("ingest must be a TOML table"))?;
+    if ingest.get("sources").is_none() {
+        ingest["sources"] = Item::ArrayOfTables(ArrayOfTables::new());
+    }
+
+    ingest["sources"]
+        .as_array_of_tables_mut()
+        .ok_or_else(|| anyhow::anyhow!("ingest.sources must be an array of tables"))
+}
+
+fn ingest_sources_mut(document: &mut DocumentMut) -> Result<Option<&mut ArrayOfTables>> {
+    let Some(ingest) = document.as_table_mut().get_mut("ingest") else {
+        return Ok(None);
+    };
+    let ingest = ingest
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!("ingest must be a TOML table"))?;
+    let Some(sources) = ingest.get_mut("sources") else {
+        return Ok(None);
+    };
+    Ok(Some(sources.as_array_of_tables_mut().ok_or_else(|| {
+        anyhow::anyhow!("ingest.sources must be an array of tables")
+    })?))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DefaultIngestSource {
+    name: &'static str,
+    harness: &'static str,
+    glob: &'static str,
+    watch_root: &'static str,
+    format: Option<&'static str>,
+}
+
+impl DefaultIngestSource {
+    fn to_table(self, enabled: bool) -> Table {
+        let mut table = Table::new();
+        table["name"] = toml_value(self.name);
+        table["harness"] = toml_value(self.harness);
+        table["enabled"] = toml_value(enabled);
+        table["glob"] = toml_value(self.glob);
+        table["watch_root"] = toml_value(self.watch_root);
+        if let Some(format) = self.format {
+            table["format"] = toml_value(format);
+        }
+        table
+    }
+}
+
+fn default_ingest_sources_for_target(target: SetupMcpTarget) -> Vec<DefaultIngestSource> {
+    match target {
+        SetupMcpTarget::ClaudeCode => vec![DefaultIngestSource {
+            name: "claude",
+            harness: "claude-code",
+            glob: "~/.claude/projects/**/*.jsonl",
+            watch_root: "~/.claude/projects",
+            format: None,
+        }],
+        SetupMcpTarget::Codex => vec![DefaultIngestSource {
+            name: "codex",
+            harness: "codex",
+            glob: "~/.codex/sessions/**/*.jsonl",
+            watch_root: "~/.codex/sessions",
+            format: None,
+        }],
+        SetupMcpTarget::Hermes => vec![DefaultIngestSource {
+            name: "hermes",
+            harness: "hermes",
+            glob: "~/.hermes/sessions/session_*.json",
+            watch_root: "~/.hermes/sessions",
+            format: Some("session_json"),
+        }],
+        SetupMcpTarget::KimiCli => vec![DefaultIngestSource {
+            name: "kimi-cli",
+            harness: "kimi-cli",
+            glob: "~/.kimi/sessions/**/wire.jsonl",
+            watch_root: "~/.kimi/sessions",
+            format: Some("jsonl"),
+        }],
+        SetupMcpTarget::OpenCode => vec![DefaultIngestSource {
+            name: "opencode",
+            harness: "opencode",
+            glob: "~/.local/share/opencode/opencode*.db",
+            watch_root: "~/.local/share/opencode",
+            format: Some("opencode_sqlite"),
+        }],
+        SetupMcpTarget::Cursor => {
+            let cursor_state_root = if cfg!(target_os = "macos") {
+                "~/Library/Application Support/Cursor/User"
+            } else {
+                "~/.config/Cursor/User"
+            };
+            vec![
+                DefaultIngestSource {
+                    name: "cursor",
+                    harness: "cursor",
+                    glob: "~/.cursor/projects/*/agent-transcripts/**/*.jsonl",
+                    watch_root: "~/.cursor/projects",
+                    format: Some("jsonl"),
+                },
+                DefaultIngestSource {
+                    name: "cursor-sqlite",
+                    harness: "cursor",
+                    glob: if cfg!(target_os = "macos") {
+                        "~/Library/Application Support/Cursor/User/**/state.vscdb"
+                    } else {
+                        "~/.config/Cursor/User/**/state.vscdb"
+                    },
+                    watch_root: cursor_state_root,
+                    format: Some("cursor_sqlite"),
+                },
+            ]
+        }
+        SetupMcpTarget::PiCodingAgent => vec![DefaultIngestSource {
+            name: "pi",
+            harness: "pi-coding-agent",
+            glob: "~/.pi/agent/sessions/**/*.jsonl",
+            watch_root: "~/.pi/agent/sessions",
+            format: Some("jsonl"),
+        }],
+    }
+}
+
+fn write_toml_atomic(path: &Path, content: &str) -> Result<()> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("config.toml");
+    for attempt in 0..100 {
+        let temp_path = parent.join(format!(
+            ".{file_name}.setup-{}-{}-{attempt}.tmp",
+            std::process::id(),
+            timestamp_suffix()
+        ));
+        match private_create_new_options().open(&temp_path) {
+            Ok(mut file) => {
+                let result = (|| {
+                    file.write_all(content.as_bytes())
+                        .with_context(|| format!("failed to write {}", temp_path.display()))?;
+                    file.flush()
+                        .with_context(|| format!("failed to flush {}", temp_path.display()))?;
+                    moraine_config::load_config(&temp_path).with_context(|| {
+                        format!(
+                            "updated config failed validation at {}",
+                            temp_path.display()
+                        )
+                    })?;
+                    fs::rename(&temp_path, path).with_context(|| {
+                        format!(
+                            "failed to persist {} to {}",
+                            temp_path.display(),
+                            path.display()
+                        )
+                    })?;
+                    Ok(())
+                })();
+                if result.is_err() {
+                    let _ = fs::remove_file(&temp_path);
+                }
+                return result;
+            }
+            Err(exc) if exc.kind() == ErrorKind::AlreadyExists => continue,
+            Err(exc) => {
+                return Err(exc)
+                    .with_context(|| format!("failed to create {}", temp_path.display()));
+            }
+        }
+    }
+
+    bail!(
+        "failed to create a unique temporary TOML file in {}",
+        parent.display()
+    );
+}
+
+#[derive(Debug, Clone)]
+struct SetupSelectionSet {
+    targets: Vec<SetupTargetSelection>,
+    apply_ingest: bool,
+    confirmed_harness: bool,
+}
+
+impl SetupSelectionSet {
+    fn harness_targets(&self) -> Vec<SetupMcpTarget> {
+        self.targets
+            .iter()
+            .filter(|selection| selection.mode.configures_harness())
+            .map(|selection| selection.target)
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SetupTargetSelection {
+    target: SetupMcpTarget,
+    mode: SetupSelectionMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SetupSelectionMode {
+    Off,
+    IngestAndHarness,
+    IngestOnly,
+    HarnessOnly,
+}
+
+impl SetupSelectionMode {
+    fn cycle(self) -> Self {
+        match self {
+            SetupSelectionMode::Off => SetupSelectionMode::IngestAndHarness,
+            SetupSelectionMode::IngestAndHarness => SetupSelectionMode::IngestOnly,
+            SetupSelectionMode::IngestOnly => SetupSelectionMode::HarnessOnly,
+            SetupSelectionMode::HarnessOnly => SetupSelectionMode::Off,
+        }
+    }
+
+    fn configures_ingest(self) -> bool {
+        matches!(
+            self,
+            SetupSelectionMode::IngestAndHarness | SetupSelectionMode::IngestOnly
+        )
+    }
+
+    fn configures_harness(self) -> bool {
+        matches!(
+            self,
+            SetupSelectionMode::IngestAndHarness | SetupSelectionMode::HarnessOnly
+        )
+    }
+
+    fn icon(self) -> &'static str {
+        match self {
+            SetupSelectionMode::Off => "○",
+            SetupSelectionMode::IngestAndHarness => "●",
+            SetupSelectionMode::IngestOnly => "◐",
+            SetupSelectionMode::HarnessOnly => "◑",
+        }
+    }
+
+    fn summary(self, target: SetupMcpTarget) -> String {
+        match self {
+            SetupSelectionMode::Off => "nothing".to_string(),
+            SetupSelectionMode::IngestAndHarness => format!("ingest + {}", target.setup_kind()),
+            SetupSelectionMode::IngestOnly => "ingest only".to_string(),
+            SetupSelectionMode::HarnessOnly => format!("{} only", target.setup_kind()),
+        }
+    }
+}
+
+fn setup_target_selections(
     args: &SetupArgs,
     interactive: bool,
     runner: &dyn CommandRunner,
-) -> Result<Vec<SetupMcpTarget>> {
+) -> Result<SetupSelectionSet> {
     if !args.mcp_targets.is_empty() {
-        return Ok(dedup_targets(&args.mcp_targets));
+        return Ok(SetupSelectionSet {
+            targets: dedup_targets(&args.mcp_targets)
+                .into_iter()
+                .map(|target| SetupTargetSelection {
+                    target,
+                    mode: SetupSelectionMode::HarnessOnly,
+                })
+                .collect(),
+            apply_ingest: false,
+            confirmed_harness: false,
+        });
     }
 
     if args.yes || args.dry_run || !interactive {
-        return Ok(Vec::new());
+        return Ok(SetupSelectionSet {
+            targets: Vec::new(),
+            apply_ingest: false,
+            confirmed_harness: false,
+        });
     }
 
-    let available = setup_targets()
-        .into_iter()
-        .filter(|target| target.is_available_for_setup(runner))
-        .collect::<Vec<_>>();
-    prompt_mcp_target_checklist(&available)
+    prompt_setup_target_selector(&setup_targets(), runner)
 }
 
 fn dedup_targets(targets: &[SetupMcpTarget]) -> Vec<SetupMcpTarget> {
@@ -485,125 +897,210 @@ fn setup_targets() -> [SetupMcpTarget; 7] {
     ]
 }
 
-fn prompt_mcp_target_checklist(available: &[SetupMcpTarget]) -> Result<Vec<SetupMcpTarget>> {
-    if available.is_empty() {
-        eprintln!("No supported agent harnesses were detected.");
-        return Ok(Vec::new());
-    }
-
-    let items = available
+fn prompt_setup_target_selector(
+    targets: &[SetupMcpTarget],
+    runner: &dyn CommandRunner,
+) -> Result<SetupSelectionSet> {
+    let mut selections = targets
         .iter()
-        .map(|target| format!("{:<14} {}", target.label(), target.setup_kind()))
+        .copied()
+        .map(|target| SetupTargetSelection {
+            target,
+            mode: SetupSelectionMode::Off,
+        })
         .collect::<Vec<_>>();
-    let defaults = vec![false; items.len()];
-    let theme = SetupPromptTheme;
-    let selected = MultiSelect::with_theme(&theme)
-        .with_prompt(
-            "Agent integrations - selected harnesses get host-wide Moraine session history access (Space toggles, Enter installs selected, Esc skips)",
-        )
-        .items(&items)
-        .defaults(&defaults)
-        .max_length(items.len())
-        .interact_opt()
-        .context("failed to read setup target selection")?
-        .unwrap_or_default();
+    let mut active = 0usize;
+    let term = Term::stderr();
+    let mut rendered_lines = 0usize;
 
-    Ok(selected_mcp_targets_from_indices(available, &selected))
-}
-
-fn selected_mcp_targets_from_indices(
-    available: &[SetupMcpTarget],
-    indices: &[usize],
-) -> Vec<SetupMcpTarget> {
-    indices
-        .iter()
-        .filter_map(|idx| available.get(*idx).copied())
-        .collect()
-}
-
-struct SetupPromptTheme;
-
-impl Theme for SetupPromptTheme {
-    fn format_prompt(&self, f: &mut dyn fmt::Write, prompt: &str) -> fmt::Result {
-        write!(
-            f,
-            "{} {} {}",
-            style("?").for_stderr().yellow(),
-            Style::new().for_stderr().bold().apply_to(prompt),
-            style("›").for_stderr().bright().black()
-        )
-    }
-
-    fn format_error(&self, f: &mut dyn fmt::Write, err: &str) -> fmt::Result {
-        write!(
-            f,
-            "{} {}",
-            style("✘").for_stderr().red(),
-            Style::new().for_stderr().red().apply_to(err)
-        )
-    }
-
-    fn format_multi_select_prompt_selection(
-        &self,
-        f: &mut dyn fmt::Write,
-        prompt: &str,
-        selections: &[&str],
-    ) -> fmt::Result {
-        write!(
-            f,
-            "{} {} {} ",
-            style("✔").for_stderr().green(),
-            Style::new().for_stderr().bold().apply_to(prompt),
-            style("·").for_stderr().bright().black()
-        )?;
-        if selections.is_empty() {
-            return write!(
-                f,
-                "{}",
-                Style::new().for_stderr().bright().black().apply_to("none")
-            );
+    loop {
+        if rendered_lines > 0 {
+            term.clear_last_lines(rendered_lines).ok();
         }
-        for (idx, selection) in selections.iter().enumerate() {
-            if idx > 0 {
-                write!(f, ", ")?;
+        rendered_lines = render_setup_selector(&term, &selections, active, runner)
+            .context("failed to render setup target selector")?;
+
+        match term
+            .read_key()
+            .context("failed to read setup target selection")?
+        {
+            Key::ArrowUp => {
+                active = active.checked_sub(1).unwrap_or(selections.len() - 1);
             }
-            write!(
-                f,
-                "{}",
-                Style::new().for_stderr().green().apply_to(selection)
-            )?;
+            Key::ArrowDown => {
+                active = (active + 1) % selections.len();
+            }
+            Key::Char(' ') => {
+                selections[active].mode = selections[active].mode.cycle();
+            }
+            Key::Enter => {
+                term.clear_last_lines(rendered_lines).ok();
+                render_setup_selection_summary(&selections);
+                return Ok(SetupSelectionSet {
+                    confirmed_harness: selections
+                        .iter()
+                        .any(|selection| selection.mode.configures_harness()),
+                    targets: selections,
+                    apply_ingest: true,
+                });
+            }
+            Key::Escape => {
+                term.clear_last_lines(rendered_lines).ok();
+                eprintln!(
+                    "{} {} {} {}",
+                    style("–").for_stderr().yellow(),
+                    Style::new()
+                        .for_stderr()
+                        .bold()
+                        .apply_to("Agent integrations"),
+                    style("·").for_stderr().bright().black(),
+                    Style::new()
+                        .for_stderr()
+                        .bright()
+                        .black()
+                        .apply_to("skipped")
+                );
+                return Ok(SetupSelectionSet {
+                    targets: Vec::new(),
+                    apply_ingest: false,
+                    confirmed_harness: false,
+                });
+            }
+            Key::CtrlC => bail!("setup target selection interrupted"),
+            _ => {}
         }
-        Ok(())
     }
+}
 
-    fn format_multi_select_prompt_item(
-        &self,
-        f: &mut dyn fmt::Write,
-        text: &str,
-        checked: bool,
-        active: bool,
-    ) -> fmt::Result {
-        let arrow = if active {
-            style("❯").for_stderr().green().to_string()
+fn render_setup_selector(
+    term: &Term,
+    selections: &[SetupTargetSelection],
+    active: usize,
+    runner: &dyn CommandRunner,
+) -> Result<usize> {
+    term.write_line(&format!(
+        "{} {} {}",
+        style("?").for_stderr().yellow(),
+        Style::new().for_stderr().bold().apply_to("Agent setup"),
+        style("›").for_stderr().bright().black()
+    ))?;
+    term.write_line(&format!(
+        "  {}",
+        Style::new()
+            .for_stderr()
+            .bright()
+            .black()
+            .apply_to("Space cycles none → ingest + harness → ingest only → harness only. Enter applies. Esc skips.")
+    ))?;
+
+    for (idx, selection) in selections.iter().enumerate() {
+        term.write_line(&format_setup_selector_row(
+            *selection,
+            idx == active,
+            selection.target.is_available_for_setup(runner),
+        ))?;
+    }
+    term.flush()?;
+    Ok(selections.len() + 2)
+}
+
+fn format_setup_selector_row(
+    selection: SetupTargetSelection,
+    active: bool,
+    harness_available: bool,
+) -> String {
+    let arrow = if active {
+        style("❯").for_stderr().green().to_string()
+    } else {
+        " ".to_string()
+    };
+    let icon_style = match selection.mode {
+        SetupSelectionMode::Off => Style::new().for_stderr().bright().black(),
+        SetupSelectionMode::IngestAndHarness => Style::new().for_stderr().green().bold(),
+        SetupSelectionMode::IngestOnly => Style::new().for_stderr().green(),
+        SetupSelectionMode::HarnessOnly => Style::new().for_stderr().cyan(),
+    };
+    let label_style = if active {
+        Style::new().for_stderr().white().bold()
+    } else {
+        Style::new().for_stderr()
+    };
+    let disabled = Style::new().for_stderr().bright().black();
+    let ingest = if selection.mode.configures_ingest() {
+        Style::new().for_stderr().green().apply_to("ingest")
+    } else {
+        disabled.apply_to("·")
+    };
+    let harness_style = if selection.mode.configures_harness() {
+        if harness_available {
+            Style::new().for_stderr().cyan()
         } else {
-            " ".to_string()
-        };
-        let marker = if checked {
-            style("[x]").for_stderr().green().to_string()
-        } else {
-            style("[ ]").for_stderr().magenta().to_string()
-        };
-        if active {
-            write!(
-                f,
-                "{} {} {}",
-                arrow,
-                marker,
-                Style::new().for_stderr().cyan().bold().apply_to(text)
-            )
-        } else {
-            write!(f, "{} {} {}", arrow, marker, text)
+            Style::new().for_stderr().yellow()
         }
+    } else {
+        disabled
+    };
+    let harness = if selection.mode.configures_harness() {
+        harness_style.apply_to(selection.target.setup_kind())
+    } else {
+        harness_style.apply_to("·")
+    };
+    let availability = if selection.mode.configures_harness() && !harness_available {
+        format!(
+            " {}",
+            Style::new().for_stderr().yellow().apply_to("not detected")
+        )
+    } else {
+        String::new()
+    };
+
+    format!(
+        "{} {} {:<16} {:<8} {}{}",
+        arrow,
+        icon_style.apply_to(selection.mode.icon()),
+        label_style.apply_to(selection.target.label()),
+        ingest,
+        harness,
+        availability
+    )
+}
+
+fn render_setup_selection_summary(selections: &[SetupTargetSelection]) {
+    let selected = selections
+        .iter()
+        .filter(|selection| selection.mode != SetupSelectionMode::Off)
+        .map(|selection| {
+            format!(
+                "{} {}",
+                selection.target.label(),
+                selection.mode.summary(selection.target)
+            )
+        })
+        .collect::<Vec<_>>();
+
+    eprint!(
+        "{} {} {} ",
+        style("✔").for_stderr().green(),
+        Style::new().for_stderr().bold().apply_to("Agent setup"),
+        style("·").for_stderr().bright().black()
+    );
+    if selected.is_empty() {
+        eprintln!(
+            "{}",
+            Style::new()
+                .for_stderr()
+                .bright()
+                .black()
+                .apply_to("nothing selected")
+        );
+    } else {
+        for (idx, selection) in selected.iter().enumerate() {
+            if idx > 0 {
+                eprint!(", ");
+            }
+            eprint!("{}", Style::new().for_stderr().green().apply_to(selection));
+        }
+        eprintln!();
     }
 }
 
@@ -2004,6 +2501,13 @@ impl ConfigReport {
             error: Some(error.to_string()),
         }
     }
+
+    fn apply_ingest_update(&mut self, update: IngestSelectionUpdate) {
+        if update.has_changes() && self.action == "unchanged" {
+            self.action = "updated".to_string();
+        }
+        self.message = format!("{}; {}", self.message, update.summary());
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -2330,6 +2834,18 @@ impl SetupMcpTarget {
         }
     }
 
+    fn harness_name(self) -> &'static str {
+        match self {
+            SetupMcpTarget::ClaudeCode => "claude-code",
+            SetupMcpTarget::Codex => "codex",
+            SetupMcpTarget::Hermes => "hermes",
+            SetupMcpTarget::KimiCli => "kimi-cli",
+            SetupMcpTarget::OpenCode => "opencode",
+            SetupMcpTarget::Cursor => "cursor",
+            SetupMcpTarget::PiCodingAgent => "pi-coding-agent",
+        }
+    }
+
     fn is_available_for_setup(self, runner: &dyn CommandRunner) -> bool {
         if self
             .program_candidates()
@@ -2450,6 +2966,27 @@ mod tests {
         }
     }
 
+    fn sources_for_harness<'a>(document: &'a DocumentMut, harness: &str) -> Vec<&'a Table> {
+        document["ingest"]["sources"]
+            .as_array_of_tables()
+            .expect("ingest sources")
+            .iter()
+            .filter(|source| source.get("harness").and_then(Item::as_str) == Some(harness))
+            .collect()
+    }
+
+    fn source_enabled(document: &DocumentMut, name: &str) -> bool {
+        document["ingest"]["sources"]
+            .as_array_of_tables()
+            .expect("ingest sources")
+            .iter()
+            .find(|source| source.get("name").and_then(Item::as_str) == Some(name))
+            .expect("source exists")
+            .get("enabled")
+            .and_then(Item::as_bool)
+            .unwrap_or(true)
+    }
+
     #[test]
     fn setup_config_target_prefers_cli_then_home() {
         let cli = resolve_setup_config_target_with(
@@ -2485,21 +3022,133 @@ mod tests {
     }
 
     #[test]
-    fn maps_mcp_target_checklist_indices() {
-        let available = [
-            SetupMcpTarget::ClaudeCode,
-            SetupMcpTarget::Codex,
-            SetupMcpTarget::Hermes,
-        ];
+    fn setup_selection_mode_cycles_through_ingest_and_harness_states() {
+        assert_eq!(
+            SetupSelectionMode::Off.cycle(),
+            SetupSelectionMode::IngestAndHarness
+        );
+        assert_eq!(
+            SetupSelectionMode::IngestAndHarness.cycle(),
+            SetupSelectionMode::IngestOnly
+        );
+        assert_eq!(
+            SetupSelectionMode::IngestOnly.cycle(),
+            SetupSelectionMode::HarnessOnly
+        );
+        assert_eq!(
+            SetupSelectionMode::HarnessOnly.cycle(),
+            SetupSelectionMode::Off
+        );
+    }
+
+    #[test]
+    fn harness_targets_include_only_modes_that_configure_harnesses() {
+        let selections = SetupSelectionSet {
+            targets: vec![
+                SetupTargetSelection {
+                    target: SetupMcpTarget::Codex,
+                    mode: SetupSelectionMode::IngestAndHarness,
+                },
+                SetupTargetSelection {
+                    target: SetupMcpTarget::Hermes,
+                    mode: SetupSelectionMode::IngestOnly,
+                },
+                SetupTargetSelection {
+                    target: SetupMcpTarget::Cursor,
+                    mode: SetupSelectionMode::HarnessOnly,
+                },
+                SetupTargetSelection {
+                    target: SetupMcpTarget::ClaudeCode,
+                    mode: SetupSelectionMode::Off,
+                },
+            ],
+            apply_ingest: true,
+            confirmed_harness: true,
+        };
 
         assert_eq!(
-            selected_mcp_targets_from_indices(&available, &[1, 2, 9]),
-            vec![SetupMcpTarget::Codex, SetupMcpTarget::Hermes]
+            selections.harness_targets(),
+            vec![SetupMcpTarget::Codex, SetupMcpTarget::Cursor]
         );
+    }
+
+    #[test]
+    fn ingest_selection_disables_existing_sources_for_unselected_harnesses() {
+        let mut document = DEFAULT_CONFIG_TEMPLATE
+            .parse::<DocumentMut>()
+            .expect("template parses");
+
+        let update = apply_ingest_selections_to_document(
+            &mut document,
+            &[
+                SetupTargetSelection {
+                    target: SetupMcpTarget::Codex,
+                    mode: SetupSelectionMode::IngestOnly,
+                },
+                SetupTargetSelection {
+                    target: SetupMcpTarget::Cursor,
+                    mode: SetupSelectionMode::HarnessOnly,
+                },
+                SetupTargetSelection {
+                    target: SetupMcpTarget::Hermes,
+                    mode: SetupSelectionMode::Off,
+                },
+            ],
+        )
+        .expect("apply ingest selections");
+
         assert_eq!(
-            selected_mcp_targets_from_indices(&available, &[]),
-            Vec::<SetupMcpTarget>::new()
+            update,
+            IngestSelectionUpdate {
+                enabled_sources: 0,
+                disabled_sources: 3,
+                added_sources: 0,
+            }
         );
+        assert!(source_enabled(&document, "codex"));
+        assert!(!source_enabled(&document, "cursor"));
+        assert!(!source_enabled(&document, "cursor-sqlite"));
+        assert!(!source_enabled(&document, "hermes"));
+    }
+
+    #[test]
+    fn ingest_selection_adds_default_sources_when_missing() {
+        let mut document = "# minimal\n"
+            .parse::<DocumentMut>()
+            .expect("minimal config parses");
+
+        let update = apply_ingest_selections_to_document(
+            &mut document,
+            &[
+                SetupTargetSelection {
+                    target: SetupMcpTarget::Cursor,
+                    mode: SetupSelectionMode::IngestOnly,
+                },
+                SetupTargetSelection {
+                    target: SetupMcpTarget::PiCodingAgent,
+                    mode: SetupSelectionMode::HarnessOnly,
+                },
+            ],
+        )
+        .expect("apply ingest selections");
+
+        assert_eq!(
+            update,
+            IngestSelectionUpdate {
+                enabled_sources: 0,
+                disabled_sources: 0,
+                added_sources: 2,
+            }
+        );
+        assert_eq!(sources_for_harness(&document, "cursor").len(), 2);
+        assert!(source_enabled(&document, "cursor"));
+        assert!(source_enabled(&document, "cursor-sqlite"));
+        assert!(sources_for_harness(&document, "pi-coding-agent").is_empty());
+
+        let path = temp_path("ingest-added-config");
+        fs::write(&path, document.to_string()).expect("write updated config");
+        moraine_config::load_config(&path).expect("updated config loads");
+        let _ = fs::remove_file(path);
     }
 
     #[test]

--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -1,0 +1,2120 @@
+use anyhow::{bail, Context, Result};
+use dialoguer::{
+    console::{style, Style},
+    theme::Theme,
+    MultiSelect,
+};
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::env;
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, IsTerminal, Write};
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::cli::{SetupArgs, SetupMcpTarget};
+use crate::render::CliOutput;
+
+const DEFAULT_CONFIG_TEMPLATE: &str = include_str!("../../../../config/moraine.toml");
+
+pub(super) fn handle(
+    output: &CliOutput,
+    raw_config: Option<PathBuf>,
+    args: SetupArgs,
+) -> Result<ExitCode> {
+    let target = resolve_setup_config_target(raw_config)?;
+    let interactive = can_prompt(output);
+    let mut runner = RealCommandRunner;
+    let report = run_setup(output, &args, target, interactive, &mut runner)?;
+    render_report(output, &report)?;
+
+    if report.success {
+        Ok(ExitCode::SUCCESS)
+    } else {
+        Ok(ExitCode::from(1))
+    }
+}
+
+fn can_prompt(output: &CliOutput) -> bool {
+    !output.is_json() && std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
+}
+
+fn run_setup(
+    output: &CliOutput,
+    args: &SetupArgs,
+    target: ConfigTarget,
+    interactive: bool,
+    runner: &mut dyn CommandRunner,
+) -> Result<SetupReport> {
+    if output.is_json() && !args.yes && !args.dry_run {
+        bail!("`moraine --output json setup` requires --yes or --dry-run");
+    }
+
+    let config = if args.skip_config {
+        ConfigReport::skipped(&target.path, "skipped by --skip-config")
+    } else {
+        setup_config(args, &target, interactive)?
+    };
+
+    let mut mcp_targets = Vec::new();
+    if !args.skip_mcp {
+        let config_allows_mcp =
+            args.skip_config || args.dry_run || config.status == SetupStatus::Ok;
+        if config_allows_mcp {
+            let selected = selected_mcp_targets(args, interactive, runner)?;
+            let targets_confirmed_by_selection =
+                args.mcp_targets.is_empty() && interactive && !args.yes && !args.dry_run;
+            for mcp_target in selected {
+                let report = setup_mcp_target(
+                    args,
+                    &target,
+                    mcp_target,
+                    interactive,
+                    targets_confirmed_by_selection,
+                    runner,
+                )?;
+                mcp_targets.push(report);
+            }
+        } else {
+            for mcp_target in dedup_targets(&args.mcp_targets) {
+                mcp_targets.push(McpTargetReport::skipped(
+                    mcp_target,
+                    "config setup did not complete; skipping MCP/plugin setup",
+                ));
+            }
+        }
+    }
+
+    let success = config.status != SetupStatus::Error
+        && mcp_targets
+            .iter()
+            .all(|target| target.status != SetupStatus::Error);
+
+    Ok(SetupReport {
+        success,
+        config,
+        mcp_targets,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct ConfigTarget {
+    path: PathBuf,
+    source: ConfigTargetSource,
+}
+
+impl ConfigTarget {
+    fn requires_explicit_mcp_config(&self) -> bool {
+        self.source != ConfigTargetSource::HomeDefault
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigTargetSource {
+    Cli,
+    HomeDefault,
+}
+
+fn resolve_setup_config_target(raw_config: Option<PathBuf>) -> Result<ConfigTarget> {
+    resolve_setup_config_target_with(raw_config, env::var_os("HOME"))
+}
+
+fn resolve_setup_config_target_with(
+    raw_config: Option<PathBuf>,
+    home: Option<std::ffi::OsString>,
+) -> Result<ConfigTarget> {
+    if let Some(path) = raw_config {
+        return Ok(ConfigTarget {
+            path: absolutize_config_path(path)?,
+            source: ConfigTargetSource::Cli,
+        });
+    }
+
+    if let Some(home) = home {
+        return Ok(ConfigTarget {
+            path: PathBuf::from(home).join(".moraine").join("config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        });
+    }
+
+    bail!("cannot choose setup config path: pass --config or set HOME");
+}
+
+fn absolutize_config_path(path: PathBuf) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path);
+    }
+    Ok(env::current_dir()
+        .context("failed to resolve current directory for config path")?
+        .join(path))
+}
+
+fn setup_config(
+    args: &SetupArgs,
+    target: &ConfigTarget,
+    interactive: bool,
+) -> Result<ConfigReport> {
+    match inspect_config(&target.path) {
+        ConfigState::Missing => {
+            if args.dry_run {
+                return Ok(ConfigReport::planned(
+                    &target.path,
+                    "would_create",
+                    "default config would be written",
+                ));
+            }
+
+            let should_write = args.yes
+                || (interactive
+                    && prompt_yes_no(
+                        &format!("Write default Moraine config to {}?", target.path.display()),
+                        true,
+                    )?);
+            if !should_write && !interactive {
+                return Ok(ConfigReport::error(
+                    &target.path,
+                    "missing",
+                    "config is missing; rerun with --yes to write the default template or --dry-run to preview",
+                ));
+            }
+            if !should_write {
+                return Ok(ConfigReport::skipped(
+                    &target.path,
+                    "user declined config creation",
+                ));
+            }
+
+            write_default_config(&target.path)
+                .with_context(|| format!("failed to write {}", target.path.display()))?;
+            Ok(ConfigReport::ok(
+                &target.path,
+                "created",
+                "default config written",
+            ))
+        }
+        ConfigState::Valid => Ok(ConfigReport::ok(
+            &target.path,
+            "unchanged",
+            "existing config loads successfully",
+        )),
+        ConfigState::Invalid(message) => {
+            if args.dry_run {
+                let action = if args.repair_config {
+                    "would_repair"
+                } else {
+                    "needs_repair"
+                };
+                return Ok(ConfigReport::planned(&target.path, action, &message));
+            }
+
+            let should_repair = args.repair_config
+                || (interactive
+                    && prompt_yes_no(
+                        &format!(
+                            "Config {} is invalid. Back it up and write the default template?",
+                            target.path.display()
+                        ),
+                        false,
+                    )?);
+
+            if !should_repair {
+                return Ok(ConfigReport::error(
+                    &target.path,
+                    "invalid",
+                    "config is invalid; rerun with --repair-config to back it up and write the default template",
+                ));
+            }
+
+            let backup_path = repair_invalid_config(&target.path)
+                .with_context(|| format!("failed to repair {}", target.path.display()))?;
+            Ok(ConfigReport::ok_with_backup(
+                &target.path,
+                backup_path,
+                "repaired",
+                "invalid config backed up and default config written",
+            ))
+        }
+        ConfigState::Unreadable(message) => Ok(ConfigReport::error(
+            &target.path,
+            "unreadable",
+            &format!("config could not be read and will not be overwritten: {message}"),
+        )),
+    }
+}
+
+enum ConfigState {
+    Missing,
+    Valid,
+    Invalid(String),
+    Unreadable(String),
+}
+
+fn inspect_config(path: &Path) -> ConfigState {
+    match path.try_exists() {
+        Ok(false) => return ConfigState::Missing,
+        Err(exc) => return ConfigState::Unreadable(exc.to_string()),
+        Ok(true) => {}
+    }
+
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(exc) => return ConfigState::Unreadable(exc.to_string()),
+    };
+    if !metadata.is_file() {
+        return ConfigState::Unreadable("path exists but is not a file".to_string());
+    }
+    if let Err(exc) = fs::read_to_string(path) {
+        return ConfigState::Unreadable(exc.to_string());
+    }
+    match moraine_config::load_config(path) {
+        Ok(_) => ConfigState::Valid,
+        Err(exc) => ConfigState::Invalid(exc.to_string()),
+    }
+}
+
+fn write_default_config(path: &Path) -> Result<()> {
+    validate_template_content()?;
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+
+    if path
+        .try_exists()
+        .with_context(|| format!("failed to inspect {}", path.display()))?
+    {
+        bail!("refusing to overwrite existing config {}", path.display());
+    }
+
+    write_template_atomic(path)
+}
+
+fn repair_invalid_config(path: &Path) -> Result<PathBuf> {
+    validate_template_content()?;
+    let backup_path = unique_backup_path(path)?;
+    fs::rename(path, &backup_path).with_context(|| {
+        format!(
+            "failed to move {} to {}",
+            path.display(),
+            backup_path.display()
+        )
+    })?;
+
+    if let Err(exc) = write_template_atomic(path) {
+        let _ = fs::rename(&backup_path, path);
+        return Err(exc);
+    }
+
+    Ok(backup_path)
+}
+
+fn write_template_atomic(path: &Path) -> Result<()> {
+    let temp_path = create_sibling_template_file(path)?;
+    let result = (|| {
+        moraine_config::load_config(&temp_path).with_context(|| {
+            format!(
+                "embedded config template failed validation at {}",
+                temp_path.display()
+            )
+        })?;
+
+        if path
+            .try_exists()
+            .with_context(|| format!("failed to inspect {}", path.display()))?
+        {
+            bail!("refusing to overwrite existing config {}", path.display());
+        }
+
+        fs::hard_link(&temp_path, path).with_context(|| {
+            format!(
+                "failed to persist {} to {}",
+                temp_path.display(),
+                path.display()
+            )
+        })?;
+        Ok(())
+    })();
+    let _ = fs::remove_file(&temp_path);
+    result
+}
+
+fn validate_template_content() -> Result<()> {
+    let temp_path = create_template_file_in(&env::temp_dir(), "moraine-setup-template")?;
+    let result = moraine_config::load_config(&temp_path)
+        .with_context(|| "embedded default config template failed validation");
+    let _ = fs::remove_file(&temp_path);
+    result.map(|_| ())
+}
+
+fn create_sibling_template_file(path: &Path) -> Result<PathBuf> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("config.toml");
+    create_template_file_in(parent, &format!(".{file_name}.setup"))
+}
+
+fn create_template_file_in(parent: &Path, prefix: &str) -> Result<PathBuf> {
+    for attempt in 0..100 {
+        let temp_path = parent.join(format!(
+            "{prefix}-{}-{}-{attempt}.tmp",
+            std::process::id(),
+            timestamp_suffix()
+        ));
+        match private_create_new_options().open(&temp_path) {
+            Ok(mut file) => {
+                if let Err(exc) = file.write_all(DEFAULT_CONFIG_TEMPLATE.as_bytes()) {
+                    let _ = fs::remove_file(&temp_path);
+                    return Err(exc)
+                        .with_context(|| format!("failed to write {}", temp_path.display()));
+                }
+                if let Err(exc) = file.flush() {
+                    let _ = fs::remove_file(&temp_path);
+                    return Err(exc)
+                        .with_context(|| format!("failed to flush {}", temp_path.display()));
+                }
+                return Ok(temp_path);
+            }
+            Err(exc) if exc.kind() == ErrorKind::AlreadyExists => continue,
+            Err(exc) => {
+                return Err(exc)
+                    .with_context(|| format!("failed to create {}", temp_path.display()));
+            }
+        }
+    }
+
+    bail!(
+        "failed to create a unique temporary config file in {}",
+        parent.display()
+    );
+}
+
+fn private_create_new_options() -> OpenOptions {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        options.mode(0o600);
+    }
+    options
+}
+
+fn unique_backup_path(path: &Path) -> Result<PathBuf> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("config.toml");
+    let base = parent.join(format!("{file_name}.bak.{}", timestamp_suffix()));
+    if !base
+        .try_exists()
+        .with_context(|| format!("failed to inspect {}", base.display()))?
+    {
+        return Ok(base);
+    }
+
+    for idx in 2.. {
+        let candidate = parent.join(format!("{file_name}.bak.{}-{idx}", timestamp_suffix()));
+        if !candidate
+            .try_exists()
+            .with_context(|| format!("failed to inspect {}", candidate.display()))?
+        {
+            return Ok(candidate);
+        }
+    }
+    unreachable!()
+}
+
+fn timestamp_suffix() -> String {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    format!("{}-{}", duration.as_secs(), duration.subsec_nanos())
+}
+
+fn selected_mcp_targets(
+    args: &SetupArgs,
+    interactive: bool,
+    runner: &dyn CommandRunner,
+) -> Result<Vec<SetupMcpTarget>> {
+    if !args.mcp_targets.is_empty() {
+        return Ok(dedup_targets(&args.mcp_targets));
+    }
+
+    if args.yes || args.dry_run || !interactive {
+        return Ok(Vec::new());
+    }
+
+    let available = executable_targets()
+        .into_iter()
+        .filter(|target| runner.command_exists(target.program()))
+        .collect::<Vec<_>>();
+    prompt_mcp_target_checklist(&available)
+}
+
+fn dedup_targets(targets: &[SetupMcpTarget]) -> Vec<SetupMcpTarget> {
+    let mut seen = BTreeSet::new();
+    targets
+        .iter()
+        .copied()
+        .filter(|target| seen.insert(*target))
+        .collect()
+}
+
+fn executable_targets() -> [SetupMcpTarget; 4] {
+    [
+        SetupMcpTarget::ClaudeCode,
+        SetupMcpTarget::Codex,
+        SetupMcpTarget::Hermes,
+        SetupMcpTarget::KimiCli,
+    ]
+}
+
+fn prompt_mcp_target_checklist(available: &[SetupMcpTarget]) -> Result<Vec<SetupMcpTarget>> {
+    if available.is_empty() {
+        eprintln!("No supported agent harness CLIs were found on PATH.");
+        return Ok(Vec::new());
+    }
+
+    let items = available
+        .iter()
+        .map(|target| format!("{:<14} {}", target.label(), target.setup_kind()))
+        .collect::<Vec<_>>();
+    let defaults = vec![false; items.len()];
+    let theme = SetupPromptTheme;
+    let selected = MultiSelect::with_theme(&theme)
+        .with_prompt(
+            "Agent integrations - selected harnesses get host-wide Moraine session history access (Space toggles, Enter installs selected, Esc skips)",
+        )
+        .items(&items)
+        .defaults(&defaults)
+        .max_length(items.len())
+        .interact_opt()
+        .context("failed to read setup target selection")?
+        .unwrap_or_default();
+
+    Ok(selected_mcp_targets_from_indices(available, &selected))
+}
+
+fn selected_mcp_targets_from_indices(
+    available: &[SetupMcpTarget],
+    indices: &[usize],
+) -> Vec<SetupMcpTarget> {
+    indices
+        .iter()
+        .filter_map(|idx| available.get(*idx).copied())
+        .collect()
+}
+
+struct SetupPromptTheme;
+
+impl Theme for SetupPromptTheme {
+    fn format_prompt(&self, f: &mut dyn fmt::Write, prompt: &str) -> fmt::Result {
+        write!(
+            f,
+            "{} {} {}",
+            style("?").for_stderr().yellow(),
+            Style::new().for_stderr().bold().apply_to(prompt),
+            style("›").for_stderr().bright().black()
+        )
+    }
+
+    fn format_error(&self, f: &mut dyn fmt::Write, err: &str) -> fmt::Result {
+        write!(
+            f,
+            "{} {}",
+            style("✘").for_stderr().red(),
+            Style::new().for_stderr().red().apply_to(err)
+        )
+    }
+
+    fn format_multi_select_prompt_selection(
+        &self,
+        f: &mut dyn fmt::Write,
+        prompt: &str,
+        selections: &[&str],
+    ) -> fmt::Result {
+        write!(
+            f,
+            "{} {} {} ",
+            style("✔").for_stderr().green(),
+            Style::new().for_stderr().bold().apply_to(prompt),
+            style("·").for_stderr().bright().black()
+        )?;
+        if selections.is_empty() {
+            return write!(
+                f,
+                "{}",
+                Style::new().for_stderr().bright().black().apply_to("none")
+            );
+        }
+        for (idx, selection) in selections.iter().enumerate() {
+            if idx > 0 {
+                write!(f, ", ")?;
+            }
+            write!(
+                f,
+                "{}",
+                Style::new().for_stderr().green().apply_to(selection)
+            )?;
+        }
+        Ok(())
+    }
+
+    fn format_multi_select_prompt_item(
+        &self,
+        f: &mut dyn fmt::Write,
+        text: &str,
+        checked: bool,
+        active: bool,
+    ) -> fmt::Result {
+        let arrow = if active {
+            style("❯").for_stderr().green().to_string()
+        } else {
+            " ".to_string()
+        };
+        let marker = if checked {
+            style("[x]").for_stderr().green().to_string()
+        } else {
+            style("[ ]").for_stderr().magenta().to_string()
+        };
+        if active {
+            write!(
+                f,
+                "{} {} {}",
+                arrow,
+                marker,
+                Style::new().for_stderr().cyan().bold().apply_to(text)
+            )
+        } else {
+            write!(f, "{} {} {}", arrow, marker, text)
+        }
+    }
+}
+
+fn setup_mcp_target(
+    args: &SetupArgs,
+    config_target: &ConfigTarget,
+    target: SetupMcpTarget,
+    interactive: bool,
+    already_confirmed: bool,
+    runner: &mut dyn CommandRunner,
+) -> Result<McpTargetReport> {
+    let plan = McpPlan::for_target(target, config_target);
+    if args.dry_run {
+        return Ok(McpTargetReport::planned(plan));
+    }
+
+    if matches!(plan.action, McpAction::ManualInstructions) {
+        return Ok(McpTargetReport::manual(plan));
+    }
+
+    if !args.yes && interactive && !already_confirmed {
+        eprintln!(
+            "Moraine MCP gives {name} access to host-wide Moraine session history visible to your user.",
+            name = target.label()
+        );
+        if !prompt_yes_no(
+            &format!("Run setup commands for {}?", target.label()),
+            false,
+        )? {
+            return Ok(McpTargetReport::skipped(
+                target,
+                "user declined MCP/plugin setup",
+            ));
+        }
+    } else if !args.yes && !interactive {
+        return Ok(McpTargetReport::error(
+            target,
+            "non-interactive MCP setup requires --yes or --dry-run",
+        ));
+    }
+
+    execute_mcp_plan(plan, runner)
+}
+
+fn execute_mcp_plan(plan: McpPlan, runner: &mut dyn CommandRunner) -> Result<McpTargetReport> {
+    let Some(first_step) = plan.steps.first() else {
+        return Ok(McpTargetReport::manual(plan));
+    };
+    let commands = plan.commands();
+
+    if !runner.command_exists(&first_step.command.program) {
+        return Ok(McpTargetReport::skipped(
+            plan.target,
+            &format!("{} was not found on PATH", first_step.command.program),
+        ));
+    }
+
+    let mut command_results = Vec::new();
+    let mut warnings = Vec::new();
+    let mut failed = None;
+
+    for step in &plan.steps {
+        let result = runner.run(&step.command)?;
+        if let Some(command_failure) = step.command_failure(&result) {
+            match step.failure_policy {
+                CommandFailurePolicy::WarnAndContinue(message) => {
+                    warnings.push(message.to_string())
+                }
+                CommandFailurePolicy::Required => {
+                    failed = Some(command_failure);
+                }
+            }
+        }
+        command_results.push(result);
+
+        if failed.is_some() {
+            break;
+        }
+    }
+
+    if let Some(error) = failed {
+        Ok(McpTargetReport {
+            target: plan.target,
+            action: plan.action,
+            status: SetupStatus::Error,
+            commands,
+            manual_snippet: plan.manual_snippet,
+            skipped_reason: None,
+            warnings,
+            error: Some(error),
+            command_results,
+        })
+    } else {
+        Ok(McpTargetReport {
+            target: plan.target,
+            action: plan.action,
+            status: SetupStatus::Ok,
+            commands,
+            manual_snippet: plan.manual_snippet,
+            skipped_reason: None,
+            warnings,
+            error: None,
+            command_results,
+        })
+    }
+}
+
+fn prompt_yes_no(question: &str, default: bool) -> Result<bool> {
+    let suffix = if default { "[Y/n]" } else { "[y/N]" };
+    loop {
+        eprint!("{question} {suffix} ");
+        std::io::stderr().flush().ok();
+
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .context("failed to read setup prompt response")?;
+        match input.trim().to_ascii_lowercase().as_str() {
+            "" => return Ok(default),
+            "y" | "yes" => return Ok(true),
+            "n" | "no" => return Ok(false),
+            _ => eprintln!("please answer 'y' or 'n'."),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct McpPlan {
+    target: SetupMcpTarget,
+    action: McpAction,
+    steps: Vec<McpPlanStep>,
+    manual_snippet: Option<String>,
+}
+
+impl McpPlan {
+    fn for_target(target: SetupMcpTarget, config_target: &ConfigTarget) -> Self {
+        match target {
+            SetupMcpTarget::ClaudeCode if config_target.requires_explicit_mcp_config() => {
+                let mut args = vec![
+                    "mcp".to_string(),
+                    "add".to_string(),
+                    "--transport".to_string(),
+                    "stdio".to_string(),
+                    "--scope".to_string(),
+                    "user".to_string(),
+                    "moraine".to_string(),
+                    "--".to_string(),
+                    "moraine".to_string(),
+                    "run".to_string(),
+                    "mcp".to_string(),
+                    "--config".to_string(),
+                ];
+                args.push(config_target.path.display().to_string());
+                let command = CommandSpec::new("claude", args);
+                Self::manual(
+                    target,
+                    format!(
+                        "Claude Code plugin installs use the default Moraine config. For this custom config target, use manual MCP registration:\n{}",
+                        command.display()
+                    ),
+                )
+            }
+            SetupMcpTarget::ClaudeCode => Self {
+                target,
+                action: McpAction::Execute,
+                steps: vec![
+                    McpPlanStep::warn_and_continue(
+                        CommandSpec::new(
+                            "claude",
+                            [
+                                "plugin",
+                                "marketplace",
+                                "add",
+                                "eric-tramel/moraine",
+                                "--sparse",
+                                ".claude-plugin",
+                                "plugins",
+                            ],
+                        ),
+                        "Claude marketplace add failed; continuing because the marketplace may already exist",
+                    ),
+                    McpPlanStep::required(CommandSpec::new(
+                        "claude",
+                        ["plugin", "install", "moraine@moraine"],
+                    )),
+                    McpPlanStep::warn_and_continue(
+                        CommandSpec::new(
+                            "claude",
+                            ["mcp", "remove", "moraine", "--scope", "user"],
+                        ),
+                        "Existing manual Claude Code MCP registration could not be removed; continuing in case it was absent",
+                    ),
+                ],
+                manual_snippet: None,
+            },
+            SetupMcpTarget::Codex if config_target.requires_explicit_mcp_config() => {
+                let command = CommandSpec::new("codex", codex_args(config_target));
+                Self::manual(
+                    target,
+                    format!(
+                        "Codex plugin installs use the default Moraine config. For this custom config target, use manual MCP registration:\n{}",
+                        command.display()
+                    ),
+                )
+            }
+            SetupMcpTarget::Codex => Self {
+                target,
+                action: McpAction::Execute,
+                steps: vec![
+                    McpPlanStep::warn_and_continue(
+                        CommandSpec::new(
+                            "codex",
+                            [
+                                "plugin",
+                                "marketplace",
+                                "add",
+                                "eric-tramel/moraine",
+                                "--sparse",
+                                ".agents/plugins",
+                                "--sparse",
+                                "plugins/moraine",
+                                "--sparse",
+                                "plugins/moraine-dev",
+                            ],
+                        ),
+                        "Codex marketplace add failed; continuing because the marketplace may already exist",
+                    ),
+                    McpPlanStep::required(CommandSpec::new(
+                        "codex",
+                        ["plugin", "add", "moraine@moraine"],
+                    )),
+                    McpPlanStep::warn_and_continue(
+                        CommandSpec::new("codex", ["mcp", "remove", "moraine"]),
+                        "Existing manual Codex MCP registration could not be removed; continuing in case it was absent",
+                    ),
+                ],
+                manual_snippet: None,
+            },
+            SetupMcpTarget::Hermes => Self::replace_registration(
+                target,
+                CommandSpec::new("hermes", ["mcp", "remove", "moraine"]),
+                McpPlanStep::required_stdout(
+                    CommandSpec::new("hermes", hermes_args(config_target)).with_stdin("\n"),
+                    "tools enabled",
+                ),
+            ),
+            SetupMcpTarget::KimiCli => Self::replace_registration(
+                target,
+                CommandSpec::new("kimi", ["mcp", "remove", "moraine"]),
+                McpPlanStep::required(CommandSpec::new("kimi", kimi_args(config_target))),
+            ),
+            SetupMcpTarget::Cursor => Self::manual(target, cursor_snippet(config_target)),
+            SetupMcpTarget::PiCodingAgent => Self::manual(target, pi_snippet(config_target)),
+        }
+    }
+
+    fn replace_registration(
+        target: SetupMcpTarget,
+        remove_command: CommandSpec,
+        add_step: McpPlanStep,
+    ) -> Self {
+        Self {
+            target,
+            action: McpAction::Execute,
+            steps: vec![
+                McpPlanStep::warn_and_continue(
+                    remove_command,
+                    "Existing MCP registration could not be removed; continuing in case it was absent",
+                ),
+                add_step,
+            ],
+            manual_snippet: None,
+        }
+    }
+
+    fn manual(target: SetupMcpTarget, snippet: String) -> Self {
+        Self {
+            target,
+            action: McpAction::ManualInstructions,
+            steps: Vec::new(),
+            manual_snippet: Some(snippet),
+        }
+    }
+
+    fn commands(&self) -> Vec<CommandSpec> {
+        self.steps.iter().map(|step| step.command.clone()).collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct McpPlanStep {
+    command: CommandSpec,
+    failure_policy: CommandFailurePolicy,
+    success_stdout_contains: Option<&'static str>,
+}
+
+impl McpPlanStep {
+    fn required(command: CommandSpec) -> Self {
+        Self {
+            command,
+            failure_policy: CommandFailurePolicy::Required,
+            success_stdout_contains: None,
+        }
+    }
+
+    fn required_stdout(command: CommandSpec, marker: &'static str) -> Self {
+        Self {
+            command,
+            failure_policy: CommandFailurePolicy::Required,
+            success_stdout_contains: Some(marker),
+        }
+    }
+
+    fn warn_and_continue(command: CommandSpec, message: &'static str) -> Self {
+        Self {
+            command,
+            failure_policy: CommandFailurePolicy::WarnAndContinue(message),
+            success_stdout_contains: None,
+        }
+    }
+
+    fn command_failure(&self, result: &CommandRunReport) -> Option<String> {
+        if !result.success {
+            return Some(format!(
+                "{} exited with status {}",
+                self.command.display(),
+                result
+                    .status_code
+                    .map(|code| code.to_string())
+                    .unwrap_or_else(|| "unknown".to_string())
+            ));
+        }
+
+        if let Some(marker) = self.success_stdout_contains {
+            if !result.stdout.contains(marker) {
+                return Some(format!(
+                    "{} did not report successful setup",
+                    self.command.display()
+                ));
+            }
+        }
+
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CommandFailurePolicy {
+    Required,
+    WarnAndContinue(&'static str),
+}
+
+fn mcp_run_args(config_target: &ConfigTarget) -> Vec<String> {
+    let mut args = vec!["run".to_string(), "mcp".to_string()];
+    if config_target.requires_explicit_mcp_config() {
+        args.push("--config".to_string());
+        args.push(config_target.path.display().to_string());
+    }
+    args
+}
+
+fn codex_args(config_target: &ConfigTarget) -> Vec<String> {
+    let mut args = vec![
+        "mcp".to_string(),
+        "add".to_string(),
+        "moraine".to_string(),
+        "--".to_string(),
+        "moraine".to_string(),
+    ];
+    args.extend(mcp_run_args(config_target));
+    args
+}
+
+fn hermes_args(config_target: &ConfigTarget) -> Vec<String> {
+    let mut args = vec![
+        "mcp".to_string(),
+        "add".to_string(),
+        "moraine".to_string(),
+        "--command".to_string(),
+        "moraine".to_string(),
+        "--args".to_string(),
+    ];
+    args.extend(mcp_run_args(config_target));
+    args
+}
+
+fn kimi_args(config_target: &ConfigTarget) -> Vec<String> {
+    let mut args = vec![
+        "mcp".to_string(),
+        "add".to_string(),
+        "--transport".to_string(),
+        "stdio".to_string(),
+        "moraine".to_string(),
+        "--".to_string(),
+        "moraine".to_string(),
+    ];
+    args.extend(mcp_run_args(config_target));
+    args
+}
+
+fn cursor_snippet(config_target: &ConfigTarget) -> String {
+    let snippet = serde_json::json!({
+        "mcpServers": {
+            "moraine": {
+                "command": "moraine",
+                "args": mcp_run_args(config_target),
+            }
+        }
+    });
+    format!(
+        "Add this server to ~/.cursor/mcp.json for global Cursor use or .cursor/mcp.json for a project:\n{}",
+        serde_json::to_string_pretty(&snippet).unwrap_or_else(|_| snippet.to_string())
+    )
+}
+
+fn pi_snippet(config_target: &ConfigTarget) -> String {
+    let snippet = serde_json::json!({
+        "mcpServers": {
+            "moraine": {
+                "transport": "stdio",
+                "command": "moraine",
+                "args": mcp_run_args(config_target),
+                "lifecycle": "eager",
+            }
+        }
+    });
+    format!(
+        "Install the Pi MCP extension first:\npi install npm:pi-mcp-extension\n\nThen add this server to ~/.pi/agent/mcp.json:\n{}",
+        serde_json::to_string_pretty(&snippet).unwrap_or_else(|_| snippet.to_string())
+    )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct CommandSpec {
+    program: String,
+    args: Vec<String>,
+    #[serde(skip)]
+    stdin: Option<String>,
+}
+
+impl CommandSpec {
+    fn new<I, S>(program: &str, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            program: program.to_string(),
+            args: args.into_iter().map(Into::into).collect(),
+            stdin: None,
+        }
+    }
+
+    fn with_stdin(mut self, input: impl Into<String>) -> Self {
+        self.stdin = Some(input.into());
+        self
+    }
+
+    fn display(&self) -> String {
+        std::iter::once(self.program.as_str())
+            .chain(self.args.iter().map(String::as_str))
+            .map(shell_display_arg)
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+fn shell_display_arg(arg: &str) -> String {
+    if arg
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || "-_./:@=".contains(ch))
+    {
+        arg.to_string()
+    } else {
+        format!("'{}'", arg.replace('\'', "'\\''"))
+    }
+}
+
+trait CommandRunner {
+    fn command_exists(&self, program: &str) -> bool;
+    fn run(&mut self, command: &CommandSpec) -> Result<CommandRunReport>;
+}
+
+struct RealCommandRunner;
+
+impl CommandRunner for RealCommandRunner {
+    fn command_exists(&self, program: &str) -> bool {
+        command_exists_on_path(program)
+    }
+
+    fn run(&mut self, command: &CommandSpec) -> Result<CommandRunReport> {
+        let mut process = Command::new(&command.program);
+        process.args(&command.args);
+        let output = if let Some(stdin) = &command.stdin {
+            let mut child = process
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .with_context(|| format!("failed to run {}", command.program))?;
+            if let Some(mut child_stdin) = child.stdin.take() {
+                child_stdin
+                    .write_all(stdin.as_bytes())
+                    .with_context(|| format!("failed to write stdin for {}", command.program))?;
+            }
+            child
+                .wait_with_output()
+                .with_context(|| format!("failed to wait for {}", command.program))?
+        } else {
+            process
+                .output()
+                .with_context(|| format!("failed to run {}", command.program))?
+        };
+        Ok(CommandRunReport {
+            command: command.clone(),
+            success: output.status.success(),
+            status_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        })
+    }
+}
+
+fn command_exists_on_path(program: &str) -> bool {
+    let path = Path::new(program);
+    if path.components().count() > 1 {
+        return is_executable_file(path);
+    }
+
+    let Some(paths) = env::var_os("PATH") else {
+        return false;
+    };
+    env::split_paths(&paths).any(|dir| is_executable_file(&dir.join(program)))
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        metadata.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CommandRunReport {
+    command: CommandSpec,
+    success: bool,
+    status_code: Option<i32>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    stdout: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    stderr: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SetupStatus {
+    Ok,
+    Planned,
+    Skipped,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum McpAction {
+    Execute,
+    ManualInstructions,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SetupReport {
+    success: bool,
+    config: ConfigReport,
+    mcp_targets: Vec<McpTargetReport>,
+}
+
+fn report_for_json(report: &SetupReport, verbose: bool) -> SetupReport {
+    let mut report = report.clone();
+    if !verbose {
+        for target in &mut report.mcp_targets {
+            for result in &mut target.command_results {
+                result.stdout.clear();
+                result.stderr.clear();
+            }
+        }
+    }
+    report
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ConfigReport {
+    action: String,
+    status: SetupStatus,
+    path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    backup_path: Option<String>,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+impl ConfigReport {
+    fn ok(path: &Path, action: &str, message: &str) -> Self {
+        Self {
+            action: action.to_string(),
+            status: SetupStatus::Ok,
+            path: path.display().to_string(),
+            backup_path: None,
+            message: message.to_string(),
+            error: None,
+        }
+    }
+
+    fn ok_with_backup(path: &Path, backup_path: PathBuf, action: &str, message: &str) -> Self {
+        Self {
+            action: action.to_string(),
+            status: SetupStatus::Ok,
+            path: path.display().to_string(),
+            backup_path: Some(backup_path.display().to_string()),
+            message: message.to_string(),
+            error: None,
+        }
+    }
+
+    fn planned(path: &Path, action: &str, message: &str) -> Self {
+        Self {
+            action: action.to_string(),
+            status: SetupStatus::Planned,
+            path: path.display().to_string(),
+            backup_path: None,
+            message: message.to_string(),
+            error: None,
+        }
+    }
+
+    fn skipped(path: &Path, message: &str) -> Self {
+        Self {
+            action: "skipped".to_string(),
+            status: SetupStatus::Skipped,
+            path: path.display().to_string(),
+            backup_path: None,
+            message: message.to_string(),
+            error: None,
+        }
+    }
+
+    fn error(path: &Path, action: &str, error: &str) -> Self {
+        Self {
+            action: action.to_string(),
+            status: SetupStatus::Error,
+            path: path.display().to_string(),
+            backup_path: None,
+            message: error.to_string(),
+            error: Some(error.to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct McpTargetReport {
+    target: SetupMcpTarget,
+    action: McpAction,
+    status: SetupStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    commands: Vec<CommandSpec>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    manual_snippet: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skipped_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    warnings: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    command_results: Vec<CommandRunReport>,
+}
+
+impl McpTargetReport {
+    fn planned(plan: McpPlan) -> Self {
+        Self {
+            target: plan.target,
+            action: plan.action,
+            status: SetupStatus::Planned,
+            commands: plan.commands(),
+            manual_snippet: plan.manual_snippet,
+            skipped_reason: None,
+            warnings: Vec::new(),
+            error: None,
+            command_results: Vec::new(),
+        }
+    }
+
+    fn manual(plan: McpPlan) -> Self {
+        Self {
+            target: plan.target,
+            action: plan.action,
+            status: SetupStatus::Skipped,
+            commands: Vec::new(),
+            manual_snippet: plan.manual_snippet,
+            skipped_reason: Some("manual instructions only".to_string()),
+            warnings: Vec::new(),
+            error: None,
+            command_results: Vec::new(),
+        }
+    }
+
+    fn skipped(target: SetupMcpTarget, reason: &str) -> Self {
+        Self {
+            target,
+            action: McpAction::Execute,
+            status: SetupStatus::Skipped,
+            commands: Vec::new(),
+            manual_snippet: None,
+            skipped_reason: Some(reason.to_string()),
+            warnings: Vec::new(),
+            error: None,
+            command_results: Vec::new(),
+        }
+    }
+
+    fn error(target: SetupMcpTarget, error: &str) -> Self {
+        Self {
+            target,
+            action: McpAction::Execute,
+            status: SetupStatus::Error,
+            commands: Vec::new(),
+            manual_snippet: None,
+            skipped_reason: None,
+            warnings: Vec::new(),
+            error: Some(error.to_string()),
+            command_results: Vec::new(),
+        }
+    }
+}
+
+fn render_report(output: &CliOutput, report: &SetupReport) -> Result<()> {
+    if output.is_json() {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report_for_json(report, output.verbose))?
+        );
+        return Ok(());
+    }
+
+    let mut config_lines = vec![format!(
+        "{} config  {}",
+        status_mark(report.config.status, output.unicode),
+        report.config.path
+    )];
+    config_lines.push(format!(
+        "   {} - {}",
+        report.config.action, report.config.message
+    ));
+    if let Some(backup_path) = &report.config.backup_path {
+        config_lines.push(format!("   backup: {backup_path}"));
+    }
+    output.section("Moraine Setup", &config_lines);
+
+    if report.mcp_targets.is_empty() {
+        output.section(
+            "Agent Integrations",
+            &[format!(
+                "{} none selected  run with --mcp-target <target> or rerun interactively",
+                status_mark(SetupStatus::Skipped, output.unicode)
+            )],
+        );
+        return Ok(());
+    }
+
+    let rows = report
+        .mcp_targets
+        .iter()
+        .map(|target| {
+            vec![
+                format!(
+                    "{} {} {}",
+                    status_mark(target.status, output.unicode),
+                    target.target.label(),
+                    target.target.setup_kind()
+                ),
+                target_status_text(target).to_string(),
+                target_detail(target),
+            ]
+        })
+        .collect::<Vec<_>>();
+    output.table("Agent Integrations", &["target", "status", "detail"], &rows);
+
+    let mut detail_lines = Vec::new();
+    for target in &report.mcp_targets {
+        append_target_details(target, output, &mut detail_lines);
+    }
+    if !detail_lines.is_empty() {
+        output.section("Integration Details", &detail_lines);
+    }
+
+    Ok(())
+}
+
+fn status_mark(status: SetupStatus, unicode: bool) -> &'static str {
+    match (status, unicode) {
+        (SetupStatus::Ok, true) => "✓",
+        (SetupStatus::Planned, true) => "◇",
+        (SetupStatus::Skipped, true) => "–",
+        (SetupStatus::Error, true) => "✗",
+        (SetupStatus::Ok, false) => "[ok]",
+        (SetupStatus::Planned, false) => "[plan]",
+        (SetupStatus::Skipped, false) => "[-]",
+        (SetupStatus::Error, false) => "[err]",
+    }
+}
+
+fn target_status_text(target: &McpTargetReport) -> &'static str {
+    match target.status {
+        SetupStatus::Ok => "configured",
+        SetupStatus::Planned => "planned",
+        SetupStatus::Skipped if target.manual_snippet.is_some() => "manual",
+        SetupStatus::Skipped => "skipped",
+        SetupStatus::Error => "error",
+    }
+}
+
+fn target_detail(target: &McpTargetReport) -> String {
+    if let Some(error) = &target.error {
+        return truncate_for_table(error);
+    }
+    if target.manual_snippet.is_some() {
+        return "manual instructions below".to_string();
+    }
+    if !target.warnings.is_empty() {
+        return "completed with warnings".to_string();
+    }
+    if let Some(reason) = &target.skipped_reason {
+        return truncate_for_table(reason);
+    }
+    let command_count = target.commands.len();
+    let commands = if command_count == 0 {
+        return match target.status {
+            SetupStatus::Ok => "ready".to_string(),
+            SetupStatus::Planned => "no commands would run".to_string(),
+            SetupStatus::Skipped => "no commands run".to_string(),
+            SetupStatus::Error => "no commands completed".to_string(),
+        };
+    } else if command_count == 1 {
+        "1 command".to_string()
+    } else {
+        format!("{command_count} commands")
+    };
+    match target.status {
+        SetupStatus::Ok => format!("{commands} completed"),
+        SetupStatus::Planned => format!("{commands} would run"),
+        SetupStatus::Skipped => format!("{commands} skipped"),
+        SetupStatus::Error => format!("{commands} attempted"),
+    }
+}
+
+fn truncate_for_table(value: &str) -> String {
+    let collapsed = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    const MAX: usize = 52;
+    if collapsed.chars().count() <= MAX {
+        return collapsed;
+    }
+    let mut truncated = collapsed
+        .chars()
+        .take(MAX.saturating_sub(3))
+        .collect::<String>();
+    truncated.push_str("...");
+    truncated
+}
+
+fn append_target_details(target: &McpTargetReport, output: &CliOutput, lines: &mut Vec<String>) {
+    let show_commands = output.verbose
+        || target.status == SetupStatus::Planned
+        || target.status == SetupStatus::Error
+        || !target.warnings.is_empty();
+    let show_command_output = output.verbose && !target.command_results.is_empty();
+    if !show_commands
+        && !show_command_output
+        && target.manual_snippet.is_none()
+        && target.warnings.is_empty()
+        && target.error.is_none()
+    {
+        return;
+    }
+
+    if !lines.is_empty() {
+        lines.push(String::new());
+    }
+    lines.push(format!("{}:", target.target.label()));
+    if show_commands {
+        for command in &target.commands {
+            lines.push(format!("  $ {}", command.display()));
+        }
+    }
+    if let Some(snippet) = &target.manual_snippet {
+        for line in snippet.lines() {
+            lines.push(format!("  {line}"));
+        }
+    }
+    for warning in &target.warnings {
+        lines.push(format!("  warning: {warning}"));
+    }
+    if let Some(error) = &target.error {
+        lines.push(format!("  error: {error}"));
+    }
+    if output.verbose {
+        for result in &target.command_results {
+            if !result.stdout.trim().is_empty() {
+                lines.push(format!(
+                    "  {} stdout: {}",
+                    result.command.program,
+                    result.stdout.trim()
+                ));
+            }
+            if !result.stderr.trim().is_empty() {
+                lines.push(format!(
+                    "  {} stderr: {}",
+                    result.command.program,
+                    result.stderr.trim()
+                ));
+            }
+        }
+    }
+}
+
+impl SetupMcpTarget {
+    fn label(self) -> &'static str {
+        match self {
+            SetupMcpTarget::ClaudeCode => "Claude Code",
+            SetupMcpTarget::Codex => "Codex",
+            SetupMcpTarget::Hermes => "Hermes",
+            SetupMcpTarget::KimiCli => "Kimi CLI",
+            SetupMcpTarget::Cursor => "Cursor",
+            SetupMcpTarget::PiCodingAgent => "Pi Coding Agent",
+        }
+    }
+
+    fn setup_kind(self) -> &'static str {
+        match self {
+            SetupMcpTarget::ClaudeCode | SetupMcpTarget::Codex => "plugin",
+            SetupMcpTarget::Hermes | SetupMcpTarget::KimiCli => "MCP",
+            SetupMcpTarget::Cursor | SetupMcpTarget::PiCodingAgent => "manual",
+        }
+    }
+
+    fn program(self) -> &'static str {
+        match self {
+            SetupMcpTarget::ClaudeCode => "claude",
+            SetupMcpTarget::Codex => "codex",
+            SetupMcpTarget::Hermes => "hermes",
+            SetupMcpTarget::KimiCli => "kimi",
+            SetupMcpTarget::Cursor => "cursor",
+            SetupMcpTarget::PiCodingAgent => "pi",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::OutputMode;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    #[derive(Default)]
+    struct FakeRunner {
+        existing: BTreeSet<String>,
+        responses: BTreeMap<String, CommandRunReport>,
+        ran: Vec<CommandSpec>,
+    }
+
+    impl FakeRunner {
+        fn with_existing(mut self, program: &str) -> Self {
+            self.existing.insert(program.to_string());
+            self
+        }
+
+        fn with_response(self, command: CommandSpec, success: bool, stderr: &str) -> Self {
+            self.with_output_response(command, success, "", stderr)
+        }
+
+        fn with_output_response(
+            mut self,
+            command: CommandSpec,
+            success: bool,
+            stdout: &str,
+            stderr: &str,
+        ) -> Self {
+            self.responses.insert(
+                command.display(),
+                CommandRunReport {
+                    command,
+                    success,
+                    status_code: Some(if success { 0 } else { 1 }),
+                    stdout: stdout.to_string(),
+                    stderr: stderr.to_string(),
+                },
+            );
+            self
+        }
+    }
+
+    impl CommandRunner for FakeRunner {
+        fn command_exists(&self, program: &str) -> bool {
+            self.existing.contains(program)
+        }
+
+        fn run(&mut self, command: &CommandSpec) -> Result<CommandRunReport> {
+            self.ran.push(command.clone());
+            self.responses
+                .get(&command.display())
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("no fake response for {}", command.display()))
+        }
+    }
+
+    fn temp_path(label: &str) -> PathBuf {
+        env::temp_dir().join(format!(
+            "moraine-setup-test-{label}-{}-{}",
+            std::process::id(),
+            timestamp_suffix()
+        ))
+    }
+
+    fn plain_output() -> CliOutput {
+        CliOutput {
+            mode: OutputMode::Plain,
+            verbose: false,
+            unicode: false,
+            width: 100,
+        }
+    }
+
+    #[test]
+    fn setup_config_target_prefers_cli_then_home() {
+        let cli = resolve_setup_config_target_with(
+            Some(PathBuf::from("/tmp/cli.toml")),
+            Some("/home/test".into()),
+        )
+        .expect("cli target");
+        assert_eq!(cli.path, PathBuf::from("/tmp/cli.toml"));
+        assert_eq!(cli.source, ConfigTargetSource::Cli);
+
+        let home =
+            resolve_setup_config_target_with(None, Some("/home/test".into())).expect("home target");
+        assert_eq!(home.path, PathBuf::from("/home/test/.moraine/config.toml"));
+        assert_eq!(home.source, ConfigTargetSource::HomeDefault);
+    }
+
+    #[test]
+    fn setup_config_target_absolutizes_relative_cli_paths() {
+        let cwd = env::current_dir().expect("current dir");
+
+        let cli = resolve_setup_config_target_with(
+            Some(PathBuf::from("relative-cli.toml")),
+            Some("/home/test".into()),
+        )
+        .expect("cli target");
+        assert_eq!(cli.path, cwd.join("relative-cli.toml"));
+    }
+
+    #[test]
+    fn setup_config_target_errors_without_home() {
+        let err = resolve_setup_config_target_with(None, None).expect_err("missing home");
+        assert!(err.to_string().contains("pass --config or set HOME"));
+    }
+
+    #[test]
+    fn maps_mcp_target_checklist_indices() {
+        let available = [
+            SetupMcpTarget::ClaudeCode,
+            SetupMcpTarget::Codex,
+            SetupMcpTarget::Hermes,
+        ];
+
+        assert_eq!(
+            selected_mcp_targets_from_indices(&available, &[1, 2, 9]),
+            vec![SetupMcpTarget::Codex, SetupMcpTarget::Hermes]
+        );
+        assert_eq!(
+            selected_mcp_targets_from_indices(&available, &[]),
+            Vec::<SetupMcpTarget>::new()
+        );
+    }
+
+    #[test]
+    fn writes_default_config_when_missing() {
+        let dir = temp_path("missing-config");
+        let path = dir.join("nested").join("config.toml");
+        let args = SetupArgs {
+            yes: true,
+            dry_run: false,
+            skip_config: false,
+            skip_mcp: true,
+            repair_config: false,
+            mcp_targets: Vec::new(),
+        };
+        let report = setup_config(
+            &args,
+            &ConfigTarget {
+                path: path.clone(),
+                source: ConfigTargetSource::Cli,
+            },
+            false,
+        )
+        .expect("setup config");
+        assert_eq!(report.status, SetupStatus::Ok);
+        assert!(path.is_file());
+        moraine_config::load_config(&path).expect("written config loads");
+        #[cfg(unix)]
+        assert_eq!(
+            fs::metadata(&path)
+                .expect("config metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn dry_run_does_not_write_missing_config() {
+        let dir = temp_path("dry-run");
+        let path = dir.join("config.toml");
+        let args = SetupArgs {
+            yes: false,
+            dry_run: true,
+            skip_config: false,
+            skip_mcp: true,
+            repair_config: false,
+            mcp_targets: Vec::new(),
+        };
+        let report = setup_config(
+            &args,
+            &ConfigTarget {
+                path: path.clone(),
+                source: ConfigTargetSource::Cli,
+            },
+            false,
+        )
+        .expect("dry-run config");
+        assert_eq!(report.status, SetupStatus::Planned);
+        assert!(!path.exists());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn repair_invalid_config_creates_backup() {
+        let dir = temp_path("repair");
+        fs::create_dir_all(&dir).expect("create dir");
+        let path = dir.join("config.toml");
+        fs::write(&path, "not = [valid").expect("write invalid config");
+        let args = SetupArgs {
+            yes: true,
+            dry_run: false,
+            skip_config: false,
+            skip_mcp: true,
+            repair_config: true,
+            mcp_targets: Vec::new(),
+        };
+        let report = setup_config(
+            &args,
+            &ConfigTarget {
+                path: path.clone(),
+                source: ConfigTargetSource::Cli,
+            },
+            false,
+        )
+        .expect("repair config");
+        assert_eq!(report.status, SetupStatus::Ok);
+        let backup = PathBuf::from(report.backup_path.expect("backup path"));
+        assert!(backup.is_file());
+        assert_eq!(
+            fs::read_to_string(backup).expect("backup content"),
+            "not = [valid"
+        );
+        moraine_config::load_config(&path).expect("repaired config loads");
+        #[cfg(unix)]
+        assert_eq!(
+            fs::metadata(&path)
+                .expect("config metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn valid_config_is_not_repaired_even_with_repair_flag() {
+        let dir = temp_path("valid-no-repair");
+        fs::create_dir_all(&dir).expect("create dir");
+        let path = dir.join("config.toml");
+        fs::write(&path, "# minimal\n").expect("write config");
+        let args = SetupArgs {
+            yes: true,
+            dry_run: false,
+            skip_config: false,
+            skip_mcp: true,
+            repair_config: true,
+            mcp_targets: Vec::new(),
+        };
+        let report = setup_config(
+            &args,
+            &ConfigTarget {
+                path: path.clone(),
+                source: ConfigTargetSource::Cli,
+            },
+            false,
+        )
+        .expect("valid config");
+        assert_eq!(report.action, "unchanged");
+        assert!(report.backup_path.is_none());
+        assert_eq!(
+            fs::read_to_string(path).expect("config content"),
+            "# minimal\n"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn codex_default_config_installs_plugin() {
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan = McpPlan::for_target(SetupMcpTarget::Codex, &target);
+        let commands = plan.commands();
+        assert_eq!(commands.len(), 3);
+        assert_eq!(
+            commands[0].args,
+            vec![
+                "plugin",
+                "marketplace",
+                "add",
+                "eric-tramel/moraine",
+                "--sparse",
+                ".agents/plugins",
+                "--sparse",
+                "plugins/moraine",
+                "--sparse",
+                "plugins/moraine-dev",
+            ]
+        );
+        assert_eq!(commands[1].args, vec!["plugin", "add", "moraine@moraine"]);
+        assert_eq!(commands[2].args, vec!["mcp", "remove", "moraine"]);
+    }
+
+    #[test]
+    fn claude_default_config_installs_plugin_and_cleans_manual_mcp() {
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan = McpPlan::for_target(SetupMcpTarget::ClaudeCode, &target);
+        let commands = plan.commands();
+        assert_eq!(commands.len(), 3);
+        assert_eq!(
+            commands[0].args,
+            vec![
+                "plugin",
+                "marketplace",
+                "add",
+                "eric-tramel/moraine",
+                "--sparse",
+                ".claude-plugin",
+                "plugins",
+            ]
+        );
+        assert_eq!(
+            commands[1].args,
+            vec!["plugin", "install", "moraine@moraine"]
+        );
+        assert_eq!(
+            commands[2].args,
+            vec!["mcp", "remove", "moraine", "--scope", "user"]
+        );
+    }
+
+    #[test]
+    fn codex_custom_config_is_manual() {
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/custom.toml"),
+            source: ConfigTargetSource::Cli,
+        };
+        let plan = McpPlan::for_target(SetupMcpTarget::Codex, &target);
+        assert_eq!(plan.action, McpAction::ManualInstructions);
+        assert!(plan
+            .manual_snippet
+            .expect("manual snippet")
+            .contains("--config /tmp/custom.toml"));
+    }
+
+    #[test]
+    fn claude_custom_config_is_manual() {
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/custom.toml"),
+            source: ConfigTargetSource::Cli,
+        };
+        let plan = McpPlan::for_target(SetupMcpTarget::ClaudeCode, &target);
+        assert_eq!(plan.action, McpAction::ManualInstructions);
+        assert!(plan
+            .manual_snippet
+            .expect("manual snippet")
+            .contains("--config /tmp/custom.toml"));
+    }
+
+    #[test]
+    fn hermes_add_accepts_tool_enable_prompt() {
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan = McpPlan::for_target(SetupMcpTarget::Hermes, &target);
+        let commands = plan.commands();
+        assert_eq!(commands.len(), 2);
+        assert_eq!(commands[0].args, vec!["mcp", "remove", "moraine"]);
+        assert_eq!(
+            commands[1].args,
+            vec![
+                "mcp",
+                "add",
+                "moraine",
+                "--command",
+                "moraine",
+                "--args",
+                "run",
+                "mcp",
+            ]
+        );
+        assert_eq!(commands[1].stdin.as_deref(), Some("\n"));
+    }
+
+    #[test]
+    fn hermes_add_cancelled_stdout_is_error_even_with_zero_status() {
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan = McpPlan::for_target(SetupMcpTarget::Hermes, &target);
+        let commands = plan.commands();
+        let mut runner = FakeRunner::default()
+            .with_existing("hermes")
+            .with_response(commands[0].clone(), false, "server not found")
+            .with_output_response(commands[1].clone(), true, "Cancelled.", "");
+        let report = execute_mcp_plan(plan, &mut runner).expect("execute mcp");
+        assert_eq!(report.status, SetupStatus::Error);
+        assert!(report
+            .error
+            .as_deref()
+            .expect("error")
+            .contains("did not report successful setup"));
+        assert_eq!(runner.ran, commands);
+    }
+
+    #[test]
+    fn explicit_noninteractive_mcp_requires_yes() {
+        let args = SetupArgs {
+            yes: false,
+            dry_run: false,
+            skip_config: true,
+            skip_mcp: false,
+            repair_config: false,
+            mcp_targets: vec![SetupMcpTarget::Codex],
+        };
+        let mut runner = FakeRunner::default().with_existing("codex");
+        let report = setup_mcp_target(
+            &args,
+            &ConfigTarget {
+                path: PathBuf::from("/tmp/config.toml"),
+                source: ConfigTargetSource::HomeDefault,
+            },
+            SetupMcpTarget::Codex,
+            false,
+            false,
+            &mut runner,
+        )
+        .expect("mcp target");
+        assert_eq!(report.status, SetupStatus::Error);
+        assert!(runner.ran.is_empty());
+    }
+
+    #[test]
+    fn fake_runner_records_codex_command() {
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan = McpPlan::for_target(SetupMcpTarget::Codex, &target);
+        let commands = plan.commands();
+        let mut runner = FakeRunner::default()
+            .with_existing("codex")
+            .with_response(commands[0].clone(), true, "")
+            .with_response(commands[1].clone(), true, "")
+            .with_response(commands[2].clone(), true, "");
+        let report = execute_mcp_plan(plan, &mut runner).expect("execute mcp");
+        assert_eq!(report.status, SetupStatus::Ok);
+        assert_eq!(runner.ran, commands);
+    }
+
+    #[test]
+    fn manual_remove_failure_continues_after_plugin_install() {
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan = McpPlan::for_target(SetupMcpTarget::Codex, &target);
+        let commands = plan.commands();
+        let mut runner = FakeRunner::default()
+            .with_existing("codex")
+            .with_response(commands[0].clone(), true, "")
+            .with_response(commands[1].clone(), true, "")
+            .with_response(commands[2].clone(), false, "server not found");
+        let report = execute_mcp_plan(plan, &mut runner).expect("execute mcp");
+        assert_eq!(report.status, SetupStatus::Ok);
+        assert!(!report.warnings.is_empty());
+        assert_eq!(runner.ran, commands);
+    }
+
+    #[test]
+    fn plugin_install_failure_is_reported_as_error() {
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan = McpPlan::for_target(SetupMcpTarget::Codex, &target);
+        let commands = plan.commands();
+        let mut runner = FakeRunner::default()
+            .with_existing("codex")
+            .with_response(commands[0].clone(), true, "")
+            .with_response(commands[1].clone(), false, "plugin install failed");
+        let report = execute_mcp_plan(plan, &mut runner).expect("execute mcp");
+        assert_eq!(report.status, SetupStatus::Error);
+        assert!(report
+            .error
+            .as_deref()
+            .expect("error")
+            .contains(&commands[1].display()));
+        assert_eq!(runner.ran, commands[..2]);
+    }
+
+    #[test]
+    fn config_failure_skips_explicit_mcp_targets() {
+        let dir = temp_path("invalid-skips-mcp");
+        fs::create_dir_all(&dir).expect("create dir");
+        let path = dir.join("config.toml");
+        fs::write(&path, "not = [valid").expect("write invalid config");
+        let args = SetupArgs {
+            yes: true,
+            dry_run: false,
+            skip_config: false,
+            skip_mcp: false,
+            repair_config: false,
+            mcp_targets: vec![SetupMcpTarget::Codex],
+        };
+        let mut runner = FakeRunner::default().with_existing("codex");
+        let report = run_setup(
+            &plain_output(),
+            &args,
+            ConfigTarget {
+                path: path.clone(),
+                source: ConfigTargetSource::Cli,
+            },
+            false,
+            &mut runner,
+        )
+        .expect("setup report");
+        assert!(!report.success);
+        assert_eq!(report.config.status, SetupStatus::Error);
+        assert_eq!(report.mcp_targets.len(), 1);
+        assert_eq!(report.mcp_targets[0].status, SetupStatus::Skipped);
+        assert!(runner.ran.is_empty());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn json_report_redacts_command_output_unless_verbose() {
+        let command = CommandSpec::new("codex", ["mcp", "list"]);
+        let report = SetupReport {
+            success: true,
+            config: ConfigReport::ok(Path::new("/tmp/config.toml"), "unchanged", "ok"),
+            mcp_targets: vec![McpTargetReport {
+                target: SetupMcpTarget::Codex,
+                action: McpAction::Execute,
+                status: SetupStatus::Ok,
+                commands: vec![command.clone()],
+                manual_snippet: None,
+                skipped_reason: None,
+                warnings: Vec::new(),
+                error: None,
+                command_results: vec![CommandRunReport {
+                    command,
+                    success: true,
+                    status_code: Some(0),
+                    stdout: "account@example.test".to_string(),
+                    stderr: "/sensitive/path".to_string(),
+                }],
+            }],
+        };
+
+        let redacted = report_for_json(&report, false);
+        let result = &redacted.mcp_targets[0].command_results[0];
+        assert!(result.stdout.is_empty());
+        assert!(result.stderr.is_empty());
+
+        let verbose = report_for_json(&report, true);
+        let result = &verbose.mcp_targets[0].command_results[0];
+        assert_eq!(result.stdout, "account@example.test");
+        assert_eq!(result.stderr, "/sensitive/path");
+    }
+}

--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -18,7 +18,7 @@ use std::process::{Command, ExitCode, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::cli::{SetupArgs, SetupMcpTarget};
-use crate::render::CliOutput;
+use crate::render::{CliOutput, OutputMode};
 
 const DEFAULT_CONFIG_TEMPLATE: &str = include_str!("../../../../config/moraine.toml");
 
@@ -69,17 +69,20 @@ fn run_setup(
             let selected = selected_mcp_targets(args, interactive, runner)?;
             let targets_confirmed_by_selection =
                 args.mcp_targets.is_empty() && interactive && !args.yes && !args.dry_run;
+            let mut progress = SetupProgress::from_output(output);
             for mcp_target in selected {
-                let report = setup_mcp_target(
+                let report = setup_mcp_target_with_progress(
                     args,
                     &target,
                     mcp_target,
                     interactive,
                     targets_confirmed_by_selection,
+                    &mut progress,
                     runner,
                 )?;
                 mcp_targets.push(report);
             }
+            progress.finish();
         } else {
             for mcp_target in dedup_targets(&args.mcp_targets) {
                 mcp_targets.push(McpTargetReport::skipped(
@@ -604,12 +607,278 @@ impl Theme for SetupPromptTheme {
     }
 }
 
+struct SetupProgress {
+    enabled: bool,
+    rich: bool,
+    unicode: bool,
+    started: bool,
+}
+
+impl SetupProgress {
+    fn from_output(output: &CliOutput) -> Self {
+        Self {
+            enabled: !output.is_json() && std::io::stderr().is_terminal(),
+            rich: output.mode == OutputMode::Rich,
+            unicode: output.unicode,
+            started: false,
+        }
+    }
+
+    #[cfg(test)]
+    fn disabled() -> Self {
+        Self {
+            enabled: false,
+            rich: false,
+            unicode: true,
+            started: false,
+        }
+    }
+
+    fn finish(&mut self) {
+        if !self.enabled || !self.started {
+            return;
+        }
+        eprintln!(
+            "{} {}",
+            self.progress_line("╰─", "`-", Style::new().bright().black()),
+            self.dim("setup summary follows")
+        );
+    }
+
+    fn target_start(&mut self, target: SetupMcpTarget, plan: &McpPlan) {
+        if !self.enabled {
+            return;
+        }
+        self.ensure_started();
+        eprintln!(
+            "{} {} {}",
+            self.progress_line("├─", "+-", Style::new().bright().black()),
+            self.bold_label(target.label()),
+            self.dim(plan.target.setup_kind())
+        );
+    }
+
+    fn target_success(&self, target: SetupMcpTarget) {
+        if !self.enabled {
+            return;
+        }
+        eprintln!(
+            "   {} {}",
+            self.mark("✓", "[ok]", Style::new().green()),
+            self.dim(&format!("{} configured", target.label()))
+        );
+    }
+
+    fn target_error(&self, target: SetupMcpTarget) {
+        if !self.enabled {
+            return;
+        }
+        eprintln!(
+            "   {} {}",
+            self.mark("✗", "[err]", Style::new().red()),
+            self.dim(&format!("{} needs attention", target.label()))
+        );
+    }
+
+    fn target_skipped(&self, target: SetupMcpTarget, reason: &str) {
+        if !self.enabled {
+            return;
+        }
+        eprintln!(
+            "   {} {} {}",
+            self.mark("–", "[-]", Style::new().yellow()),
+            self.dim(target.label()),
+            self.dim(reason)
+        );
+    }
+
+    fn command_start(&self, step: &McpPlanStep) {
+        if !self.enabled {
+            return;
+        }
+        eprintln!(
+            "   {} {}",
+            self.mark("→", ">", Style::new().cyan()),
+            self.label(step.progress_label)
+        );
+    }
+
+    fn command_success(&self, step: &McpPlanStep) {
+        if !self.enabled {
+            return;
+        }
+        eprintln!(
+            "   {} {}",
+            self.mark("✓", "[ok]", Style::new().green()),
+            self.dim(step.success_label)
+        );
+    }
+
+    fn command_warning(&self, step: &McpPlanStep, warning: &str) {
+        if !self.enabled {
+            return;
+        }
+        eprintln!(
+            "   {} {} {}",
+            self.mark("!", "[warn]", Style::new().yellow()),
+            self.dim(step.warning_label),
+            self.dim(warning)
+        );
+    }
+
+    fn command_error(&self, step: &McpPlanStep, error: &str) {
+        if !self.enabled {
+            return;
+        }
+        eprintln!(
+            "   {} {} {}",
+            self.mark("✗", "[err]", Style::new().red()),
+            self.dim(step.error_label),
+            self.dim(error)
+        );
+    }
+
+    fn config_start(&self, write: &McpConfigWrite) {
+        if !self.enabled {
+            return;
+        }
+        eprintln!(
+            "   {} {}",
+            self.mark("→", ">", Style::new().cyan()),
+            self.label(&format!(
+                "Updating {} config at {}",
+                write.kind.label(),
+                write.path().display()
+            ))
+        );
+    }
+
+    fn config_success(&self, write: &McpConfigWrite) {
+        if !self.enabled {
+            return;
+        }
+        eprintln!(
+            "   {} {}",
+            self.mark("✓", "[ok]", Style::new().green()),
+            self.dim(&format!("Updated {}", write.path().display()))
+        );
+    }
+
+    fn config_error(&self, write: &McpConfigWrite, error: &str) {
+        if !self.enabled {
+            return;
+        }
+        eprintln!(
+            "   {} {} {}",
+            self.mark("✗", "[err]", Style::new().red()),
+            self.dim(&format!("Could not update {}", write.path().display())),
+            self.dim(error)
+        );
+    }
+
+    fn ensure_started(&mut self) {
+        if self.started {
+            return;
+        }
+        self.started = true;
+        if self.rich {
+            eprintln!();
+            eprintln!(
+                "{} {}",
+                self.progress_line("╭─", ".-", Style::new().cyan()),
+                Style::new()
+                    .cyan()
+                    .bold()
+                    .for_stderr()
+                    .apply_to("Installing agent integrations")
+            );
+        } else {
+            eprintln!("Installing agent integrations");
+        }
+    }
+
+    fn mark<'a>(&self, unicode: &'a str, ascii: &'a str, style: Style) -> impl fmt::Display + 'a {
+        if self.rich {
+            style
+                .for_stderr()
+                .apply_to(if self.unicode { unicode } else { ascii })
+        } else {
+            Style::new()
+                .for_stderr()
+                .apply_to(if self.unicode { unicode } else { ascii })
+        }
+    }
+
+    fn label<'a>(&self, value: &'a str) -> impl fmt::Display + 'a {
+        if self.rich {
+            Style::new().white().for_stderr().apply_to(value)
+        } else {
+            Style::new().for_stderr().apply_to(value)
+        }
+    }
+
+    fn bold_label<'a>(&self, value: &'a str) -> impl fmt::Display + 'a {
+        if self.rich {
+            Style::new().white().bold().for_stderr().apply_to(value)
+        } else {
+            Style::new().for_stderr().apply_to(value)
+        }
+    }
+
+    fn dim<'a>(&self, value: &'a str) -> impl fmt::Display + 'a {
+        if self.rich {
+            Style::new().bright().black().for_stderr().apply_to(value)
+        } else {
+            Style::new().for_stderr().apply_to(value)
+        }
+    }
+
+    fn progress_line<'a>(
+        &self,
+        unicode: &'a str,
+        ascii: &'a str,
+        style: Style,
+    ) -> impl fmt::Display + 'a {
+        if self.rich {
+            style
+                .for_stderr()
+                .apply_to(if self.unicode { unicode } else { ascii })
+        } else {
+            Style::new()
+                .for_stderr()
+                .apply_to(if self.unicode { unicode } else { ascii })
+        }
+    }
+}
+
+#[cfg(test)]
 fn setup_mcp_target(
     args: &SetupArgs,
     config_target: &ConfigTarget,
     target: SetupMcpTarget,
     interactive: bool,
     already_confirmed: bool,
+    runner: &mut dyn CommandRunner,
+) -> Result<McpTargetReport> {
+    let mut progress = SetupProgress::disabled();
+    setup_mcp_target_with_progress(
+        args,
+        config_target,
+        target,
+        interactive,
+        already_confirmed,
+        &mut progress,
+        runner,
+    )
+}
+
+fn setup_mcp_target_with_progress(
+    args: &SetupArgs,
+    config_target: &ConfigTarget,
+    target: SetupMcpTarget,
+    interactive: bool,
+    already_confirmed: bool,
+    progress: &mut SetupProgress,
     runner: &mut dyn CommandRunner,
 ) -> Result<McpTargetReport> {
     let plan = McpPlan::for_target(target, config_target);
@@ -639,17 +908,32 @@ fn setup_mcp_target(
         ));
     }
 
-    execute_mcp_plan(plan, runner)
+    execute_mcp_plan_with_progress(plan, runner, progress)
 }
 
+#[cfg(test)]
 fn execute_mcp_plan(plan: McpPlan, runner: &mut dyn CommandRunner) -> Result<McpTargetReport> {
+    let mut progress = SetupProgress::disabled();
+    execute_mcp_plan_with_progress(plan, runner, &mut progress)
+}
+
+fn execute_mcp_plan_with_progress(
+    plan: McpPlan,
+    runner: &mut dyn CommandRunner,
+    progress: &mut SetupProgress,
+) -> Result<McpTargetReport> {
     if plan.steps.is_empty() && plan.config_writes.is_empty() {
         return Ok(McpTargetReport::manual(plan));
     }
     let commands = plan.commands();
+    progress.target_start(plan.target, &plan);
 
     if let Some(first_step) = plan.steps.first() {
         if !runner.command_exists(&first_step.command.program) {
+            progress.target_skipped(
+                plan.target,
+                &format!("{} was not found on PATH", first_step.command.program),
+            );
             return Ok(McpTargetReport::skipped(
                 plan.target,
                 &format!("{} was not found on PATH", first_step.command.program),
@@ -662,16 +946,29 @@ fn execute_mcp_plan(plan: McpPlan, runner: &mut dyn CommandRunner) -> Result<Mcp
     let mut failed = None;
 
     for step in &plan.steps {
-        let result = runner.run(&step.command)?;
+        progress.command_start(step);
+        let result = match runner.run(&step.command) {
+            Ok(result) => result,
+            Err(exc) => {
+                let error = exc.to_string();
+                progress.command_error(step, &error);
+                progress.target_error(plan.target);
+                return Err(exc);
+            }
+        };
         if let Some(command_failure) = step.command_failure(&result) {
             match step.failure_policy {
                 CommandFailurePolicy::WarnAndContinue(message) => {
+                    progress.command_warning(step, message);
                     warnings.push(message.to_string())
                 }
                 CommandFailurePolicy::Required => {
+                    progress.command_error(step, &command_failure);
                     failed = Some(command_failure);
                 }
             }
+        } else {
+            progress.command_success(step);
         }
         command_results.push(result);
 
@@ -683,10 +980,15 @@ fn execute_mcp_plan(plan: McpPlan, runner: &mut dyn CommandRunner) -> Result<Mcp
     let mut config_files = Vec::new();
     if failed.is_none() {
         for write in &plan.config_writes {
+            progress.config_start(write);
             match apply_mcp_config_write(write) {
-                Ok(report) => config_files.push(report),
+                Ok(report) => {
+                    progress.config_success(write);
+                    config_files.push(report);
+                }
                 Err(exc) => {
                     let error = format!("failed to update {}: {exc}", write.path().display());
+                    progress.config_error(write, &exc.to_string());
                     config_files.push(McpConfigFileReport::error(write, &exc.to_string()));
                     failed = Some(error);
                     break;
@@ -696,6 +998,7 @@ fn execute_mcp_plan(plan: McpPlan, runner: &mut dyn CommandRunner) -> Result<Mcp
     }
 
     if let Some(error) = failed {
+        progress.target_error(plan.target);
         Ok(McpTargetReport {
             target: plan.target,
             action: plan.action,
@@ -709,6 +1012,7 @@ fn execute_mcp_plan(plan: McpPlan, runner: &mut dyn CommandRunner) -> Result<Mcp
             command_results,
         })
     } else {
+        progress.target_success(plan.target);
         Ok(McpTargetReport {
             target: plan.target,
             action: plan.action,
@@ -810,17 +1114,35 @@ impl McpPlan {
                             ],
                         ),
                         "Claude marketplace add failed; continuing because the marketplace may already exist",
+                    )
+                    .with_progress(
+                        "Adding Claude Code plugin marketplace",
+                        "Claude Code marketplace ready",
+                        "Claude Code marketplace already present or unavailable",
+                        "Claude Code marketplace add failed",
                     ),
                     McpPlanStep::required(CommandSpec::new(
                         "claude",
                         ["plugin", "install", "moraine@moraine"],
-                    )),
+                    ))
+                    .with_progress(
+                        "Installing Claude Code Moraine plugin",
+                        "Claude Code plugin installed",
+                        "Claude Code plugin install warning",
+                        "Claude Code plugin install failed",
+                    ),
                     McpPlanStep::warn_and_continue(
                         CommandSpec::new(
                             "claude",
                             ["mcp", "remove", "moraine", "--scope", "user"],
                         ),
                         "Existing manual Claude Code MCP registration could not be removed; continuing in case it was absent",
+                    )
+                    .with_progress(
+                        "Cleaning up old Claude Code MCP registration",
+                        "Old Claude Code MCP registration removed or absent",
+                        "Old Claude Code MCP registration left unchanged",
+                        "Old Claude Code MCP cleanup failed",
                     ),
                 ],
                 config_writes: Vec::new(),
@@ -857,14 +1179,32 @@ impl McpPlan {
                             ],
                         ),
                         "Codex marketplace add failed; continuing because the marketplace may already exist",
+                    )
+                    .with_progress(
+                        "Adding Codex plugin marketplace",
+                        "Codex marketplace ready",
+                        "Codex marketplace already present or unavailable",
+                        "Codex marketplace add failed",
                     ),
                     McpPlanStep::required(CommandSpec::new(
                         "codex",
                         ["plugin", "add", "moraine@moraine"],
-                    )),
+                    ))
+                    .with_progress(
+                        "Installing Codex Moraine plugin",
+                        "Codex plugin installed",
+                        "Codex plugin install warning",
+                        "Codex plugin install failed",
+                    ),
                     McpPlanStep::warn_and_continue(
                         CommandSpec::new("codex", ["mcp", "remove", "moraine"]),
                         "Existing manual Codex MCP registration could not be removed; continuing in case it was absent",
+                    )
+                    .with_progress(
+                        "Cleaning up old Codex MCP registration",
+                        "Old Codex MCP registration removed or absent",
+                        "Old Codex MCP registration left unchanged",
+                        "Old Codex MCP cleanup failed",
                     ),
                 ],
                 config_writes: Vec::new(),
@@ -876,12 +1216,24 @@ impl McpPlan {
                 McpPlanStep::required_stdout(
                     CommandSpec::new("hermes", hermes_args(config_target)).with_stdin("\n"),
                     "tools enabled",
+                )
+                .with_progress(
+                    "Registering Moraine MCP in Hermes",
+                    "Hermes MCP tools enabled",
+                    "Hermes MCP registration warning",
+                    "Hermes MCP registration failed",
                 ),
             ),
             SetupMcpTarget::KimiCli => Self::replace_registration(
                 target,
                 CommandSpec::new("kimi", ["mcp", "remove", "moraine"]),
-                McpPlanStep::required(CommandSpec::new("kimi", kimi_args(config_target))),
+                McpPlanStep::required(CommandSpec::new("kimi", kimi_args(config_target)))
+                    .with_progress(
+                        "Registering Moraine MCP in Kimi CLI",
+                        "Kimi CLI MCP registered",
+                        "Kimi CLI MCP registration warning",
+                        "Kimi CLI MCP registration failed",
+                    ),
             ),
             SetupMcpTarget::OpenCode => Self::write_config(
                 target,
@@ -907,7 +1259,13 @@ impl McpPlan {
                     plan.steps.push(McpPlanStep::required(CommandSpec::new(
                         "pi",
                         ["install", "npm:pi-mcp-extension"],
-                    )));
+                    ))
+                    .with_progress(
+                        "Installing Pi MCP extension",
+                        "Pi MCP extension installed",
+                        "Pi MCP extension install warning",
+                        "Pi MCP extension install failed",
+                    ));
                 }
                 plan
             }
@@ -926,6 +1284,12 @@ impl McpPlan {
                 McpPlanStep::warn_and_continue(
                     remove_command,
                     "Existing MCP registration could not be removed; continuing in case it was absent",
+                )
+                .with_progress(
+                    "Removing existing Moraine MCP registration",
+                    "Existing MCP registration removed or absent",
+                    "Existing MCP registration left unchanged",
+                    "Existing MCP cleanup failed",
                 ),
                 add_step,
             ],
@@ -982,6 +1346,10 @@ struct McpPlanStep {
     command: CommandSpec,
     failure_policy: CommandFailurePolicy,
     success_stdout_contains: Option<&'static str>,
+    progress_label: &'static str,
+    success_label: &'static str,
+    warning_label: &'static str,
+    error_label: &'static str,
 }
 
 impl McpPlanStep {
@@ -990,6 +1358,10 @@ impl McpPlanStep {
             command,
             failure_policy: CommandFailurePolicy::Required,
             success_stdout_contains: None,
+            progress_label: "Running setup command",
+            success_label: "Command completed",
+            warning_label: "Command completed with warning",
+            error_label: "Command failed",
         }
     }
 
@@ -998,6 +1370,10 @@ impl McpPlanStep {
             command,
             failure_policy: CommandFailurePolicy::Required,
             success_stdout_contains: Some(marker),
+            progress_label: "Running setup command",
+            success_label: "Command completed",
+            warning_label: "Command completed with warning",
+            error_label: "Command failed",
         }
     }
 
@@ -1006,7 +1382,25 @@ impl McpPlanStep {
             command,
             failure_policy: CommandFailurePolicy::WarnAndContinue(message),
             success_stdout_contains: None,
+            progress_label: "Running optional setup command",
+            success_label: "Optional command completed",
+            warning_label: "Optional command skipped",
+            error_label: "Optional command failed",
         }
+    }
+
+    fn with_progress(
+        mut self,
+        progress_label: &'static str,
+        success_label: &'static str,
+        warning_label: &'static str,
+        error_label: &'static str,
+    ) -> Self {
+        self.progress_label = progress_label;
+        self.success_label = success_label;
+        self.warning_label = warning_label;
+        self.error_label = error_label;
+        self
     }
 
     fn command_failure(&self, result: &CommandRunReport) -> Option<String> {
@@ -1228,6 +1622,16 @@ enum McpConfigKind {
     Cursor,
     Pi,
     OpenCode,
+}
+
+impl McpConfigKind {
+    fn label(self) -> &'static str {
+        match self {
+            McpConfigKind::Cursor => "Cursor",
+            McpConfigKind::Pi => "Pi",
+            McpConfigKind::OpenCode => "OpenCode",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -5,6 +5,7 @@ use dialoguer::{
     MultiSelect,
 };
 use serde::Serialize;
+use serde_json::{Map, Value};
 use std::collections::BTreeSet;
 use std::env;
 use std::fmt;
@@ -453,9 +454,9 @@ fn selected_mcp_targets(
         return Ok(Vec::new());
     }
 
-    let available = executable_targets()
+    let available = setup_targets()
         .into_iter()
-        .filter(|target| runner.command_exists(target.program()))
+        .filter(|target| target.is_available_for_setup(runner))
         .collect::<Vec<_>>();
     prompt_mcp_target_checklist(&available)
 }
@@ -469,18 +470,21 @@ fn dedup_targets(targets: &[SetupMcpTarget]) -> Vec<SetupMcpTarget> {
         .collect()
 }
 
-fn executable_targets() -> [SetupMcpTarget; 4] {
+fn setup_targets() -> [SetupMcpTarget; 7] {
     [
         SetupMcpTarget::ClaudeCode,
         SetupMcpTarget::Codex,
         SetupMcpTarget::Hermes,
         SetupMcpTarget::KimiCli,
+        SetupMcpTarget::OpenCode,
+        SetupMcpTarget::Cursor,
+        SetupMcpTarget::PiCodingAgent,
     ]
 }
 
 fn prompt_mcp_target_checklist(available: &[SetupMcpTarget]) -> Result<Vec<SetupMcpTarget>> {
     if available.is_empty() {
-        eprintln!("No supported agent harness CLIs were found on PATH.");
+        eprintln!("No supported agent harnesses were detected.");
         return Ok(Vec::new());
     }
 
@@ -622,10 +626,7 @@ fn setup_mcp_target(
             "Moraine MCP gives {name} access to host-wide Moraine session history visible to your user.",
             name = target.label()
         );
-        if !prompt_yes_no(
-            &format!("Run setup commands for {}?", target.label()),
-            false,
-        )? {
+        if !prompt_yes_no(&format!("Configure {} integration?", target.label()), false)? {
             return Ok(McpTargetReport::skipped(
                 target,
                 "user declined MCP/plugin setup",
@@ -642,16 +643,18 @@ fn setup_mcp_target(
 }
 
 fn execute_mcp_plan(plan: McpPlan, runner: &mut dyn CommandRunner) -> Result<McpTargetReport> {
-    let Some(first_step) = plan.steps.first() else {
+    if plan.steps.is_empty() && plan.config_writes.is_empty() {
         return Ok(McpTargetReport::manual(plan));
-    };
+    }
     let commands = plan.commands();
 
-    if !runner.command_exists(&first_step.command.program) {
-        return Ok(McpTargetReport::skipped(
-            plan.target,
-            &format!("{} was not found on PATH", first_step.command.program),
-        ));
+    if let Some(first_step) = plan.steps.first() {
+        if !runner.command_exists(&first_step.command.program) {
+            return Ok(McpTargetReport::skipped(
+                plan.target,
+                &format!("{} was not found on PATH", first_step.command.program),
+            ));
+        }
     }
 
     let mut command_results = Vec::new();
@@ -677,12 +680,28 @@ fn execute_mcp_plan(plan: McpPlan, runner: &mut dyn CommandRunner) -> Result<Mcp
         }
     }
 
+    let mut config_files = Vec::new();
+    if failed.is_none() {
+        for write in &plan.config_writes {
+            match apply_mcp_config_write(write) {
+                Ok(report) => config_files.push(report),
+                Err(exc) => {
+                    let error = format!("failed to update {}: {exc}", write.path().display());
+                    config_files.push(McpConfigFileReport::error(write, &exc.to_string()));
+                    failed = Some(error);
+                    break;
+                }
+            }
+        }
+    }
+
     if let Some(error) = failed {
         Ok(McpTargetReport {
             target: plan.target,
             action: plan.action,
             status: SetupStatus::Error,
             commands,
+            config_files,
             manual_snippet: plan.manual_snippet,
             skipped_reason: None,
             warnings,
@@ -695,6 +714,7 @@ fn execute_mcp_plan(plan: McpPlan, runner: &mut dyn CommandRunner) -> Result<Mcp
             action: plan.action,
             status: SetupStatus::Ok,
             commands,
+            config_files,
             manual_snippet: plan.manual_snippet,
             skipped_reason: None,
             warnings,
@@ -728,11 +748,24 @@ struct McpPlan {
     target: SetupMcpTarget,
     action: McpAction,
     steps: Vec<McpPlanStep>,
+    config_writes: Vec<McpConfigWrite>,
     manual_snippet: Option<String>,
 }
 
 impl McpPlan {
     fn for_target(target: SetupMcpTarget, config_target: &ConfigTarget) -> Self {
+        Self::for_target_with_home(
+            target,
+            config_target,
+            env::var_os("HOME").map(PathBuf::from),
+        )
+    }
+
+    fn for_target_with_home(
+        target: SetupMcpTarget,
+        config_target: &ConfigTarget,
+        home: Option<PathBuf>,
+    ) -> Self {
         match target {
             SetupMcpTarget::ClaudeCode if config_target.requires_explicit_mcp_config() => {
                 let mut args = vec![
@@ -790,6 +823,7 @@ impl McpPlan {
                         "Existing manual Claude Code MCP registration could not be removed; continuing in case it was absent",
                     ),
                 ],
+                config_writes: Vec::new(),
                 manual_snippet: None,
             },
             SetupMcpTarget::Codex if config_target.requires_explicit_mcp_config() => {
@@ -833,6 +867,7 @@ impl McpPlan {
                         "Existing manual Codex MCP registration could not be removed; continuing in case it was absent",
                     ),
                 ],
+                config_writes: Vec::new(),
                 manual_snippet: None,
             },
             SetupMcpTarget::Hermes => Self::replace_registration(
@@ -848,8 +883,34 @@ impl McpPlan {
                 CommandSpec::new("kimi", ["mcp", "remove", "moraine"]),
                 McpPlanStep::required(CommandSpec::new("kimi", kimi_args(config_target))),
             ),
-            SetupMcpTarget::Cursor => Self::manual(target, cursor_snippet(config_target)),
-            SetupMcpTarget::PiCodingAgent => Self::manual(target, pi_snippet(config_target)),
+            SetupMcpTarget::OpenCode => Self::write_config(
+                target,
+                home
+                    .as_ref()
+                    .map(|home| McpConfigWrite::opencode(home, config_target)),
+                opencode_snippet(config_target),
+            ),
+            SetupMcpTarget::Cursor => Self::write_config(
+                target,
+                home.as_ref()
+                    .map(|home| McpConfigWrite::cursor(home, config_target)),
+                cursor_snippet(config_target),
+            ),
+            SetupMcpTarget::PiCodingAgent => {
+                let mut plan = Self::write_config(
+                    target,
+                    home.as_ref()
+                        .map(|home| McpConfigWrite::pi(home, config_target)),
+                    pi_snippet(config_target),
+                );
+                if !plan.config_writes.is_empty() {
+                    plan.steps.push(McpPlanStep::required(CommandSpec::new(
+                        "pi",
+                        ["install", "npm:pi-mcp-extension"],
+                    )));
+                }
+                plan
+            }
         }
     }
 
@@ -868,6 +929,7 @@ impl McpPlan {
                 ),
                 add_step,
             ],
+            config_writes: Vec::new(),
             manual_snippet: None,
         }
     }
@@ -877,12 +939,41 @@ impl McpPlan {
             target,
             action: McpAction::ManualInstructions,
             steps: Vec::new(),
+            config_writes: Vec::new(),
             manual_snippet: Some(snippet),
+        }
+    }
+
+    fn write_config(
+        target: SetupMcpTarget,
+        write: Option<McpConfigWrite>,
+        fallback_snippet: String,
+    ) -> Self {
+        let Some(write) = write else {
+            return Self::manual(
+                target,
+                format!("HOME is not set, so Moraine cannot choose a global MCP config path.\n{fallback_snippet}"),
+            );
+        };
+
+        Self {
+            target,
+            action: McpAction::WriteConfig,
+            steps: Vec::new(),
+            config_writes: vec![write],
+            manual_snippet: None,
         }
     }
 
     fn commands(&self) -> Vec<CommandSpec> {
         self.steps.iter().map(|step| step.command.clone()).collect()
+    }
+
+    fn planned_config_files(&self) -> Vec<McpConfigFileReport> {
+        self.config_writes
+            .iter()
+            .map(McpConfigFileReport::planned)
+            .collect()
     }
 }
 
@@ -1001,6 +1092,7 @@ fn cursor_snippet(config_target: &ConfigTarget) -> String {
     let snippet = serde_json::json!({
         "mcpServers": {
             "moraine": {
+                "type": "stdio",
                 "command": "moraine",
                 "args": mcp_run_args(config_target),
             }
@@ -1008,6 +1100,23 @@ fn cursor_snippet(config_target: &ConfigTarget) -> String {
     });
     format!(
         "Add this server to ~/.cursor/mcp.json for global Cursor use or .cursor/mcp.json for a project:\n{}",
+        serde_json::to_string_pretty(&snippet).unwrap_or_else(|_| snippet.to_string())
+    )
+}
+
+fn opencode_snippet(config_target: &ConfigTarget) -> String {
+    let snippet = serde_json::json!({
+        "$schema": "https://opencode.ai/config.json",
+        "mcp": {
+            "moraine": {
+                "type": "local",
+                "command": opencode_command(config_target),
+                "enabled": true,
+            }
+        }
+    });
+    format!(
+        "Add this server to ~/.config/opencode/opencode.json:\n{}",
         serde_json::to_string_pretty(&snippet).unwrap_or_else(|_| snippet.to_string())
     )
 }
@@ -1027,6 +1136,233 @@ fn pi_snippet(config_target: &ConfigTarget) -> String {
         "Install the Pi MCP extension first:\npi install npm:pi-mcp-extension\n\nThen add this server to ~/.pi/agent/mcp.json:\n{}",
         serde_json::to_string_pretty(&snippet).unwrap_or_else(|_| snippet.to_string())
     )
+}
+
+fn opencode_command(config_target: &ConfigTarget) -> Vec<String> {
+    std::iter::once("moraine".to_string())
+        .chain(mcp_run_args(config_target))
+        .collect()
+}
+
+#[derive(Debug, Clone)]
+struct McpConfigWrite {
+    path: PathBuf,
+    kind: McpConfigKind,
+    command: Vec<String>,
+}
+
+impl McpConfigWrite {
+    fn cursor(home: &Path, config_target: &ConfigTarget) -> Self {
+        Self {
+            path: home.join(".cursor").join("mcp.json"),
+            kind: McpConfigKind::Cursor,
+            command: mcp_run_args(config_target),
+        }
+    }
+
+    fn pi(home: &Path, config_target: &ConfigTarget) -> Self {
+        Self {
+            path: home.join(".pi").join("agent").join("mcp.json"),
+            kind: McpConfigKind::Pi,
+            command: mcp_run_args(config_target),
+        }
+    }
+
+    fn opencode(home: &Path, config_target: &ConfigTarget) -> Self {
+        Self {
+            path: home.join(".config").join("opencode").join("opencode.json"),
+            kind: McpConfigKind::OpenCode,
+            command: opencode_command(config_target),
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn merge_into(&self, root: &mut Map<String, Value>) -> Result<()> {
+        match self.kind {
+            McpConfigKind::Cursor => {
+                let servers = object_entry_mut(root, "mcpServers")?;
+                servers.insert(
+                    "moraine".to_string(),
+                    serde_json::json!({
+                        "type": "stdio",
+                        "command": "moraine",
+                        "args": self.command.clone(),
+                    }),
+                );
+            }
+            McpConfigKind::Pi => {
+                let servers = object_entry_mut(root, "mcpServers")?;
+                servers.insert(
+                    "moraine".to_string(),
+                    serde_json::json!({
+                        "transport": "stdio",
+                        "command": "moraine",
+                        "args": self.command.clone(),
+                        "lifecycle": "eager",
+                    }),
+                );
+            }
+            McpConfigKind::OpenCode => {
+                root.entry("$schema".to_string())
+                    .or_insert_with(|| serde_json::json!("https://opencode.ai/config.json"));
+                let servers = object_entry_mut(root, "mcp")?;
+                servers.insert(
+                    "moraine".to_string(),
+                    serde_json::json!({
+                        "type": "local",
+                        "command": self.command.clone(),
+                        "enabled": true,
+                    }),
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum McpConfigKind {
+    Cursor,
+    Pi,
+    OpenCode,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct McpConfigFileReport {
+    path: String,
+    action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+impl McpConfigFileReport {
+    fn planned(write: &McpConfigWrite) -> Self {
+        Self {
+            path: write.path().display().to_string(),
+            action: "would_update".to_string(),
+            error: None,
+        }
+    }
+
+    fn written(write: &McpConfigWrite) -> Self {
+        Self {
+            path: write.path().display().to_string(),
+            action: "updated".to_string(),
+            error: None,
+        }
+    }
+
+    fn error(write: &McpConfigWrite, error: &str) -> Self {
+        Self {
+            path: write.path().display().to_string(),
+            action: "error".to_string(),
+            error: Some(error.to_string()),
+        }
+    }
+}
+
+fn apply_mcp_config_write(write: &McpConfigWrite) -> Result<McpConfigFileReport> {
+    let mut root = read_json_object_or_default(write.path())?;
+    write.merge_into(&mut root)?;
+    write_json_atomic(write.path(), &Value::Object(root))?;
+    Ok(McpConfigFileReport::written(write))
+}
+
+fn read_json_object_or_default(path: &Path) -> Result<Map<String, Value>> {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(exc) if exc.kind() == ErrorKind::NotFound => return Ok(Map::new()),
+        Err(exc) => {
+            return Err(exc).with_context(|| format!("failed to read {}", path.display()));
+        }
+    };
+
+    if content.trim().is_empty() {
+        return Ok(Map::new());
+    }
+
+    let value: Value = serde_json::from_str(&content)
+        .with_context(|| format!("{} is not valid JSON", path.display()))?;
+    match value {
+        Value::Object(object) => Ok(object),
+        _ => bail!("{} must contain a JSON object", path.display()),
+    }
+}
+
+fn object_entry_mut<'a>(
+    root: &'a mut Map<String, Value>,
+    key: &str,
+) -> Result<&'a mut Map<String, Value>> {
+    let value = root
+        .entry(key.to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !value.is_object() {
+        bail!("{key} must be a JSON object");
+    }
+    Ok(value
+        .as_object_mut()
+        .expect("value was checked as a JSON object"))
+}
+
+fn write_json_atomic(path: &Path, value: &Value) -> Result<()> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("mcp.json");
+    for attempt in 0..100 {
+        let temp_path = parent.join(format!(
+            ".{file_name}.setup-{}-{}-{attempt}.tmp",
+            std::process::id(),
+            timestamp_suffix()
+        ));
+        match private_create_new_options().open(&temp_path) {
+            Ok(mut file) => {
+                let result = (|| {
+                    serde_json::to_writer_pretty(&mut file, value).with_context(|| {
+                        format!("failed to serialize JSON for {}", path.display())
+                    })?;
+                    file.write_all(b"\n")
+                        .with_context(|| format!("failed to write {}", temp_path.display()))?;
+                    file.flush()
+                        .with_context(|| format!("failed to flush {}", temp_path.display()))?;
+                    fs::rename(&temp_path, path).with_context(|| {
+                        format!(
+                            "failed to persist {} to {}",
+                            temp_path.display(),
+                            path.display()
+                        )
+                    })?;
+                    Ok(())
+                })();
+                if result.is_err() {
+                    let _ = fs::remove_file(&temp_path);
+                }
+                return result;
+            }
+            Err(exc) if exc.kind() == ErrorKind::AlreadyExists => continue,
+            Err(exc) => {
+                return Err(exc)
+                    .with_context(|| format!("failed to create {}", temp_path.display()));
+            }
+        }
+    }
+
+    bail!(
+        "failed to create a unique temporary JSON file in {}",
+        parent.display()
+    );
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -1173,6 +1509,7 @@ enum SetupStatus {
 #[serde(rename_all = "snake_case")]
 enum McpAction {
     Execute,
+    WriteConfig,
     ManualInstructions,
 }
 
@@ -1272,6 +1609,8 @@ struct McpTargetReport {
     status: SetupStatus,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     commands: Vec<CommandSpec>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    config_files: Vec<McpConfigFileReport>,
     #[serde(skip_serializing_if = "Option::is_none")]
     manual_snippet: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1291,6 +1630,7 @@ impl McpTargetReport {
             action: plan.action,
             status: SetupStatus::Planned,
             commands: plan.commands(),
+            config_files: plan.planned_config_files(),
             manual_snippet: plan.manual_snippet,
             skipped_reason: None,
             warnings: Vec::new(),
@@ -1305,6 +1645,7 @@ impl McpTargetReport {
             action: plan.action,
             status: SetupStatus::Skipped,
             commands: Vec::new(),
+            config_files: Vec::new(),
             manual_snippet: plan.manual_snippet,
             skipped_reason: Some("manual instructions only".to_string()),
             warnings: Vec::new(),
@@ -1319,6 +1660,7 @@ impl McpTargetReport {
             action: McpAction::Execute,
             status: SetupStatus::Skipped,
             commands: Vec::new(),
+            config_files: Vec::new(),
             manual_snippet: None,
             skipped_reason: Some(reason.to_string()),
             warnings: Vec::new(),
@@ -1333,6 +1675,7 @@ impl McpTargetReport {
             action: McpAction::Execute,
             status: SetupStatus::Error,
             commands: Vec::new(),
+            config_files: Vec::new(),
             manual_snippet: None,
             skipped_reason: None,
             warnings: Vec::new(),
@@ -1442,23 +1785,32 @@ fn target_detail(target: &McpTargetReport) -> String {
         return truncate_for_table(reason);
     }
     let command_count = target.commands.len();
-    let commands = if command_count == 0 {
+    let config_count = target.config_files.len();
+    let mut parts = Vec::new();
+    if command_count == 1 {
+        parts.push("1 command".to_string());
+    } else if command_count > 1 {
+        parts.push(format!("{command_count} commands"));
+    }
+    if config_count == 1 {
+        parts.push("1 config file".to_string());
+    } else if config_count > 1 {
+        parts.push(format!("{config_count} config files"));
+    }
+    if parts.is_empty() {
         return match target.status {
             SetupStatus::Ok => "ready".to_string(),
             SetupStatus::Planned => "no commands would run".to_string(),
             SetupStatus::Skipped => "no commands run".to_string(),
             SetupStatus::Error => "no commands completed".to_string(),
         };
-    } else if command_count == 1 {
-        "1 command".to_string()
-    } else {
-        format!("{command_count} commands")
-    };
+    }
+    let work = parts.join(" + ");
     match target.status {
-        SetupStatus::Ok => format!("{commands} completed"),
-        SetupStatus::Planned => format!("{commands} would run"),
-        SetupStatus::Skipped => format!("{commands} skipped"),
-        SetupStatus::Error => format!("{commands} attempted"),
+        SetupStatus::Ok => format!("{work} completed"),
+        SetupStatus::Planned => format!("{work} would update"),
+        SetupStatus::Skipped => format!("{work} skipped"),
+        SetupStatus::Error => format!("{work} attempted"),
     }
 }
 
@@ -1481,8 +1833,14 @@ fn append_target_details(target: &McpTargetReport, output: &CliOutput, lines: &m
         || target.status == SetupStatus::Planned
         || target.status == SetupStatus::Error
         || !target.warnings.is_empty();
+    let show_config_files = !target.config_files.is_empty()
+        && (output.verbose
+            || target.status == SetupStatus::Ok
+            || target.status == SetupStatus::Planned
+            || target.status == SetupStatus::Error);
     let show_command_output = output.verbose && !target.command_results.is_empty();
     if !show_commands
+        && !show_config_files
         && !show_command_output
         && target.manual_snippet.is_none()
         && target.warnings.is_empty()
@@ -1498,6 +1856,21 @@ fn append_target_details(target: &McpTargetReport, output: &CliOutput, lines: &m
     if show_commands {
         for command in &target.commands {
             lines.push(format!("  $ {}", command.display()));
+        }
+    }
+    if show_config_files {
+        for config_file in &target.config_files {
+            if let Some(error) = &config_file.error {
+                lines.push(format!(
+                    "  file: {} ({}, {error})",
+                    config_file.path, config_file.action
+                ));
+            } else {
+                lines.push(format!(
+                    "  file: {} ({})",
+                    config_file.path, config_file.action
+                ));
+            }
         }
     }
     if let Some(snippet) = &target.manual_snippet {
@@ -1538,6 +1911,7 @@ impl SetupMcpTarget {
             SetupMcpTarget::Codex => "Codex",
             SetupMcpTarget::Hermes => "Hermes",
             SetupMcpTarget::KimiCli => "Kimi CLI",
+            SetupMcpTarget::OpenCode => "OpenCode",
             SetupMcpTarget::Cursor => "Cursor",
             SetupMcpTarget::PiCodingAgent => "Pi Coding Agent",
         }
@@ -1547,18 +1921,52 @@ impl SetupMcpTarget {
         match self {
             SetupMcpTarget::ClaudeCode | SetupMcpTarget::Codex => "plugin",
             SetupMcpTarget::Hermes | SetupMcpTarget::KimiCli => "MCP",
-            SetupMcpTarget::Cursor | SetupMcpTarget::PiCodingAgent => "manual",
+            SetupMcpTarget::OpenCode | SetupMcpTarget::Cursor => "MCP config",
+            SetupMcpTarget::PiCodingAgent => "MCP extension",
         }
     }
 
-    fn program(self) -> &'static str {
+    fn is_available_for_setup(self, runner: &dyn CommandRunner) -> bool {
+        if self
+            .program_candidates()
+            .iter()
+            .any(|program| runner.command_exists(program))
+        {
+            return true;
+        }
+        self.default_probe_paths().iter().any(|path| path.exists())
+    }
+
+    fn program_candidates(self) -> &'static [&'static str] {
         match self {
-            SetupMcpTarget::ClaudeCode => "claude",
-            SetupMcpTarget::Codex => "codex",
-            SetupMcpTarget::Hermes => "hermes",
-            SetupMcpTarget::KimiCli => "kimi",
-            SetupMcpTarget::Cursor => "cursor",
-            SetupMcpTarget::PiCodingAgent => "pi",
+            SetupMcpTarget::ClaudeCode => &["claude"],
+            SetupMcpTarget::Codex => &["codex"],
+            SetupMcpTarget::Hermes => &["hermes"],
+            SetupMcpTarget::KimiCli => &["kimi"],
+            SetupMcpTarget::OpenCode => &["opencode"],
+            SetupMcpTarget::Cursor => &["cursor", "cursor-agent"],
+            SetupMcpTarget::PiCodingAgent => &["pi"],
+        }
+    }
+
+    fn default_probe_paths(self) -> Vec<PathBuf> {
+        let Some(home) = env::var_os("HOME").map(PathBuf::from) else {
+            return Vec::new();
+        };
+        match self {
+            SetupMcpTarget::OpenCode => vec![
+                home.join(".config").join("opencode"),
+                home.join(".local").join("share").join("opencode"),
+            ],
+            SetupMcpTarget::Cursor => vec![
+                home.join(".cursor"),
+                home.join("Library")
+                    .join("Application Support")
+                    .join("Cursor"),
+                home.join(".config").join("Cursor"),
+            ],
+            SetupMcpTarget::PiCodingAgent => vec![home.join(".pi").join("agent")],
+            _ => Vec::new(),
         }
     }
 }
@@ -1915,6 +2323,177 @@ mod tests {
     }
 
     #[test]
+    fn cursor_config_write_merges_global_mcp_json() {
+        let home = temp_path("cursor-home");
+        let cursor_dir = home.join(".cursor");
+        fs::create_dir_all(&cursor_dir).expect("create cursor dir");
+        let path = cursor_dir.join("mcp.json");
+        fs::write(
+            &path,
+            r#"{"mcpServers":{"other":{"command":"node"}},"enabled":true}"#,
+        )
+        .expect("write existing cursor config");
+
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let write = McpConfigWrite::cursor(&home, &target);
+        let report = apply_mcp_config_write(&write).expect("write cursor config");
+        assert_eq!(report.action, "updated");
+
+        let value: Value =
+            serde_json::from_str(&fs::read_to_string(&path).expect("read cursor config"))
+                .expect("cursor config json");
+        assert_eq!(value["enabled"], true);
+        assert_eq!(value["mcpServers"]["other"]["command"], "node");
+        assert_eq!(value["mcpServers"]["moraine"]["type"], "stdio");
+        assert_eq!(value["mcpServers"]["moraine"]["command"], "moraine");
+        assert_eq!(
+            value["mcpServers"]["moraine"]["args"],
+            serde_json::json!(["run", "mcp"])
+        );
+        #[cfg(unix)]
+        assert_eq!(
+            fs::metadata(&path)
+                .expect("cursor metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn opencode_config_write_merges_global_config_with_custom_moraine_config() {
+        let home = temp_path("opencode-home");
+        let opencode_dir = home.join(".config").join("opencode");
+        fs::create_dir_all(&opencode_dir).expect("create opencode dir");
+        let path = opencode_dir.join("opencode.json");
+        fs::write(
+            &path,
+            r#"{"theme":"system","mcp":{"other":{"type":"local","command":["node","server.js"]}}}"#,
+        )
+        .expect("write existing opencode config");
+
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/custom.toml"),
+            source: ConfigTargetSource::Cli,
+        };
+        let write = McpConfigWrite::opencode(&home, &target);
+        apply_mcp_config_write(&write).expect("write opencode config");
+
+        let value: Value =
+            serde_json::from_str(&fs::read_to_string(&path).expect("read opencode config"))
+                .expect("opencode config json");
+        assert_eq!(value["theme"], "system");
+        assert_eq!(value["$schema"], "https://opencode.ai/config.json");
+        assert_eq!(value["mcp"]["other"]["type"], "local");
+        assert_eq!(value["mcp"]["moraine"]["type"], "local");
+        assert_eq!(value["mcp"]["moraine"]["enabled"], true);
+        assert_eq!(
+            value["mcp"]["moraine"]["command"],
+            serde_json::json!(["moraine", "run", "mcp", "--config", "/tmp/custom.toml"])
+        );
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn pi_plan_installs_extension_then_writes_config() {
+        let home = temp_path("pi-home");
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan = McpPlan::for_target_with_home(
+            SetupMcpTarget::PiCodingAgent,
+            &target,
+            Some(home.clone()),
+        );
+        assert_eq!(plan.action, McpAction::WriteConfig);
+        let commands = plan.commands();
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].program, "pi");
+        assert_eq!(commands[0].args, vec!["install", "npm:pi-mcp-extension"]);
+
+        let mut runner =
+            FakeRunner::default()
+                .with_existing("pi")
+                .with_response(commands[0].clone(), true, "");
+        let report = execute_mcp_plan(plan, &mut runner).expect("execute pi plan");
+        assert_eq!(report.status, SetupStatus::Ok);
+        assert_eq!(runner.ran, commands);
+        assert_eq!(report.config_files.len(), 1);
+
+        let path = home.join(".pi").join("agent").join("mcp.json");
+        let value: Value =
+            serde_json::from_str(&fs::read_to_string(&path).expect("read pi config"))
+                .expect("pi config json");
+        assert_eq!(value["mcpServers"]["moraine"]["transport"], "stdio");
+        assert_eq!(value["mcpServers"]["moraine"]["command"], "moraine");
+        assert_eq!(
+            value["mcpServers"]["moraine"]["args"],
+            serde_json::json!(["run", "mcp"])
+        );
+        assert_eq!(value["mcpServers"]["moraine"]["lifecycle"], "eager");
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn invalid_json_config_write_reports_error() {
+        let home = temp_path("bad-cursor-home");
+        let cursor_dir = home.join(".cursor");
+        fs::create_dir_all(&cursor_dir).expect("create cursor dir");
+        let path = cursor_dir.join("mcp.json");
+        fs::write(&path, "not json").expect("write bad cursor config");
+
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan =
+            McpPlan::for_target_with_home(SetupMcpTarget::Cursor, &target, Some(home.clone()));
+        let mut runner = FakeRunner::default();
+        let report = execute_mcp_plan(plan, &mut runner).expect("execute cursor plan");
+        assert_eq!(report.status, SetupStatus::Error);
+        assert!(report
+            .error
+            .as_deref()
+            .expect("error")
+            .contains("not valid JSON"));
+        assert_eq!(report.config_files.len(), 1);
+        assert_eq!(report.config_files[0].action, "error");
+        assert!(runner.ran.is_empty());
+        assert_eq!(
+            fs::read_to_string(&path).expect("bad config content"),
+            "not json"
+        );
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn dry_run_reports_planned_config_file_without_writing() {
+        let home = temp_path("cursor-dry-run");
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan =
+            McpPlan::for_target_with_home(SetupMcpTarget::Cursor, &target, Some(home.clone()));
+        let report = McpTargetReport::planned(plan);
+        assert_eq!(report.status, SetupStatus::Planned);
+        assert_eq!(report.action, McpAction::WriteConfig);
+        assert_eq!(report.config_files.len(), 1);
+        assert_eq!(report.config_files[0].action, "would_update");
+        assert_eq!(
+            report.config_files[0].path,
+            home.join(".cursor").join("mcp.json").display().to_string()
+        );
+        assert!(!home.exists());
+    }
+
+    #[test]
     fn hermes_add_accepts_tool_enable_prompt() {
         let target = ConfigTarget {
             path: PathBuf::from("/tmp/config.toml"),
@@ -2093,6 +2672,7 @@ mod tests {
                 action: McpAction::Execute,
                 status: SetupStatus::Ok,
                 commands: vec![command.clone()],
+                config_files: Vec::new(),
                 manual_snippet: None,
                 skipped_reason: None,
                 warnings: Vec::new(),

--- a/apps/moraine/src/commands/setup/harnesses.rs
+++ b/apps/moraine/src/commands/setup/harnesses.rs
@@ -1,0 +1,721 @@
+use std::iter;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Result};
+use serde_json::{Map, Value};
+use toml_edit::{value as toml_value, Table};
+
+use super::{CommandSpec, ConfigTarget, McpPlan, McpPlanStep, SetupMcpTarget};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct DefaultIngestSourceUpdate {
+    pub(super) enabled_changed: bool,
+    pub(super) metadata_changed: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct DefaultIngestSource {
+    name: &'static str,
+    harness: &'static str,
+    glob: &'static str,
+    watch_root: &'static str,
+    format: Option<&'static str>,
+}
+
+impl DefaultIngestSource {
+    pub(super) fn name(self) -> &'static str {
+        self.name
+    }
+
+    pub(super) fn harness(self) -> &'static str {
+        self.harness
+    }
+
+    pub(super) fn to_table(self, enabled: bool) -> Table {
+        let mut table = Table::new();
+        table["name"] = toml_value(self.name);
+        table["harness"] = toml_value(self.harness);
+        table["enabled"] = toml_value(enabled);
+        table["glob"] = toml_value(self.glob);
+        table["watch_root"] = toml_value(self.watch_root);
+        if let Some(format) = self.format {
+            table["format"] = toml_value(format);
+        }
+        table
+    }
+
+    pub(super) fn reconcile_table(
+        self,
+        table: &mut Table,
+        enabled: bool,
+    ) -> DefaultIngestSourceUpdate {
+        let enabled_changed = set_bool(table, "enabled", enabled);
+        let mut metadata_changed = false;
+
+        metadata_changed |= set_str(table, "name", self.name);
+        metadata_changed |= set_str(table, "harness", self.harness);
+        metadata_changed |= set_str(table, "glob", self.glob);
+        metadata_changed |= set_str(table, "watch_root", self.watch_root);
+        metadata_changed |= match self.format {
+            Some(format) => set_str(table, "format", format),
+            None => table.remove("format").is_some(),
+        };
+
+        DefaultIngestSourceUpdate {
+            enabled_changed,
+            metadata_changed,
+        }
+    }
+}
+
+fn set_str(table: &mut Table, key: &str, expected: &str) -> bool {
+    if table.get(key).and_then(toml_edit::Item::as_str) == Some(expected) {
+        return false;
+    }
+    table[key] = toml_value(expected);
+    true
+}
+
+fn set_bool(table: &mut Table, key: &str, expected: bool) -> bool {
+    if table.get(key).and_then(toml_edit::Item::as_bool) == Some(expected) {
+        return false;
+    }
+    table[key] = toml_value(expected);
+    true
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ProbePaths {
+    None,
+    OpenCode,
+    Cursor,
+    Pi,
+}
+
+impl ProbePaths {
+    fn paths(self, home: &Path) -> Vec<PathBuf> {
+        match self {
+            ProbePaths::None => Vec::new(),
+            ProbePaths::OpenCode => vec![
+                home.join(".config").join("opencode"),
+                home.join(".local").join("share").join("opencode"),
+            ],
+            ProbePaths::Cursor => vec![
+                home.join(".cursor"),
+                home.join("Library")
+                    .join("Application Support")
+                    .join("Cursor"),
+                home.join(".config").join("Cursor"),
+            ],
+            ProbePaths::Pi => vec![home.join(".pi").join("agent")],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct HarnessSpec {
+    pub(super) target: SetupMcpTarget,
+    label: &'static str,
+    setup_kind: &'static str,
+    programs: &'static [&'static str],
+    probe_paths: ProbePaths,
+    ingest_sources: &'static [DefaultIngestSource],
+}
+
+impl HarnessSpec {
+    pub(super) fn label(self) -> &'static str {
+        self.label
+    }
+
+    pub(super) fn setup_kind(self) -> &'static str {
+        self.setup_kind
+    }
+
+    pub(super) fn program_candidates(self) -> &'static [&'static str] {
+        self.programs
+    }
+
+    pub(super) fn default_probe_paths(self, home: &Path) -> Vec<PathBuf> {
+        self.probe_paths.paths(home)
+    }
+
+    pub(super) fn ingest_sources(self) -> &'static [DefaultIngestSource] {
+        self.ingest_sources
+    }
+}
+
+const CODEX_INGEST: [DefaultIngestSource; 1] = [DefaultIngestSource {
+    name: "codex",
+    harness: "codex",
+    glob: "~/.codex/sessions/**/*.jsonl",
+    watch_root: "~/.codex/sessions",
+    format: None,
+}];
+
+const CLAUDE_INGEST: [DefaultIngestSource; 1] = [DefaultIngestSource {
+    name: "claude",
+    harness: "claude-code",
+    glob: "~/.claude/projects/**/*.jsonl",
+    watch_root: "~/.claude/projects",
+    format: None,
+}];
+
+const HERMES_INGEST: [DefaultIngestSource; 1] = [DefaultIngestSource {
+    name: "hermes",
+    harness: "hermes",
+    glob: "~/.hermes/sessions/session_*.json",
+    watch_root: "~/.hermes/sessions",
+    format: Some("session_json"),
+}];
+
+const KIMI_INGEST: [DefaultIngestSource; 1] = [DefaultIngestSource {
+    name: "kimi-cli",
+    harness: "kimi-cli",
+    glob: "~/.kimi/sessions/**/wire.jsonl",
+    watch_root: "~/.kimi/sessions",
+    format: Some("jsonl"),
+}];
+
+const OPENCODE_INGEST: [DefaultIngestSource; 1] = [DefaultIngestSource {
+    name: "opencode",
+    harness: "opencode",
+    glob: "~/.local/share/opencode/opencode*.db",
+    watch_root: "~/.local/share/opencode",
+    format: Some("opencode_sqlite"),
+}];
+
+#[cfg(target_os = "macos")]
+const CURSOR_SQLITE_GLOB: &str = "~/Library/Application Support/Cursor/User/**/state.vscdb";
+#[cfg(target_os = "macos")]
+const CURSOR_SQLITE_ROOT: &str = "~/Library/Application Support/Cursor/User";
+#[cfg(not(target_os = "macos"))]
+const CURSOR_SQLITE_GLOB: &str = "~/.config/Cursor/User/**/state.vscdb";
+#[cfg(not(target_os = "macos"))]
+const CURSOR_SQLITE_ROOT: &str = "~/.config/Cursor/User";
+
+const CURSOR_INGEST: [DefaultIngestSource; 2] = [
+    DefaultIngestSource {
+        name: "cursor",
+        harness: "cursor",
+        glob: "~/.cursor/projects/*/agent-transcripts/**/*.jsonl",
+        watch_root: "~/.cursor/projects",
+        format: Some("jsonl"),
+    },
+    DefaultIngestSource {
+        name: "cursor-sqlite",
+        harness: "cursor",
+        glob: CURSOR_SQLITE_GLOB,
+        watch_root: CURSOR_SQLITE_ROOT,
+        format: Some("cursor_sqlite"),
+    },
+];
+
+const PI_INGEST: [DefaultIngestSource; 1] = [DefaultIngestSource {
+    name: "pi",
+    harness: "pi-coding-agent",
+    glob: "~/.pi/agent/sessions/**/*.jsonl",
+    watch_root: "~/.pi/agent/sessions",
+    format: Some("jsonl"),
+}];
+
+const SPECS: [HarnessSpec; 7] = [
+    HarnessSpec {
+        target: SetupMcpTarget::ClaudeCode,
+        label: "Claude Code",
+        setup_kind: "plugin",
+        programs: &["claude"],
+        probe_paths: ProbePaths::None,
+        ingest_sources: &CLAUDE_INGEST,
+    },
+    HarnessSpec {
+        target: SetupMcpTarget::Codex,
+        label: "Codex",
+        setup_kind: "plugin",
+        programs: &["codex"],
+        probe_paths: ProbePaths::None,
+        ingest_sources: &CODEX_INGEST,
+    },
+    HarnessSpec {
+        target: SetupMcpTarget::Hermes,
+        label: "Hermes",
+        setup_kind: "MCP",
+        programs: &["hermes"],
+        probe_paths: ProbePaths::None,
+        ingest_sources: &HERMES_INGEST,
+    },
+    HarnessSpec {
+        target: SetupMcpTarget::KimiCli,
+        label: "Kimi CLI",
+        setup_kind: "MCP",
+        programs: &["kimi"],
+        probe_paths: ProbePaths::None,
+        ingest_sources: &KIMI_INGEST,
+    },
+    HarnessSpec {
+        target: SetupMcpTarget::OpenCode,
+        label: "OpenCode",
+        setup_kind: "MCP config",
+        programs: &["opencode"],
+        probe_paths: ProbePaths::OpenCode,
+        ingest_sources: &OPENCODE_INGEST,
+    },
+    HarnessSpec {
+        target: SetupMcpTarget::Cursor,
+        label: "Cursor",
+        setup_kind: "MCP config",
+        programs: &["cursor", "cursor-agent"],
+        probe_paths: ProbePaths::Cursor,
+        ingest_sources: &CURSOR_INGEST,
+    },
+    HarnessSpec {
+        target: SetupMcpTarget::PiCodingAgent,
+        label: "Pi Coding Agent",
+        setup_kind: "MCP extension",
+        programs: &["pi"],
+        probe_paths: ProbePaths::Pi,
+        ingest_sources: &PI_INGEST,
+    },
+];
+
+pub(super) fn setup_targets() -> Vec<SetupMcpTarget> {
+    SPECS.iter().map(|spec| spec.target).collect()
+}
+
+pub(super) fn spec(target: SetupMcpTarget) -> &'static HarnessSpec {
+    SPECS
+        .iter()
+        .find(|spec| spec.target == target)
+        .expect("every setup target has a harness spec")
+}
+
+pub(super) fn default_ingest_sources(target: SetupMcpTarget) -> &'static [DefaultIngestSource] {
+    spec(target).ingest_sources()
+}
+
+pub(super) fn mcp_plan(
+    target: SetupMcpTarget,
+    config_target: &ConfigTarget,
+    home: Option<PathBuf>,
+) -> McpPlan {
+    match target {
+        SetupMcpTarget::ClaudeCode if config_target.requires_explicit_mcp_config() => {
+            let mut args = vec![
+                "mcp".to_string(),
+                "add".to_string(),
+                "--transport".to_string(),
+                "stdio".to_string(),
+                "--scope".to_string(),
+                "user".to_string(),
+                "moraine".to_string(),
+                "--".to_string(),
+                "moraine".to_string(),
+                "run".to_string(),
+                "mcp".to_string(),
+                "--config".to_string(),
+            ];
+            args.push(config_target.path.display().to_string());
+            let command = CommandSpec::new("claude", args);
+            McpPlan::manual(
+                target,
+                format!(
+                    "Claude Code plugin installs use the default Moraine config. For this custom config target, use manual MCP registration:\n{}",
+                    command.display()
+                ),
+            )
+        }
+        SetupMcpTarget::ClaudeCode => McpPlan {
+            target,
+            action: super::McpAction::Execute,
+            steps: vec![
+                McpPlanStep::warn_and_continue(
+                    CommandSpec::new(
+                        "claude",
+                        [
+                            "plugin",
+                            "marketplace",
+                            "add",
+                            "eric-tramel/moraine",
+                            "--sparse",
+                            ".claude-plugin",
+                            "plugins",
+                        ],
+                    ),
+                    "Claude marketplace add failed; continuing because the marketplace may already exist",
+                )
+                .with_progress(
+                    "Adding Claude Code plugin marketplace",
+                    "Claude Code marketplace ready",
+                    "Claude Code marketplace already present or unavailable",
+                    "Claude Code marketplace add failed",
+                ),
+                McpPlanStep::required(CommandSpec::new(
+                    "claude",
+                    ["plugin", "install", "moraine@moraine"],
+                ))
+                .with_progress(
+                    "Installing Claude Code Moraine plugin",
+                    "Claude Code plugin installed",
+                    "Claude Code plugin install warning",
+                    "Claude Code plugin install failed",
+                ),
+                McpPlanStep::warn_and_continue(
+                    CommandSpec::new("claude", ["mcp", "remove", "moraine", "--scope", "user"]),
+                    "Existing manual Claude Code MCP registration could not be removed; continuing in case it was absent",
+                )
+                .with_progress(
+                    "Cleaning up old Claude Code MCP registration",
+                    "Old Claude Code MCP registration removed or absent",
+                    "Old Claude Code MCP registration left unchanged",
+                    "Old Claude Code MCP cleanup failed",
+                ),
+            ],
+            config_writes: Vec::new(),
+            manual_snippet: None,
+        },
+        SetupMcpTarget::Codex if config_target.requires_explicit_mcp_config() => {
+            let command = CommandSpec::new("codex", codex_args(config_target));
+            McpPlan::manual(
+                target,
+                format!(
+                    "Codex plugin installs use the default Moraine config. For this custom config target, use manual MCP registration:\n{}",
+                    command.display()
+                ),
+            )
+        }
+        SetupMcpTarget::Codex => McpPlan {
+            target,
+            action: super::McpAction::Execute,
+            steps: vec![
+                McpPlanStep::warn_and_continue(
+                    CommandSpec::new(
+                        "codex",
+                        [
+                            "plugin",
+                            "marketplace",
+                            "add",
+                            "eric-tramel/moraine",
+                            "--sparse",
+                            ".agents/plugins",
+                            "--sparse",
+                            "plugins/moraine",
+                            "--sparse",
+                            "plugins/moraine-dev",
+                        ],
+                    ),
+                    "Codex marketplace add failed; continuing because the marketplace may already exist",
+                )
+                .with_progress(
+                    "Adding Codex plugin marketplace",
+                    "Codex marketplace ready",
+                    "Codex marketplace already present or unavailable",
+                    "Codex marketplace add failed",
+                ),
+                McpPlanStep::required(CommandSpec::new(
+                    "codex",
+                    ["plugin", "add", "moraine@moraine"],
+                ))
+                .with_progress(
+                    "Installing Codex Moraine plugin",
+                    "Codex plugin installed",
+                    "Codex plugin install warning",
+                    "Codex plugin install failed",
+                ),
+                McpPlanStep::warn_and_continue(
+                    CommandSpec::new("codex", ["mcp", "remove", "moraine"]),
+                    "Existing manual Codex MCP registration could not be removed; continuing in case it was absent",
+                )
+                .with_progress(
+                    "Cleaning up old Codex MCP registration",
+                    "Old Codex MCP registration removed or absent",
+                    "Old Codex MCP registration left unchanged",
+                    "Old Codex MCP cleanup failed",
+                ),
+            ],
+            config_writes: Vec::new(),
+            manual_snippet: None,
+        },
+        SetupMcpTarget::Hermes => McpPlan::replace_registration(
+            target,
+            CommandSpec::new("hermes", ["mcp", "remove", "moraine"]),
+            McpPlanStep::required_stdout(
+                CommandSpec::new("hermes", hermes_args(config_target)).with_stdin("\n"),
+                "tools enabled",
+            )
+            .with_progress(
+                "Registering Moraine MCP in Hermes",
+                "Hermes MCP tools enabled",
+                "Hermes MCP registration warning",
+                "Hermes MCP registration failed",
+            ),
+        ),
+        SetupMcpTarget::KimiCli => McpPlan::replace_registration(
+            target,
+            CommandSpec::new("kimi", ["mcp", "remove", "moraine"]),
+            McpPlanStep::required(CommandSpec::new("kimi", kimi_args(config_target)))
+                .with_progress(
+                    "Registering Moraine MCP in Kimi CLI",
+                    "Kimi CLI MCP registered",
+                    "Kimi CLI MCP registration warning",
+                    "Kimi CLI MCP registration failed",
+                ),
+        ),
+        SetupMcpTarget::OpenCode => McpPlan::write_config(
+            target,
+            home.as_ref()
+                .map(|home| McpConfigWrite::opencode(home, config_target)),
+            opencode_snippet(config_target),
+        ),
+        SetupMcpTarget::Cursor => McpPlan::write_config(
+            target,
+            home.as_ref()
+                .map(|home| McpConfigWrite::cursor(home, config_target)),
+            cursor_snippet(config_target),
+        ),
+        SetupMcpTarget::PiCodingAgent => {
+            let mut plan = McpPlan::write_config(
+                target,
+                home.as_ref()
+                    .map(|home| McpConfigWrite::pi(home, config_target)),
+                pi_snippet(config_target),
+            );
+            if !plan.config_writes.is_empty() {
+                plan.steps.push(
+                    McpPlanStep::required(CommandSpec::new(
+                        "pi",
+                        ["install", "npm:pi-mcp-extension"],
+                    ))
+                    .with_progress(
+                        "Installing Pi MCP extension",
+                        "Pi MCP extension installed",
+                        "Pi MCP extension install warning",
+                        "Pi MCP extension install failed",
+                    ),
+                );
+            }
+            plan
+        }
+    }
+}
+
+pub(super) fn mcp_run_args(config_target: &ConfigTarget) -> Vec<String> {
+    let mut args = vec!["run".to_string(), "mcp".to_string()];
+    if config_target.requires_explicit_mcp_config() {
+        args.push("--config".to_string());
+        args.push(config_target.path.display().to_string());
+    }
+    args
+}
+
+pub(super) fn opencode_command(config_target: &ConfigTarget) -> Vec<String> {
+    iter::once("moraine".to_string())
+        .chain(mcp_run_args(config_target))
+        .collect()
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum McpConfigFormat {
+    Json,
+    Jsonc,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct McpConfigWrite {
+    path: PathBuf,
+    kind: McpConfigKind,
+    command: Vec<String>,
+}
+
+impl McpConfigWrite {
+    pub(super) fn cursor(home: &Path, config_target: &ConfigTarget) -> Self {
+        Self {
+            path: home.join(".cursor").join("mcp.json"),
+            kind: McpConfigKind::Cursor,
+            command: mcp_run_args(config_target),
+        }
+    }
+
+    pub(super) fn pi(home: &Path, config_target: &ConfigTarget) -> Self {
+        Self {
+            path: home.join(".pi").join("agent").join("mcp.json"),
+            kind: McpConfigKind::Pi,
+            command: mcp_run_args(config_target),
+        }
+    }
+
+    pub(super) fn opencode(home: &Path, config_target: &ConfigTarget) -> Self {
+        Self {
+            path: home.join(".config").join("opencode").join("opencode.json"),
+            kind: McpConfigKind::OpenCode,
+            command: opencode_command(config_target),
+        }
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(super) fn label(&self) -> &'static str {
+        self.kind.label()
+    }
+
+    pub(super) fn format(&self) -> McpConfigFormat {
+        self.kind.format()
+    }
+
+    pub(super) fn merge_into(&self, root: &mut Map<String, Value>) -> Result<()> {
+        match self.kind {
+            McpConfigKind::Cursor => {
+                let servers = object_entry_mut(root, "mcpServers")?;
+                servers.insert("moraine".to_string(), self.server_value());
+            }
+            McpConfigKind::Pi => {
+                let servers = object_entry_mut(root, "mcpServers")?;
+                servers.insert("moraine".to_string(), self.server_value());
+            }
+            McpConfigKind::OpenCode => {
+                root.entry("$schema".to_string())
+                    .or_insert_with(|| serde_json::json!("https://opencode.ai/config.json"));
+                let servers = object_entry_mut(root, "mcp")?;
+                servers.insert("moraine".to_string(), self.server_value());
+            }
+        }
+        Ok(())
+    }
+
+    fn server_value(&self) -> Value {
+        match self.kind {
+            McpConfigKind::Cursor => serde_json::json!({
+                "type": "stdio",
+                "command": "moraine",
+                "args": self.command.clone(),
+            }),
+            McpConfigKind::Pi => serde_json::json!({
+                "transport": "stdio",
+                "command": "moraine",
+                "args": self.command.clone(),
+                "lifecycle": "eager",
+            }),
+            McpConfigKind::OpenCode => serde_json::json!({
+                "type": "local",
+                "command": self.command.clone(),
+                "enabled": true,
+            }),
+        }
+    }
+
+    fn snippet_root(&self) -> Map<String, Value> {
+        let mut root = Map::new();
+        self.merge_into(&mut root)
+            .expect("snippet roots are built from empty JSON objects");
+        root
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum McpConfigKind {
+    Cursor,
+    Pi,
+    OpenCode,
+}
+
+impl McpConfigKind {
+    fn label(self) -> &'static str {
+        match self {
+            McpConfigKind::Cursor => "Cursor",
+            McpConfigKind::Pi => "Pi",
+            McpConfigKind::OpenCode => "OpenCode",
+        }
+    }
+
+    fn format(self) -> McpConfigFormat {
+        match self {
+            McpConfigKind::Cursor | McpConfigKind::Pi => McpConfigFormat::Json,
+            McpConfigKind::OpenCode => McpConfigFormat::Jsonc,
+        }
+    }
+}
+
+fn object_entry_mut<'a>(
+    root: &'a mut Map<String, Value>,
+    key: &str,
+) -> Result<&'a mut Map<String, Value>> {
+    let value = root
+        .entry(key.to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !value.is_object() {
+        bail!("{key} must be a JSON object");
+    }
+    Ok(value
+        .as_object_mut()
+        .expect("value was checked as a JSON object"))
+}
+
+fn codex_args(config_target: &ConfigTarget) -> Vec<String> {
+    let mut args = vec![
+        "mcp".to_string(),
+        "add".to_string(),
+        "moraine".to_string(),
+        "--".to_string(),
+        "moraine".to_string(),
+    ];
+    args.extend(mcp_run_args(config_target));
+    args
+}
+
+fn hermes_args(config_target: &ConfigTarget) -> Vec<String> {
+    let mut args = vec![
+        "mcp".to_string(),
+        "add".to_string(),
+        "moraine".to_string(),
+        "--command".to_string(),
+        "moraine".to_string(),
+        "--args".to_string(),
+    ];
+    args.extend(mcp_run_args(config_target));
+    args
+}
+
+fn kimi_args(config_target: &ConfigTarget) -> Vec<String> {
+    let mut args = vec![
+        "mcp".to_string(),
+        "add".to_string(),
+        "--transport".to_string(),
+        "stdio".to_string(),
+        "moraine".to_string(),
+        "--".to_string(),
+        "moraine".to_string(),
+    ];
+    args.extend(mcp_run_args(config_target));
+    args
+}
+
+fn cursor_snippet(config_target: &ConfigTarget) -> String {
+    snippet(
+        "Add this server to ~/.cursor/mcp.json for global Cursor use or .cursor/mcp.json for a project",
+        Value::Object(McpConfigWrite::cursor(Path::new("~"), config_target).snippet_root()),
+    )
+}
+
+fn opencode_snippet(config_target: &ConfigTarget) -> String {
+    snippet(
+        "Add this server to ~/.config/opencode/opencode.json",
+        Value::Object(McpConfigWrite::opencode(Path::new("~"), config_target).snippet_root()),
+    )
+}
+
+fn pi_snippet(config_target: &ConfigTarget) -> String {
+    format!(
+        "Install the Pi MCP extension first:\npi install npm:pi-mcp-extension\n\nThen add this server to ~/.pi/agent/mcp.json:\n{}",
+        serde_json::to_string_pretty(&Value::Object(
+            McpConfigWrite::pi(Path::new("~"), config_target).snippet_root()
+        ))
+        .unwrap_or_else(|_| "{}".to_string())
+    )
+}
+
+fn snippet(intro: &str, value: Value) -> String {
+    format!(
+        "{intro}:\n{}",
+        serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string())
+    )
+}

--- a/apps/moraine/src/render.rs
+++ b/apps/moraine/src/render.rs
@@ -184,7 +184,9 @@ impl CliOutput {
 }
 
 fn render_panel(title: &str, lines: &[String], width: u16, unicode: bool) -> String {
-    let area = Rect::new(0, 0, width, (lines.len().max(1) as u16).saturating_add(2));
+    let inner_width = width.saturating_sub(2).max(1);
+    let body_height = wrapped_line_count(lines, inner_width).max(1);
+    let area = Rect::new(0, 0, width, body_height.saturating_add(2));
     let mut buffer = Buffer::empty(area);
     let mut block = Block::default()
         .title(Line::from(title.to_string()))
@@ -200,6 +202,18 @@ fn render_panel(title: &str, lines: &[String], width: u16, unicode: bool) -> Str
         .style(Style::default().fg(Color::White));
     paragraph.render(area, &mut buffer);
     buffer_to_string(&buffer)
+}
+
+fn wrapped_line_count(lines: &[String], width: u16) -> u16 {
+    let width = usize::from(width.max(1));
+    let count = lines
+        .iter()
+        .map(|line| {
+            let char_count = line.chars().count().max(1);
+            char_count.div_ceil(width)
+        })
+        .sum::<usize>();
+    count.min(usize::from(u16::MAX)) as u16
 }
 
 fn render_table(
@@ -653,5 +667,19 @@ mod tests {
         let cli = Cli::parse_from(["moraine", "--output", "json", "status"]);
         let output = CliOutput::from_cli(&cli);
         assert_eq!(output.mode, OutputMode::Json);
+    }
+
+    #[test]
+    fn rich_panel_height_accounts_for_wrapped_lines() {
+        let panel = render_panel(
+            "Preview",
+            &["abcdefghijklmnopqrstuvwxyz".to_string()],
+            12,
+            false,
+        );
+        assert!(panel.lines().count() >= 5);
+        assert!(panel.contains("abcdefghij"));
+        assert!(panel.contains("klmnopqrst"));
+        assert!(panel.contains("uvwxyz"));
     }
 }

--- a/docs/agent-mcp-search/install.md
+++ b/docs/agent-mcp-search/install.md
@@ -10,6 +10,23 @@ Run `moraine up` first so ClickHouse, ingest, and the monitor are available.
 If you use a non-default Moraine config, pass it through the harness's
 environment support as `MORAINE_MCP_CONFIG=/path/to/moraine.toml`.
 
+## Guided setup (recommended)
+
+For default user-scoped setup, let Moraine create or repair its config and
+install or update supported harness integrations:
+
+```bash
+uv tool install moraine-cli
+moraine setup
+moraine up
+```
+
+`moraine setup` installs the Claude Code and Codex plugins, registers command
+based MCP clients such as Hermes and Kimi CLI, and writes global MCP config for
+OpenCode, Cursor, and Pi Coding Agent when selected. Use the manual sections
+below for project-scoped servers, `--project-only`, or custom environment
+wiring.
+
 ## Claude Code plugin marketplace (recommended)
 
 For Claude Code, the recommended user-scoped setup is the Moraine plugin. The
@@ -241,13 +258,38 @@ kimi mcp list
 kimi mcp test moraine
 ```
 
+## OpenCode
+
+OpenCode reads MCP servers from the `mcp` object in its config. For global use,
+`moraine setup --mcp-target opencode` creates or updates
+`~/.config/opencode/opencode.json`. OpenCode's docs describe local MCP servers
+with `type = "local"` and a `command` array:
+[OpenCode MCP servers](https://opencode.ai/docs/mcp-servers) and
+[OpenCode config](https://opencode.ai/docs/config/).
+
+Equivalent manual config:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "moraine": {
+      "type": "local",
+      "command": ["moraine", "run", "mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+
 ## Cursor
 
-Cursor and `cursor-agent` read MCP server definitions from `mcp.json`. Cursor's
-docs describe project config at `.cursor/mcp.json`, global config at
-`~/.cursor/mcp.json`, and CLI inspection through `cursor-agent mcp`:
-[Cursor MCP guide](https://docs.cursor.com/advanced/model-context-protocol) and
-[Cursor CLI MCP guide](https://docs.cursor.com/cli/mcp).
+Cursor reads MCP server definitions from `mcp.json`. For global use,
+`moraine setup --mcp-target cursor` creates or updates `~/.cursor/mcp.json`.
+Cursor's docs describe project config at `.cursor/mcp.json`, global config at
+`~/.cursor/mcp.json`, and CLI inspection through `agent mcp`:
+[Cursor MCP guide](https://cursor.com/docs/mcp.md) and
+[Cursor CLI MCP guide](https://cursor.com/docs/cli/mcp.md).
 
 For global use, create or update `~/.cursor/mcp.json`:
 
@@ -255,6 +297,7 @@ For global use, create or update `~/.cursor/mcp.json`:
 {
   "mcpServers": {
     "moraine": {
+      "type": "stdio",
       "command": "moraine",
       "args": ["run", "mcp"]
     }
@@ -262,11 +305,11 @@ For global use, create or update `~/.cursor/mcp.json`:
 }
 ```
 
-Then verify from the CLI when `cursor-agent` is installed:
+Then verify from the Cursor CLI when it is installed:
 
 ```bash
-cursor-agent mcp list
-cursor-agent mcp list-tools moraine
+agent mcp list
+agent mcp list-tools moraine
 ```
 
 For project-only use, put the same JSON in `.cursor/mcp.json` at the project
@@ -275,9 +318,10 @@ root.
 ## Pi Coding Agent
 
 Pi uses an extension to bridge MCP servers into Pi tools. Install the MCP
-extension, then add a Moraine stdio server to Pi's MCP config. The extension
-docs describe global config at `~/.pi/agent/mcp.json`, project config at
-`.pi/mcp.json`, and stdio server fields:
+extension, then add a Moraine stdio server to Pi's MCP config.
+`moraine setup --mcp-target pi-coding-agent` runs the extension install and
+creates or updates global `~/.pi/agent/mcp.json`. The extension docs describe
+global and project `mcp.json` files plus stdio server fields:
 [Pi MCP extension](https://pi.dev/packages/pi-mcp-extension).
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,6 +26,34 @@ The bundle installer places binaries in `~/.local/bin` by default and writes
 `~/.moraine/config.toml` when that file does not already exist. Add
 `~/.local/bin` to `PATH` if your shell does not find `moraine`.
 
+## Guided Setup
+
+Run the guided setup once after installing, or rerun it later to repair a broken
+config and install or update agent harness integrations:
+
+```bash
+moraine setup
+```
+
+In non-interactive scripts, create a missing config without registering agent
+harnesses:
+
+```bash
+moraine setup --yes
+```
+
+To preview MCP or plugin registration without touching host agent config, pass
+explicit targets:
+
+```bash
+moraine setup --dry-run --mcp-target claude-code --mcp-target codex
+```
+
+The Claude Code and Codex plugins, plus global MCP registrations, can expose
+host-wide Moraine session history to that harness. `moraine setup` asks before
+making those changes; for project-scoped or custom harness setup, see
+[Agent MCP Search → Install](agent-mcp-search/install.md).
+
 ## Start Moraine
 
 Start the local stack:
@@ -62,67 +90,38 @@ unchanged; if the shared server is not running, `moraine run mcp` falls back to
 an embedded server automatically. See
 [Agent MCP Search → Install](agent-mcp-search/install.md#shared-central-server-default).
 
-For Claude Code, install the Moraine plugin marketplace entry. It registers the
-MCP server and bundles Moraine search skills. Upgrade Moraine first if your
-installed CLI is not current:
+Use `moraine setup` to connect your agent harnesses. In an interactive terminal,
+setup shows a selector for detected harnesses; use the arrow keys to move, Space
+to choose integrations, and Enter to install the selected plugins or MCP
+registrations:
 
 ```bash
-claude plugin marketplace add eric-tramel/moraine --sparse .claude-plugin plugins
-claude plugin install moraine@moraine
+moraine setup
 ```
 
-The user-scoped plugin can search the host-wide Moraine history visible to your
-user. Enable it only in trusted Claude Code environments. Use manual
-project-scoped setup when you need `--project-only`.
-
-If you already added Moraine manually to Claude Code, remove the manual server
-first to avoid duplicate MCP tools:
+You can also target harnesses directly, which is useful for scripts or for
+rerunning setup after installing a new harness CLI:
 
 ```bash
-claude mcp remove moraine --scope user
+moraine setup --yes --mcp-target claude-code --mcp-target codex
 ```
 
-Manual registration still works and is useful for project-scoped Claude Code
-setups or other harnesses.
-
-For Codex, install the Moraine plugin marketplace entry. It registers the MCP
-server and bundles the same Moraine search skills:
+Preview those changes without touching host agent config:
 
 ```bash
-codex plugin marketplace add eric-tramel/moraine --sparse .agents/plugins --sparse plugins/moraine --sparse plugins/moraine-dev
-codex plugin add moraine@moraine
+moraine setup --dry-run --mcp-target claude-code --mcp-target codex --mcp-target hermes
 ```
 
-The same marketplace also contains the contributor-only `moraine-dev` plugin for
-Moraine maintainers; end users should install `moraine@moraine`.
-
-The user-scoped plugin can search the host-wide Moraine history visible to your
-user. Enable it only in trusted Codex environments. Use manual project-scoped
-setup when you need `--project-only`.
-
-If you already added Moraine manually to Codex, remove the manual server first
-to avoid duplicate MCP tools:
-
-```bash
-codex mcp remove moraine
-```
-
-Manual registration still works and is useful for project-scoped Codex setups or
-other harnesses. Add Moraine to Codex globally:
-
-```bash
-codex mcp add moraine -- moraine run mcp
-```
-
-Add Moraine to Hermes:
-
-```bash
-hermes mcp add moraine --command moraine --args run mcp
-```
+The Claude Code and Codex plugins bundle Moraine search guidance. `moraine
+setup` installs those plugins for default user-scoped setup, and registers MCP
+directly for supported harnesses such as Hermes and Kimi CLI. These user-scoped
+integrations can search the host-wide Moraine history visible to your user, so
+enable them only in trusted harness environments.
 
 The MCP server uses the same config resolution rules as the rest of Moraine, with
 `MORAINE_MCP_CONFIG` taking precedence over the generic `MORAINE_CONFIG`.
-For Cursor, Kimi CLI, Pi, project-scoped Claude Code, and other clients, see
+For manual cleanup, Cursor, Pi, project-scoped Claude Code or Codex, and other
+custom setup, see
 [Agent MCP Search](agent-mcp-search/install.md).
 
 ## Common Commands
@@ -131,6 +130,7 @@ For Cursor, Kimi CLI, Pi, project-scoped Claude Code, and other clients, see
 | --- | --- |
 | `moraine up` | Start ClickHouse, ingest, the monitor UI, and the shared MCP server. |
 | `moraine up --mcp` | Force-start the shared MCP server (also on by default). |
+| `moraine setup` | Create or repair config and guide MCP/plugin registration. |
 | `moraine status` | Print service and ingest health. |
 | `moraine logs` | Show recent service logs. |
 | `moraine logs ingest --lines 500` | Show recent ingest logs. |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -103,25 +103,25 @@ You can also target harnesses directly, which is useful for scripts or for
 rerunning setup after installing a new harness CLI:
 
 ```bash
-moraine setup --yes --mcp-target claude-code --mcp-target codex
+moraine setup --yes --mcp-target claude-code --mcp-target codex --mcp-target opencode --mcp-target cursor
 ```
 
 Preview those changes without touching host agent config:
 
 ```bash
-moraine setup --dry-run --mcp-target claude-code --mcp-target codex --mcp-target hermes
+moraine setup --dry-run --mcp-target claude-code --mcp-target codex --mcp-target opencode --mcp-target cursor --mcp-target pi-coding-agent
 ```
 
 The Claude Code and Codex plugins bundle Moraine search guidance. `moraine
 setup` installs those plugins for default user-scoped setup, and registers MCP
-directly for supported harnesses such as Hermes and Kimi CLI. These user-scoped
-integrations can search the host-wide Moraine history visible to your user, so
-enable them only in trusted harness environments.
+directly or writes global MCP config for supported harnesses such as Hermes,
+Kimi CLI, OpenCode, Cursor, and Pi Coding Agent. These user-scoped integrations
+can search the host-wide Moraine history visible to your user, so enable them
+only in trusted harness environments.
 
 The MCP server uses the same config resolution rules as the rest of Moraine, with
 `MORAINE_MCP_CONFIG` taking precedence over the generic `MORAINE_CONFIG`.
-For manual cleanup, Cursor, Pi, project-scoped Claude Code or Codex, and other
-custom setup, see
+For manual cleanup, project-scoped setup, and other custom setup, see
 [Agent MCP Search](agent-mcp-search/install.md).
 
 ## Common Commands


### PR DESCRIPTION
## Description

**What.** Adds a guided `moraine setup` command for first-run config creation, config repair, ingest-source selection, and harness MCP/plugin registration.

**Why.** New users need one textual entry point that can create `~/.moraine/config.toml`, choose which agent histories Moraine should ingest, explain host-wide session-history exposure, and install or update common agent harness integrations without hand-copying docs commands.

The new command runs before normal runtime config loading so it can create or repair the selected config file. By default, setup writes `~/.moraine/config.toml`; an explicit global `--config <path>` is the only way to direct setup at another config file. Ambient `MORAINE_CONFIG` remains a runtime config override, but it does not redirect `moraine setup` writes. Newly generated setup config files are created with user-only permissions on Unix.

Interactive setup presents a terminal selector for Claude Code, Codex, Hermes, Kimi CLI, OpenCode, Cursor, and Pi Coding Agent. Arrow keys move the highlighted row. Space cycles each row through `nothing -> ingest + harness -> ingest only -> harness only -> nothing`, with distinct icons and action columns showing exactly what will happen. Enter applies the selected ingest and harness choices, while Esc skips integration changes. The selector warns that selected harness integrations receive host-wide Moraine session history access.

Interactive selections now also update `config.toml`: selected ingest modes enable, add, or repair setup-owned `[[ingest.sources]]` entries for that harness, while unselected or harness-only rows disable setup-owned ingest sources for that harness. Custom same-harness sources are preserved.

After selection, setup streams a progress block on terminal stderr before each install command and config-file write. Users see which integration is being configured, which command is running, whether optional cleanup was skipped, and when the final setup summary follows. JSON output remains machine-readable and does not emit the terminal progress stream.

For default config, Claude Code and Codex use the recommended plugin marketplace installs. Claude Code and Codex remove old manual `moraine` MCP registrations only after the plugin install succeeds, so a failed plugin install does not remove a previously working manual MCP server. For custom config paths, Codex and Claude Code print manual MCP registration snippets because the plugin launchers use the default `moraine run mcp` path.

Hermes and Kimi replace an existing `moraine` MCP registration before adding the desired command. Hermes setup answers Hermes' post-discovery tool-enable prompt with its default acceptance and verifies that Hermes reported tools enabled, so a cancelled `hermes mcp add` cannot be mistaken for a successful setup.

OpenCode, Cursor, and Pi Coding Agent are file-backed setup targets. Setup merges a `moraine` server into each global config while preserving existing top-level settings and existing MCP servers:

- OpenCode: `~/.config/opencode/opencode.json`, top-level `mcp.moraine`, `type = "local"`, command array `['moraine', 'run', 'mcp']`.
- Cursor: `~/.cursor/mcp.json`, `mcpServers.moraine`, `type = "stdio"`, command `moraine`, args `['run', 'mcp']`.
- Pi Coding Agent: installs `pi-mcp-extension` with `pi install npm:pi-mcp-extension`, then writes `~/.pi/agent/mcp.json` with an eager stdio `mcpServers.moraine` entry.

The setup implementation keeps harness-specific behavior in `apps/moraine/src/commands/setup/harnesses.rs`: target ordering, labels, setup kinds, probes, default ingest specs, command recipes, file-backed config schemas, snippets, and MCP plans live there. `setup.rs` keeps orchestration, selector rendering, runner execution, generic read/write mechanics, config repair, and reporting.

README and the quickstart now direct users to `moraine setup` for supported plugin and MCP harness registration, with manual install docs left as the escape hatch for project-scoped, cleanup, and custom harness cases.

## Usage

Interactive first-run setup:

```bash
moraine setup
```

The harness prompt is an interactive terminal selector:

```text
? Agent setup ›
  Space cycles none -> ingest + harness -> ingest only -> harness only. Enter applies. Esc skips.
❯ ○ Claude Code      ·        ·
  ● Codex            ingest   plugin
  ◐ Hermes           ingest   ·
  ◑ Cursor           ·        MCP config
```

Installation then streams progress before the final report:

```text
╭─ Installing agent integrations
├─ Cursor MCP config
   → Updating Cursor config at ~/.cursor/mcp.json
   ✓ Updated ~/.cursor/mcp.json
   ✓ Cursor configured
╰─ setup summary follows
```

Preview selected harness changes:

```bash
moraine setup --dry-run --mcp-target claude-code --mcp-target codex --mcp-target opencode --mcp-target cursor --mcp-target pi-coding-agent
```

Use a custom setup config path explicitly:

```bash
moraine --config /path/to/config.toml setup --yes
```

README users see the shorter happy path:

```bash
uv tool install moraine-cli
moraine setup
moraine up
```

## Changelog

- Adds `moraine setup` with guided config creation/repair, ingest source selection, and harness MCP/plugin registration.
- Makes setup write `~/.moraine/config.toml` by default, ignoring ambient `MORAINE_CONFIG` unless `--config` is passed.
- Creates setup-written config templates with Unix `0600` permissions.
- Adds a four-state interactive selector that can configure ingest + harness, ingest only, harness only, or nothing per supported harness.
- Updates setup-owned `[[ingest.sources]]` in `config.toml` from interactive setup selections, preserving custom same-harness sources and unrelated config settings.
- Installs the Claude Code and Codex Moraine plugins for default setup.
- Streams per-target setup progress during plugin installs, MCP registration commands, and config-file writes.
- Warns in the selector that selected harness integrations receive host-wide Moraine session history access.
- Removes old Claude Code/Codex manual MCP registrations only after plugin install succeeds.
- Ensures Hermes setup persists an enabled `moraine` MCP server instead of treating a prompt cancellation as success.
- Adds OpenCode, Cursor, and Pi Coding Agent setup targets that write or merge the correct global MCP config files.
- Centralizes harness-specific setup metadata, ingest defaults, file-backed config schemas, snippets, and MCP plans into a harness module.
- Updates README, quickstart, and MCP install docs to recommend `moraine setup` and document setup-managed config targets.

## Bug Evidence

Hermes' `mcp add` command probes the server and then prompts `Enable all <n> tools? [Y/n/select]`. When `moraine setup` ran it through captured stdio, Hermes received EOF, printed `Cancelled.`, exited with status 0, and wrote no `mcp_servers.moraine` entry. Setup interpreted that zero exit as success.

This PR supplies a blank-line response for the Hermes add step, which accepts Hermes' default "enable all" choice after a successful probe while declining the default-false "save config anyway" path after a failed probe. The command result is also required to contain Hermes' `tools enabled` success text.

## Code Review

Ran the full delegated `$moraine-dev:code-review` wave with all seven personas: elegance, idiom, correctness, completeness, security, YAGNI, and scope. After the setup UI and harness additions, ran a second focused review wave on `setup.rs` modularity with the same personas.

Accepted fixes from the first review wave:

- Correctness: install Claude Code/Codex plugins before removing old manual MCP registrations, and add Claude manual cleanup.
- Security: create setup-written config files with Unix `0600` permissions and keep the host-wide access warning visible inside the selector prompt.
- Completeness: add `--yes` to the quickstart scripted explicit-target example.
- Elegance: keep MCP target identity typed through reports and move Hermes stdout validation to the Hermes call site.
- Idiom: require executable bits for PATH detection on Unix.

Accepted fixes from the focused modularity review:

- Extracted `apps/moraine/src/commands/setup/harnesses.rs` for harness labels, setup kinds, command probes, probe paths, default ingest sources, target order, command recipes, snippets, and MCP plan construction.
- Moved Cursor/OpenCode/Pi file-backed config paths, root keys, server JSON schemas, and JSON-vs-JSONC parse policy behind the harness config write type.
- Made MCP manual snippets render from the same config write schema used for actual writes.
- Changed ingest reconciliation to operate on setup-owned source `(name, harness)` specs, add missing setup-owned sources, repair stale setup-owned source metadata, and preserve custom same-harness sources.
- Added OpenCode JSONC parsing for existing `opencode.json` files with comments or trailing commas.
- Kept the host-wide history warning visible in the selector consent path.

Rejected/deferred review suggestions:

- YAGNI suggested dropping Cursor/Pi manual-only targets and partial skip flags. Kept and then completed the file-backed Cursor/Pi path because setup now writes their global MCP config directly.
- Idiom suggested converting yes/no prompts to `dialoguer::Confirm` and using Ratatui-native panel height measurement. Deferred as non-blocking refinements; the selector and render tests cover the behavior this PR needs.
- The focused modularity review noted possible follow-ups around progress-copy placement, `McpPlan` simplification, and injecting HOME/probe paths. Deferred because the current split localizes harness behavior without widening the PR into executor redesign.

Targeted follow-up reviewers re-checked the accepted fixes. All seven focused-review sessions were closed with no remaining blocking findings.

## Validation

Ran successfully:

```bash
cargo fmt --all
cargo fmt --all -- --check
git diff --check
cargo check -p moraine --locked
cargo test -p moraine setup --locked
cargo test -p moraine --locked
cargo test --workspace --locked
CARGO_TARGET_DIR=target/clippy-rustup-stable RUSTC=/Users/eric/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc rustup run stable cargo clippy -p moraine --all-targets --locked -- -D warnings
make docs-build
```

The pre-commit hook also ran `make fmt` and the repository strict clippy baseline successfully during commit.

Rendered the interactive TUI in pseudo-terminals with throwaway `HOME` directories. Covered Esc skip, Space + Enter harness installation, and Space + Space + Enter ingest-only selection. The ingest-only smoke selected Claude Code ingest only, then verified the temporary `config.toml` left Claude ingest enabled and disabled Codex, Kimi, OpenCode, Cursor JSONL, Cursor SQLite, Pi, and Hermes setup-owned sources.

Exercised the new installation progress stream in pseudo-terminals with temporary `HOME` directories:

```bash
script -q /dev/null env TERM=xterm-256color HOME="$tmpdir" \
  target/debug/moraine --output rich setup --yes --skip-config --mcp-target cursor

script -q /dev/null env TERM=xterm-256color HOME="$tmpdir" PATH="$tmpdir/bin:$PATH" \
  target/debug/moraine --output rich setup --yes --skip-config --mcp-target pi-coding-agent
```

The Cursor smoke showed progress for writing `~/.cursor/mcp.json`. The Pi smoke used a fake `pi` executable that slept briefly, showed progress before `pi install npm:pi-mcp-extension`, then showed progress for writing `~/.pi/agent/mcp.json`.

Ran JSON CLI smoke checks with `target/debug/moraine`: `moraine setup --yes --skip-mcp` with a temporary `HOME` and `MORAINE_CONFIG` pointing elsewhere wrote `HOME/.moraine/config.toml` and left the env path untouched; explicit `moraine --config <path> setup --yes --skip-mcp` wrote the custom path and still left the env path untouched. Also checked default Codex `setup --dry-run --mcp-target codex` with `MORAINE_CONFIG` unset and custom-config Codex `setup --dry-run --mcp-target codex`. The default Codex dry-run produced `codex plugin marketplace add ...`, `codex plugin add moraine@moraine`, and then `codex mcp remove moraine`; the custom-config dry-run produced a manual `codex mcp add ... --config <path>` snippet.

Built the workspace with `cargo build --workspace --locked`, then ran an isolated Hermes setup smoke with a temporary `HOME` and `target/debug` first on `PATH`:

```bash
HOME="$tmp_home" PATH="$PWD/target/debug:$PATH" HERMES_ACCEPT_HOOKS=1 \
  target/debug/moraine --output json setup --yes --mcp-target hermes
HOME="$tmp_home" HERMES_ACCEPT_HOOKS=1 hermes mcp list
```

That created `HOME/.moraine/config.toml`, wrote `mcp_servers.moraine` to `HOME/.hermes/config.yaml`, and `hermes mcp list` showed `moraine run mcp` as enabled.

Sandbox QA was not run because this PR changes CLI setup, documentation, and setup-authored config files, but does not change ingest runtime processing, monitor behavior, MCP runtime behavior, ClickHouse schema, or stack services.
