### PR TITLE
fix(plugin): avoid project-relative MCP launcher

### DIFF
--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -2348,6 +2348,8 @@ mod tests {
     use super::*;
     use crate::render::OutputMode;
     use std::collections::{BTreeMap, BTreeSet};
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use toml_edit::value as toml_value;
 
     #[derive(Default)]
@@ -2408,6 +2410,32 @@ mod tests {
             std::process::id(),
             timestamp_suffix()
         ))
+    }
+
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("repo root")
+            .to_path_buf()
+    }
+
+    fn shared_plugin_mcp_config() -> Value {
+        let shared_mcp_path = repo_root()
+            .join("plugins")
+            .join("moraine")
+            .join(".mcp.json");
+        serde_json::from_str(
+            &fs::read_to_string(&shared_mcp_path).expect("read shared plugin mcp config"),
+        )
+        .expect("shared plugin mcp json")
+    }
+
+    fn shared_plugin_launcher() -> String {
+        shared_plugin_mcp_config()["mcpServers"]["moraine"]["args"][2]
+            .as_str()
+            .expect("shared inline launcher script")
+            .to_string()
     }
 
     fn plain_output() -> CliOutput {
@@ -2906,6 +2934,137 @@ watch_root = "~/custom"
             commands[2].args,
             vec!["mcp", "remove", "moraine", "--scope", "user"]
         );
+    }
+
+    #[test]
+    fn plugin_mcp_configs_are_client_specific() {
+        let repo_root = repo_root();
+
+        let shared_mcp = shared_plugin_mcp_config();
+        let shared_server = shared_mcp["mcpServers"]["moraine"]
+            .as_object()
+            .expect("shared moraine server object");
+        assert_eq!(
+            shared_server.get("command"),
+            Some(&serde_json::json!("/bin/sh"))
+        );
+        assert!(shared_server.get("cwd").is_none());
+        let shared_args = shared_server["args"].as_array().expect("shared args array");
+        assert_eq!(shared_args.first(), Some(&serde_json::json!("-eu")));
+        let shared_launcher = shared_args
+            .get(2)
+            .and_then(Value::as_str)
+            .expect("shared inline launcher script");
+        assert!(shared_launcher.contains("moraine plugin launch error: binary_untrusted"));
+        assert!(shared_launcher.contains("exec \"$moraine_bin\" run mcp"));
+        assert!(!shared_launcher.contains("scripts/launch.sh"));
+
+        let codex_manifest_path = repo_root
+            .join("plugins")
+            .join("moraine")
+            .join(".codex-plugin")
+            .join("plugin.json");
+        let codex_manifest: Value = serde_json::from_str(
+            &fs::read_to_string(&codex_manifest_path).expect("read codex plugin manifest"),
+        )
+        .expect("codex plugin manifest json");
+        assert_eq!(codex_manifest["mcpServers"], "./.mcp.json");
+
+        let claude_manifest_path = repo_root
+            .join("plugins")
+            .join("moraine")
+            .join(".claude-plugin")
+            .join("plugin.json");
+        let claude_manifest: Value = serde_json::from_str(
+            &fs::read_to_string(&claude_manifest_path).expect("read claude plugin manifest"),
+        )
+        .expect("claude plugin manifest json");
+        assert_eq!(claude_manifest["mcpServers"], "./.claude-mcp.json");
+
+        let claude_mcp_path = repo_root
+            .join("plugins")
+            .join("moraine")
+            .join(".claude-mcp.json");
+        let claude_mcp: Value = serde_json::from_str(
+            &fs::read_to_string(&claude_mcp_path).expect("read claude plugin mcp config"),
+        )
+        .expect("claude plugin mcp json");
+        assert_eq!(
+            claude_mcp["mcpServers"]["moraine"]["command"],
+            "${CLAUDE_PLUGIN_ROOT}/scripts/launch.sh"
+        );
+        assert_eq!(
+            claude_mcp["mcpServers"]["moraine"]["args"],
+            serde_json::json!([])
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_plugin_launcher_rejects_relative_path_moraine() {
+        let dir = temp_path("relative-path-launcher");
+        let rel_bin = dir.join("rel-bin");
+        fs::create_dir_all(&rel_bin).expect("create relative bin dir");
+        let fake_moraine = rel_bin.join("moraine");
+        fs::write(&fake_moraine, "#!/bin/sh\nexit 99\n").expect("write fake moraine");
+        let mut permissions = fs::metadata(&fake_moraine)
+            .expect("fake metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&fake_moraine, permissions).expect("chmod fake moraine");
+
+        let output = Command::new("/bin/sh")
+            .arg("-eu")
+            .arg("-c")
+            .arg(shared_plugin_launcher())
+            .current_dir(&dir)
+            .env("PATH", "rel-bin")
+            .output()
+            .expect("run shared plugin launcher");
+
+        assert_eq!(output.status.code(), Some(126));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("binary_untrusted"));
+        assert!(stderr.contains("relative PATH entry"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_plugin_launcher_execs_trusted_absolute_moraine() {
+        let dir = temp_path("trusted-launcher");
+        let project = dir.join("project");
+        let bin = dir.join("bin");
+        fs::create_dir_all(&project).expect("create project dir");
+        fs::create_dir_all(&bin).expect("create bin dir");
+        let fake_moraine = bin.join("moraine");
+        fs::write(
+            &fake_moraine,
+            "#!/bin/sh\nprintf 'fake-moraine:%s:%s\\n' \"$1\" \"$2\"\n",
+        )
+        .expect("write fake moraine");
+        let mut permissions = fs::metadata(&fake_moraine)
+            .expect("fake metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&fake_moraine, permissions).expect("chmod fake moraine");
+
+        let output = Command::new("/bin/sh")
+            .arg("-eu")
+            .arg("-c")
+            .arg(shared_plugin_launcher())
+            .current_dir(&project)
+            .env("PATH", &bin)
+            .output()
+            .expect("run shared plugin launcher");
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "fake-moraine:run:mcp\n"
+        );
+        assert!(output.stderr.is_empty());
+        let _ = fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/docs/agent-mcp-search/install.md
+++ b/docs/agent-mcp-search/install.md
@@ -54,7 +54,7 @@ claude plugin marketplace add eric-tramel/moraine --sparse .claude-plugin plugin
 claude plugin install moraine@moraine
 ```
 
-The plugin MCP launcher looks for `moraine` on `PATH` and then runs
+The Claude plugin MCP launcher looks for `moraine` on `PATH` and then runs
 `moraine run mcp`. If the CLI is missing, it reports a `binary_missing` message
 with install guidance instead of failing as a raw command-not-found error.
 
@@ -105,9 +105,11 @@ codex plugin add moraine@moraine
 The same marketplace also exposes the contributor-only `moraine-dev` plugin for
 Moraine maintainers; end users should install `moraine@moraine`.
 
-The plugin MCP launcher looks for `moraine` on `PATH` and then runs
-`moraine run mcp`. If the CLI is missing, it reports a `binary_missing` message
-with install guidance instead of failing as a raw command-not-found error.
+The Codex plugin registers a hardened stdio launcher that finds an installed
+`moraine` on `PATH` and then runs `moraine run mcp`. If the CLI is missing, the
+launcher reports `binary_missing`; reinstall or upgrade it with
+`uv tool install moraine-cli` or `uv tool upgrade moraine-cli`, then restart
+Codex from a shell where `moraine` is on `PATH`.
 
 Security note: the user-scoped plugin launches unscoped `moraine run mcp`, so
 Codex can search the host-wide Moraine history visible to your user. Enable the
@@ -340,6 +342,11 @@ agent mcp list-tools moraine
 
 For project-only use, put the same JSON in `.cursor/mcp.json` at the project
 root.
+
+If Cursor reports a spawn error for a path such as
+`/path/to/project/scripts/launch.sh`, replace that stale server entry with the
+JSON above. That launcher path belongs to the Claude plugin bundle and is not a
+valid Cursor command.
 
 ## Pi Coding Agent
 

--- a/plugins/moraine/.claude-mcp.json
+++ b/plugins/moraine/.claude-mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "moraine": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch.sh",
+      "args": []
+    }
+  }
+}

--- a/plugins/moraine/.claude-plugin/plugin.json
+++ b/plugins/moraine/.claude-plugin/plugin.json
@@ -18,5 +18,5 @@
     "session-search",
     "realtime-agents"
   ],
-  "mcpServers": "./.mcp.json"
+  "mcpServers": "./.claude-mcp.json"
 }

--- a/plugins/moraine/.mcp.json
+++ b/plugins/moraine/.mcp.json
@@ -1,9 +1,12 @@
 {
   "mcpServers": {
     "moraine": {
-      "command": "./scripts/launch.sh",
-      "args": [],
-      "cwd": "."
+      "command": "/bin/sh",
+      "args": [
+        "-eu",
+        "-c",
+        "moraine_bin=''; old_ifs=\"$IFS\"; IFS=:; for path_dir in $PATH; do case \"$path_dir\" in /*) candidate=\"$path_dir/moraine\" ;; *) candidate=\"${path_dir:-.}/moraine\"; if [ -x \"$candidate\" ] && [ ! -d \"$candidate\" ]; then IFS=\"$old_ifs\"; { printf '%s\\n' 'moraine plugin launch error: binary_untrusted'; printf '%s\\n' 'Refusing to run a moraine executable resolved from a relative PATH entry.'; printf '%s\\n' 'Restart your agent harness from a trusted shell where moraine resolves to an absolute installed path.'; } >&2; exit 126; fi; continue ;; esac; if [ -x \"$candidate\" ] && [ ! -d \"$candidate\" ]; then moraine_bin=\"$candidate\"; break; fi; done; IFS=\"$old_ifs\"; if [ -z \"$moraine_bin\" ]; then { printf '%s\\n' 'moraine plugin launch error: binary_missing'; printf '%s\\n' 'The Moraine plugin requires the moraine CLI on PATH.'; printf '%s\\n' 'Install: uv tool install moraine-cli'; printf '%s\\n' 'Upgrade: uv tool upgrade moraine-cli'; printf '%s\\n' 'Start the stack before using MCP search: moraine up'; printf '%s\\n' 'If Moraine is already installed, restart your agent harness with its bin directory on PATH.'; } >&2; exit 127; fi; cwd=\"$(pwd -P 2>/dev/null || pwd)\"; moraine_name=\"${moraine_bin##*/}\"; moraine_parent=\"${moraine_bin%/*}\"; moraine_dir=\"$(CDPATH= cd -- \"$moraine_parent\" 2>/dev/null && pwd -P || printf '%s\\n' \"$moraine_parent\")\"; moraine_bin=\"$moraine_dir/$moraine_name\"; scan_dir=\"$moraine_dir\"; while [ \"$scan_dir\" != / ]; do if [ -e \"$scan_dir/.git\" ]; then { printf '%s\\n' 'moraine plugin launch error: binary_untrusted'; printf '%s\\n' 'Refusing to run a moraine executable from a Git worktree.'; printf '%s\\n' 'Restart your agent harness with the installed moraine CLI earlier on a trusted PATH.'; } >&2; exit 126; fi; scan_dir=\"${scan_dir%/*}\"; if [ -z \"$scan_dir\" ]; then scan_dir=/; fi; done; case \"$moraine_bin\" in \"$cwd\"/*) { printf '%s\\n' 'moraine plugin launch error: binary_untrusted'; printf '%s\\n' 'Refusing to run a moraine executable from the current project directory.'; printf '%s\\n' 'Restart your agent harness with the installed moraine CLI earlier on a trusted PATH.'; } >&2; exit 126 ;; esac; exec \"$moraine_bin\" run mcp"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Description

**What.** Splits Moraine plugin MCP launch config so Cursor does not inherit a project-relative launcher path while plugin clients keep hardened startup behavior.

**Why.** Cursor can interpret `./scripts/launch.sh` relative to the active project, producing failures like `spawn /Users/me/scripts/launch.sh ENOENT`.

The shared Codex plugin MCP config now uses an absolute `/bin/sh` inline launcher that preserves the existing trust checks before executing `moraine run mcp`: relative `PATH` entries, Git-worktree binaries, and project-local binaries are rejected. Claude Code now has its own `./.claude-mcp.json` companion config that keeps the `${CLAUDE_PLUGIN_ROOT}/scripts/launch.sh` plugin-root launcher.

## Bug Evidence

Before this PR, the shared plugin MCP config used:

```json
{ "command": "./scripts/launch.sh", "args": [], "cwd": "." }
```

Cursor booted Moraine MCP by resolving that relative command against the active project, which failed with:

```text
spawn /Users/me/scripts/launch.sh ENOENT
```

The root cause was sharing a plugin-relative launcher config with clients that do not resolve it against the plugin installation directory. This PR removes the relative script command from the shared `.mcp.json`, keeps the Claude plugin-root launcher in a Claude-specific companion file, and adds tests for both routing and launcher behavior.

## Usage

Cursor users with a stale server entry pointing at `/path/to/project/scripts/launch.sh` should replace it with the documented Cursor config that runs `moraine run mcp`. Codex and Claude plugin users should not need to change commands; the plugin configs route each client to the right launcher.

## Changelog

- Fixes Moraine plugin MCP startup so Cursor does not try to spawn a project-relative `scripts/launch.sh`.
- Preserves hardened plugin launcher checks for Codex and Claude Code plugin installs.
- Adds regression tests for plugin MCP config routing and shared launcher trust checks.

## Validation

Validated locally with `cargo fmt --all -- --check`, `python3 /Users/eric/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/moraine`, `claude plugin validate plugins/moraine`, and `cargo test -p moraine setup::tests --locked` with 41 tests passing. The pre-commit hook also reran formatting and the strict clippy baseline successfully during commit.

Ran the delegated Moraine code-review wave across elegance, idiom, correctness, completeness, security, YAGNI, and scope; accepted and fixed the security finding about preserving launcher hardening, then got clean security and correctness follow-up reviews.

Ran isolated sandbox QA in `sb-b5876f`: installed `rustfmt` in the sandbox toolchain, ran `cargo fmt --all -- --check` and `cargo test -p moraine setup::tests --locked` inside `/repo`, verified `http://127.0.0.1:59919/api/health`, and tore the sandbox down successfully with `scripts/dev/sandbox/moraine-sandbox down sb-b5876f`.
