### PR TITLE
chore(release): cut v0.6.3

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.6.2)"
+        description: "Tag to release (for example v0.6.3)"
         required: true
         type: string
       target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "moraine"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "glob",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/moraine-ingest/Cargo.toml
+++ b/apps/moraine-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Moraine ingest service binary"
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Moraine MCP stdio server"
 

--- a/apps/moraine-monitor/Cargo.toml
+++ b/apps/moraine-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Moraine monitor HTTP/UI service"
 

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Unified runtime control plane for Moraine services"
 

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-clickhouse"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Shared Moraine ClickHouse client and query helpers"
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-config"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Shared Moraine configuration schema and loaders"
 

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-conversations"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "High-level read/query APIs for Moraine conversations"
 

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest-core"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Core ingestion pipeline internals for Moraine"
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp-core"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "MCP protocol and tool routing core for Moraine"
 

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor-core"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Analytics and query logic for Moraine monitor service"
 

--- a/plugins/hermes-moraine/plugin.yaml
+++ b/plugins/hermes-moraine/plugin.yaml
@@ -1,6 +1,6 @@
 manifest_version: 1
 name: moraine
-version: "0.6.2"
+version: "0.6.3"
 description: "Hermes integration for Moraine MCP session search, realtime agent awareness, sanitized bug reports, and setup diagnostics."
 author: "Moraine maintainers"
 provides_tools:

--- a/plugins/moraine/.claude-plugin/plugin.json
+++ b/plugins/moraine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "displayName": "Moraine",
   "description": "Claude Code plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {

--- a/plugins/moraine/.codex-plugin/plugin.json
+++ b/plugins/moraine/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Codex plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {
     "name": "Moraine maintainers",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ install directory precedence:
 
 examples:
   scripts/install.sh
-  MORAINE_INSTALL_VERSION=v0.6.2 scripts/install.sh
+  MORAINE_INSTALL_VERSION=v0.6.3 scripts/install.sh
   MORAINE_INSTALL_ASSET_BASE_URL=http://127.0.0.1:8080 \
     MORAINE_INSTALL_VERSION=ci-e2e scripts/install.sh
   MORAINE_INSTALL_DIR="$HOME/bin" MORAINE_INSTALL_SKIP_CLICKHOUSE=1 scripts/install.sh


### PR DESCRIPTION
## What changed

Bumps Moraine release-managed versions from `0.6.2` to `0.6.3` across the Rust workspace, lockfile, release workflow example tag, install-script example, and user plugin manifests.

## User-facing changes since v0.6.2

- [#430](https://github.com/eric-tramel/moraine/pull/430), [#433](https://github.com/eric-tramel/moraine/pull/433), and [#434](https://github.com/eric-tramel/moraine/pull/434) make ingest continue past oversized JSON rows/JSONL lines by quarantining compact metadata in `ingest_errors` instead of wedging the retry loop.
- [#429](https://github.com/eric-tramel/moraine/pull/429) adds `moraine export events --format jsonl` plus `moraine schema analytics --json` for scriptable analytics export with sensitive columns behind explicit opt-in.
- [#426](https://github.com/eric-tramel/moraine/pull/426) fixes plugin MCP startup for Cursor while keeping hardened plugin launch behavior for Codex and Claude Code.
- [#435](https://github.com/eric-tramel/moraine/pull/435) adds the `moraine:bug-report` skill to Codex, Claude Code, and Hermes plugin integrations.

## Validation

- `git diff --check` passed.
- `cargo fmt --all -- --check` passed.
- `cargo test --workspace --locked` passed.
- Plugin manifests parsed with `python3 -m json.tool` and Ruby YAML parsing.
- Pre-commit hook passed `make fmt` and the strict clippy baseline while creating the release commit.
- Sandbox QA `sb-9f2092` passed and was torn down successfully:
  - monitor health endpoint returned `ok: true` against ClickHouse 25.12.5.44,
  - `cargo test -p moraine-ingest-core --locked` passed inside the sandbox,
  - `cargo test -p moraine --locked export` passed inside the sandbox,
  - `MORAINECTL_BIN=/home/moraine/target/debug/moraine bash scripts/ci/e2e-stack.sh` passed inside the sandbox, including ingest, monitor API routes, and MCP smoke checks across supported harness fixtures.

## Operational impact

No config or schema migration is introduced by the release bump itself. After this PR merges, an annotated `v0.6.3` tag on the merge commit will trigger `.github/workflows/release-moraine.yml`, build release bundles, create GitHub release assets, and publish `moraine-cli==0.6.3` to PyPI via the tag-triggered `publish-pypi` job.
