### PR TITLE
feat(plugins): add Moraine bug report skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,13 +4,13 @@
     "name": "Eric Tramel",
     "email": "eric.tramel@gmail.com"
   },
-  "description": "Moraine plugins for local agent-session search and realtime agent awareness.",
+  "description": "Moraine plugins for local agent-session search, realtime agent awareness, and sanitized bug reports.",
   "plugins": [
     {
       "name": "moraine",
       "displayName": "Moraine",
       "source": "./plugins/moraine",
-      "description": "Connect Claude Code to Moraine MCP search and bundled session-search skills.",
+      "description": "Connect Claude Code to Moraine MCP search and bundled Moraine guidance skills.",
       "author": {
         "name": "Eric Tramel",
         "email": "eric.tramel@gmail.com"
@@ -24,7 +24,8 @@
         "mcp",
         "claude-code",
         "agent-memory",
-        "search"
+        "search",
+        "bug-report"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ Codex, and Hermes, or to register Moraine MCP for supported harnesses such as
 OpenCode, Cursor, Kimi CLI, and Pi Coding Agent. The integrations use the
 `moraine` CLI on your `PATH` and the running local stack.
 
-Start a new agent session after installing an integration. Claude Code, Codex, and
-Hermes sessions get the `moraine:session-search` and `moraine:realtime-peek`
-guidance, and Moraine MCP tools are exposed with each harness's MCP naming
-scheme. Then ask:
+Start a new agent session after installing an integration. Claude Code, Codex,
+and Hermes sessions get `moraine:session-search`, `moraine:realtime-peek`, and
+`moraine:bug-report` guidance, and Moraine MCP tools are exposed with each
+harness's MCP naming scheme. Then ask:
 
 ```text
 What are my agents doing right now?

--- a/docs/agent-mcp-search/install.md
+++ b/docs/agent-mcp-search/install.md
@@ -30,10 +30,10 @@ wiring.
 ## Claude Code plugin marketplace (recommended)
 
 For Claude Code, the recommended user-scoped setup is the Moraine plugin. The
-plugin registers the MCP server and bundles Moraine search skills, but it does
-not install Moraine itself and it does not start ClickHouse, ingest, or the
-monitor. Install the CLI first, or upgrade it if Moraine is already installed.
-Then start the stack:
+plugin registers the MCP server and bundles Moraine search, realtime, and
+bug-report skills, but it does not install Moraine itself and it does not start
+ClickHouse, ingest, or the monitor. Install the CLI first, or upgrade it if
+Moraine is already installed. Then start the stack:
 
 ```bash
 uv tool install moraine-cli
@@ -79,8 +79,9 @@ Manual Claude MCP registration remains useful for project-scoped setup,
 ## Codex plugin marketplace (recommended)
 
 For Codex, the recommended user-scoped setup is the Moraine plugin. The plugin
-registers the MCP server and bundles Moraine search skills, but it does not
-install Moraine itself and it does not start ClickHouse, ingest, or the monitor.
+registers the MCP server and bundles Moraine search, realtime, and bug-report
+skills, but it does not install Moraine itself and it does not start ClickHouse,
+ingest, or the monitor.
 Install or upgrade the CLI first, then start the stack:
 
 ```bash
@@ -237,10 +238,11 @@ may ask you to approve project-scoped MCP servers before it uses them.
 
 For Hermes, the recommended user-scoped setup is `moraine setup`, which installs
 and enables the Moraine Hermes plugin, then asks the plugin to register MCP for
-the active Hermes profile. The plugin registers plugin-scoped Moraine search
-skills, injects compact guidance when the user asks about prior or active agent
-sessions, and adds setup/doctor commands. It still uses the `moraine` CLI on
-`PATH` and the running local stack.
+the active Hermes profile. The plugin registers plugin-scoped Moraine search,
+realtime, and bug-report skills, injects compact guidance when the user asks
+about prior or active agent sessions or Moraine bug reports, and adds
+setup/doctor commands. It still uses the `moraine` CLI on `PATH` and the running
+local stack.
 
 ```bash
 moraine setup --mcp-target hermes

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -112,12 +112,13 @@ Preview those changes without touching host agent config:
 moraine setup --dry-run --mcp-target claude-code --mcp-target codex --mcp-target hermes --mcp-target opencode --mcp-target cursor --mcp-target pi-coding-agent
 ```
 
-The Claude Code, Codex, and Hermes plugins bundle Moraine search guidance.
-`moraine setup` installs those plugins for default user-scoped setup, and
-registers MCP directly or writes global MCP config for supported harnesses such
-as Kimi CLI, OpenCode, Cursor, and Pi Coding Agent. These user-scoped
-integrations can search the host-wide Moraine history visible to your user, so
-enable them only in trusted harness environments.
+The Claude Code, Codex, and Hermes plugins bundle Moraine search, realtime, and
+sanitized bug-report guidance. `moraine setup` installs those plugins for
+default user-scoped setup, and registers MCP directly or writes global MCP
+config for supported harnesses such as Kimi CLI, OpenCode, Cursor, and Pi
+Coding Agent. These user-scoped integrations can search the host-wide Moraine
+history visible to your user, so enable them only in trusted harness
+environments.
 
 The same Codex marketplace also contains the contributor-only `moraine-dev`
 plugin for Moraine maintainers; end users should install `moraine@moraine`.

--- a/plugins/hermes-moraine/README.md
+++ b/plugins/hermes-moraine/README.md
@@ -14,9 +14,11 @@ hermes moraine doctor
 
 What it adds:
 
-- `moraine:session-search` and `moraine:realtime-peek` plugin skills.
+- `moraine:session-search`, `moraine:realtime-peek`, and
+  `moraine:bug-report` plugin skills.
 - A compact context hook that reminds Hermes how to use Moraine when a turn
-  asks about prior sessions, active agents, or agent history.
+  asks about prior sessions, active agents, agent history, or Moraine bug
+  reports.
 - `moraine_doctor`, a read-only tool for checking Moraine/Hermes wiring.
 - `hermes moraine status`, `hermes moraine doctor`, and `hermes moraine setup`.
 

--- a/plugins/hermes-moraine/__init__.py
+++ b/plugins/hermes-moraine/__init__.py
@@ -32,7 +32,7 @@ HERMES_FAILURE_MARKERS = (
     "not found",
     "traceback",
 )
-GUIDANCE_TRIGGERS = (
+SESSION_GUIDANCE_TRIGGERS = (
     "another agent",
     "other agent",
     "agents doing",
@@ -51,6 +51,14 @@ GUIDANCE_TRIGGERS = (
     "search sessions",
     "session history",
     "who touched",
+)
+BUG_REPORT_GUIDANCE_TRIGGERS = (
+    "bug report",
+    "file a bug",
+    "file an issue",
+    "github issue",
+    "report a bug",
+    "report an issue",
 )
 
 DOCTOR_SCHEMA = {
@@ -87,6 +95,11 @@ def register(ctx) -> None:
         PLUGIN_DIR / "skills" / "realtime-peek" / "SKILL.md",
         "Inspect active or very recent agent sessions through Moraine.",
     )
+    ctx.register_skill(
+        "bug-report",
+        PLUGIN_DIR / "skills" / "bug-report" / "SKILL.md",
+        "Prepare a sanitized Moraine bug report with explicit user approval.",
+    )
     ctx.register_tool(
         name="moraine_doctor",
         toolset=DIAGNOSTIC_TOOLSET,
@@ -114,15 +127,23 @@ def _doctor_tool(args: dict[str, Any], **_kwargs: Any) -> str:
 
 
 def _pre_llm_call(user_message: str = "", **_kwargs: Any) -> dict[str, str] | None:
-    """Inject compact Moraine guidance only on turns that imply session recall."""
+    """Inject compact Moraine guidance only on turns that imply it."""
     text = (user_message or "").lower()
     if "moraine guidance for hermes" in text:
         return None
-    if "moraine" not in text and not any(trigger in text for trigger in GUIDANCE_TRIGGERS):
+    mentions_moraine = "moraine" in text
+    wants_bug_report = mentions_moraine and any(
+        trigger in text for trigger in BUG_REPORT_GUIDANCE_TRIGGERS
+    )
+    wants_session_guidance = any(trigger in text for trigger in SESSION_GUIDANCE_TRIGGERS) or (
+        mentions_moraine and not wants_bug_report
+    )
+    if not wants_session_guidance and not wants_bug_report:
         return None
 
-    return {
-        "context": (
+    guidance: list[str] = []
+    if wants_session_guidance:
+        guidance.append(
             "Moraine guidance for Hermes: when the user asks about prior work, "
             "agent history, active agents, or files touched by other agents, use "
             "the Moraine MCP tools registered as `mcp_moraine_search_sessions`, "
@@ -135,7 +156,15 @@ def _pre_llm_call(user_message: str = "", **_kwargs: Any) -> dict[str, str] | No
             "missing, ask the user to run `hermes moraine doctor` or "
             "`hermes moraine setup`."
         )
-    }
+    if wants_bug_report:
+        guidance.append(
+            "Moraine bug-report guidance for Hermes: load "
+            "`skill_view(\"moraine:bug-report\")`, keep the report limited to "
+            "reproducible Moraine defects, redact private data and exact host "
+            "details, and ask for explicit posting confirmation before creating "
+            "or uploading a GitHub issue."
+        )
+    return {"context": " ".join(guidance)}
 
 
 def _setup_cli(parser) -> None:
@@ -403,7 +432,11 @@ def _doctor_report(*, run_mcp_test: bool) -> dict[str, Any]:
         "ok": ok,
         "summary": "Moraine is ready for Hermes." if ok else "Moraine needs attention before Hermes can search it.",
         "checks": checks,
-        "skills": ["moraine:session-search", "moraine:realtime-peek"],
+        "skills": [
+            "moraine:session-search",
+            "moraine:realtime-peek",
+            "moraine:bug-report",
+        ],
         "expected_tools": sorted(f"mcp_moraine_{tool}" for tool in REQUIRED_MCP_TOOLS),
     }
 

--- a/plugins/hermes-moraine/after-install.md
+++ b/plugins/hermes-moraine/after-install.md
@@ -24,5 +24,6 @@ Start a new Hermes session after setup. Ask:
 What are my agents doing right now?
 ```
 
-The plugin adds Moraine guidance and diagnostics, but the search tools still
-come from the MCP server launched as `moraine run mcp`.
+The plugin adds Moraine guidance, sanitized bug-report help, and diagnostics,
+but the search tools still come from the MCP server launched as
+`moraine run mcp`.

--- a/plugins/hermes-moraine/plugin.yaml
+++ b/plugins/hermes-moraine/plugin.yaml
@@ -1,7 +1,7 @@
 manifest_version: 1
 name: moraine
 version: "0.6.2"
-description: "Hermes integration for Moraine MCP session search, realtime agent awareness, and setup diagnostics."
+description: "Hermes integration for Moraine MCP session search, realtime agent awareness, sanitized bug reports, and setup diagnostics."
 author: "Moraine maintainers"
 provides_tools:
   - moraine_doctor
@@ -12,3 +12,4 @@ provides_commands:
 provides_skills:
   - session-search
   - realtime-peek
+  - bug-report

--- a/plugins/hermes-moraine/skills/bug-report/SKILL.md
+++ b/plugins/hermes-moraine/skills/bug-report/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: bug-report
+description: Help prepare and, only with explicit user approval, file a sanitized Moraine bug report for reproducible defects in Moraine itself.
+---
+
+# Bug Report
+
+Use this skill when the user hit a likely Moraine defect and wants help turning
+it into a useful GitHub issue. A Moraine bug is a reproducible problem in the
+Moraine CLI, ingest, monitor, MCP server, setup flow, packaging, documentation,
+or bundled plugins.
+
+Do not use this skill for general support, one-off local setup help, unrelated
+agent-harness issues, or private debugging that cannot be generalized into a
+Moraine repository issue. Troubleshoot those locally instead, and file a report
+only if the evidence points to a fixable Moraine defect.
+
+## Destination
+
+The Moraine repository is:
+
+```text
+https://github.com/eric-tramel/moraine
+```
+
+New bug reports go through GitHub Issues:
+
+```text
+https://github.com/eric-tramel/moraine/issues/new
+```
+
+If a GitHub issue tool, browser, or `gh` is available, use it only after the
+user explicitly confirms the final redacted report. If no posting tool is
+available, provide the issue URL and the prepared report body.
+
+## Consent Boundary
+
+Never silently post an issue on the user's behalf. Even if the user says "file
+it", first show the final sanitized title and body, then ask for explicit
+confirmation before creating the issue. If the user declines, stop after
+providing the draft.
+
+Do not upload logs, configs, screenshots, session transcripts, or command output
+without the same explicit confirmation.
+
+## Privacy Rules
+
+All bug reports must anonymize PII and host-specific details before they leave
+the user's machine.
+
+Redact or generalize:
+
+- Usernames, hostnames, emails, organization names, repo names, client names, and
+  internal project names.
+- Exact absolute paths such as home directories, workspace roots, socket paths,
+  and temp directories.
+- Secrets, tokens, API keys, cookies, auth headers, database URLs, and credentials.
+- Private prompts, agent transcripts, file contents, logs, or screenshots unless
+  the user explicitly approves a minimal sanitized excerpt.
+- Exact host environment details that fingerprint the machine. Prefer broad
+  labels like "macOS on Apple Silicon", "Linux x86_64", "Homebrew install", or
+  "uv tool install" instead of full hardware, hostname, local account, or full
+  directory layouts.
+
+Use placeholders such as `<home>`, `<repo>`, `<project>`, `<host>`,
+`<workspace>`, `<token>`, and `<private transcript omitted>`.
+
+## Triage
+
+Before drafting a report, determine whether the issue belongs in the Moraine
+repo:
+
+1. Identify the affected Moraine surface: CLI, setup, ingest source, monitor,
+   MCP search, ClickHouse schema, packaging, documentation, Codex plugin,
+   Claude Code plugin, Hermes plugin, or another bundled integration.
+2. Check whether the behavior is reproducible or has enough evidence to debug.
+3. Separate Moraine defects from user-specific environment problems. A missing
+   local dependency, local permissions issue, custom shell setup, broken external
+   harness install, or private repo configuration is usually support unless
+   Moraine handles it incorrectly or gives a misleading failure.
+4. Prefer a small sanitized reproducer over broad environment dumps.
+
+## Report Structure
+
+Draft reports in this shape:
+
+```markdown
+## Summary
+
+One or two sentences describing the Moraine bug and affected surface.
+
+## Affected Area
+
+- Moraine component: CLI | setup | ingest | monitor | MCP | packaging | docs | plugin
+- Harness, if relevant: Codex | Claude Code | Hermes | OpenCode | Cursor | Kimi CLI | Pi Coding Agent | other
+- Install method, if relevant: release bundle | uv tool | Homebrew | source checkout | unknown
+
+## Version
+
+- Moraine version: output of `moraine --version`, if available
+- Broad platform: sanitized OS and architecture category only
+
+## Steps To Reproduce
+
+1. Minimal first step.
+2. Minimal second step.
+3. Command or action that triggers the bug, with paths and private names replaced.
+
+## Expected Behavior
+
+What Moraine should have done.
+
+## Actual Behavior
+
+What happened instead, including the sanitized error message or symptom.
+
+## Sanitized Evidence
+
+Short redacted excerpts only. Replace private values with placeholders.
+
+## Workaround
+
+Known workaround, if any.
+
+## Notes
+
+Any suspected regression range, related issue, or additional context that does
+not expose private data.
+```
+
+## Evidence Collection
+
+Ask before running commands that may read local state. Prefer narrow commands
+whose output can be summarized and redacted, such as:
+
+```bash
+moraine --version
+moraine status
+moraine logs --lines 100
+```
+
+When logs are useful, include only the shortest sanitized excerpt that explains
+the failure. Do not include full session content or full config files. Summarize
+config shape instead of posting exact values.
+
+If prior agent context matters and Moraine MCP tools are available, use the
+current harness's Moraine search tools to recover the relevant session or error,
+then apply the same redaction rules before drafting the issue.
+
+## Posting Workflow
+
+1. Draft a sanitized title and body using the report structure.
+2. Point out any assumptions or missing reproduction details.
+3. Ask the user whether they want to post it to GitHub.
+4. If they say yes, show the final redacted report and ask for explicit posting
+   confirmation.
+5. Create the GitHub issue only after that confirmation, then return the issue
+   URL.
+6. If they do not confirm, leave them with the draft and the new-issue URL.

--- a/plugins/moraine/.claude-plugin/plugin.json
+++ b/plugins/moraine/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "moraine",
   "version": "0.6.2",
   "displayName": "Moraine",
-  "description": "Claude Code plugin for Moraine MCP session search and realtime agent awareness.",
+  "description": "Claude Code plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {
     "name": "Moraine maintainers",
     "email": "eric.tramel@gmail.com"
@@ -16,7 +16,8 @@
     "claude-code",
     "agent-memory",
     "session-search",
-    "realtime-agents"
+    "realtime-agents",
+    "bug-report"
   ],
   "mcpServers": "./.mcp.json"
 }

--- a/plugins/moraine/.codex-plugin/plugin.json
+++ b/plugins/moraine/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "moraine",
   "version": "0.6.2",
-  "description": "Codex plugin for Moraine MCP session search and realtime agent awareness.",
+  "description": "Codex plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {
     "name": "Moraine maintainers",
     "email": "eric.tramel@gmail.com",
@@ -16,14 +16,15 @@
     "codex",
     "agent-memory",
     "session-search",
-    "realtime-agents"
+    "realtime-agents",
+    "bug-report"
   ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Moraine",
-    "shortDescription": "Search local agent sessions from Codex.",
-    "longDescription": "Connects Codex to Moraine MCP session search, realtime agent awareness, and bundled guidance for recovering prior agent context.",
+    "shortDescription": "Use Moraine guidance from Codex.",
+    "longDescription": "Connects Codex to Moraine MCP session search, realtime agent awareness, and bundled guidance for recovering prior agent context or preparing sanitized Moraine bug reports.",
     "developerName": "Moraine maintainers",
     "category": "Developer Tools",
     "capabilities": [
@@ -32,7 +33,8 @@
     "defaultPrompt": [
       "Search my past agent sessions with Moraine.",
       "Check what another agent is doing now.",
-      "Find prior context for this issue."
+      "Find prior context for this issue.",
+      "Prepare a sanitized Moraine bug report."
     ],
     "brandColor": "#2F6F73"
   }

--- a/plugins/moraine/skills/bug-report/SKILL.md
+++ b/plugins/moraine/skills/bug-report/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: bug-report
+description: Help prepare and, only with explicit user approval, file a sanitized Moraine bug report for reproducible defects in Moraine itself.
+---
+
+# Bug Report
+
+Use this skill when the user hit a likely Moraine defect and wants help turning
+it into a useful GitHub issue. A Moraine bug is a reproducible problem in the
+Moraine CLI, ingest, monitor, MCP server, setup flow, packaging, documentation,
+or bundled plugins.
+
+Do not use this skill for general support, one-off local setup help, unrelated
+agent-harness issues, or private debugging that cannot be generalized into a
+Moraine repository issue. Troubleshoot those locally instead, and file a report
+only if the evidence points to a fixable Moraine defect.
+
+## Destination
+
+The Moraine repository is:
+
+```text
+https://github.com/eric-tramel/moraine
+```
+
+New bug reports go through GitHub Issues:
+
+```text
+https://github.com/eric-tramel/moraine/issues/new
+```
+
+If a GitHub issue tool, browser, or `gh` is available, use it only after the
+user explicitly confirms the final redacted report. If no posting tool is
+available, provide the issue URL and the prepared report body.
+
+## Consent Boundary
+
+Never silently post an issue on the user's behalf. Even if the user says "file
+it", first show the final sanitized title and body, then ask for explicit
+confirmation before creating the issue. If the user declines, stop after
+providing the draft.
+
+Do not upload logs, configs, screenshots, session transcripts, or command output
+without the same explicit confirmation.
+
+## Privacy Rules
+
+All bug reports must anonymize PII and host-specific details before they leave
+the user's machine.
+
+Redact or generalize:
+
+- Usernames, hostnames, emails, organization names, repo names, client names, and
+  internal project names.
+- Exact absolute paths such as home directories, workspace roots, socket paths,
+  and temp directories.
+- Secrets, tokens, API keys, cookies, auth headers, database URLs, and credentials.
+- Private prompts, agent transcripts, file contents, logs, or screenshots unless
+  the user explicitly approves a minimal sanitized excerpt.
+- Exact host environment details that fingerprint the machine. Prefer broad
+  labels like "macOS on Apple Silicon", "Linux x86_64", "Homebrew install", or
+  "uv tool install" instead of full hardware, hostname, local account, or full
+  directory layouts.
+
+Use placeholders such as `<home>`, `<repo>`, `<project>`, `<host>`,
+`<workspace>`, `<token>`, and `<private transcript omitted>`.
+
+## Triage
+
+Before drafting a report, determine whether the issue belongs in the Moraine
+repo:
+
+1. Identify the affected Moraine surface: CLI, setup, ingest source, monitor,
+   MCP search, ClickHouse schema, packaging, documentation, Codex plugin,
+   Claude Code plugin, Hermes plugin, or another bundled integration.
+2. Check whether the behavior is reproducible or has enough evidence to debug.
+3. Separate Moraine defects from user-specific environment problems. A missing
+   local dependency, local permissions issue, custom shell setup, broken external
+   harness install, or private repo configuration is usually support unless
+   Moraine handles it incorrectly or gives a misleading failure.
+4. Prefer a small sanitized reproducer over broad environment dumps.
+
+## Report Structure
+
+Draft reports in this shape:
+
+```markdown
+## Summary
+
+One or two sentences describing the Moraine bug and affected surface.
+
+## Affected Area
+
+- Moraine component: CLI | setup | ingest | monitor | MCP | packaging | docs | plugin
+- Harness, if relevant: Codex | Claude Code | Hermes | OpenCode | Cursor | Kimi CLI | Pi Coding Agent | other
+- Install method, if relevant: release bundle | uv tool | Homebrew | source checkout | unknown
+
+## Version
+
+- Moraine version: output of `moraine --version`, if available
+- Broad platform: sanitized OS and architecture category only
+
+## Steps To Reproduce
+
+1. Minimal first step.
+2. Minimal second step.
+3. Command or action that triggers the bug, with paths and private names replaced.
+
+## Expected Behavior
+
+What Moraine should have done.
+
+## Actual Behavior
+
+What happened instead, including the sanitized error message or symptom.
+
+## Sanitized Evidence
+
+Short redacted excerpts only. Replace private values with placeholders.
+
+## Workaround
+
+Known workaround, if any.
+
+## Notes
+
+Any suspected regression range, related issue, or additional context that does
+not expose private data.
+```
+
+## Evidence Collection
+
+Ask before running commands that may read local state. Prefer narrow commands
+whose output can be summarized and redacted, such as:
+
+```bash
+moraine --version
+moraine status
+moraine logs --lines 100
+```
+
+When logs are useful, include only the shortest sanitized excerpt that explains
+the failure. Do not include full session content or full config files. Summarize
+config shape instead of posting exact values.
+
+If prior agent context matters and Moraine MCP tools are available, use the
+current harness's Moraine search tools to recover the relevant session or error,
+then apply the same redaction rules before drafting the issue.
+
+## Posting Workflow
+
+1. Draft a sanitized title and body using the report structure.
+2. Point out any assumptions or missing reproduction details.
+3. Ask the user whether they want to post it to GitHub.
+4. If they say yes, show the final redacted report and ask for explicit posting
+   confirmation.
+5. Create the GitHub issue only after that confirmation, then return the issue
+   URL.
+6. If they do not confirm, leave them with the draft and the new-issue URL.


### PR DESCRIPTION
## Description

**What.** Adds a user-facing `moraine:bug-report` skill to the Moraine plugin integrations.

**Why.** Users need a consistent, privacy-preserving way to turn reproducible Moraine defects into actionable GitHub issues without leaking PII or host-specific details.

This adds the bug-report skill to the shared Codex/Claude Code plugin skill directory and the Hermes plugin skill directory. The skill points users at `https://github.com/eric-tramel/moraine`, gives a structured issue template, distinguishes reproducible Moraine bugs from general support or user-specific setup issues, and requires explicit user confirmation before posting or uploading anything.

Hermes now registers `moraine:bug-report`, advertises it in plugin metadata and doctor output, and injects a compact bug-report reminder only for Moraine-specific bug-report requests. Generic prompts such as reporting a bug in an unrelated app do not activate Moraine bug-report guidance.

## Usage

After installing or refreshing the user plugin through `moraine setup`, Codex, Claude Code, and Hermes sessions can use:

```text
Use moraine:bug-report to help me report a Moraine bug.
```

The agent should draft a sanitized report, ask whether the user wants to file it, then ask for explicit confirmation before creating the GitHub issue.

## Changelog

- Adds `moraine:bug-report` guidance for Codex, Claude Code, and Hermes plugin users.
- Updates plugin manifests, Hermes registration, Hermes doctor skill output, and setup docs to include the new skill.
- No Moraine runtime stack, database, ingest, monitor, or MCP protocol behavior change.

## Validation

Validated plugin metadata with `python3 -m json.tool` for the Codex/Claude marketplaces and Moraine plugin manifests. Checked Hermes plugin syntax with `python3 -m py_compile plugins/hermes-moraine/__init__.py` and parsed `plugins/hermes-moraine/plugin.yaml` with Ruby YAML.

Confirmed the Codex/Claude and Hermes `bug-report` skill files are identical with `diff -u`. Exercised Hermes hook routing with direct import assertions: generic app bug reports do not inject Moraine guidance; Moraine bug-report prompts inject only `moraine:bug-report`; prior-agent prompts still inject session-search guidance; general Moraine setup prompts keep the existing MCP guidance path.

Verified the three plugin harnesses in isolated homes. For Codex, a temp `CODEX_HOME` local marketplace install produced the installed cache with `skills/bug-report/SKILL.md` and exactly `bug-report`, `realtime-peek`, and `session-search` skill directories. For Claude Code, `claude plugin validate --strict` passed for the marketplace and plugin, and a temp `HOME` install reported `Skills (3) bug-report, realtime-peek, session-search` via `claude plugin details`; the cached bug-report skill contained the expected GitHub URL, consent boundary, PII redaction, and support-boundary text. For Hermes, a temp `HERMES_HOME` install from `file://...#plugins/hermes-moraine` enabled the plugin, `hermes moraine setup --no-test --json` succeeded, `hermes moraine doctor --no-mcp-test --json` returned `ok: true` with `moraine:bug-report` in `skills`, and the installed plugin contained `skills/bug-report/SKILL.md` alongside the two existing skills.

Ran `git diff --check`, `cargo test -p moraine --locked plugin`, and `make docs-build` successfully. A full delegated review wave ran across elegance, idiom, correctness, completeness, security, YAGNI, and scope; the accepted Hermes trigger-scope finding was fixed and re-checked clean. Sandbox QA was not run because this change does not touch ingest, MCP server behavior, monitor, ClickHouse schema, or stack lifecycle code.
