### PR TITLE
fix(ci): make duplicate-row e2e assertion relative

### DIFF
--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -882,11 +882,20 @@ PY
   # point: it is exactly what #388 guards against. FINAL still dedups at read
   # time, so the FINAL / turn-count assertions are unaffected by the freeze.
   clickhouse_scalar "$clickhouse_url" "SYSTEM STOP MERGES ${clickhouse_database}.events" >/dev/null
+  local codex_live_user_messages_before
+  codex_live_user_messages_before="$(clickhouse_scalar "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.events WHERE source_name = 'ci-codex' AND session_id = '${codex_session_id}' AND actor_kind = 'user' AND event_kind = 'message'")"
+  if [[ ! "$codex_live_user_messages_before" =~ ^[0-9]+$ ]] || (( codex_live_user_messages_before < 1 )); then
+    echo "[e2e] expected at least one live codex user-message row before duplicate insert, got: ${codex_live_user_messages_before}" >&2
+    return 1
+  fi
+  local codex_live_user_messages_after
+  codex_live_user_messages_after="$((codex_live_user_messages_before + 1))"
+  assert_clickhouse_count "$clickhouse_url" "codex user-message row collapses under FINAL before duplicate insert" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND session_id = '${codex_session_id}' AND actor_kind = 'user' AND event_kind = 'message'" "1"
   # Plant a duplicate of the codex user message in a fresh, un-merged part:
   # SELECT * preserves ingested_at (so it lands in the same partition and shares
   # the sort key), REPLACE bumps event_version so FINAL keeps exactly one row.
   clickhouse_scalar "$clickhouse_url" "INSERT INTO ${clickhouse_database}.events SELECT * REPLACE (event_version + 1 AS event_version) FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND session_id = '${codex_session_id}' AND actor_kind = 'user' AND event_kind = 'message'" >/dev/null
-  assert_clickhouse_count "$clickhouse_url" "codex duplicate user-message row is live (un-merged)" "SELECT count() FROM ${clickhouse_database}.events WHERE source_name = 'ci-codex' AND session_id = '${codex_session_id}' AND actor_kind = 'user' AND event_kind = 'message'" "2"
+  assert_clickhouse_count "$clickhouse_url" "codex duplicate user-message row increases live physical count" "SELECT count() FROM ${clickhouse_database}.events WHERE source_name = 'ci-codex' AND session_id = '${codex_session_id}' AND actor_kind = 'user' AND event_kind = 'message'" "$codex_live_user_messages_after"
   assert_clickhouse_count "$clickhouse_url" "codex duplicate collapses under FINAL" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND session_id = '${codex_session_id}' AND actor_kind = 'user' AND event_kind = 'message'" "1"
   assert_clickhouse_scalar "$clickhouse_url" "codex turn_seq unchanged by un-merged duplicate" "SELECT max(turn_seq) FROM ${clickhouse_database}.v_conversation_trace WHERE session_id = '${codex_session_id}'" "$codex_turns_before"
   assert_clickhouse_scalar "$clickhouse_url" "codex session summary turn count unchanged by un-merged duplicate" "SELECT total_turns FROM ${clickhouse_database}.v_session_summary WHERE session_id = '${codex_session_id}'" "$codex_turns_before"


### PR DESCRIPTION
## Description

**What.** Makes the #388 duplicate-row e2e assertion compare against the observed physical-row baseline plus one instead of a hard-coded count of two.

**Why.** The latest red `main` run failed when the x86 Linux functional job already had an unmerged duplicate physical row before the test inserted its synthetic duplicate.

The failure was in `ci-functional` run `27927800958`, job `functional-x86_64-unknown-linux-gnu`, during `scripts/ci/e2e-stack.sh`:

```text
[e2e] ClickHouse assertion failed: codex duplicate user-message row is live (un-merged)
[e2e] expected: 2
[e2e] actual:   3
```

The inspected `functional-x86_64-apple-darwin` job in that same run completed successfully, so this patch targets the currently red main-branch functional failure while preserving the existing Intel Mac artifact-server fixes.

The test still verifies the important #388 invariants: `events FINAL` collapses to one logical Codex user message, the explicit duplicate insert increases the live physical count by exactly one, and `v_conversation_trace` / `v_session_summary` turn counts remain unchanged.

## Usage

No user-facing usage change. This only changes CI test behavior.

## Changelog

- Stabilizes the functional e2e duplicate-row assertion when ClickHouse has pre-existing unmerged physical duplicates.
- No runtime behavior change.

## Validation

Validated the shell script with `bash -n scripts/ci/e2e-stack.sh` and `git diff --check`.

Ran the full stack smoke test inside sandbox `sb-a9df68` with:

```bash
MORAINECTL_BIN=/home/moraine/target/debug/moraine MORAINE_SERVICE_BIN_DIR=/home/moraine/target/debug bash scripts/ci/e2e-stack.sh
```

The stack test passed end-to-end, including monitor route checks, the #388 duplicate-row block, all MCP smoke checks, and project-only MCP checks. The sandbox was torn down with `scripts/dev/sandbox/moraine-sandbox down sb-a9df68`.

A delegated review wave covered elegance, idiom, correctness, completeness, security, YAGNI, and scope; no actionable findings remained.
