### PR TITLE
feat: add analytics event export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ name = "moraine"
 version = "0.6.2"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "dialoguer",
  "jsonc-parser",
@@ -1152,6 +1153,7 @@ dependencies = [
  "sha2",
  "tokio",
  "toml_edit",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1.0"
 tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "time"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = { version = "4.5", features = ["derive"] }
 dialoguer = { version = "0.11", default-features = false }
 jsonc-parser = { version = "0.32", features = ["serde"] }
@@ -16,5 +17,6 @@ ratatui = { version = "0.29", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 sha2 = "0.10"
 toml_edit = "0.22"
+uuid = { version = "1.11", features = ["v4"] }
 moraine-config = { path = "../../crates/moraine-config" }
 moraine-clickhouse = { path = "../../crates/moraine-clickhouse" }

--- a/apps/moraine/src/cli.rs
+++ b/apps/moraine/src/cli.rs
@@ -75,22 +75,16 @@ pub(crate) enum ExportCommand {
 
 #[derive(Debug, Args)]
 pub(crate) struct ExportEventsArgs {
-    #[arg(long, value_enum)]
-    pub(crate) format: Option<ExportRowFormat>,
+    #[arg(long, value_enum, required = true)]
+    pub(crate) format: ExportRowFormat,
     #[arg(long)]
     pub(crate) columns: Option<String>,
     #[arg(long, default_value_t = false)]
     pub(crate) include_sensitive: bool,
-    #[arg(long, value_enum, default_value_t = ExportMetadataMode::Stderr)]
-    pub(crate) metadata: ExportMetadataMode,
-    #[arg(long, value_name = "PATH")]
-    pub(crate) metadata_file: Option<PathBuf>,
     #[arg(long)]
     pub(crate) limit: Option<usize>,
     #[arg(long, default_value_t = false)]
     pub(crate) all: bool,
-    #[arg(long, default_value_t = 600)]
-    pub(crate) max_execution_seconds: u64,
     #[arg(long)]
     pub(crate) since: Option<String>,
     #[arg(long)]
@@ -126,13 +120,6 @@ pub(crate) struct ExportEventsArgs {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(crate) enum ExportRowFormat {
     Jsonl,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub(crate) enum ExportMetadataMode {
-    Stderr,
-    None,
-    File,
 }
 
 #[derive(Debug, Args)]
@@ -307,35 +294,30 @@ mod tests {
             "--columns",
             "session_id,event_uid,event_ts,payload_json",
             "--include-sensitive",
-            "--metadata",
-            "file",
-            "--metadata-file",
-            "/tmp/export-meta.json",
             "--limit",
             "100",
-            "--max-execution-seconds",
-            "30",
         ]);
         match cli.command {
             CliCommand::Export(args) => match args.command {
                 ExportCommand::Events(events) => {
-                    assert_eq!(events.format, Some(ExportRowFormat::Jsonl));
+                    assert_eq!(events.format, ExportRowFormat::Jsonl);
                     assert_eq!(events.since.as_deref(), Some("2026-06-01T00:00:00Z"));
                     assert_eq!(events.until.as_deref(), Some("2026-06-15T00:00:00Z"));
                     assert_eq!(events.harness, vec!["codex", "hermes"]);
                     assert_eq!(events.project_id, vec!["agent-stuff"]);
                     assert!(events.include_sensitive);
-                    assert_eq!(events.metadata, ExportMetadataMode::File);
-                    assert_eq!(
-                        events.metadata_file,
-                        Some(PathBuf::from("/tmp/export-meta.json"))
-                    );
                     assert_eq!(events.limit, Some(100));
-                    assert_eq!(events.max_execution_seconds, 30);
                 }
             },
             _ => panic!("expected export events command"),
         }
+    }
+
+    #[test]
+    fn clap_rejects_export_events_without_format() {
+        let err = Cli::try_parse_from(["moraine", "export", "events", "--all"])
+            .expect_err("export row format is required");
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 
     #[test]

--- a/apps/moraine/src/cli.rs
+++ b/apps/moraine/src/cli.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use crate::service::Service;
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(crate) enum OutputFormat {
     Auto,
     Rich,
@@ -35,6 +35,8 @@ pub(crate) enum CliCommand {
     Down,
     Status,
     Logs(LogsArgs),
+    Export(Box<ExportArgs>),
+    Schema(SchemaArgs),
     Db(DbArgs),
     Clickhouse(ClickhouseArgs),
     Config(ConfigArgs),
@@ -58,6 +60,96 @@ pub(crate) struct LogsArgs {
     pub(crate) service: Option<Service>,
     #[arg(long, default_value_t = 200)]
     pub(crate) lines: usize,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ExportArgs {
+    #[command(subcommand)]
+    pub(crate) command: ExportCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ExportCommand {
+    Events(ExportEventsArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ExportEventsArgs {
+    #[arg(long, value_enum)]
+    pub(crate) format: Option<ExportRowFormat>,
+    #[arg(long)]
+    pub(crate) columns: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) include_sensitive: bool,
+    #[arg(long, value_enum, default_value_t = ExportMetadataMode::Stderr)]
+    pub(crate) metadata: ExportMetadataMode,
+    #[arg(long, value_name = "PATH")]
+    pub(crate) metadata_file: Option<PathBuf>,
+    #[arg(long)]
+    pub(crate) limit: Option<usize>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) all: bool,
+    #[arg(long, default_value_t = 600)]
+    pub(crate) max_execution_seconds: u64,
+    #[arg(long)]
+    pub(crate) since: Option<String>,
+    #[arg(long)]
+    pub(crate) until: Option<String>,
+    #[arg(long)]
+    pub(crate) session_id: Vec<String>,
+    #[arg(long)]
+    pub(crate) harness: Vec<String>,
+    #[arg(long)]
+    pub(crate) source_name: Vec<String>,
+    #[arg(long)]
+    pub(crate) project_id: Vec<String>,
+    #[arg(long)]
+    pub(crate) cwd_prefix: Vec<String>,
+    #[arg(long)]
+    pub(crate) worktree_root: Vec<String>,
+    #[arg(long)]
+    pub(crate) repo_rel_path: Vec<String>,
+    #[arg(long)]
+    pub(crate) event_kind: Vec<String>,
+    #[arg(long)]
+    pub(crate) payload_type: Vec<String>,
+    #[arg(long)]
+    pub(crate) actor_kind: Vec<String>,
+    #[arg(long)]
+    pub(crate) model_name: Vec<String>,
+    #[arg(long)]
+    pub(crate) tool_name: Vec<String>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) tool_error_only: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum ExportRowFormat {
+    Jsonl,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum ExportMetadataMode {
+    Stderr,
+    None,
+    File,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SchemaArgs {
+    #[command(subcommand)]
+    pub(crate) command: SchemaCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum SchemaCommand {
+    Analytics(SchemaAnalyticsArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct SchemaAnalyticsArgs {
+    #[arg(long)]
+    pub(crate) json: bool,
 }
 
 #[derive(Debug, Args)]
@@ -191,6 +283,69 @@ mod tests {
                 command: ConfigCommand::Get(get),
             }) => assert_eq!(get.key, "clickhouse.url"),
             _ => panic!("expected config get command"),
+        }
+    }
+
+    #[test]
+    fn clap_parses_export_events_flags() {
+        let cli = Cli::parse_from([
+            "moraine",
+            "export",
+            "events",
+            "--format",
+            "jsonl",
+            "--since",
+            "2026-06-01T00:00:00Z",
+            "--until",
+            "2026-06-15T00:00:00Z",
+            "--harness",
+            "codex",
+            "--harness",
+            "hermes",
+            "--project-id",
+            "agent-stuff",
+            "--columns",
+            "session_id,event_uid,event_ts,payload_json",
+            "--include-sensitive",
+            "--metadata",
+            "file",
+            "--metadata-file",
+            "/tmp/export-meta.json",
+            "--limit",
+            "100",
+            "--max-execution-seconds",
+            "30",
+        ]);
+        match cli.command {
+            CliCommand::Export(args) => match args.command {
+                ExportCommand::Events(events) => {
+                    assert_eq!(events.format, Some(ExportRowFormat::Jsonl));
+                    assert_eq!(events.since.as_deref(), Some("2026-06-01T00:00:00Z"));
+                    assert_eq!(events.until.as_deref(), Some("2026-06-15T00:00:00Z"));
+                    assert_eq!(events.harness, vec!["codex", "hermes"]);
+                    assert_eq!(events.project_id, vec!["agent-stuff"]);
+                    assert!(events.include_sensitive);
+                    assert_eq!(events.metadata, ExportMetadataMode::File);
+                    assert_eq!(
+                        events.metadata_file,
+                        Some(PathBuf::from("/tmp/export-meta.json"))
+                    );
+                    assert_eq!(events.limit, Some(100));
+                    assert_eq!(events.max_execution_seconds, 30);
+                }
+            },
+            _ => panic!("expected export events command"),
+        }
+    }
+
+    #[test]
+    fn clap_parses_schema_analytics_json() {
+        let cli = Cli::parse_from(["moraine", "schema", "analytics", "--json"]);
+        match cli.command {
+            CliCommand::Schema(SchemaArgs {
+                command: SchemaCommand::Analytics(analytics),
+            }) => assert!(analytics.json),
+            _ => panic!("expected schema analytics command"),
         }
     }
 

--- a/apps/moraine/src/commands.rs
+++ b/apps/moraine/src/commands.rs
@@ -55,7 +55,7 @@ pub(crate) async fn dispatch(cli: Cli, output: CliOutput) -> Result<ExitCode> {
         CliCommand::Export(args) => {
             if cli.output != OutputFormat::Auto {
                 bail!(
-                    "moraine export writes row data to stdout; use --format for export row format instead of global --output"
+                    "moraine export always writes JSONL row data to stdout and metadata to stderr; use --format jsonl instead of global --output"
                 );
             }
             let (_, cfg) = load_cfg(cli.config.clone())?;
@@ -303,14 +303,11 @@ mod tests {
             verbose: false,
             command: CliCommand::Export(Box::new(crate::cli::ExportArgs {
                 command: ExportCommand::Events(crate::cli::ExportEventsArgs {
-                    format: Some(crate::cli::ExportRowFormat::Jsonl),
+                    format: crate::cli::ExportRowFormat::Jsonl,
                     columns: None,
                     include_sensitive: false,
-                    metadata: crate::cli::ExportMetadataMode::Stderr,
-                    metadata_file: None,
                     limit: None,
                     all: true,
-                    max_execution_seconds: 600,
                     since: None,
                     until: None,
                     session_id: Vec::new(),

--- a/apps/moraine/src/commands.rs
+++ b/apps/moraine/src/commands.rs
@@ -1,5 +1,7 @@
 mod down;
+mod export;
 mod logs;
+mod schema;
 mod setup;
 mod status;
 mod up;
@@ -10,7 +12,10 @@ use moraine_config::AppConfig;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use crate::cli::{Cli, CliCommand, ClickhouseCommand, ConfigCommand, DbCommand, RunArgs};
+use crate::cli::{
+    Cli, CliCommand, ClickhouseCommand, ConfigCommand, DbCommand, ExportCommand, OutputFormat,
+    RunArgs, SchemaCommand,
+};
 use crate::managed_clickhouse::{
     cmd_clickhouse_install, cmd_clickhouse_status, cmd_clickhouse_uninstall,
     run_foreground_clickhouse,
@@ -47,6 +52,23 @@ pub(crate) async fn dispatch(cli: Cli, output: CliOutput) -> Result<ExitCode> {
             render_logs(&output, &snapshot)?;
             Ok(ExitCode::SUCCESS)
         }
+        CliCommand::Export(args) => {
+            if cli.output != OutputFormat::Auto {
+                bail!(
+                    "moraine export writes row data to stdout; use --format for export row format instead of global --output"
+                );
+            }
+            let (_, cfg) = load_cfg(cli.config.clone())?;
+            match args.command {
+                ExportCommand::Events(events) => export::events(&cfg, events).await,
+            }
+        }
+        CliCommand::Schema(args) => match args.command {
+            SchemaCommand::Analytics(analytics) => {
+                schema::render_analytics(&analytics)?;
+                Ok(ExitCode::SUCCESS)
+            }
+        },
         CliCommand::Db(args) => {
             let (_, cfg) = load_cfg(cli.config.clone())?;
             match args.command {
@@ -221,6 +243,16 @@ fn doctor_is_healthy(report: &DoctorReport) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::render::OutputMode;
+
+    fn plain_output() -> CliOutput {
+        CliOutput {
+            mode: OutputMode::Plain,
+            verbose: false,
+            unicode: false,
+            width: 100,
+        }
+    }
 
     #[test]
     fn parse_config_flag_preserves_inline_config_and_rest() {
@@ -261,5 +293,63 @@ mod tests {
         let cfg = AppConfig::default();
         let err = cmd_config_get(&cfg, "runtime.root_dir").expect_err("unknown key");
         assert!(err.to_string().contains("unsupported config key"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dispatch_rejects_global_output_for_export_before_loading_config() {
+        let cli = Cli {
+            config: Some(PathBuf::from("/definitely/missing/moraine.toml")),
+            output: OutputFormat::Json,
+            verbose: false,
+            command: CliCommand::Export(Box::new(crate::cli::ExportArgs {
+                command: ExportCommand::Events(crate::cli::ExportEventsArgs {
+                    format: Some(crate::cli::ExportRowFormat::Jsonl),
+                    columns: None,
+                    include_sensitive: false,
+                    metadata: crate::cli::ExportMetadataMode::Stderr,
+                    metadata_file: None,
+                    limit: None,
+                    all: true,
+                    max_execution_seconds: 600,
+                    since: None,
+                    until: None,
+                    session_id: Vec::new(),
+                    harness: Vec::new(),
+                    source_name: Vec::new(),
+                    project_id: Vec::new(),
+                    cwd_prefix: Vec::new(),
+                    worktree_root: Vec::new(),
+                    repo_rel_path: Vec::new(),
+                    event_kind: Vec::new(),
+                    payload_type: Vec::new(),
+                    actor_kind: Vec::new(),
+                    model_name: Vec::new(),
+                    tool_name: Vec::new(),
+                    tool_error_only: false,
+                }),
+            })),
+        };
+
+        let err = dispatch(cli, plain_output())
+            .await
+            .expect_err("export must reject explicit output");
+        assert!(err.to_string().contains("use --format"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dispatch_schema_analytics_is_config_free() {
+        let cli = Cli {
+            config: Some(PathBuf::from("/definitely/missing/moraine.toml")),
+            output: OutputFormat::Auto,
+            verbose: false,
+            command: CliCommand::Schema(crate::cli::SchemaArgs {
+                command: SchemaCommand::Analytics(crate::cli::SchemaAnalyticsArgs { json: true }),
+            }),
+        };
+
+        let code = dispatch(cli, plain_output())
+            .await
+            .expect("schema command should not load config");
+        assert_eq!(code, ExitCode::SUCCESS);
     }
 }

--- a/apps/moraine/src/commands/analytics_schema_v1.golden.json
+++ b/apps/moraine/src/commands/analytics_schema_v1.golden.json
@@ -1,0 +1,554 @@
+{
+  "column_semantics": {
+    "booleans": "emitted as JSON booleans",
+    "numbers": "unknown numeric values follow storage defaults",
+    "strings": "unknown or unavailable values are emitted as empty strings"
+  },
+  "columns": [
+    {
+      "default": true,
+      "name": "session_id",
+      "sensitive": false,
+      "source_expression": "e.session_id",
+      "type": "string"
+    },
+    {
+      "default": true,
+      "name": "event_uid",
+      "sensitive": false,
+      "source_expression": "e.event_uid",
+      "type": "string"
+    },
+    {
+      "default": true,
+      "name": "event_ts",
+      "sensitive": false,
+      "source_expression": "CLI format of e.event_unix_ms",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "event_unix_ms",
+      "sensitive": false,
+      "source_expression": "e.event_unix_ms",
+      "type": "integer"
+    },
+    {
+      "default": true,
+      "name": "event_order",
+      "sensitive": false,
+      "source_expression": "e.event_order",
+      "type": "integer"
+    },
+    {
+      "default": true,
+      "name": "turn_seq",
+      "sensitive": false,
+      "source_expression": "e.turn_seq",
+      "type": "integer"
+    },
+    {
+      "default": true,
+      "name": "harness",
+      "sensitive": false,
+      "source_expression": "e.harness",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "inference_provider",
+      "sensitive": false,
+      "source_expression": "e.inference_provider",
+      "type": "string"
+    },
+    {
+      "default": true,
+      "name": "source_name",
+      "sensitive": false,
+      "source_expression": "e.source_name",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "source_generation",
+      "sensitive": false,
+      "source_expression": "e.source_generation",
+      "type": "integer"
+    },
+    {
+      "default": false,
+      "name": "source_line_no",
+      "sensitive": false,
+      "source_expression": "e.source_line_no",
+      "type": "integer"
+    },
+    {
+      "default": false,
+      "name": "source_offset",
+      "sensitive": false,
+      "source_expression": "e.source_offset",
+      "type": "integer"
+    },
+    {
+      "default": false,
+      "name": "source_file",
+      "sensitive": true,
+      "source_expression": "e.source_file",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "source_ref",
+      "sensitive": true,
+      "source_expression": "e.source_ref",
+      "type": "string"
+    },
+    {
+      "default": true,
+      "name": "event_kind",
+      "sensitive": false,
+      "source_expression": "e.event_kind",
+      "type": "string"
+    },
+    {
+      "default": true,
+      "name": "payload_type",
+      "sensitive": false,
+      "source_expression": "e.payload_type",
+      "type": "string"
+    },
+    {
+      "default": true,
+      "name": "actor_kind",
+      "sensitive": false,
+      "source_expression": "e.actor_kind",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "op_kind",
+      "sensitive": false,
+      "source_expression": "e.op_kind",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "op_status",
+      "sensitive": false,
+      "source_expression": "e.op_status",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "request_id",
+      "sensitive": false,
+      "source_expression": "e.request_id",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "trace_id",
+      "sensitive": false,
+      "source_expression": "e.trace_id",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "item_id",
+      "sensitive": false,
+      "source_expression": "e.item_id",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "tool_call_id",
+      "sensitive": false,
+      "source_expression": "e.tool_call_id",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "parent_tool_call_id",
+      "sensitive": false,
+      "source_expression": "e.parent_tool_call_id",
+      "type": "string"
+    },
+    {
+      "default": true,
+      "name": "tool_name",
+      "sensitive": false,
+      "source_expression": "e.tool_name",
+      "type": "string"
+    },
+    {
+      "default": true,
+      "name": "tool_phase",
+      "sensitive": false,
+      "source_expression": "e.tool_phase",
+      "type": "string"
+    },
+    {
+      "default": true,
+      "name": "tool_error",
+      "sensitive": false,
+      "source_expression": "e.tool_error != 0",
+      "type": "boolean"
+    },
+    {
+      "default": false,
+      "name": "agent_run_id",
+      "sensitive": false,
+      "source_expression": "e.agent_run_id",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "agent_label",
+      "sensitive": false,
+      "source_expression": "e.agent_label",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "coord_group_id",
+      "sensitive": false,
+      "source_expression": "e.coord_group_id",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "coord_group_label",
+      "sensitive": false,
+      "source_expression": "e.coord_group_label",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "is_substream",
+      "sensitive": false,
+      "source_expression": "e.is_substream != 0",
+      "type": "boolean"
+    },
+    {
+      "default": true,
+      "name": "model",
+      "sensitive": false,
+      "source_expression": "e.model",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "endpoint_kind",
+      "sensitive": false,
+      "source_expression": "e.endpoint_kind",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "input_tokens",
+      "sensitive": false,
+      "source_expression": "e.input_tokens",
+      "type": "integer"
+    },
+    {
+      "default": false,
+      "name": "output_tokens",
+      "sensitive": false,
+      "source_expression": "e.output_tokens",
+      "type": "integer"
+    },
+    {
+      "default": false,
+      "name": "cache_read_tokens",
+      "sensitive": false,
+      "source_expression": "e.cache_read_tokens",
+      "type": "integer"
+    },
+    {
+      "default": false,
+      "name": "cache_write_tokens",
+      "sensitive": false,
+      "source_expression": "e.cache_write_tokens",
+      "type": "integer"
+    },
+    {
+      "default": false,
+      "name": "latency_ms",
+      "sensitive": false,
+      "source_expression": "e.latency_ms",
+      "type": "integer"
+    },
+    {
+      "default": false,
+      "name": "retry_count",
+      "sensitive": false,
+      "source_expression": "e.retry_count",
+      "type": "integer"
+    },
+    {
+      "default": false,
+      "name": "service_tier",
+      "sensitive": false,
+      "source_expression": "e.service_tier",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "content_types",
+      "sensitive": false,
+      "source_expression": "e.content_types",
+      "type": "array<string>"
+    },
+    {
+      "default": false,
+      "name": "has_reasoning",
+      "sensitive": false,
+      "source_expression": "e.has_reasoning != 0",
+      "type": "boolean"
+    },
+    {
+      "default": true,
+      "name": "project_id",
+      "sensitive": false,
+      "source_expression": "e.project_id",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "repo_rel_path",
+      "sensitive": true,
+      "source_expression": "e.repo_rel_path",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "worktree_root",
+      "sensitive": true,
+      "source_expression": "e.worktree_root",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "cwd",
+      "sensitive": true,
+      "source_expression": "e.cwd",
+      "type": "string"
+    },
+    {
+      "default": true,
+      "name": "text_preview",
+      "sensitive": false,
+      "source_expression": "e.text_preview",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "text_content",
+      "sensitive": true,
+      "source_expression": "e.text_content",
+      "type": "string"
+    },
+    {
+      "default": false,
+      "name": "payload_json",
+      "sensitive": true,
+      "source_expression": "e.payload_json",
+      "type": "JSON string"
+    },
+    {
+      "default": false,
+      "name": "token_usage_json",
+      "sensitive": true,
+      "source_expression": "e.token_usage_json",
+      "type": "JSON string"
+    },
+    {
+      "default": false,
+      "name": "token_usage_buckets",
+      "sensitive": false,
+      "source_expression": "e.token_usage_buckets",
+      "type": "object"
+    },
+    {
+      "default": false,
+      "name": "token_usage_native_units",
+      "sensitive": false,
+      "source_expression": "e.token_usage_native_units",
+      "type": "object"
+    },
+    {
+      "default": false,
+      "name": "event_version",
+      "sensitive": false,
+      "source_expression": "e.event_version",
+      "type": "integer"
+    }
+  ],
+  "data_schema_version": "moraine.analytics.events.v1",
+  "default_columns": [
+    "session_id",
+    "event_uid",
+    "event_ts",
+    "turn_seq",
+    "event_order",
+    "harness",
+    "source_name",
+    "event_kind",
+    "payload_type",
+    "actor_kind",
+    "tool_name",
+    "tool_phase",
+    "tool_error",
+    "model",
+    "project_id",
+    "text_preview"
+  ],
+  "export_kind": "events",
+  "filters": [
+    {
+      "arity": "single",
+      "empty_value": "invalid timestamp fails",
+      "flag": "--since",
+      "name": "since",
+      "source": "canonical event time >= value"
+    },
+    {
+      "arity": "single",
+      "empty_value": "invalid timestamp fails",
+      "flag": "--until",
+      "name": "until",
+      "source": "canonical event time < value"
+    },
+    {
+      "arity": "repeatable",
+      "empty_value": "rejected",
+      "flag": "--session-id",
+      "name": "session_id",
+      "source": "session_id = value"
+    },
+    {
+      "arity": "repeatable",
+      "empty_value": "rejected",
+      "flag": "--harness",
+      "name": "harness",
+      "source": "harness = value"
+    },
+    {
+      "arity": "repeatable",
+      "empty_value": "rejected",
+      "flag": "--source-name",
+      "name": "source_name",
+      "source": "source_name = value"
+    },
+    {
+      "arity": "repeatable",
+      "empty_value": "rejected",
+      "flag": "--project-id",
+      "name": "project_id",
+      "source": "project_id = value"
+    },
+    {
+      "arity": "repeatable",
+      "empty_value": "rejected",
+      "flag": "--cwd-prefix",
+      "name": "cwd_prefix",
+      "source": "cwd = value OR startsWith(cwd, value + \"/\")"
+    },
+    {
+      "arity": "repeatable",
+      "empty_value": "rejected",
+      "flag": "--worktree-root",
+      "name": "worktree_root",
+      "source": "worktree_root = value"
+    },
+    {
+      "arity": "repeatable",
+      "empty_value": "rejected",
+      "flag": "--repo-rel-path",
+      "name": "repo_rel_path",
+      "source": "repo_rel_path = value"
+    },
+    {
+      "arity": "repeatable",
+      "empty_value": "rejected",
+      "flag": "--event-kind",
+      "name": "event_kind",
+      "source": "event_kind = value"
+    },
+    {
+      "arity": "repeatable",
+      "empty_value": "rejected",
+      "flag": "--payload-type",
+      "name": "payload_type",
+      "source": "payload_type = value"
+    },
+    {
+      "arity": "repeatable",
+      "empty_value": "rejected",
+      "flag": "--actor-kind",
+      "name": "actor_kind",
+      "source": "actor_kind = value"
+    },
+    {
+      "arity": "repeatable",
+      "empty_value": "rejected",
+      "flag": "--model-name",
+      "name": "model_name",
+      "source": "model = value"
+    },
+    {
+      "arity": "repeatable",
+      "empty_value": "rejected",
+      "flag": "--tool-name",
+      "name": "tool_name",
+      "source": "tool_name = value"
+    },
+    {
+      "arity": "single boolean",
+      "empty_value": "not applicable",
+      "flag": "--tool-error-only",
+      "name": "tool_error_only",
+      "source": "tool_error = 1"
+    }
+  ],
+  "formats": [
+    "jsonl"
+  ],
+  "metadata_modes": [
+    "stderr",
+    "none",
+    "file"
+  ],
+  "metadata_schema_version": "moraine.analytics.export_metadata.v1",
+  "schema_version": "moraine.analytics.schema.v1",
+  "scope": {
+    "excluded": [
+      "sessions",
+      "turns",
+      "tool-io",
+      "raw-events",
+      "csv",
+      "http",
+      "mcp-batch-open"
+    ],
+    "included": [
+      "events"
+    ]
+  },
+  "sensitive_columns": [
+    "source_file",
+    "source_ref",
+    "repo_rel_path",
+    "worktree_root",
+    "cwd",
+    "text_content",
+    "payload_json",
+    "token_usage_json"
+  ],
+  "timestamp_semantics": {
+    "event_ts": "UTC RFC3339 string with millisecond precision",
+    "since": "inclusive",
+    "source": "ifNull(parseDateTime64BestEffortOrNull(record_ts), ingested_at)",
+    "until": "exclusive"
+  }
+}

--- a/apps/moraine/src/commands/analytics_schema_v1.golden.json
+++ b/apps/moraine/src/commands/analytics_schema_v1.golden.json
@@ -335,9 +335,9 @@
       "type": "string"
     },
     {
-      "default": true,
+      "default": false,
       "name": "text_preview",
-      "sensitive": false,
+      "sensitive": true,
       "source_expression": "e.text_preview",
       "type": "string"
     },
@@ -400,8 +400,7 @@
     "tool_phase",
     "tool_error",
     "model",
-    "project_id",
-    "text_preview"
+    "project_id"
   ],
   "export_kind": "events",
   "filters": [
@@ -514,12 +513,8 @@
   "formats": [
     "jsonl"
   ],
-  "metadata_modes": [
-    "stderr",
-    "none",
-    "file"
-  ],
   "metadata_schema_version": "moraine.analytics.export_metadata.v1",
+  "metadata_target": "stderr",
   "schema_version": "moraine.analytics.schema.v1",
   "scope": {
     "excluded": [
@@ -541,6 +536,7 @@
     "repo_rel_path",
     "worktree_root",
     "cwd",
+    "text_preview",
     "text_content",
     "payload_json",
     "token_usage_json"

--- a/apps/moraine/src/commands/export.rs
+++ b/apps/moraine/src/commands/export.rs
@@ -5,9 +5,7 @@ use moraine_config::AppConfig;
 use serde::Serialize;
 use serde_json::{Map, Value};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
 use std::io::{ErrorKind, Write};
-use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
@@ -16,15 +14,15 @@ use super::schema::{
     all_non_sensitive_event_columns, default_event_columns, event_column, EventColumn,
     EVENTS_SCHEMA_VERSION, EXPORT_METADATA_SCHEMA_VERSION,
 };
-use crate::cli::{ExportEventsArgs, ExportMetadataMode, ExportRowFormat};
+use crate::cli::{ExportEventsArgs, ExportRowFormat};
 
 const EXPORT_KIND_EVENTS: &str = "events";
 const DEFAULT_BACKEND: &str = "default";
-const MAX_DISABLED_CLIENT_TIMEOUT_SECONDS: u64 = 24 * 60 * 60;
+const DEFAULT_MAX_EXECUTION_SECONDS: u64 = 600;
+const EXPORT_REQUEST_TIMEOUT_GRACE_SECONDS: u64 = 30;
 
 pub(crate) async fn events(cfg: &AppConfig, args: ExportEventsArgs) -> Result<ExitCode> {
     let prepared = prepare_export(cfg, args)?;
-    preflight_metadata_file(&prepared.metadata)?;
 
     let client = ClickHouseClient::new(cfg.clickhouse.clone())?;
     ensure_schema_ready(&client).await?;
@@ -41,10 +39,7 @@ pub(crate) async fn events(cfg: &AppConfig, args: ExportEventsArgs) -> Result<Ex
             Some(&cfg.clickhouse.database),
             None,
             &params,
-            Some(request_timeout(
-                cfg.clickhouse.timeout_seconds,
-                prepared.max_execution_seconds,
-            )),
+            Some(request_timeout(cfg.clickhouse.timeout_seconds)),
         )
         .await?;
 
@@ -74,7 +69,7 @@ pub(crate) async fn events(cfg: &AppConfig, args: ExportEventsArgs) -> Result<Ex
         elapsed_ms: started.elapsed().as_millis() as u64,
         sensitive_columns_requested: prepared.sensitive_columns_requested,
     };
-    write_completion_metadata(&prepared.metadata, &metadata)?;
+    write_completion_metadata(&metadata)?;
 
     Ok(ExitCode::SUCCESS)
 }
@@ -83,20 +78,11 @@ pub(crate) async fn events(cfg: &AppConfig, args: ExportEventsArgs) -> Result<Ex
 struct PreparedExport {
     columns: Vec<&'static EventColumn>,
     sensitive_columns_requested: Vec<String>,
-    metadata: MetadataTarget,
     limit: Option<usize>,
-    max_execution_seconds: u64,
     query_id: String,
     query_params: Vec<(String, String)>,
     query: String,
     filters_metadata: BTreeMap<String, Value>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum MetadataTarget {
-    Stderr,
-    None,
-    File(PathBuf),
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -123,9 +109,8 @@ struct CompletionMetadata<'a> {
 }
 
 fn prepare_export(cfg: &AppConfig, args: ExportEventsArgs) -> Result<PreparedExport> {
-    validate_format(args.format)?;
     validate_limit(args.limit)?;
-    let metadata = metadata_target(args.metadata, args.metadata_file.clone())?;
+    validate_format(args.format)?;
     let columns = select_columns(args.columns.as_deref(), args.include_sensitive)?;
     let sensitive_columns_requested = columns
         .iter()
@@ -139,14 +124,12 @@ fn prepare_export(cfg: &AppConfig, args: ExportEventsArgs) -> Result<PreparedExp
 
     let query_id = Uuid::new_v4().to_string();
     let query = build_events_query(&cfg.clickhouse.database, &columns, &filters, args.limit)?;
-    let query_params = build_query_params(&query_id, args.max_execution_seconds);
+    let query_params = build_query_params(&query_id);
 
     Ok(PreparedExport {
         columns,
         sensitive_columns_requested,
-        metadata,
         limit: args.limit,
-        max_execution_seconds: args.max_execution_seconds,
         query_id,
         query_params,
         query,
@@ -154,10 +137,9 @@ fn prepare_export(cfg: &AppConfig, args: ExportEventsArgs) -> Result<PreparedExp
     })
 }
 
-fn validate_format(format: Option<ExportRowFormat>) -> Result<()> {
+fn validate_format(format: ExportRowFormat) -> Result<()> {
     match format {
-        Some(ExportRowFormat::Jsonl) => Ok(()),
-        None => bail!("moraine export events requires --format jsonl"),
+        ExportRowFormat::Jsonl => Ok(()),
     }
 }
 
@@ -166,18 +148,6 @@ fn validate_limit(limit: Option<usize>) -> Result<()> {
         bail!("--limit must be a positive integer");
     }
     Ok(())
-}
-
-fn metadata_target(mode: ExportMetadataMode, path: Option<PathBuf>) -> Result<MetadataTarget> {
-    match (mode, path) {
-        (ExportMetadataMode::Stderr, None) => Ok(MetadataTarget::Stderr),
-        (ExportMetadataMode::None, None) => Ok(MetadataTarget::None),
-        (ExportMetadataMode::File, Some(path)) => Ok(MetadataTarget::File(path)),
-        (ExportMetadataMode::File, None) => {
-            bail!("--metadata file requires --metadata-file <path>")
-        }
-        (_, Some(_)) => bail!("--metadata-file requires --metadata file"),
-    }
 }
 
 fn select_columns(raw: Option<&str>, include_sensitive: bool) -> Result<Vec<&'static EventColumn>> {
@@ -222,27 +192,21 @@ fn select_columns(raw: Option<&str>, include_sensitive: bool) -> Result<Vec<&'st
     Ok(columns)
 }
 
-fn build_query_params(query_id: &str, max_execution_seconds: u64) -> Vec<(String, String)> {
-    let mut params = vec![
+fn build_query_params(query_id: &str) -> Vec<(String, String)> {
+    vec![
         ("query_id".to_string(), query_id.to_string()),
         ("readonly".to_string(), "1".to_string()),
-    ];
-    if max_execution_seconds > 0 {
-        params.push((
+        (
             "max_execution_time".to_string(),
-            max_execution_seconds.to_string(),
-        ));
-    }
-    params
+            DEFAULT_MAX_EXECUTION_SECONDS.to_string(),
+        ),
+    ]
 }
 
-fn request_timeout(config_timeout_seconds: f64, max_execution_seconds: u64) -> Duration {
+fn request_timeout(config_timeout_seconds: f64) -> Duration {
     let configured = config_timeout_seconds.max(1.0).ceil() as u64;
-    let seconds = if max_execution_seconds == 0 {
-        configured.max(MAX_DISABLED_CLIENT_TIMEOUT_SECONDS)
-    } else {
-        configured.max(max_execution_seconds.saturating_add(30))
-    };
+    let seconds = configured
+        .max(DEFAULT_MAX_EXECUTION_SECONDS.saturating_add(EXPORT_REQUEST_TIMEOUT_GRACE_SECONDS));
     Duration::from_secs(seconds)
 }
 
@@ -569,15 +533,15 @@ async fn stream_jsonl_rows<W: Write>(
     let mut result = StreamRowsResult::default();
 
     while let Some(chunk) = stream.next_chunk().await? {
-        for line in framer.push_chunk(&chunk) {
-            if process_export_line(&line, writer, columns, limit, &mut result)? {
-                return Ok(result);
-            }
+        if framer.push_chunk(&chunk, |line| {
+            process_export_line(line, writer, columns, limit, &mut result)
+        })? {
+            return Ok(result);
         }
     }
 
-    if let Some(line) = framer.finish() {
-        process_export_line(&line, writer, columns, limit, &mut result)?;
+    if framer.finish(|line| process_export_line(line, writer, columns, limit, &mut result))? {
+        return Ok(result);
     }
 
     if let Err(err) = writer.flush() {
@@ -602,15 +566,15 @@ fn stream_jsonl_chunks<W: Write>(
     let mut result = StreamRowsResult::default();
 
     for chunk in chunks {
-        for line in framer.push_chunk(chunk) {
-            if process_export_line(&line, writer, columns, limit, &mut result)? {
-                return Ok(result);
-            }
+        if framer.push_chunk(chunk, |line| {
+            process_export_line(line, writer, columns, limit, &mut result)
+        })? {
+            return Ok(result);
         }
     }
 
-    if let Some(line) = framer.finish() {
-        process_export_line(&line, writer, columns, limit, &mut result)?;
+    if framer.finish(|line| process_export_line(line, writer, columns, limit, &mut result))? {
+        return Ok(result);
     }
     writer.flush().context("failed to flush export writer")?;
 
@@ -705,56 +669,71 @@ struct LineFramer {
 }
 
 impl LineFramer {
-    fn push_chunk(&mut self, chunk: &[u8]) -> Vec<Vec<u8>> {
-        self.pending.extend_from_slice(chunk);
-        let mut lines = Vec::new();
-        while let Some(pos) = self.pending.iter().position(|byte| *byte == b'\n') {
-            let mut line = self.pending.drain(..=pos).collect::<Vec<u8>>();
-            if line.ends_with(b"\n") {
-                line.pop();
+    fn push_chunk<F>(&mut self, chunk: &[u8], mut on_line: F) -> Result<bool>
+    where
+        F: FnMut(&[u8]) -> Result<bool>,
+    {
+        let mut start = 0;
+
+        if !self.pending.is_empty() {
+            let Some(pos) = chunk.iter().position(|byte| *byte == b'\n') else {
+                self.pending.extend_from_slice(chunk);
+                return Ok(false);
+            };
+
+            self.pending.extend_from_slice(&chunk[..pos]);
+            if self.emit_pending(&mut on_line)? {
+                return Ok(true);
             }
-            if line.ends_with(b"\r") {
-                line.pop();
-            }
-            lines.push(line);
+            start = pos + 1;
         }
-        lines
+
+        while let Some(offset) = chunk[start..].iter().position(|byte| *byte == b'\n') {
+            let end = start + offset;
+            let line = trim_cr(&chunk[start..end]);
+            if on_line(line)? {
+                return Ok(true);
+            }
+            start = end + 1;
+        }
+
+        if start < chunk.len() {
+            self.pending.extend_from_slice(&chunk[start..]);
+        }
+        Ok(false)
     }
 
-    fn finish(mut self) -> Option<Vec<u8>> {
+    fn finish<F>(&mut self, mut on_line: F) -> Result<bool>
+    where
+        F: FnMut(&[u8]) -> Result<bool>,
+    {
         if self.pending.is_empty() {
-            None
-        } else {
-            Some(std::mem::take(&mut self.pending))
+            return Ok(false);
         }
+        self.emit_pending(&mut on_line)
+    }
+
+    fn emit_pending<F>(&mut self, on_line: &mut F) -> Result<bool>
+    where
+        F: FnMut(&[u8]) -> Result<bool>,
+    {
+        let stop = {
+            let line = trim_cr(&self.pending);
+            on_line(line)?
+        };
+        self.pending.clear();
+        Ok(stop)
     }
 }
 
-fn preflight_metadata_file(target: &MetadataTarget) -> Result<()> {
-    if let MetadataTarget::File(path) = target {
-        fs::File::create(path)
-            .with_context(|| format!("failed to preflight metadata file {}", path.display()))?;
-    }
-    Ok(())
+fn trim_cr(line: &[u8]) -> &[u8] {
+    line.strip_suffix(b"\r").unwrap_or(line)
 }
 
-fn write_completion_metadata(
-    target: &MetadataTarget,
-    metadata: &CompletionMetadata<'_>,
-) -> Result<()> {
-    match target {
-        MetadataTarget::Stderr => {
-            let mut stderr = std::io::stderr().lock();
-            write_completion_metadata_line(&mut stderr, metadata)
-                .context("failed to write export metadata to stderr")
-        }
-        MetadataTarget::None => Ok(()),
-        MetadataTarget::File(path) => {
-            let json = completion_metadata_json(metadata)?;
-            fs::write(path, format!("{json}\n"))
-                .with_context(|| format!("failed to write export metadata file {}", path.display()))
-        }
-    }
+fn write_completion_metadata(metadata: &CompletionMetadata<'_>) -> Result<()> {
+    let mut stderr = std::io::stderr().lock();
+    write_completion_metadata_line(&mut stderr, metadata)
+        .context("failed to write export metadata to stderr")
 }
 
 fn completion_metadata_json(metadata: &CompletionMetadata<'_>) -> Result<String> {
@@ -772,19 +751,16 @@ fn write_completion_metadata_line<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli::{ExportMetadataMode, ExportRowFormat};
+    use crate::cli::ExportRowFormat;
     use serde_json::json;
 
     fn base_args() -> ExportEventsArgs {
         ExportEventsArgs {
-            format: Some(ExportRowFormat::Jsonl),
+            format: ExportRowFormat::Jsonl,
             columns: None,
             include_sensitive: false,
-            metadata: ExportMetadataMode::Stderr,
-            metadata_file: None,
             limit: None,
             all: false,
-            max_execution_seconds: 600,
             since: None,
             until: None,
             session_id: Vec::new(),
@@ -811,10 +787,12 @@ mod tests {
             Some("session_id")
         );
         assert!(defaults.iter().all(|column| !column.sensitive));
+        assert!(defaults.iter().all(|column| column.name != "text_preview"));
 
         let all = select_columns(Some("all"), true).expect("all columns");
         assert!(all.iter().any(|column| column.name == "event_unix_ms"));
         assert!(all.iter().all(|column| !column.sensitive));
+        assert!(all.iter().all(|column| column.name != "text_preview"));
     }
 
     #[test]
@@ -943,14 +921,6 @@ mod tests {
     fn prepare_export_requires_format_filter_and_positive_limit() {
         let cfg = AppConfig::default();
         let mut args = base_args();
-        args.format = None;
-        args.all = true;
-        assert!(prepare_export(&cfg, args)
-            .expect_err("missing format")
-            .to_string()
-            .contains("--format jsonl"));
-
-        let mut args = base_args();
         args.all = true;
         args.limit = Some(0);
         assert!(prepare_export(&cfg, args)
@@ -966,25 +936,25 @@ mod tests {
     }
 
     #[test]
-    fn query_params_omit_max_execution_time_when_disabled() {
-        let params = build_query_params("qid", 0);
+    fn query_params_use_readonly_and_internal_execution_limit() {
+        let params = build_query_params("qid");
         assert_eq!(
             params,
             vec![
                 ("query_id".to_string(), "qid".to_string()),
                 ("readonly".to_string(), "1".to_string()),
+                (
+                    "max_execution_time".to_string(),
+                    DEFAULT_MAX_EXECUTION_SECONDS.to_string()
+                ),
             ]
         );
     }
 
     #[test]
-    fn request_timeout_outlives_clickhouse_execution_setting() {
-        assert_eq!(request_timeout(30.0, 600), Duration::from_secs(630));
-        assert_eq!(
-            request_timeout(30.0, 0),
-            Duration::from_secs(MAX_DISABLED_CLIENT_TIMEOUT_SECONDS)
-        );
-        assert_eq!(request_timeout(900.0, 600), Duration::from_secs(900));
+    fn request_timeout_outlives_internal_execution_setting() {
+        assert_eq!(request_timeout(30.0), Duration::from_secs(630));
+        assert_eq!(request_timeout(900.0), Duration::from_secs(900));
     }
 
     #[test]
@@ -1024,6 +994,31 @@ mod tests {
         assert!(rows.contains("\"tool_error\":false"));
         assert!(rows.contains("\"tool_error\":true"));
         assert!(!rows.contains("sentinel"));
+    }
+
+    #[test]
+    fn stream_chunks_frames_multiple_rows_from_one_chunk() {
+        let columns = select_columns(Some("event_uid,event_ts"), false).expect("columns");
+        let chunks = [br#"{"event_uid":"a","event_ts":1780317296789}
+{"event_uid":"b","event_ts":1780317296790}
+{"event_uid":"c","event_ts":1780317296791}
+"#
+        .as_slice()];
+        let mut out = Vec::new();
+        let result = stream_jsonl_chunks(&chunks, &mut out, &columns, None).expect("stream chunks");
+
+        assert_eq!(
+            result,
+            StreamRowsResult {
+                row_count: 3,
+                truncated: false,
+                broken_pipe: false,
+            }
+        );
+        let rows = String::from_utf8(out).expect("utf8");
+        assert!(rows.contains("\"event_uid\":\"a\""));
+        assert!(rows.contains("\"event_uid\":\"b\""));
+        assert!(rows.contains("\"event_uid\":\"c\""));
     }
 
     struct BrokenPipeWriter;
@@ -1078,17 +1073,6 @@ mod tests {
         }
     }
 
-    fn temp_metadata_path(label: &str) -> PathBuf {
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system time")
-            .as_nanos();
-        std::env::temp_dir().join(format!(
-            "moraine-export-{label}-{}-{nanos}.json",
-            std::process::id()
-        ))
-    }
-
     #[test]
     fn metadata_json_line_matches_stderr_payload() {
         let metadata = sample_metadata();
@@ -1107,31 +1091,5 @@ mod tests {
             Value::String("codex".to_string())
         );
         assert!(String::from_utf8(out).expect("utf8").ends_with('\n'));
-    }
-
-    #[test]
-    fn metadata_targets_write_file_and_allow_none() {
-        let metadata = sample_metadata();
-        let path = temp_metadata_path("target");
-        let target = MetadataTarget::File(path.clone());
-
-        preflight_metadata_file(&target).expect("metadata file preflight");
-        write_completion_metadata(&target, &metadata).expect("metadata file write");
-
-        let contents = fs::read_to_string(&path).expect("metadata file contents");
-        let value: Value = serde_json::from_str(contents.trim_end()).expect("metadata file json");
-        assert_eq!(value["query_id"], Value::String("qid-test".to_string()));
-        assert!(contents.ends_with('\n'));
-        let _ = fs::remove_file(path);
-
-        write_completion_metadata(&MetadataTarget::None, &metadata).expect("none metadata target");
-    }
-
-    #[test]
-    fn metadata_file_preflight_fails_for_missing_parent() {
-        let target = MetadataTarget::File(PathBuf::from(
-            "/definitely/missing/moraine-export-metadata.json",
-        ));
-        assert!(preflight_metadata_file(&target).is_err());
     }
 }

--- a/apps/moraine/src/commands/export.rs
+++ b/apps/moraine/src/commands/export.rs
@@ -1,0 +1,1137 @@
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::{DateTime, SecondsFormat, TimeZone, Utc};
+use moraine_clickhouse::ClickHouseClient;
+use moraine_config::AppConfig;
+use serde::Serialize;
+use serde_json::{Map, Value};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::{ErrorKind, Write};
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::time::{Duration, Instant};
+use uuid::Uuid;
+
+use super::schema::{
+    all_non_sensitive_event_columns, default_event_columns, event_column, EventColumn,
+    EVENTS_SCHEMA_VERSION, EXPORT_METADATA_SCHEMA_VERSION,
+};
+use crate::cli::{ExportEventsArgs, ExportMetadataMode, ExportRowFormat};
+
+const EXPORT_KIND_EVENTS: &str = "events";
+const DEFAULT_BACKEND: &str = "default";
+const MAX_DISABLED_CLIENT_TIMEOUT_SECONDS: u64 = 24 * 60 * 60;
+
+pub(crate) async fn events(cfg: &AppConfig, args: ExportEventsArgs) -> Result<ExitCode> {
+    let prepared = prepare_export(cfg, args)?;
+    preflight_metadata_file(&prepared.metadata)?;
+
+    let client = ClickHouseClient::new(cfg.clickhouse.clone())?;
+    ensure_schema_ready(&client).await?;
+
+    let started = Instant::now();
+    let params = prepared
+        .query_params
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect::<Vec<_>>();
+    let mut stream = client
+        .request_stream_with_params(
+            &prepared.query,
+            Some(&cfg.clickhouse.database),
+            None,
+            &params,
+            Some(request_timeout(
+                cfg.clickhouse.timeout_seconds,
+                prepared.max_execution_seconds,
+            )),
+        )
+        .await?;
+
+    let mut stdout = std::io::stdout().lock();
+    let stream_result =
+        stream_jsonl_rows(&mut stream, &mut stdout, &prepared.columns, prepared.limit).await?;
+
+    if stream_result.broken_pipe {
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    let metadata = CompletionMetadata {
+        schema_version: EXPORT_METADATA_SCHEMA_VERSION,
+        data_schema_version: EVENTS_SCHEMA_VERSION,
+        export_kind: EXPORT_KIND_EVENTS,
+        backend: DEFAULT_BACKEND,
+        query_id: &prepared.query_id,
+        columns: prepared
+            .columns
+            .iter()
+            .map(|column| column.name)
+            .collect::<Vec<_>>(),
+        filters: prepared.filters_metadata,
+        limit: prepared.limit,
+        row_count: stream_result.row_count,
+        truncated: stream_result.truncated,
+        elapsed_ms: started.elapsed().as_millis() as u64,
+        sensitive_columns_requested: prepared.sensitive_columns_requested,
+    };
+    write_completion_metadata(&prepared.metadata, &metadata)?;
+
+    Ok(ExitCode::SUCCESS)
+}
+
+#[derive(Debug)]
+struct PreparedExport {
+    columns: Vec<&'static EventColumn>,
+    sensitive_columns_requested: Vec<String>,
+    metadata: MetadataTarget,
+    limit: Option<usize>,
+    max_execution_seconds: u64,
+    query_id: String,
+    query_params: Vec<(String, String)>,
+    query: String,
+    filters_metadata: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MetadataTarget {
+    Stderr,
+    None,
+    File(PathBuf),
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct StreamRowsResult {
+    row_count: usize,
+    truncated: bool,
+    broken_pipe: bool,
+}
+
+#[derive(Serialize)]
+struct CompletionMetadata<'a> {
+    schema_version: &'static str,
+    data_schema_version: &'static str,
+    export_kind: &'static str,
+    backend: &'static str,
+    query_id: &'a str,
+    columns: Vec<&'static str>,
+    filters: BTreeMap<String, Value>,
+    limit: Option<usize>,
+    row_count: usize,
+    truncated: bool,
+    elapsed_ms: u64,
+    sensitive_columns_requested: Vec<String>,
+}
+
+fn prepare_export(cfg: &AppConfig, args: ExportEventsArgs) -> Result<PreparedExport> {
+    validate_format(args.format)?;
+    validate_limit(args.limit)?;
+    let metadata = metadata_target(args.metadata, args.metadata_file.clone())?;
+    let columns = select_columns(args.columns.as_deref(), args.include_sensitive)?;
+    let sensitive_columns_requested = columns
+        .iter()
+        .filter(|column| column.sensitive)
+        .map(|column| column.name.to_string())
+        .collect::<Vec<_>>();
+    let filters = EventFilters::from_args(&args)?;
+    if !args.all && !filters.has_any_filter() {
+        bail!("moraine export events requires at least one filter unless --all is supplied");
+    }
+
+    let query_id = Uuid::new_v4().to_string();
+    let query = build_events_query(&cfg.clickhouse.database, &columns, &filters, args.limit)?;
+    let query_params = build_query_params(&query_id, args.max_execution_seconds);
+
+    Ok(PreparedExport {
+        columns,
+        sensitive_columns_requested,
+        metadata,
+        limit: args.limit,
+        max_execution_seconds: args.max_execution_seconds,
+        query_id,
+        query_params,
+        query,
+        filters_metadata: filters.metadata,
+    })
+}
+
+fn validate_format(format: Option<ExportRowFormat>) -> Result<()> {
+    match format {
+        Some(ExportRowFormat::Jsonl) => Ok(()),
+        None => bail!("moraine export events requires --format jsonl"),
+    }
+}
+
+fn validate_limit(limit: Option<usize>) -> Result<()> {
+    if limit == Some(0) {
+        bail!("--limit must be a positive integer");
+    }
+    Ok(())
+}
+
+fn metadata_target(mode: ExportMetadataMode, path: Option<PathBuf>) -> Result<MetadataTarget> {
+    match (mode, path) {
+        (ExportMetadataMode::Stderr, None) => Ok(MetadataTarget::Stderr),
+        (ExportMetadataMode::None, None) => Ok(MetadataTarget::None),
+        (ExportMetadataMode::File, Some(path)) => Ok(MetadataTarget::File(path)),
+        (ExportMetadataMode::File, None) => {
+            bail!("--metadata file requires --metadata-file <path>")
+        }
+        (_, Some(_)) => bail!("--metadata-file requires --metadata file"),
+    }
+}
+
+fn select_columns(raw: Option<&str>, include_sensitive: bool) -> Result<Vec<&'static EventColumn>> {
+    let columns = match raw {
+        None => default_event_columns(),
+        Some(value) if value.trim() == "all" => all_non_sensitive_event_columns(),
+        Some(value) => {
+            let mut seen = BTreeSet::new();
+            let mut columns = Vec::new();
+            for name in value.split(',') {
+                let trimmed = name.trim();
+                if trimmed.is_empty() {
+                    bail!("--columns contains an empty column name");
+                }
+                let column = event_column(trimmed).ok_or_else(|| {
+                    anyhow!(
+                        "unsupported export column '{}'; run `moraine schema analytics --json` for the public column list",
+                        trimmed
+                    )
+                })?;
+                if !seen.insert(column.name) {
+                    bail!("duplicate export column '{}'", column.name);
+                }
+                columns.push(column);
+            }
+            columns
+        }
+    };
+
+    let sensitive = columns
+        .iter()
+        .filter(|column| column.sensitive)
+        .map(|column| column.name)
+        .collect::<Vec<_>>();
+    if !include_sensitive && !sensitive.is_empty() {
+        bail!(
+            "sensitive export columns require --include-sensitive: {}",
+            sensitive.join(", ")
+        );
+    }
+
+    Ok(columns)
+}
+
+fn build_query_params(query_id: &str, max_execution_seconds: u64) -> Vec<(String, String)> {
+    let mut params = vec![
+        ("query_id".to_string(), query_id.to_string()),
+        ("readonly".to_string(), "1".to_string()),
+    ];
+    if max_execution_seconds > 0 {
+        params.push((
+            "max_execution_time".to_string(),
+            max_execution_seconds.to_string(),
+        ));
+    }
+    params
+}
+
+fn request_timeout(config_timeout_seconds: f64, max_execution_seconds: u64) -> Duration {
+    let configured = config_timeout_seconds.max(1.0).ceil() as u64;
+    let seconds = if max_execution_seconds == 0 {
+        configured.max(MAX_DISABLED_CLIENT_TIMEOUT_SECONDS)
+    } else {
+        configured.max(max_execution_seconds.saturating_add(30))
+    };
+    Duration::from_secs(seconds)
+}
+
+async fn ensure_schema_ready(client: &ClickHouseClient) -> Result<()> {
+    let skew = client
+        .schema_skew()
+        .await
+        .context("failed to check ClickHouse schema state before export")?;
+    if skew.is_clean() {
+        return Ok(());
+    }
+
+    let mut parts = Vec::new();
+    if !skew.missing_on_server.is_empty() {
+        parts.push(format!(
+            "missing migrations on server: {}",
+            skew.missing_on_server.join(", ")
+        ));
+    }
+    if !skew.unknown_on_server.is_empty() {
+        parts.push(format!(
+            "unknown migrations on server: {}",
+            skew.unknown_on_server.join(", ")
+        ));
+    }
+    bail!(
+        "ClickHouse schema is not compatible with this export contract ({}). Run `moraine db migrate` for the default backend or upgrade moraine if the server is newer.",
+        parts.join("; ")
+    );
+}
+
+#[derive(Debug)]
+struct EventFilters {
+    conditions: Vec<String>,
+    metadata: BTreeMap<String, Value>,
+    has_filter: bool,
+}
+
+impl EventFilters {
+    fn from_args(args: &ExportEventsArgs) -> Result<Self> {
+        let mut filters = Self {
+            conditions: Vec::new(),
+            metadata: BTreeMap::new(),
+            has_filter: false,
+        };
+
+        let since = parse_optional_timestamp("--since", args.since.as_deref())?;
+        let until = parse_optional_timestamp("--until", args.until.as_deref())?;
+        if let (Some((since_raw, since_ms)), Some((until_raw, until_ms))) = (&since, &until) {
+            if since_ms >= until_ms {
+                bail!("--since must be earlier than --until");
+            }
+            filters.insert_metadata_string("since", since_raw.clone());
+            filters.insert_metadata_string("until", until_raw.clone());
+        } else {
+            if let Some((raw, _)) = &since {
+                filters.insert_metadata_string("since", raw.clone());
+            }
+            if let Some((raw, _)) = &until {
+                filters.insert_metadata_string("until", raw.clone());
+            }
+        }
+
+        if let Some((_, ms)) = since {
+            filters.conditions.push(format!("e.event_unix_ms >= {ms}"));
+            filters.has_filter = true;
+        }
+        if let Some((_, ms)) = until {
+            filters.conditions.push(format!("e.event_unix_ms < {ms}"));
+            filters.has_filter = true;
+        }
+
+        filters.add_exact("session_id", "session_id", &args.session_id)?;
+        filters.add_exact("harness", "harness", &args.harness)?;
+        filters.add_exact("source_name", "source_name", &args.source_name)?;
+        filters.add_exact("project_id", "project_id", &args.project_id)?;
+        filters.add_cwd_prefix(&args.cwd_prefix)?;
+        filters.add_exact("worktree_root", "worktree_root", &args.worktree_root)?;
+        filters.add_exact("repo_rel_path", "repo_rel_path", &args.repo_rel_path)?;
+        filters.add_exact("event_kind", "event_kind", &args.event_kind)?;
+        filters.add_exact("payload_type", "payload_type", &args.payload_type)?;
+        filters.add_exact("actor_kind", "actor_kind", &args.actor_kind)?;
+        filters.add_exact("model_name", "model", &args.model_name)?;
+        filters.add_exact("tool_name", "tool_name", &args.tool_name)?;
+
+        if args.tool_error_only {
+            filters.conditions.push("e.tool_error != 0".to_string());
+            filters
+                .metadata
+                .insert("tool_error_only".to_string(), Value::Bool(true));
+            filters.has_filter = true;
+        }
+
+        Ok(filters)
+    }
+
+    fn has_any_filter(&self) -> bool {
+        self.has_filter
+    }
+
+    fn insert_metadata_string(&mut self, key: &str, value: String) {
+        self.metadata.insert(key.to_string(), Value::String(value));
+        self.has_filter = true;
+    }
+
+    fn insert_metadata_array(&mut self, key: &str, values: &[String]) {
+        self.metadata.insert(
+            key.to_string(),
+            Value::Array(values.iter().cloned().map(Value::String).collect()),
+        );
+        self.has_filter = true;
+    }
+
+    fn add_exact(&mut self, metadata_key: &str, column: &str, values: &[String]) -> Result<()> {
+        validate_filter_values(metadata_key, values)?;
+        if values.is_empty() {
+            return Ok(());
+        }
+
+        let conditions = values
+            .iter()
+            .map(|value| format!("e.{} = {}", sql_identifier(column), sql_quote(value)))
+            .collect::<Vec<_>>();
+        self.conditions.push(parenthesize_or(conditions));
+        self.insert_metadata_array(metadata_key, values);
+        Ok(())
+    }
+
+    fn add_cwd_prefix(&mut self, values: &[String]) -> Result<()> {
+        validate_filter_values("cwd_prefix", values)?;
+        if values.is_empty() {
+            return Ok(());
+        }
+
+        let conditions = values
+            .iter()
+            .map(|value| {
+                let normalized = normalize_cwd_prefix(value);
+                let literal = sql_quote(&normalized);
+                if normalized == "/" {
+                    "(e.`cwd` = '/' OR startsWith(e.`cwd`, '/'))".to_string()
+                } else {
+                    format!("(e.`cwd` = {literal} OR startsWith(e.`cwd`, concat({literal}, '/')))")
+                }
+            })
+            .collect::<Vec<_>>();
+        self.conditions.push(parenthesize_or(conditions));
+        self.insert_metadata_array("cwd_prefix", values);
+        Ok(())
+    }
+}
+
+fn parse_optional_timestamp(flag: &str, raw: Option<&str>) -> Result<Option<(String, i64)>> {
+    raw.map(|value| {
+        let dt = DateTime::parse_from_rfc3339(value)
+            .with_context(|| format!("{flag} must be an RFC3339 timestamp"))?;
+        Ok((value.to_string(), dt.with_timezone(&Utc).timestamp_millis()))
+    })
+    .transpose()
+}
+
+fn validate_filter_values(name: &str, values: &[String]) -> Result<()> {
+    for value in values {
+        if value.is_empty() {
+            bail!("--{} values must not be empty", name.replace('_', "-"));
+        }
+        if value.contains(',') {
+            bail!(
+                "--{} does not accept comma-separated lists in v1; repeat the flag instead",
+                name.replace('_', "-")
+            );
+        }
+    }
+    Ok(())
+}
+
+fn normalize_cwd_prefix(value: &str) -> String {
+    let trimmed = value.trim_end_matches('/');
+    if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn parenthesize_or(conditions: Vec<String>) -> String {
+    if conditions.len() == 1 {
+        conditions.into_iter().next().expect("one condition")
+    } else {
+        format!("({})", conditions.join(" OR "))
+    }
+}
+
+fn build_events_query(
+    database: &str,
+    columns: &[&EventColumn],
+    filters: &EventFilters,
+    limit: Option<usize>,
+) -> Result<String> {
+    validate_identifier(database)?;
+    let projections = columns
+        .iter()
+        .map(|column| {
+            format!(
+                "  {} AS {}",
+                projection_expression(column),
+                sql_identifier(column.name)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n");
+    let where_clause = if filters.conditions.is_empty() {
+        "1 = 1".to_string()
+    } else {
+        filters.conditions.join("\n  AND ")
+    };
+    let limit_clause = limit
+        .map(|value| format!("\nLIMIT {}", value.saturating_add(1)))
+        .unwrap_or_default();
+
+    Ok(format!(
+        "WITH latest_events AS (
+  SELECT *
+  FROM (
+    SELECT
+      e.*,
+      ifNull(parseDateTime64BestEffortOrNull(record_ts), ingested_at) AS canonical_event_time,
+      row_number() OVER (
+        PARTITION BY event_uid
+        ORDER BY event_version DESC,
+                 canonical_event_time DESC,
+                 source_file DESC,
+                 source_generation DESC,
+                 source_offset DESC,
+                 source_line_no DESC,
+                 event_uid DESC
+      ) AS event_uid_rank
+    FROM {database}.events AS e FINAL
+  )
+  WHERE event_uid_rank = 1
+),
+trace_events AS (
+  SELECT
+    latest_events.*,
+    row_number() OVER (
+      PARTITION BY session_id
+      ORDER BY canonical_event_time,
+               source_file,
+               source_generation,
+               source_offset,
+               source_line_no,
+               event_uid
+    ) AS event_order,
+    if(
+      toUInt32OrZero(toString(turn_index)) > 0,
+      toUInt32OrZero(toString(turn_index)),
+      greatest(
+        toUInt32(1),
+        toUInt32(
+          sum(if(actor_kind = 'user' AND event_kind = 'message', 1, 0)) OVER (
+            PARTITION BY session_id
+            ORDER BY canonical_event_time,
+                     source_file,
+                     source_generation,
+                     source_offset,
+                     source_line_no,
+                     event_uid
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+          )
+        )
+      )
+    ) AS turn_seq,
+    toInt64(toUnixTimestamp64Milli(canonical_event_time)) AS event_unix_ms
+  FROM latest_events
+)
+SELECT
+{projections}
+FROM trace_events AS e
+WHERE {where_clause}
+ORDER BY event_unix_ms ASC, session_id ASC, event_order ASC, event_uid ASC{limit_clause}
+FORMAT JSONEachRow",
+        database = sql_identifier(database),
+    ))
+}
+
+fn projection_expression(column: &EventColumn) -> String {
+    if column.name == "event_ts" {
+        return "e.event_unix_ms".to_string();
+    }
+
+    if column.value_type == "boolean" {
+        format!("CAST({}, 'Bool')", column.select_expression)
+    } else {
+        column.select_expression.to_string()
+    }
+}
+
+fn validate_identifier(identifier: &str) -> Result<()> {
+    if identifier.is_empty()
+        || !identifier
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+    {
+        bail!("ClickHouse database name contains unsupported characters: {identifier}");
+    }
+    Ok(())
+}
+
+fn sql_identifier(value: &str) -> String {
+    format!("`{}`", value.replace('`', "``"))
+}
+
+fn sql_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\\', "\\\\").replace('\'', "''"))
+}
+
+async fn stream_jsonl_rows<W: Write>(
+    stream: &mut moraine_clickhouse::ClickHouseByteStream,
+    writer: &mut W,
+    columns: &[&EventColumn],
+    limit: Option<usize>,
+) -> Result<StreamRowsResult> {
+    let mut framer = LineFramer::default();
+    let mut result = StreamRowsResult::default();
+
+    while let Some(chunk) = stream.next_chunk().await? {
+        for line in framer.push_chunk(&chunk) {
+            if process_export_line(&line, writer, columns, limit, &mut result)? {
+                return Ok(result);
+            }
+        }
+    }
+
+    if let Some(line) = framer.finish() {
+        process_export_line(&line, writer, columns, limit, &mut result)?;
+    }
+
+    if let Err(err) = writer.flush() {
+        if err.kind() == ErrorKind::BrokenPipe {
+            result.broken_pipe = true;
+            return Ok(result);
+        }
+        return Err(err).context("failed to flush export stdout");
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+fn stream_jsonl_chunks<W: Write>(
+    chunks: &[&[u8]],
+    writer: &mut W,
+    columns: &[&EventColumn],
+    limit: Option<usize>,
+) -> Result<StreamRowsResult> {
+    let mut framer = LineFramer::default();
+    let mut result = StreamRowsResult::default();
+
+    for chunk in chunks {
+        for line in framer.push_chunk(chunk) {
+            if process_export_line(&line, writer, columns, limit, &mut result)? {
+                return Ok(result);
+            }
+        }
+    }
+
+    if let Some(line) = framer.finish() {
+        process_export_line(&line, writer, columns, limit, &mut result)?;
+    }
+    writer.flush().context("failed to flush export writer")?;
+
+    Ok(result)
+}
+
+fn process_export_line<W: Write>(
+    line: &[u8],
+    writer: &mut W,
+    columns: &[&EventColumn],
+    limit: Option<usize>,
+    result: &mut StreamRowsResult,
+) -> Result<bool> {
+    if line.iter().all(|byte| byte.is_ascii_whitespace()) {
+        return Ok(false);
+    }
+
+    if limit.is_some_and(|limit| result.row_count >= limit) {
+        result.truncated = true;
+        return Ok(true);
+    }
+
+    let public_row = public_row_json(line, columns)?;
+    if let Err(err) = writer.write_all(&public_row) {
+        if err.kind() == ErrorKind::BrokenPipe {
+            result.broken_pipe = true;
+            return Ok(true);
+        }
+        return Err(err).context("failed to write export row to stdout");
+    }
+    if let Err(err) = writer.write_all(b"\n") {
+        if err.kind() == ErrorKind::BrokenPipe {
+            result.broken_pipe = true;
+            return Ok(true);
+        }
+        return Err(err).context("failed to write export row delimiter to stdout");
+    }
+
+    result.row_count += 1;
+    Ok(false)
+}
+
+fn public_row_json(line: &[u8], columns: &[&EventColumn]) -> Result<Vec<u8>> {
+    let mut raw = serde_json::from_slice::<Map<String, Value>>(line).with_context(|| {
+        format!(
+            "failed to parse ClickHouse JSONEachRow line: {}",
+            lossy(line)
+        )
+    })?;
+    let mut public = Map::new();
+
+    for column in columns {
+        let mut value = raw.remove(column.name).unwrap_or(Value::Null);
+        if column.name == "event_ts" {
+            let ms = value
+                .as_i64()
+                .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
+                .ok_or_else(|| anyhow!("ClickHouse row returned non-integer event_ts sentinel"))?;
+            value = Value::String(format_event_ts(ms)?);
+        } else if column.value_type == "boolean" {
+            value = json_value_as_bool(value);
+        }
+        public.insert(column.name.to_string(), value);
+    }
+
+    serde_json::to_vec(&Value::Object(public)).context("failed to serialize export JSONL row")
+}
+
+fn json_value_as_bool(value: Value) -> Value {
+    match value {
+        Value::Bool(_) => value,
+        Value::Number(number) => Value::Bool(number.as_u64().unwrap_or(0) != 0),
+        other => other,
+    }
+}
+
+fn format_event_ts(unix_ms: i64) -> Result<String> {
+    let dt = Utc
+        .timestamp_millis_opt(unix_ms)
+        .single()
+        .ok_or_else(|| anyhow!("event timestamp is out of range: {unix_ms}"))?;
+    Ok(dt.to_rfc3339_opts(SecondsFormat::Millis, true))
+}
+
+fn lossy(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+#[derive(Default)]
+struct LineFramer {
+    pending: Vec<u8>,
+}
+
+impl LineFramer {
+    fn push_chunk(&mut self, chunk: &[u8]) -> Vec<Vec<u8>> {
+        self.pending.extend_from_slice(chunk);
+        let mut lines = Vec::new();
+        while let Some(pos) = self.pending.iter().position(|byte| *byte == b'\n') {
+            let mut line = self.pending.drain(..=pos).collect::<Vec<u8>>();
+            if line.ends_with(b"\n") {
+                line.pop();
+            }
+            if line.ends_with(b"\r") {
+                line.pop();
+            }
+            lines.push(line);
+        }
+        lines
+    }
+
+    fn finish(mut self) -> Option<Vec<u8>> {
+        if self.pending.is_empty() {
+            None
+        } else {
+            Some(std::mem::take(&mut self.pending))
+        }
+    }
+}
+
+fn preflight_metadata_file(target: &MetadataTarget) -> Result<()> {
+    if let MetadataTarget::File(path) = target {
+        fs::File::create(path)
+            .with_context(|| format!("failed to preflight metadata file {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn write_completion_metadata(
+    target: &MetadataTarget,
+    metadata: &CompletionMetadata<'_>,
+) -> Result<()> {
+    match target {
+        MetadataTarget::Stderr => {
+            let mut stderr = std::io::stderr().lock();
+            write_completion_metadata_line(&mut stderr, metadata)
+                .context("failed to write export metadata to stderr")
+        }
+        MetadataTarget::None => Ok(()),
+        MetadataTarget::File(path) => {
+            let json = completion_metadata_json(metadata)?;
+            fs::write(path, format!("{json}\n"))
+                .with_context(|| format!("failed to write export metadata file {}", path.display()))
+        }
+    }
+}
+
+fn completion_metadata_json(metadata: &CompletionMetadata<'_>) -> Result<String> {
+    serde_json::to_string(metadata).context("failed to serialize export metadata")
+}
+
+fn write_completion_metadata_line<W: Write>(
+    writer: &mut W,
+    metadata: &CompletionMetadata<'_>,
+) -> Result<()> {
+    let json = completion_metadata_json(metadata)?;
+    writeln!(writer, "{json}").context("failed to write export metadata")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{ExportMetadataMode, ExportRowFormat};
+    use serde_json::json;
+
+    fn base_args() -> ExportEventsArgs {
+        ExportEventsArgs {
+            format: Some(ExportRowFormat::Jsonl),
+            columns: None,
+            include_sensitive: false,
+            metadata: ExportMetadataMode::Stderr,
+            metadata_file: None,
+            limit: None,
+            all: false,
+            max_execution_seconds: 600,
+            since: None,
+            until: None,
+            session_id: Vec::new(),
+            harness: Vec::new(),
+            source_name: Vec::new(),
+            project_id: Vec::new(),
+            cwd_prefix: Vec::new(),
+            worktree_root: Vec::new(),
+            repo_rel_path: Vec::new(),
+            event_kind: Vec::new(),
+            payload_type: Vec::new(),
+            actor_kind: Vec::new(),
+            model_name: Vec::new(),
+            tool_name: Vec::new(),
+            tool_error_only: false,
+        }
+    }
+
+    #[test]
+    fn select_columns_defaults_and_all_omit_sensitive() {
+        let defaults = select_columns(None, false).expect("default columns");
+        assert_eq!(
+            defaults.first().map(|column| column.name),
+            Some("session_id")
+        );
+        assert!(defaults.iter().all(|column| !column.sensitive));
+
+        let all = select_columns(Some("all"), true).expect("all columns");
+        assert!(all.iter().any(|column| column.name == "event_unix_ms"));
+        assert!(all.iter().all(|column| !column.sensitive));
+    }
+
+    #[test]
+    fn select_columns_rejects_sensitive_without_opt_in() {
+        let err = select_columns(Some("session_id,payload_json"), false)
+            .expect_err("sensitive column should require opt-in");
+        assert!(err.to_string().contains("--include-sensitive"));
+    }
+
+    #[test]
+    fn select_columns_rejects_empty_unknown_and_duplicate_names() {
+        assert!(select_columns(Some("session_id,"), false)
+            .expect_err("empty")
+            .to_string()
+            .contains("empty"));
+        assert!(select_columns(Some("session_id,nope"), false)
+            .expect_err("unknown")
+            .to_string()
+            .contains("unsupported export column"));
+        assert!(select_columns(Some("session_id,session_id"), false)
+            .expect_err("duplicate")
+            .to_string()
+            .contains("duplicate"));
+    }
+
+    #[test]
+    fn filters_reject_empty_and_comma_lists() {
+        let mut args = base_args();
+        args.session_id.push(String::new());
+        assert!(EventFilters::from_args(&args)
+            .expect_err("empty filter")
+            .to_string()
+            .contains("must not be empty"));
+
+        let mut args = base_args();
+        args.harness.push("codex,hermes".to_string());
+        assert!(EventFilters::from_args(&args)
+            .expect_err("comma list")
+            .to_string()
+            .contains("repeat the flag"));
+    }
+
+    #[test]
+    fn filters_parse_time_bounds_and_validate_order() {
+        let mut args = base_args();
+        args.since = Some("2026-06-01T00:00:00Z".to_string());
+        args.until = Some("2026-06-15T00:00:00Z".to_string());
+        let filters = EventFilters::from_args(&args).expect("filters");
+        assert!(filters
+            .conditions
+            .iter()
+            .any(|condition| condition == "e.event_unix_ms >= 1780272000000"));
+        assert!(filters
+            .conditions
+            .iter()
+            .any(|condition| condition == "e.event_unix_ms < 1781481600000"));
+
+        args.until = Some("2026-05-01T00:00:00Z".to_string());
+        assert!(EventFilters::from_args(&args)
+            .expect_err("bad order")
+            .to_string()
+            .contains("earlier"));
+    }
+
+    #[test]
+    fn filters_normalize_cwd_prefix_trailing_slash_and_root() {
+        let mut args = base_args();
+        args.cwd_prefix = vec!["/repo/".to_string(), "/".to_string()];
+        let filters = EventFilters::from_args(&args).expect("filters");
+        let sql = build_events_query(
+            "moraine",
+            &select_columns(Some("event_uid"), false).expect("columns"),
+            &filters,
+            None,
+        )
+        .expect("sql");
+
+        assert!(
+            sql.contains("(e.`cwd` = '/repo' OR startsWith(e.`cwd`, concat('/repo', '/')))"),
+            "{sql}"
+        );
+        assert!(
+            sql.contains("(e.`cwd` = '/' OR startsWith(e.`cwd`, '/'))"),
+            "{sql}"
+        );
+    }
+
+    #[test]
+    fn query_builder_applies_filters_after_dedupe_and_uses_limit_sentinel() {
+        let mut args = base_args();
+        args.harness = vec!["codex".to_string(), "hermes".to_string()];
+        args.cwd_prefix = vec!["/repo".to_string()];
+        let filters = EventFilters::from_args(&args).expect("filters");
+        let columns = select_columns(Some("session_id,event_uid,event_ts,tool_error"), false)
+            .expect("columns");
+        let sql = build_events_query("moraine", &columns, &filters, Some(100)).expect("sql");
+
+        assert!(sql.contains("row_number() OVER (\n        PARTITION BY event_uid"));
+        assert!(sql.contains("FROM `moraine`.events AS e FINAL"));
+        assert!(sql.contains("FROM trace_events AS e\nWHERE"));
+        assert!(sql.contains("(e.`harness` = 'codex' OR e.`harness` = 'hermes')"));
+        assert!(sql.contains("(e.`cwd` = '/repo' OR startsWith(e.`cwd`, concat('/repo', '/')))"));
+        assert!(sql.contains("LIMIT 101"));
+        assert!(sql.contains("CAST(e.tool_error != 0, 'Bool') AS `tool_error`"));
+        assert!(sql.ends_with("FORMAT JSONEachRow"));
+    }
+
+    #[test]
+    fn sql_quote_escapes_quotes_backslashes_and_semicolons_as_data() {
+        let mut args = base_args();
+        args.tool_name = vec!["tool\\name'; DROP TABLE moraine.events; --".to_string()];
+        let filters = EventFilters::from_args(&args).expect("filters");
+        let sql = build_events_query(
+            "moraine",
+            &select_columns(Some("event_uid"), false).expect("columns"),
+            &filters,
+            None,
+        )
+        .expect("sql");
+
+        assert!(sql.contains("tool\\\\name''; DROP TABLE moraine.events; --"));
+        assert!(!sql.contains("tool\\name'; DROP"));
+    }
+
+    #[test]
+    fn prepare_export_requires_format_filter_and_positive_limit() {
+        let cfg = AppConfig::default();
+        let mut args = base_args();
+        args.format = None;
+        args.all = true;
+        assert!(prepare_export(&cfg, args)
+            .expect_err("missing format")
+            .to_string()
+            .contains("--format jsonl"));
+
+        let mut args = base_args();
+        args.all = true;
+        args.limit = Some(0);
+        assert!(prepare_export(&cfg, args)
+            .expect_err("zero limit")
+            .to_string()
+            .contains("positive"));
+
+        let args = base_args();
+        assert!(prepare_export(&cfg, args)
+            .expect_err("missing filter")
+            .to_string()
+            .contains("at least one filter"));
+    }
+
+    #[test]
+    fn query_params_omit_max_execution_time_when_disabled() {
+        let params = build_query_params("qid", 0);
+        assert_eq!(
+            params,
+            vec![
+                ("query_id".to_string(), "qid".to_string()),
+                ("readonly".to_string(), "1".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn request_timeout_outlives_clickhouse_execution_setting() {
+        assert_eq!(request_timeout(30.0, 600), Duration::from_secs(630));
+        assert_eq!(
+            request_timeout(30.0, 0),
+            Duration::from_secs(MAX_DISABLED_CLIENT_TIMEOUT_SECONDS)
+        );
+        assert_eq!(request_timeout(900.0, 600), Duration::from_secs(900));
+    }
+
+    #[test]
+    fn format_event_ts_uses_utc_millisecond_precision() {
+        assert_eq!(
+            format_event_ts(1780317296789).expect("timestamp"),
+            "2026-06-01T12:34:56.789Z"
+        );
+    }
+
+    #[test]
+    fn stream_chunks_frames_rows_formats_timestamps_and_handles_truncation() {
+        let columns =
+            select_columns(Some("event_uid,event_ts,tool_error"), false).expect("columns");
+        let chunks = [
+            br#"{"event_uid":"a","event_ts":1780317296789,"tool_error":0}"#.as_slice(),
+            b"\n",
+            br#"{"event_uid":"b","event_ts":1780317296790,"tool_error":1}"#.as_slice(),
+            b"\n",
+            br#"{"event_uid":"sentinel","event_ts":1780317296791,"tool_error":0}"#.as_slice(),
+            b"\n",
+        ];
+        let mut out = Vec::new();
+        let result =
+            stream_jsonl_chunks(&chunks, &mut out, &columns, Some(2)).expect("stream chunks");
+
+        assert_eq!(
+            result,
+            StreamRowsResult {
+                row_count: 2,
+                truncated: true,
+                broken_pipe: false,
+            }
+        );
+        let rows = String::from_utf8(out).expect("utf8");
+        assert!(rows.contains("\"event_ts\":\"2026-06-01T12:34:56.789Z\""));
+        assert!(rows.contains("\"tool_error\":false"));
+        assert!(rows.contains("\"tool_error\":true"));
+        assert!(!rows.contains("sentinel"));
+    }
+
+    struct BrokenPipeWriter;
+
+    impl Write for BrokenPipeWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(
+                ErrorKind::BrokenPipe,
+                "test pipe closed",
+            ))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn stream_chunks_treats_broken_pipe_as_success() {
+        let columns = select_columns(Some("event_uid,event_ts"), false).expect("columns");
+        let chunks = [br#"{"event_uid":"a","event_ts":1780317296789}"#.as_slice()];
+        let mut writer = BrokenPipeWriter;
+        let result =
+            stream_jsonl_chunks(&chunks, &mut writer, &columns, None).expect("stream chunks");
+
+        assert_eq!(
+            result,
+            StreamRowsResult {
+                row_count: 0,
+                truncated: false,
+                broken_pipe: true,
+            }
+        );
+    }
+
+    fn sample_metadata() -> CompletionMetadata<'static> {
+        let mut filters = BTreeMap::new();
+        filters.insert("harness".to_string(), json!(["codex"]));
+        CompletionMetadata {
+            schema_version: EXPORT_METADATA_SCHEMA_VERSION,
+            data_schema_version: EVENTS_SCHEMA_VERSION,
+            export_kind: EXPORT_KIND_EVENTS,
+            backend: DEFAULT_BACKEND,
+            query_id: "qid-test",
+            columns: vec!["session_id", "event_uid"],
+            filters,
+            limit: Some(100),
+            row_count: 42,
+            truncated: false,
+            elapsed_ms: 123,
+            sensitive_columns_requested: Vec::new(),
+        }
+    }
+
+    fn temp_metadata_path(label: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "moraine-export-{label}-{}-{nanos}.json",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn metadata_json_line_matches_stderr_payload() {
+        let metadata = sample_metadata();
+        let mut out = Vec::new();
+
+        write_completion_metadata_line(&mut out, &metadata).expect("metadata line");
+
+        let value: Value =
+            serde_json::from_slice(&out).expect("metadata line should be valid JSON");
+        assert_eq!(
+            value["schema_version"],
+            Value::String(EXPORT_METADATA_SCHEMA_VERSION.to_string())
+        );
+        assert_eq!(
+            value["filters"]["harness"][0],
+            Value::String("codex".to_string())
+        );
+        assert!(String::from_utf8(out).expect("utf8").ends_with('\n'));
+    }
+
+    #[test]
+    fn metadata_targets_write_file_and_allow_none() {
+        let metadata = sample_metadata();
+        let path = temp_metadata_path("target");
+        let target = MetadataTarget::File(path.clone());
+
+        preflight_metadata_file(&target).expect("metadata file preflight");
+        write_completion_metadata(&target, &metadata).expect("metadata file write");
+
+        let contents = fs::read_to_string(&path).expect("metadata file contents");
+        let value: Value = serde_json::from_str(contents.trim_end()).expect("metadata file json");
+        assert_eq!(value["query_id"], Value::String("qid-test".to_string()));
+        assert!(contents.ends_with('\n'));
+        let _ = fs::remove_file(path);
+
+        write_completion_metadata(&MetadataTarget::None, &metadata).expect("none metadata target");
+    }
+
+    #[test]
+    fn metadata_file_preflight_fails_for_missing_parent() {
+        let target = MetadataTarget::File(PathBuf::from(
+            "/definitely/missing/moraine-export-metadata.json",
+        ));
+        assert!(preflight_metadata_file(&target).is_err());
+    }
+}

--- a/apps/moraine/src/commands/schema.rs
+++ b/apps/moraine/src/commands/schema.rs
@@ -1,0 +1,706 @@
+use anyhow::{bail, Result};
+use serde::Serialize;
+use serde_json::json;
+
+use crate::cli::SchemaAnalyticsArgs;
+
+pub(super) const EVENTS_SCHEMA_VERSION: &str = "moraine.analytics.events.v1";
+pub(super) const EXPORT_METADATA_SCHEMA_VERSION: &str = "moraine.analytics.export_metadata.v1";
+
+pub(super) const DEFAULT_EVENT_COLUMNS: &[&str] = &[
+    "session_id",
+    "event_uid",
+    "event_ts",
+    "turn_seq",
+    "event_order",
+    "harness",
+    "source_name",
+    "event_kind",
+    "payload_type",
+    "actor_kind",
+    "tool_name",
+    "tool_phase",
+    "tool_error",
+    "model",
+    "project_id",
+    "text_preview",
+];
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub(super) struct EventColumn {
+    pub name: &'static str,
+    pub source_expression: &'static str,
+    #[serde(skip)]
+    pub select_expression: &'static str,
+    #[serde(rename = "type")]
+    pub value_type: &'static str,
+    pub default: bool,
+    pub sensitive: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+struct EventFilter {
+    name: &'static str,
+    flag: &'static str,
+    arity: &'static str,
+    source: &'static str,
+    empty_value: &'static str,
+}
+
+const fn col(
+    name: &'static str,
+    source_expression: &'static str,
+    select_expression: &'static str,
+    value_type: &'static str,
+    default: bool,
+    sensitive: bool,
+) -> EventColumn {
+    EventColumn {
+        name,
+        source_expression,
+        select_expression,
+        value_type,
+        default,
+        sensitive,
+    }
+}
+
+pub(super) const EVENT_COLUMNS: &[EventColumn] = &[
+    col(
+        "session_id",
+        "e.session_id",
+        "e.session_id",
+        "string",
+        true,
+        false,
+    ),
+    col(
+        "event_uid",
+        "e.event_uid",
+        "e.event_uid",
+        "string",
+        true,
+        false,
+    ),
+    col(
+        "event_ts",
+        "CLI format of e.event_unix_ms",
+        "e.event_unix_ms",
+        "string",
+        true,
+        false,
+    ),
+    col(
+        "event_unix_ms",
+        "e.event_unix_ms",
+        "e.event_unix_ms",
+        "integer",
+        false,
+        false,
+    ),
+    col(
+        "event_order",
+        "e.event_order",
+        "e.event_order",
+        "integer",
+        true,
+        false,
+    ),
+    col(
+        "turn_seq",
+        "e.turn_seq",
+        "e.turn_seq",
+        "integer",
+        true,
+        false,
+    ),
+    col("harness", "e.harness", "e.harness", "string", true, false),
+    col(
+        "inference_provider",
+        "e.inference_provider",
+        "e.inference_provider",
+        "string",
+        false,
+        false,
+    ),
+    col(
+        "source_name",
+        "e.source_name",
+        "e.source_name",
+        "string",
+        true,
+        false,
+    ),
+    col(
+        "source_generation",
+        "e.source_generation",
+        "e.source_generation",
+        "integer",
+        false,
+        false,
+    ),
+    col(
+        "source_line_no",
+        "e.source_line_no",
+        "e.source_line_no",
+        "integer",
+        false,
+        false,
+    ),
+    col(
+        "source_offset",
+        "e.source_offset",
+        "e.source_offset",
+        "integer",
+        false,
+        false,
+    ),
+    col(
+        "source_file",
+        "e.source_file",
+        "e.source_file",
+        "string",
+        false,
+        true,
+    ),
+    col(
+        "source_ref",
+        "e.source_ref",
+        "e.source_ref",
+        "string",
+        false,
+        true,
+    ),
+    col(
+        "event_kind",
+        "e.event_kind",
+        "e.event_kind",
+        "string",
+        true,
+        false,
+    ),
+    col(
+        "payload_type",
+        "e.payload_type",
+        "e.payload_type",
+        "string",
+        true,
+        false,
+    ),
+    col(
+        "actor_kind",
+        "e.actor_kind",
+        "e.actor_kind",
+        "string",
+        true,
+        false,
+    ),
+    col("op_kind", "e.op_kind", "e.op_kind", "string", false, false),
+    col(
+        "op_status",
+        "e.op_status",
+        "e.op_status",
+        "string",
+        false,
+        false,
+    ),
+    col(
+        "request_id",
+        "e.request_id",
+        "e.request_id",
+        "string",
+        false,
+        false,
+    ),
+    col(
+        "trace_id",
+        "e.trace_id",
+        "e.trace_id",
+        "string",
+        false,
+        false,
+    ),
+    col("item_id", "e.item_id", "e.item_id", "string", false, false),
+    col(
+        "tool_call_id",
+        "e.tool_call_id",
+        "e.tool_call_id",
+        "string",
+        false,
+        false,
+    ),
+    col(
+        "parent_tool_call_id",
+        "e.parent_tool_call_id",
+        "e.parent_tool_call_id",
+        "string",
+        false,
+        false,
+    ),
+    col(
+        "tool_name",
+        "e.tool_name",
+        "e.tool_name",
+        "string",
+        true,
+        false,
+    ),
+    col(
+        "tool_phase",
+        "e.tool_phase",
+        "e.tool_phase",
+        "string",
+        true,
+        false,
+    ),
+    col(
+        "tool_error",
+        "e.tool_error != 0",
+        "e.tool_error != 0",
+        "boolean",
+        true,
+        false,
+    ),
+    col(
+        "agent_run_id",
+        "e.agent_run_id",
+        "e.agent_run_id",
+        "string",
+        false,
+        false,
+    ),
+    col(
+        "agent_label",
+        "e.agent_label",
+        "e.agent_label",
+        "string",
+        false,
+        false,
+    ),
+    col(
+        "coord_group_id",
+        "e.coord_group_id",
+        "e.coord_group_id",
+        "string",
+        false,
+        false,
+    ),
+    col(
+        "coord_group_label",
+        "e.coord_group_label",
+        "e.coord_group_label",
+        "string",
+        false,
+        false,
+    ),
+    col(
+        "is_substream",
+        "e.is_substream != 0",
+        "e.is_substream != 0",
+        "boolean",
+        false,
+        false,
+    ),
+    col("model", "e.model", "e.model", "string", true, false),
+    col(
+        "endpoint_kind",
+        "e.endpoint_kind",
+        "e.endpoint_kind",
+        "string",
+        false,
+        false,
+    ),
+    col(
+        "input_tokens",
+        "e.input_tokens",
+        "e.input_tokens",
+        "integer",
+        false,
+        false,
+    ),
+    col(
+        "output_tokens",
+        "e.output_tokens",
+        "e.output_tokens",
+        "integer",
+        false,
+        false,
+    ),
+    col(
+        "cache_read_tokens",
+        "e.cache_read_tokens",
+        "e.cache_read_tokens",
+        "integer",
+        false,
+        false,
+    ),
+    col(
+        "cache_write_tokens",
+        "e.cache_write_tokens",
+        "e.cache_write_tokens",
+        "integer",
+        false,
+        false,
+    ),
+    col(
+        "latency_ms",
+        "e.latency_ms",
+        "e.latency_ms",
+        "integer",
+        false,
+        false,
+    ),
+    col(
+        "retry_count",
+        "e.retry_count",
+        "e.retry_count",
+        "integer",
+        false,
+        false,
+    ),
+    col(
+        "service_tier",
+        "e.service_tier",
+        "e.service_tier",
+        "string",
+        false,
+        false,
+    ),
+    col(
+        "content_types",
+        "e.content_types",
+        "e.content_types",
+        "array<string>",
+        false,
+        false,
+    ),
+    col(
+        "has_reasoning",
+        "e.has_reasoning != 0",
+        "e.has_reasoning != 0",
+        "boolean",
+        false,
+        false,
+    ),
+    col(
+        "project_id",
+        "e.project_id",
+        "e.project_id",
+        "string",
+        true,
+        false,
+    ),
+    col(
+        "repo_rel_path",
+        "e.repo_rel_path",
+        "e.repo_rel_path",
+        "string",
+        false,
+        true,
+    ),
+    col(
+        "worktree_root",
+        "e.worktree_root",
+        "e.worktree_root",
+        "string",
+        false,
+        true,
+    ),
+    col("cwd", "e.cwd", "e.cwd", "string", false, true),
+    col(
+        "text_preview",
+        "e.text_preview",
+        "e.text_preview",
+        "string",
+        true,
+        false,
+    ),
+    col(
+        "text_content",
+        "e.text_content",
+        "e.text_content",
+        "string",
+        false,
+        true,
+    ),
+    col(
+        "payload_json",
+        "e.payload_json",
+        "e.payload_json",
+        "JSON string",
+        false,
+        true,
+    ),
+    col(
+        "token_usage_json",
+        "e.token_usage_json",
+        "e.token_usage_json",
+        "JSON string",
+        false,
+        true,
+    ),
+    col(
+        "token_usage_buckets",
+        "e.token_usage_buckets",
+        "e.token_usage_buckets",
+        "object",
+        false,
+        false,
+    ),
+    col(
+        "token_usage_native_units",
+        "e.token_usage_native_units",
+        "e.token_usage_native_units",
+        "object",
+        false,
+        false,
+    ),
+    col(
+        "event_version",
+        "e.event_version",
+        "e.event_version",
+        "integer",
+        false,
+        false,
+    ),
+];
+
+const EVENT_FILTERS: &[EventFilter] = &[
+    EventFilter {
+        name: "since",
+        flag: "--since",
+        arity: "single",
+        source: "canonical event time >= value",
+        empty_value: "invalid timestamp fails",
+    },
+    EventFilter {
+        name: "until",
+        flag: "--until",
+        arity: "single",
+        source: "canonical event time < value",
+        empty_value: "invalid timestamp fails",
+    },
+    EventFilter {
+        name: "session_id",
+        flag: "--session-id",
+        arity: "repeatable",
+        source: "session_id = value",
+        empty_value: "rejected",
+    },
+    EventFilter {
+        name: "harness",
+        flag: "--harness",
+        arity: "repeatable",
+        source: "harness = value",
+        empty_value: "rejected",
+    },
+    EventFilter {
+        name: "source_name",
+        flag: "--source-name",
+        arity: "repeatable",
+        source: "source_name = value",
+        empty_value: "rejected",
+    },
+    EventFilter {
+        name: "project_id",
+        flag: "--project-id",
+        arity: "repeatable",
+        source: "project_id = value",
+        empty_value: "rejected",
+    },
+    EventFilter {
+        name: "cwd_prefix",
+        flag: "--cwd-prefix",
+        arity: "repeatable",
+        source: "cwd = value OR startsWith(cwd, value + \"/\")",
+        empty_value: "rejected",
+    },
+    EventFilter {
+        name: "worktree_root",
+        flag: "--worktree-root",
+        arity: "repeatable",
+        source: "worktree_root = value",
+        empty_value: "rejected",
+    },
+    EventFilter {
+        name: "repo_rel_path",
+        flag: "--repo-rel-path",
+        arity: "repeatable",
+        source: "repo_rel_path = value",
+        empty_value: "rejected",
+    },
+    EventFilter {
+        name: "event_kind",
+        flag: "--event-kind",
+        arity: "repeatable",
+        source: "event_kind = value",
+        empty_value: "rejected",
+    },
+    EventFilter {
+        name: "payload_type",
+        flag: "--payload-type",
+        arity: "repeatable",
+        source: "payload_type = value",
+        empty_value: "rejected",
+    },
+    EventFilter {
+        name: "actor_kind",
+        flag: "--actor-kind",
+        arity: "repeatable",
+        source: "actor_kind = value",
+        empty_value: "rejected",
+    },
+    EventFilter {
+        name: "model_name",
+        flag: "--model-name",
+        arity: "repeatable",
+        source: "model = value",
+        empty_value: "rejected",
+    },
+    EventFilter {
+        name: "tool_name",
+        flag: "--tool-name",
+        arity: "repeatable",
+        source: "tool_name = value",
+        empty_value: "rejected",
+    },
+    EventFilter {
+        name: "tool_error_only",
+        flag: "--tool-error-only",
+        arity: "single boolean",
+        source: "tool_error = 1",
+        empty_value: "not applicable",
+    },
+];
+
+pub(super) fn event_column(name: &str) -> Option<&'static EventColumn> {
+    EVENT_COLUMNS.iter().find(|column| column.name == name)
+}
+
+pub(super) fn default_event_columns() -> Vec<&'static EventColumn> {
+    DEFAULT_EVENT_COLUMNS
+        .iter()
+        .map(|name| event_column(name).expect("default event column must be in public schema"))
+        .collect()
+}
+
+pub(super) fn all_non_sensitive_event_columns() -> Vec<&'static EventColumn> {
+    EVENT_COLUMNS
+        .iter()
+        .filter(|column| !column.sensitive)
+        .collect()
+}
+
+pub(crate) fn render_analytics(args: &SchemaAnalyticsArgs) -> Result<()> {
+    if !args.json {
+        bail!("moraine schema analytics currently requires --json");
+    }
+
+    println!("{}", serde_json::to_string_pretty(&analytics_schema())?);
+    Ok(())
+}
+
+fn analytics_schema() -> serde_json::Value {
+    let default_columns = DEFAULT_EVENT_COLUMNS.to_vec();
+    let sensitive_columns = EVENT_COLUMNS
+        .iter()
+        .filter(|column| column.sensitive)
+        .map(|column| column.name)
+        .collect::<Vec<_>>();
+
+    json!({
+        "schema_version": "moraine.analytics.schema.v1",
+        "data_schema_version": EVENTS_SCHEMA_VERSION,
+        "export_kind": "events",
+        "formats": ["jsonl"],
+        "default_columns": default_columns,
+        "sensitive_columns": sensitive_columns,
+        "columns": EVENT_COLUMNS,
+        "filters": EVENT_FILTERS,
+        "timestamp_semantics": {
+            "event_ts": "UTC RFC3339 string with millisecond precision",
+            "source": "ifNull(parseDateTime64BestEffortOrNull(record_ts), ingested_at)",
+            "since": "inclusive",
+            "until": "exclusive"
+        },
+        "column_semantics": {
+            "strings": "unknown or unavailable values are emitted as empty strings",
+            "numbers": "unknown numeric values follow storage defaults",
+            "booleans": "emitted as JSON booleans"
+        },
+        "metadata_schema_version": EXPORT_METADATA_SCHEMA_VERSION,
+        "metadata_modes": ["stderr", "none", "file"],
+        "scope": {
+            "included": ["events"],
+            "excluded": ["sessions", "turns", "tool-io", "raw-events", "csv", "http", "mcp-batch-open"]
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ANALYTICS_SCHEMA_GOLDEN: &str = include_str!("analytics_schema_v1.golden.json");
+
+    #[test]
+    fn analytics_schema_json_matches_golden() {
+        let rendered = serde_json::to_string_pretty(&analytics_schema()).expect("render schema");
+        assert_eq!(rendered, ANALYTICS_SCHEMA_GOLDEN.trim_end());
+    }
+
+    #[test]
+    fn analytics_schema_has_expected_versions_and_defaults() {
+        let schema = analytics_schema();
+        assert_eq!(schema["schema_version"], "moraine.analytics.schema.v1");
+        assert_eq!(schema["data_schema_version"], EVENTS_SCHEMA_VERSION);
+        assert_eq!(
+            schema["default_columns"]
+                .as_array()
+                .expect("default columns"),
+            &DEFAULT_EVENT_COLUMNS
+                .iter()
+                .map(|name| json!(name))
+                .collect::<Vec<_>>()
+        );
+        assert!(schema["columns"]
+            .as_array()
+            .expect("columns")
+            .iter()
+            .any(|column| column["name"] == "event_ts"
+                && column["type"] == "string"
+                && column["default"] == true
+                && column["sensitive"] == false));
+    }
+
+    #[test]
+    fn sensitive_column_set_matches_contract() {
+        let sensitive = EVENT_COLUMNS
+            .iter()
+            .filter(|column| column.sensitive)
+            .map(|column| column.name)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            sensitive,
+            vec![
+                "source_file",
+                "source_ref",
+                "repo_rel_path",
+                "worktree_root",
+                "cwd",
+                "text_content",
+                "payload_json",
+                "token_usage_json",
+            ]
+        );
+    }
+
+    #[test]
+    fn default_columns_are_public_and_non_sensitive() {
+        for column in default_event_columns() {
+            assert!(column.default, "{} should be marked default", column.name);
+            assert!(!column.sensitive, "{} must not be sensitive", column.name);
+        }
+    }
+}

--- a/apps/moraine/src/commands/schema.rs
+++ b/apps/moraine/src/commands/schema.rs
@@ -23,7 +23,6 @@ pub(super) const DEFAULT_EVENT_COLUMNS: &[&str] = &[
     "tool_error",
     "model",
     "project_id",
-    "text_preview",
 ];
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -412,8 +411,8 @@ pub(super) const EVENT_COLUMNS: &[EventColumn] = &[
         "e.text_preview",
         "e.text_preview",
         "string",
-        true,
         false,
+        true,
     ),
     col(
         "text_content",
@@ -629,7 +628,7 @@ fn analytics_schema() -> serde_json::Value {
             "booleans": "emitted as JSON booleans"
         },
         "metadata_schema_version": EXPORT_METADATA_SCHEMA_VERSION,
-        "metadata_modes": ["stderr", "none", "file"],
+        "metadata_target": "stderr",
         "scope": {
             "included": ["events"],
             "excluded": ["sessions", "turns", "tool-io", "raw-events", "csv", "http", "mcp-batch-open"]
@@ -689,6 +688,7 @@ mod tests {
                 "repo_rel_path",
                 "worktree_root",
                 "cwd",
+                "text_preview",
                 "text_content",
                 "payload_json",
                 "token_usage_json",

--- a/apps/moraine/tests/export_cli.rs
+++ b/apps/moraine/tests/export_cli.rs
@@ -37,8 +37,6 @@ database = "moraine"
             "--format",
             "jsonl",
             "--all",
-            "--metadata",
-            "stderr",
             "--columns",
             "payload_json",
         ])

--- a/apps/moraine/tests/export_cli.rs
+++ b/apps/moraine/tests/export_cli.rs
@@ -1,0 +1,56 @@
+use std::fs;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const EXPORT_METADATA_SCHEMA_VERSION: &str = "moraine.analytics.export_metadata.v1";
+
+fn temp_config_path() -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "moraine-export-cli-test-{}-{nanos}.toml",
+        std::process::id()
+    ))
+}
+
+#[test]
+fn invalid_export_columns_emit_no_completion_metadata() {
+    let config = temp_config_path();
+    fs::write(
+        &config,
+        r#"
+[clickhouse]
+url = "http://127.0.0.1:9"
+database = "moraine"
+"#,
+    )
+    .expect("write temp config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_moraine"))
+        .arg("--config")
+        .arg(&config)
+        .args([
+            "export",
+            "events",
+            "--format",
+            "jsonl",
+            "--all",
+            "--metadata",
+            "stderr",
+            "--columns",
+            "payload_json",
+        ])
+        .output()
+        .expect("run moraine");
+    let _ = fs::remove_file(config);
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.is_empty(), "stdout should be empty: {stdout}");
+    assert!(stderr.contains("--include-sensitive"), "{stderr}");
+    assert!(!stdout.contains(EXPORT_METADATA_SCHEMA_VERSION), "{stdout}");
+    assert!(!stderr.contains(EXPORT_METADATA_SCHEMA_VERSION), "{stderr}");
+}

--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use moraine_config::ClickHouseConfig;
 use reqwest::{
     header::{CONTENT_LENGTH, CONTENT_TYPE},
-    Client, Url,
+    Client, RequestBuilder, Url,
 };
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
@@ -16,6 +16,30 @@ use std::time::Duration;
 pub struct ClickHouseClient {
     cfg: ClickHouseConfig,
     http: Client,
+}
+
+#[derive(Debug)]
+pub struct ClickHouseByteStream {
+    response: reqwest::Response,
+}
+
+impl ClickHouseByteStream {
+    pub async fn next_chunk(&mut self) -> Result<Option<Vec<u8>>> {
+        let chunk = self
+            .response
+            .chunk()
+            .await
+            .context("failed to read clickhouse response chunk")?;
+        Ok(chunk.map(|bytes| bytes.to_vec()))
+    }
+}
+
+struct ClickHouseRequestOptions<'a> {
+    database: Option<&'a str>,
+    async_insert: bool,
+    default_format: Option<&'a str>,
+    params: &'a [(&'a str, &'a str)],
+    request_timeout: Option<Duration>,
 }
 
 #[derive(Deserialize)]
@@ -77,6 +101,70 @@ impl ClickHouseClient {
         Url::parse(&self.cfg.url).context("invalid ClickHouse URL")
     }
 
+    fn request_builder(
+        &self,
+        query: &str,
+        body: Vec<u8>,
+        options: ClickHouseRequestOptions<'_>,
+    ) -> Result<RequestBuilder> {
+        let mut url = self.base_url()?;
+        {
+            let mut qp = url.query_pairs_mut();
+            qp.append_pair("query", query);
+            if let Some(database) = options.database {
+                qp.append_pair("database", database);
+            }
+            if let Some(default_format) = options.default_format {
+                qp.append_pair("default_format", default_format);
+            }
+            if options.async_insert && self.cfg.async_insert {
+                qp.append_pair("async_insert", "1");
+                if self.cfg.wait_for_async_insert {
+                    qp.append_pair("wait_for_async_insert", "1");
+                }
+            }
+            for (key, value) in options.params {
+                qp.append_pair(key, value);
+            }
+        }
+
+        // ClickHouse HTTP treats GET as readonly, so use POST for both reads and writes.
+        let payload_len = body.len();
+        let mut req = self
+            .http
+            .post(url)
+            .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+            // Some ClickHouse builds require an explicit Content-Length on POST.
+            .header(CONTENT_LENGTH, payload_len)
+            .body(body);
+
+        if let Some(timeout) = options.request_timeout {
+            req = req.timeout(timeout);
+        }
+
+        if !self.cfg.username.is_empty() {
+            req = req.basic_auth(self.cfg.username.clone(), Some(self.cfg.password.clone()));
+        }
+
+        Ok(req)
+    }
+
+    async fn send_checked_response(&self, req: RequestBuilder) -> Result<reqwest::Response> {
+        let response = req.send().await.context("clickhouse request failed")?;
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.with_context(|| {
+                format!(
+                    "failed to read clickhouse response body (status {})",
+                    status
+                )
+            })?;
+            return Err(anyhow!("clickhouse returned {}: {}", status, text));
+        }
+
+        Ok(response)
+    }
+
     pub async fn request_text(
         &self,
         query: &str,
@@ -98,44 +186,18 @@ impl ClickHouseClient {
         default_format: Option<&str>,
         params: &[(&str, &str)],
     ) -> Result<String> {
-        let mut url = self.base_url()?;
-        {
-            let mut qp = url.query_pairs_mut();
-            qp.append_pair("query", query);
-            if let Some(database) = database {
-                qp.append_pair("database", database);
-            }
-            if let Some(default_format) = default_format {
-                qp.append_pair("default_format", default_format);
-            }
-            if async_insert && self.cfg.async_insert {
-                qp.append_pair("async_insert", "1");
-                if self.cfg.wait_for_async_insert {
-                    qp.append_pair("wait_for_async_insert", "1");
-                }
-            }
-            for (key, value) in params {
-                qp.append_pair(key, value);
-            }
-        }
-
-        // ClickHouse HTTP treats GET as readonly, so use POST for both reads and writes.
-        let payload = body.unwrap_or_default();
-        let payload_len = payload.len();
-
-        let mut req = self
-            .http
-            .post(url)
-            .header(CONTENT_TYPE, "text/plain; charset=utf-8")
-            // Some ClickHouse builds require an explicit Content-Length on POST.
-            .header(CONTENT_LENGTH, payload_len)
-            .body(payload);
-
-        if !self.cfg.username.is_empty() {
-            req = req.basic_auth(self.cfg.username.clone(), Some(self.cfg.password.clone()));
-        }
-
-        let response = req.send().await.context("clickhouse request failed")?;
+        let req = self.request_builder(
+            query,
+            body.unwrap_or_default(),
+            ClickHouseRequestOptions {
+                database,
+                async_insert,
+                default_format,
+                params,
+                request_timeout: None,
+            },
+        )?;
+        let response = self.send_checked_response(req).await?;
         let status = response.status();
         let text = response.text().await.with_context(|| {
             format!(
@@ -144,11 +206,31 @@ impl ClickHouseClient {
             )
         })?;
 
-        if !status.is_success() {
-            return Err(anyhow!("clickhouse returned {}: {}", status, text));
-        }
-
         Ok(text)
+    }
+
+    pub async fn request_stream_with_params(
+        &self,
+        query: &str,
+        database: Option<&str>,
+        default_format: Option<&str>,
+        params: &[(&str, &str)],
+        request_timeout: Option<Duration>,
+    ) -> Result<ClickHouseByteStream> {
+        let req = self.request_builder(
+            query,
+            Vec::new(),
+            ClickHouseRequestOptions {
+                database,
+                async_insert: false,
+                default_format,
+                params,
+                request_timeout,
+            },
+        )?;
+        let response = self.send_checked_response(req).await?;
+
+        Ok(ClickHouseByteStream { response })
     }
 
     pub async fn ping(&self) -> Result<()> {
@@ -926,6 +1008,50 @@ mod tests {
     }
 
     #[derive(Clone)]
+    struct StreamCaptureState {
+        params: Arc<Mutex<Vec<HashMap<String, String>>>>,
+        content_lengths: Arc<Mutex<Vec<Option<String>>>>,
+    }
+
+    async fn spawn_stream_capture_server(state: StreamCaptureState) -> String {
+        async fn handler(
+            State(state): State<StreamCaptureState>,
+            Query(params): Query<HashMap<String, String>>,
+            headers: HeaderMap,
+        ) -> (StatusCode, &'static str) {
+            state
+                .params
+                .lock()
+                .expect("stream params mutex poisoned")
+                .push(params);
+            state
+                .content_lengths
+                .lock()
+                .expect("stream headers mutex poisoned")
+                .push(
+                    headers
+                        .get("content-length")
+                        .and_then(|value| value.to_str().ok())
+                        .map(ToString::to_string),
+                );
+
+            (StatusCode::OK, "{\"value\":1}\n{\"value\":2}\n")
+        }
+
+        let app = Router::new().route("/", post(handler)).with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind stream capture listener");
+        let addr = listener.local_addr().expect("listener addr");
+
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        format!("http://{}", addr)
+    }
+
+    #[derive(Clone)]
     struct SkewMockState {
         ledger_exists: bool,
         versions: Vec<String>,
@@ -1403,6 +1529,84 @@ mod tests {
             lengths.iter().all(|len| *len < MAX_INSERT_PAYLOAD_BYTES),
             "each captured payload should stay below the byte cap: {lengths:?}"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn request_stream_with_params_sends_read_settings_and_streams_chunks() {
+        let params = Arc::new(Mutex::new(Vec::<HashMap<String, String>>::new()));
+        let content_lengths = Arc::new(Mutex::new(Vec::<Option<String>>::new()));
+        let base_url = spawn_stream_capture_server(StreamCaptureState {
+            params: params.clone(),
+            content_lengths: content_lengths.clone(),
+        })
+        .await;
+        let client = ClickHouseClient::new(test_clickhouse_config(base_url)).expect("new client");
+
+        let mut stream = client
+            .request_stream_with_params(
+                "SELECT value FROM events FORMAT JSONEachRow",
+                Some("moraine"),
+                None,
+                &[
+                    ("query_id", "qid-test"),
+                    ("readonly", "1"),
+                    ("max_execution_time", "600"),
+                ],
+                Some(Duration::from_secs(630)),
+            )
+            .await
+            .expect("stream request");
+
+        let mut body = Vec::new();
+        while let Some(chunk) = stream.next_chunk().await.expect("chunk") {
+            body.extend_from_slice(&chunk);
+        }
+
+        assert_eq!(
+            String::from_utf8(body).expect("utf8"),
+            "{\"value\":1}\n{\"value\":2}\n"
+        );
+
+        let params = params.lock().expect("stream params mutex poisoned");
+        assert_eq!(params.len(), 1);
+        assert_eq!(
+            params[0].get("query").map(String::as_str),
+            Some("SELECT value FROM events FORMAT JSONEachRow")
+        );
+        assert_eq!(
+            params[0].get("database").map(String::as_str),
+            Some("moraine")
+        );
+        assert_eq!(
+            params[0].get("query_id").map(String::as_str),
+            Some("qid-test")
+        );
+        assert_eq!(params[0].get("readonly").map(String::as_str), Some("1"));
+        assert_eq!(
+            params[0].get("max_execution_time").map(String::as_str),
+            Some("600")
+        );
+
+        let content_lengths = content_lengths
+            .lock()
+            .expect("stream headers mutex poisoned");
+        assert_eq!(content_lengths.as_slice(), &[Some("0".to_string())]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn request_stream_with_params_includes_status_and_body_on_http_failure() {
+        let base_url = spawn_mock_server().await;
+        let client = ClickHouseClient::new(test_clickhouse_config(base_url)).expect("new client");
+
+        let err = client
+            .request_stream_with_params("SELECT FAIL", None, None, &[], None)
+            .await
+            .expect_err("expected HTTP failure");
+
+        let msg = err.to_string();
+        assert!(msg.contains("clickhouse returned"));
+        assert!(msg.contains("500"));
+        assert!(msg.contains("boom"));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/docs/export.md
+++ b/docs/export.md
@@ -1,0 +1,122 @@
+# Analytics Export
+
+Moraine can stream normalized event rows from the default ClickHouse backend for
+offline trace mining:
+
+```bash
+moraine export events \
+  --format jsonl \
+  --since 2026-06-01T00:00:00Z \
+  --until 2026-06-15T00:00:00Z \
+  --harness codex \
+  --project-id agent-stuff \
+  --columns session_id,event_uid,event_ts,turn_seq,event_kind,payload_type,actor_kind,tool_name,tool_phase,tool_error,text_content,payload_json \
+  --include-sensitive
+```
+
+V1 exports events only. Sessions, turns, tool I/O, raw events, CSV, named
+backend selection, MCP batch open, HTTP export, and monitor UI export are not in
+scope.
+
+## Row Format
+
+`moraine export events` requires `--format jsonl`. Stdout contains JSONL data
+rows only: one JSON object per line, UTF-8 encoded. Completion metadata is never
+written to stdout, so output can be piped into tools such as `jq`, `head`, or
+offline mining jobs.
+
+The global `--output` flag is for normal command rendering. Export commands
+reject explicit `--output plain`, `--output rich`, or `--output json`; use
+`--format jsonl` for export rows.
+
+## Schema
+
+Print the static, config-free public schema with:
+
+```bash
+moraine schema analytics --json
+```
+
+The v1 data schema is `moraine.analytics.events.v1`. Default event columns are:
+
+```text
+session_id,event_uid,event_ts,turn_seq,event_order,harness,source_name,event_kind,payload_type,actor_kind,tool_name,tool_phase,tool_error,model,project_id,text_preview
+```
+
+`--columns all` means all non-sensitive public v1 columns. It is not physical
+`SELECT *`.
+
+## Sensitive Columns
+
+The default export omits sensitive full text, payloads, token usage JSON, source
+references, and path-like fields. These columns require `--include-sensitive`
+when named in `--columns`:
+
+```text
+source_file,source_ref,repo_rel_path,worktree_root,cwd,text_content,payload_json,token_usage_json
+```
+
+Metadata is out of band, but it can still include the filter values supplied on
+the command line, including path filters. Treat metadata files and stderr logs as
+trace-adjacent data.
+
+## Filters
+
+Without `--all`, at least one filter is required. String filters are exact and
+case-sensitive. Repeat a flag to OR values within that field; different fields
+are ANDed together. Comma-separated value lists are rejected in v1.
+
+Supported filters:
+
+```text
+--since <rfc3339>
+--until <rfc3339>
+--session-id <id>
+--harness <name>
+--source-name <name>
+--project-id <id>
+--cwd-prefix <path>
+--worktree-root <path>
+--repo-rel-path <path>
+--event-kind <kind>
+--payload-type <type>
+--actor-kind <kind>
+--model-name <name>
+--tool-name <name>
+--tool-error-only
+```
+
+`--since` is inclusive and `--until` is exclusive. Both use Moraine's canonical
+event time: `record_ts` parsed as RFC3339 when possible, otherwise
+`ingested_at`. Public `event_ts` values are UTC RFC3339 strings with exactly
+millisecond precision, for example `2026-06-01T12:34:56.789Z`.
+
+## Metadata
+
+Completion metadata is one JSON object. By default it is written to stderr:
+
+```json
+{"schema_version":"moraine.analytics.export_metadata.v1","data_schema_version":"moraine.analytics.events.v1","export_kind":"events","backend":"default","query_id":"...","columns":["session_id","event_uid"],"filters":{"harness":["codex"]},"limit":1000,"row_count":1000,"truncated":true,"elapsed_ms":1234,"sensitive_columns_requested":[]}
+```
+
+Use `--metadata none` to suppress it, or `--metadata file --metadata-file <path>`
+to write it to a file. Metadata files are created before streaming starts so
+path errors fail before any data rows are emitted.
+
+Stream, preflight, and query failures exit nonzero and do not emit completion
+metadata. If stdout is closed by a downstream consumer, such as `head`, Moraine
+stops streaming, suppresses completion metadata, and exits successfully.
+
+## Limits And Schema Checks
+
+`--limit <n>` writes at most `n` rows. Moraine asks ClickHouse for `n + 1` rows
+and drops the sentinel row, so `truncated` metadata is exact.
+
+`--max-execution-seconds <n>` controls ClickHouse `max_execution_time` and
+defaults to 600 seconds. Set it to `0` to omit the ClickHouse execution-time
+setting; Moraine still uses a long client-side timeout for the streaming request.
+
+Exports run against the default `[clickhouse]` backend only. Before streaming,
+Moraine checks the backend migration ledger and refuses to export if the server
+schema is behind or ahead of this build. Run `moraine db migrate` for an older
+default backend, or upgrade Moraine if the server is newer.

--- a/docs/export.md
+++ b/docs/export.md
@@ -40,7 +40,7 @@ moraine schema analytics --json
 The v1 data schema is `moraine.analytics.events.v1`. Default event columns are:
 
 ```text
-session_id,event_uid,event_ts,turn_seq,event_order,harness,source_name,event_kind,payload_type,actor_kind,tool_name,tool_phase,tool_error,model,project_id,text_preview
+session_id,event_uid,event_ts,turn_seq,event_order,harness,source_name,event_kind,payload_type,actor_kind,tool_name,tool_phase,tool_error,model,project_id
 ```
 
 `--columns all` means all non-sensitive public v1 columns. It is not physical
@@ -48,16 +48,16 @@ session_id,event_uid,event_ts,turn_seq,event_order,harness,source_name,event_kin
 
 ## Sensitive Columns
 
-The default export omits sensitive full text, payloads, token usage JSON, source
-references, and path-like fields. These columns require `--include-sensitive`
-when named in `--columns`:
+The default export omits sensitive previews, full text, payloads, token usage
+JSON, source references, and path-like fields. These columns require
+`--include-sensitive` when named in `--columns`:
 
 ```text
-source_file,source_ref,repo_rel_path,worktree_root,cwd,text_content,payload_json,token_usage_json
+source_file,source_ref,repo_rel_path,worktree_root,cwd,text_preview,text_content,payload_json,token_usage_json
 ```
 
 Metadata is out of band, but it can still include the filter values supplied on
-the command line, including path filters. Treat metadata files and stderr logs as
+the command line, including path filters. Treat stderr metadata as
 trace-adjacent data.
 
 ## Filters
@@ -93,15 +93,11 @@ millisecond precision, for example `2026-06-01T12:34:56.789Z`.
 
 ## Metadata
 
-Completion metadata is one JSON object. By default it is written to stderr:
+Completion metadata is one JSON object written to stderr:
 
 ```json
 {"schema_version":"moraine.analytics.export_metadata.v1","data_schema_version":"moraine.analytics.events.v1","export_kind":"events","backend":"default","query_id":"...","columns":["session_id","event_uid"],"filters":{"harness":["codex"]},"limit":1000,"row_count":1000,"truncated":true,"elapsed_ms":1234,"sensitive_columns_requested":[]}
 ```
-
-Use `--metadata none` to suppress it, or `--metadata file --metadata-file <path>`
-to write it to a file. Metadata files are created before streaming starts so
-path errors fail before any data rows are emitted.
 
 Stream, preflight, and query failures exit nonzero and do not emit completion
 metadata. If stdout is closed by a downstream consumer, such as `head`, Moraine
@@ -111,10 +107,6 @@ stops streaming, suppresses completion metadata, and exits successfully.
 
 `--limit <n>` writes at most `n` rows. Moraine asks ClickHouse for `n + 1` rows
 and drops the sentinel row, so `truncated` metadata is exact.
-
-`--max-execution-seconds <n>` controls ClickHouse `max_execution_time` and
-defaults to 600 seconds. Set it to `0` to omit the ClickHouse execution-time
-setting; Moraine still uses a long client-side timeout for the streaming request.
 
 Exports run against the default `[clickhouse]` backend only. Before streaming,
 Moraine checks the backend migration ledger and refuses to export if the server

--- a/zensical.toml
+++ b/zensical.toml
@@ -14,6 +14,7 @@ nav = [
   { "Quickstart and Installation" = "quickstart.md" },
   { "Configuration" = "configuration.md" },
   { "Remote ClickHouse" = "remote-clickhouse.md" },
+  { "Analytics Export" = "export.md" },
   { "Agent MCP Search" = [
     { "Overview" = "agent-mcp-search/index.md" },
     { "Install by Harness" = "agent-mcp-search/install.md" },


### PR DESCRIPTION
## Description

**What.** Adds a V1 `moraine export events --format jsonl` CLI for streaming normalized analytics event rows from the default ClickHouse backend.

**Why.** Issue #428 calls for a stable, scriptable event export surface for offline trace mining while keeping prompt, output, payload, and path-like data behind explicit sensitivity opt-in.

This adds the export command, a config-free `moraine schema analytics --json` contract, ClickHouse streaming support, schema-skew checks before export, stderr completion metadata, default/non-sensitive column handling, sensitive column opt-in, deterministic filtering, and documentation.

Closes #428.

## Usage

```bash
moraine export events \
  --format jsonl \
  --since 2026-06-01T00:00:00Z \
  --until 2026-06-15T00:00:00Z \
  --harness codex \
  --columns session_id,event_uid,event_ts,turn_seq,text_preview \
  --include-sensitive
```

Inspect the static contract with:

```bash
moraine schema analytics --json
```

## Changelog

- Adds `moraine export events --format jsonl` for default-backend event JSONL export.
- Adds `moraine schema analytics --json` and a golden schema contract test.
- Gates sensitive columns, including `text_preview`, behind `--include-sensitive` and keeps defaults non-sensitive.
- Simplifies the export surface: row data always streams to stdout and completion metadata always writes to stderr.
- Keeps ClickHouse export safety controls internal with read-only query settings and an internal execution cap.
- Avoids unnecessary JSONL buffering by streaming complete chunk-local rows without front-draining accumulated bytes.
- Documents filters, stderr metadata, sensitive columns, limits, and schema checks.

## Operational Impact

Exports are read-only and target the default `[clickhouse]` backend. Before streaming, the CLI checks the migration ledger and refuses to export against a backend whose schema is behind or ahead of the current build. Stdout is always JSONL row data; one completion metadata JSON object is written to stderr after successful export completion.

## Validation

Local validation passed:

```bash
cargo fmt --all -- --check
cargo test -p moraine --locked export
cargo test -p moraine --locked schema_analytics
cargo test -p moraine-clickhouse --locked request_stream_with_params
make docs-build
```

The pre-commit hook also passed `make fmt` and the strict clippy baseline while creating commit `4bfd128`.

Sandbox QA used `sb-48a255` and was torn down successfully with `scripts/dev/sandbox/moraine-sandbox down sb-48a255`. Inside the sandbox, a seeded live ClickHouse export asserted:

- default export excludes sensitive `text_preview` and `payload_json`,
- `text_preview` fails without `--include-sensitive`,
- `text_preview` exports successfully with `--include-sensitive` and is reported in metadata,
- duplicate `event_uid` rows collapse to the latest `event_version`,
- computed `turn_seq` remains stable across user, assistant, and tool events,
- limit metadata reports exact truncation,
- completion metadata stays out of stdout,
- `--metadata` and `--max-execution-seconds` are absent from help,
- missing `--format` is rejected by clap before config/backend work,
- global `--output` is rejected with export-specific guidance.
