### PR TITLE
chore(release): cut v0.6.2

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.6.1)"
+        description: "Tag to release (for example v0.6.2)"
         required: true
         type: string
       target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "moraine"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "glob",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/moraine-ingest/Cargo.toml
+++ b/apps/moraine-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Moraine ingest service binary"
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Moraine MCP stdio server"
 

--- a/apps/moraine-monitor/Cargo.toml
+++ b/apps/moraine-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Moraine monitor HTTP/UI service"
 

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Unified runtime control plane for Moraine services"
 

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-clickhouse"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Shared Moraine ClickHouse client and query helpers"
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-config"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Shared Moraine configuration schema and loaders"
 

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-conversations"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "High-level read/query APIs for Moraine conversations"
 

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest-core"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Core ingestion pipeline internals for Moraine"
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp-core"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "MCP protocol and tool routing core for Moraine"
 

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor-core"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Analytics and query logic for Moraine monitor service"
 

--- a/plugins/hermes-moraine/plugin.yaml
+++ b/plugins/hermes-moraine/plugin.yaml
@@ -1,6 +1,6 @@
 manifest_version: 1
 name: moraine
-version: "0.6.1"
+version: "0.6.2"
 description: "Hermes integration for Moraine MCP session search, realtime agent awareness, and setup diagnostics."
 author: "Moraine maintainers"
 provides_tools:

--- a/plugins/moraine/.claude-plugin/plugin.json
+++ b/plugins/moraine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "displayName": "Moraine",
   "description": "Claude Code plugin for Moraine MCP session search and realtime agent awareness.",
   "author": {

--- a/plugins/moraine/.codex-plugin/plugin.json
+++ b/plugins/moraine/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Codex plugin for Moraine MCP session search and realtime agent awareness.",
   "author": {
     "name": "Moraine maintainers",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ install directory precedence:
 
 examples:
   scripts/install.sh
-  MORAINE_INSTALL_VERSION=v0.6.1 scripts/install.sh
+  MORAINE_INSTALL_VERSION=v0.6.2 scripts/install.sh
   MORAINE_INSTALL_ASSET_BASE_URL=http://127.0.0.1:8080 \
     MORAINE_INSTALL_VERSION=ci-e2e scripts/install.sh
   MORAINE_INSTALL_DIR="$HOME/bin" MORAINE_INSTALL_SKIP_CLICKHOUSE=1 scripts/install.sh


### PR DESCRIPTION
## Description

**What.** Bumps Moraine from `0.6.1` to `0.6.2` across the release-managed crates, lockfile, install example, release workflow example tag, and runtime plugin manifests.

**Why.** Publishes the user-facing and operational changes merged since `v0.6.1` through the normal tagged release workflow.

This release includes the work merged since `v0.6.1`:

- Guided first-run `moraine setup` for config creation, ingest-source selection, and harness MCP/plugin registration ([#422](https://github.com/eric-tramel/moraine/pull/422)).
- First-class Claude Code, Codex, and Hermes plugin paths for Moraine session search and realtime agent awareness ([#416](https://github.com/eric-tramel/moraine/pull/416), [#417](https://github.com/eric-tramel/moraine/pull/417), [#418](https://github.com/eric-tramel/moraine/pull/418), [#421](https://github.com/eric-tramel/moraine/pull/421), [#424](https://github.com/eric-tramel/moraine/pull/424)).
- Normalized file-attention path fields and exact lookup support while preserving suffix fallback behavior ([#420](https://github.com/eric-tramel/moraine/pull/420)).
- Intel macOS release artifacts and PyPI wheel coverage, plus release target guardrails ([#413](https://github.com/eric-tramel/moraine/pull/413)).
- CI and contributor workflow fixes that stabilize release validation and PR authoring expectations ([#414](https://github.com/eric-tramel/moraine/pull/414), [#415](https://github.com/eric-tramel/moraine/pull/415), [#419](https://github.com/eric-tramel/moraine/pull/419), [#423](https://github.com/eric-tramel/moraine/pull/423)).

## Usage

After the release tag is published, users can install or upgrade through the normal package path:

```bash
uv tool install moraine-cli
uv tool upgrade moraine-cli
moraine setup
moraine up
```

Existing manual MCP users can move to the guided setup or plugin paths for Claude Code, Codex, and Hermes.

## Changelog

- Bumps all release-managed Moraine Rust packages and `Cargo.lock` to `0.6.2`.
- Bumps the Claude Code, Codex, and Hermes Moraine runtime plugin manifests to `0.6.2`.
- Updates release/install examples from `v0.6.1` to `v0.6.2`.

## Operational Impact

Merging this PR does not publish the release by itself. After merge, an annotated `v0.6.2` tag on the merge commit will trigger `.github/workflows/release-moraine.yml`, build platform bundles, create/update the GitHub release, and publish `moraine-cli==0.6.2` to PyPI.

## Validation

Validated locally from `/Users/eric/src/moraine-worktrees/release-v0.6.2`:

```bash
git diff --check
cargo fmt --all -- --check
cargo test --workspace --locked
```

The release commit hook also ran `make fmt` and the repo strict clippy baseline successfully before accepting `chore(release): cut v0.6.2`.

Sandbox QA used `sb-f72843`, which was torn down successfully with `scripts/dev/sandbox/moraine-sandbox down sb-f72843`.

Sandbox checks:

```bash
cargo fmt --all -- --check
cargo test -p moraine-clickhouse -p moraine-ingest-core -p moraine-conversations -p moraine-mcp-core --locked
MORAINECTL_BIN=/home/moraine/target/debug/moraine MORAINE_SERVICE_BIN_DIR=/home/moraine/target/debug bash scripts/ci/e2e-stack.sh
curl -fsS http://127.0.0.1:56522/api/health
```

The sandbox stack smoke passed, including migration `021`, monitor route checks, duplicate-row checks, MCP smoke across Codex, Claude, Kimi, Cursor, Pi, Hermes, and project-only mode. The monitor health response returned `ok: true` against ClickHouse `25.12.5.44`.

`ANTHROPIC_API_KEY` was not present, so `scripts/dev/sandbox/agent-smoke-e2e` was not run.
