### PR TITLE
fix(plugin): trust Moraine source checkout CLI

### DIFF
--- a/plugins/hermes-moraine/__init__.py
+++ b/plugins/hermes-moraine/__init__.py
@@ -211,14 +211,13 @@ def _handle_cli(args) -> None:
 
 def _setup_mcp(*, force: bool, run_test: bool) -> dict[str, Any]:
     steps: list[dict[str, Any]] = []
-    moraine = _resolve_executable("moraine")
+    moraine, trust = _resolve_trusted_moraine()
     if not moraine:
         return {
             "ok": False,
             "summary": "Moraine CLI was not found on PATH.",
             "steps": [{"status": "error", "message": "Install Moraine first, then rerun setup."}],
         }
-    trust = _moraine_path_trust(moraine)
     if trust:
         return {
             "ok": False,
@@ -374,10 +373,9 @@ def _save_hermes_config_section(config_path: Path, server_config: dict[str, Any]
 def _doctor_report(*, run_mcp_test: bool) -> dict[str, Any]:
     checks: list[dict[str, Any]] = []
 
-    moraine = _resolve_executable("moraine")
+    moraine, trust = _resolve_trusted_moraine()
     moraine_trusted = False
     if moraine:
-        trust = _moraine_path_trust(moraine)
         if trust:
             checks.append(_check("Moraine CLI", "error", trust, detail=f"Resolved path: {moraine}"))
         else:
@@ -583,12 +581,9 @@ def _string_list(value: Any) -> list[str] | None:
 
 
 def _moraine_command_mismatch(command: str) -> str:
-    trusted = _resolve_executable(MCP_SERVER_NAME)
+    trusted, trust = _resolve_trusted_moraine()
     if not trusted:
-        return "Could not find a trusted Moraine CLI on PATH to compare with the MCP registration."
-    trusted_issue = _moraine_path_trust(trusted)
-    if trusted_issue:
-        return trusted_issue
+        return trust or "Could not find a trusted Moraine CLI on PATH to compare with the MCP registration."
     try:
         if Path(command).resolve() != Path(trusted).resolve():
             return (
@@ -637,23 +632,100 @@ def _resolve_executable(name: str) -> str | None:
     return found if found else None
 
 
-def _moraine_path_trust(path: str) -> str:
+def _resolve_trusted_moraine() -> tuple[str | None, str]:
+    candidates = _resolve_executable_candidates(MCP_SERVER_NAME)
+    if not candidates:
+        return None, "Moraine CLI was not found on PATH."
+
+    first_issue = ""
+    for candidate in candidates:
+        issue = _moraine_path_trust(candidate, allow_source_checkout=False)
+        if not issue:
+            return candidate, ""
+        if not first_issue:
+            first_issue = issue
+
+    for candidate in candidates:
+        issue = _moraine_path_trust(candidate, allow_source_checkout=True)
+        if not issue:
+            return candidate, ""
+        if not first_issue:
+            first_issue = issue
+
+    return candidates[0], first_issue
+
+
+def _resolve_executable_candidates(name: str) -> list[str]:
+    paths = os.environ.get("PATH", "")
+    if not paths:
+        return []
+
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for directory in paths.split(os.pathsep):
+        if not directory:
+            continue
+        candidate = Path(directory) / name
+        if not candidate.is_file() or not os.access(candidate, os.X_OK):
+            continue
+        key = str(candidate)
+        if key in seen:
+            continue
+        seen.add(key)
+        candidates.append(key)
+    return candidates
+
+
+def _moraine_path_trust(path: str, *, allow_source_checkout: bool = True) -> str:
     candidate = Path(path)
     if not candidate.is_absolute():
         return "Moraine resolved to a non-absolute PATH entry; start Hermes from a trusted shell."
 
+    try:
+        resolved = candidate.resolve()
+    except OSError:
+        return "Could not resolve Moraine CLI path for trust checks."
+
+    if allow_source_checkout and _is_moraine_source_checkout_cli(resolved):
+        return ""
+
     cwd = Path.cwd().resolve()
     try:
-        if candidate.resolve().is_relative_to(cwd):
+        if resolved.is_relative_to(cwd):
             return "Moraine resolves inside the current project directory; prefer an installed CLI earlier on PATH."
     except OSError:
         return "Could not resolve Moraine CLI path for trust checks."
 
-    scan = candidate.resolve().parent
+    scan = resolved.parent
     for parent in [scan, *scan.parents]:
         if (parent / ".git").exists():
             return "Moraine resolves inside a Git worktree; prefer an installed CLI earlier on PATH."
     return ""
+
+
+def _is_moraine_source_checkout_cli(candidate: Path) -> bool:
+    for root in [candidate.parent, *candidate.parents]:
+        if not _looks_like_moraine_source_root(root):
+            continue
+        try:
+            relative = candidate.relative_to(root)
+        except ValueError:
+            continue
+        parts = relative.parts
+        if parts == ("bin", MCP_SERVER_NAME):
+            return True
+        if len(parts) >= 2 and parts[0] == "target" and parts[-1] == MCP_SERVER_NAME:
+            return True
+    return False
+
+
+def _looks_like_moraine_source_root(root: Path) -> bool:
+    return (
+        (root / "Cargo.toml").is_file()
+        and (root / "apps" / "moraine" / "Cargo.toml").is_file()
+        and (root / "crates" / "moraine-mcp-core" / "Cargo.toml").is_file()
+        and (root / "plugins" / "hermes-moraine" / "plugin.yaml").is_file()
+    )
 
 
 def _run_command(


### PR DESCRIPTION
## Description

**What.** Updates the Hermes Moraine plugin to resolve a usable Moraine CLI across all `PATH` candidates instead of failing on the first project-local candidate.

**Why.** After #437, `hermes moraine setup --no-test` no longer probes MCP, but it still failed when `moraine` resolved to this repository's `bin/moraine` wrapper while users were running setup from the Moraine checkout.

The resolver now prefers the first installed, non-worktree `moraine` on `PATH`. If no installed candidate exists, it allows `bin/moraine` or `target/**/moraine` only when that executable is inside a verified Moraine source checkout. Arbitrary current-project executables are still rejected.

## Bug Evidence

The failing command reported:

```text
hermes moraine setup --no-test --json
"detail": "Moraine resolves inside the current project directory; prefer an installed CLI earlier on PATH."
```

That happened even with the merged #437 plugin installed, because the remaining failure was the trust guard in `_moraine_path_trust`, not the old `hermes mcp add` probe.

## Usage

Users running from an installed CLI remain on the installed path. Developers running setup from the Moraine checkout can now use the repository wrapper:

```bash
PATH=/path/to/moraine/bin:$PATH hermes moraine setup --no-test
```

The plugin still rejects a fake `bin/moraine` in an arbitrary current project.

## Changelog

- Fixes Hermes setup from a Moraine source checkout when `bin/moraine` is first on `PATH`.
- Preserves the trust guard for arbitrary project-local `moraine` executables.

## Validation

Validated syntax with `PYTHONPATH=/Users/eric/.hermes/hermes-agent /Users/eric/.hermes/hermes-agent/venv/bin/python3 -m py_compile plugins/hermes-moraine/__init__.py`.

Exercised the resolver directly with temporary `HERMES_HOME` values: when `PATH` preferred `/Users/eric/src/moraine/bin` but an installed `/Users/eric/.local/bin/moraine` was later on `PATH`, setup wrote the installed path; when only `/Users/eric/src/moraine/bin` was available, setup accepted the source-checkout wrapper; when a fake current-project `bin/moraine` was available, setup still rejected it.

Loaded the branch plugin through a real temporary Hermes home and ran `/Users/eric/.local/bin/hermes moraine setup --no-test --json` with `PATH=/Users/eric/src/moraine/bin`; it returned `ok: true` and wrote `mcp_servers.moraine.command: /Users/eric/src/moraine/bin/moraine`.

Ran `git diff --check` successfully. Rust tests were not run because this is a Python-only Hermes plugin change.