### PR TITLE
docs: complete configuration reference

### DIFF
--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -134,7 +134,7 @@ pub struct McpConfig {
     pub default_exclude_codex_mcp: bool,
     #[serde(default = "default_false")]
     pub prewarm_on_initialize: bool,
-    #[serde(default = "default_false")]
+    #[serde(default = "default_true")]
     pub async_log_writes: bool,
     #[serde(default = "default_protocol_version")]
     pub protocol_version: String,
@@ -1421,6 +1421,7 @@ max_results = 25
         let cfg = load_config(&path).expect("legacy mcp config should load");
         std::fs::remove_file(&path).ok();
         assert_eq!(cfg.mcp.max_results, 25);
+        assert!(cfg.mcp.async_log_writes);
         assert!(cfg.mcp.use_central_server);
         assert!(cfg.mcp.start_central_on_up);
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,11 @@ Moraine reads TOML configuration. The default template is
 `config/moraine.toml`, and runtime installs normally use
 `~/.moraine/config.toml`.
 
+For a copyable, full-file reference with comments beside every supported key,
+see [Fully Commented Configuration TOML](full-config.toml). That file is
+intended as a documentation reference; the shipped runtime template stays more
+compact.
+
 ## Resolution Order
 
 The top-level `moraine` command resolves config in this order:
@@ -22,6 +27,25 @@ service-specific environment variables:
 | MCP | `MORAINE_MCP_CONFIG`, then `MORAINE_CONFIG` |
 | Monitor | `MORAINE_MONITOR_CONFIG`, then `MORAINE_CONFIG` |
 | Ingest | `MORAINE_INGEST_CONFIG`, then `MORAINE_CONFIG` |
+
+Unknown top-level sections and unknown keys inside normal config tables are
+rejected at load time. The only intentionally loose file is a repo-level
+`.moraine.toml`, which is a name-only backend reference and ignores unknown
+future keys.
+
+## Top-Level Sections
+
+| Section | Purpose |
+| --- | --- |
+| `[clickhouse]` | Default ClickHouse backend used by local ingest, monitor, MCP, and migrations. |
+| `[backends.<name>]` | Optional named ClickHouse backend for project mirroring and routed MCP. |
+| `[[routes]]` | Optional ordered working-directory routes to named backends. |
+| `[ingest]` | Ingest batching, backfill, watcher, checkpoint, and heartbeat settings. |
+| `[[ingest.sources]]` | Watched agent trace sources. |
+| `[mcp]` | MCP retrieval defaults and shared central server settings. |
+| `[bm25]` | Search ranking defaults. |
+| `[monitor]` | Monitor HTTP bind settings. |
+| `[runtime]` | Runtime directories, service startup behavior, and managed ClickHouse settings. |
 
 ## Minimal Example
 
@@ -57,6 +81,7 @@ password = ""
 timeout_seconds = 30.0
 async_insert = true
 wait_for_async_insert = true
+allow_newer_server = false
 ```
 
 For a managed local install, leave these values at their defaults. For an
@@ -67,6 +92,17 @@ server examples, see [Remote ClickHouse Tutorial](remote-clickhouse.md).
 `[clickhouse]` is an alias for `[backends.default]`. To mirror specific
 projects to additional servers, see
 [Backends and Per-Project Routing](#backends-and-per-project-routing).
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `url` | `http://127.0.0.1:8123` | ClickHouse HTTP endpoint. Managed ClickHouse is started only for local URLs; remote endpoints must already be running. |
+| `database` | `moraine` | Database containing Moraine tables. |
+| `username` | `default` | ClickHouse user for ingest, monitor, MCP, and migrations. |
+| `password` | empty | ClickHouse password. |
+| `timeout_seconds` | `30.0` | Per-request ClickHouse HTTP timeout. |
+| `async_insert` | `true` | Enables ClickHouse async insert mode on writes. |
+| `wait_for_async_insert` | `true` | Waits for async insert completion before advancing checkpoints, so write failures are visible. |
+| `allow_newer_server` | `false` | Allows a non-default backend whose migration ledger is ahead of this Moraine build. The default backend is migrated by Moraine itself, so this is only useful on `[backends.<name>]`. |
 
 ## Backends and Per-Project Routing
 
@@ -218,6 +254,15 @@ glob = "~/.claude/projects/**/*.jsonl"
 watch_root = "~/.claude/projects"
 format = "jsonl"
 ```
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `name` | empty string | Stable source name used in logs, checkpoints, heartbeats, and health output. |
+| `harness` | empty string | Source normalizer. Must be one of the supported harness values below. |
+| `enabled` | `true` | Keeps a source configured while allowing it to be skipped. |
+| `glob` | empty string | Files this source ingests. `~` expands during config load. |
+| `watch_root` | derived from `glob` when empty | Directory watched for changes. Set it explicitly when the glob root is ambiguous or platform-specific. |
+| `format` | inferred from `harness` and `glob` | On-disk parser: `jsonl`, `session_json`, `cursor_sqlite`, or `opencode_sqlite`. |
 
 Supported `harness` values are `codex`, `claude-code`, `cursor`, `kimi-cli`,
 `opencode`, `hermes`, and `pi-coding-agent`. Each value maps to a registered
@@ -433,7 +478,23 @@ state_dir = "~/.moraine/ingestor"
 backfill_on_start = true
 max_file_workers = 8
 max_inflight_batches = 16
+debounce_ms = 50
+reconcile_interval_seconds = 30.0
+heartbeat_interval_seconds = 5.0
 ```
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `batch_size` | `4000` | Maximum rows collected before a sink flushes to ClickHouse. |
+| `max_batch_bytes` | `8388608` | Maximum serialized JSONEachRow batch size, in bytes, before flushing. |
+| `flush_interval_seconds` | `0.5` | Maximum time a non-empty batch waits before flushing. |
+| `state_dir` | `~/.moraine/ingestor` | Directory for ingest checkpoints and local ingestor state. |
+| `backfill_on_start` | `true` | Enumerates matching files at startup and ingests records newer than stored checkpoints. |
+| `max_file_workers` | `8` | Maximum source files processed concurrently during enumeration, backfill, and replay. |
+| `max_inflight_batches` | `16` | Maximum pending batches between processors and sink tasks. |
+| `debounce_ms` | `50` | Milliseconds to coalesce repeated filesystem notifications for the same tracked file. |
+| `reconcile_interval_seconds` | `30.0` | Seconds between reconciliation scans for missed watcher events, deleted files, and lagging backend replay. |
+| `heartbeat_interval_seconds` | `5.0` | Seconds between ingest heartbeat writes. |
 
 ## MCP
 
@@ -455,6 +516,22 @@ start_central_on_up = true
 central_socket_path = "mcp.sock"
 central_connect_timeout_ms = 250
 ```
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `max_results` | `25` | Default result limit for MCP tools when a request omits an explicit limit. |
+| `preview_chars` | `320` | Text preview characters included per result row. |
+| `default_context_before` | `3` | Default number of records included before a matched event. |
+| `default_context_after` | `3` | Default number of records included after a matched event. |
+| `default_include_tool_events` | `false` | Includes tool-call and tool-result events in MCP responses by default. |
+| `default_exclude_codex_mcp` | `true` | Filters Moraine's own Codex MCP traffic by default to reduce self-noise. |
+| `prewarm_on_initialize` | `false` | Warms query metadata during MCP initialize, trading startup work for lower first-search latency. |
+| `async_log_writes` | `true` | Writes MCP observability rows asynchronously so tool calls stay responsive. |
+| `protocol_version` | `2024-11-05` | MCP protocol version advertised by the server. |
+| `use_central_server` | `true` | Makes `moraine run mcp` prefer the shared central server socket, with embedded fallback. |
+| `start_central_on_up` | `true` | Starts the shared central MCP server when `moraine up` starts services. |
+| `central_socket_path` | `mcp.sock` | Unix socket path. Bare filenames resolve under `runtime.pids_dir`; absolute paths are used verbatim. |
+| `central_connect_timeout_ms` | `250` | Milliseconds a proxy client waits for the central socket before falling back to embedded mode. |
 
 Raise `max_results` only when clients need larger result windows. Increase
 context defaults when retrieval snippets are too narrow.
@@ -514,6 +591,29 @@ max_query_terms = 32
 
 Most installations should keep these defaults.
 
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `k1` | `1.2` | BM25 term-frequency saturation. Larger values give repeated terms more influence. |
+| `b` | `0.75` | BM25 length normalization. `0` disables length normalization; `1` applies full normalization. |
+| `default_min_score` | `0.0` | Default minimum BM25 score when a request omits `min_score`. |
+| `default_min_should_match` | `1` | Default minimum number of query terms that should match. |
+| `max_query_terms` | `32` | Maximum query terms kept after tokenization. |
+
+## Monitor
+
+`[monitor]` controls the monitor HTTP server:
+
+```toml
+[monitor]
+host = "127.0.0.1"
+port = 8080
+```
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `host` | `127.0.0.1` | Interface the monitor binds. Keep the default for local-only access. |
+| `port` | `8080` | Monitor HTTP port. |
+
 ## Runtime Paths
 
 `[runtime]` controls where Moraine keeps state and where it finds service
@@ -526,11 +626,29 @@ logs_dir = "logs"
 pids_dir = "run"
 service_bin_dir = "~/.local/bin"
 managed_clickhouse_dir = "~/.local/lib/moraine/clickhouse/current"
+clickhouse_start_timeout_seconds = 30.0
+healthcheck_interval_ms = 500
 clickhouse_auto_install = true
+clickhouse_version = "v25.12.5.44-stable"
 start_monitor_on_up = true
+start_mcp_on_up = false
 ```
 
 Relative `logs_dir` and `pids_dir` values are resolved under `root_dir`.
 `service_bin_dir` must contain `moraine-ingest`, `moraine-monitor`, and
 `moraine-mcp`, unless `MORAINE_SERVICE_BIN_DIR` is set or source-tree mode is
 enabled.
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `root_dir` | `~/.moraine` | Root directory for Moraine runtime state. |
+| `logs_dir` | `logs` | Log directory. Relative paths resolve under `root_dir`. |
+| `pids_dir` | `run` | PID and socket directory. Relative paths resolve under `root_dir`. |
+| `service_bin_dir` | `~/.local/bin` | Directory containing installed service binaries. |
+| `managed_clickhouse_dir` | `~/.local/lib/moraine/clickhouse/current` | Directory for the managed ClickHouse installation. |
+| `clickhouse_start_timeout_seconds` | `30.0` | Seconds to wait for managed ClickHouse to become healthy during startup. |
+| `healthcheck_interval_ms` | `500` | Milliseconds between service health checks while waiting for startup. |
+| `clickhouse_auto_install` | `true` | Automatically installs the managed ClickHouse binary when needed. |
+| `clickhouse_version` | `v25.12.5.44-stable` | Managed ClickHouse release tag expected by this Moraine build. |
+| `start_monitor_on_up` | `true` | Starts the monitor service when `moraine up` starts services. |
+| `start_mcp_on_up` | `false` | Deprecated compatibility flag. Existing configs may keep it; new configs should use `mcp.start_central_on_up`. |

--- a/docs/full-config.toml
+++ b/docs/full-config.toml
@@ -1,0 +1,310 @@
+# Fully commented Moraine configuration reference.
+#
+# Runtime installs normally read ~/.moraine/config.toml. You can also point any
+# command at another file with --config, or set MORAINE_CONFIG. Service-specific
+# binaries also accept MORAINE_INGEST_CONFIG, MORAINE_MCP_CONFIG, or
+# MORAINE_MONITOR_CONFIG.
+#
+# The shipped runtime template is config/moraine.toml. This file is a more
+# verbose documentation reference: it includes every supported key, comments
+# for what each key does, and commented examples for optional named backends,
+# routes, and extra ingest sources.
+
+[clickhouse]
+# HTTP URL for the default ClickHouse backend. Moraine starts managed
+# ClickHouse only for local URLs; remote URLs must already be reachable.
+url = "http://127.0.0.1:8123"
+
+# Database Moraine reads and writes inside the default backend.
+database = "moraine"
+
+# ClickHouse username used by ingest, monitor, MCP, and migrations.
+username = "default"
+
+# ClickHouse password. Leave empty for the managed local default user.
+password = ""
+
+# Per-request ClickHouse HTTP timeout, in seconds.
+timeout_seconds = 30.0
+
+# Add async_insert=1 to writes so ClickHouse can acknowledge batched inserts
+# before fully flushing them.
+async_insert = true
+
+# Add wait_for_async_insert=1 so async inserts still report write errors before
+# Moraine advances checkpoints.
+wait_for_async_insert = true
+
+# Accept a server whose schema_migrations ledger is ahead of this Moraine
+# build. This is only meaningful for non-default backends; the default backend
+# is migrated by Moraine itself.
+allow_newer_server = false
+
+# Optional named ClickHouse backends for per-project mirroring and routed MCP.
+# The [clickhouse] block above is the "default" backend. Do not declare both
+# [clickhouse] and [backends.default] in the same file.
+#
+# [backends.team-ch]
+# url = "https://ch.team.example:8443"
+# database = "moraine_team"
+# username = "svc-moraine"
+# password = ""
+# timeout_seconds = 30.0
+# async_insert = true
+# wait_for_async_insert = true
+# allow_newer_server = false
+
+# Optional ordered routing rules. The first matching rule wins. Routed ingest
+# is mirrored to the named backend in addition to the default backend.
+#
+# [[routes]]
+# # Directory glob matched against the session's absolute working directory.
+# # "~" expands while loading config. A trailing "/**" matches the base
+# # directory itself and everything below it.
+# dir = "~/src/teamproject/**"
+#
+# # Name of a configured [backends.<name>] entry. "default" is accepted but is
+# # a no-op because the default backend already receives every session.
+# backend = "team-ch"
+#
+# # Routing mode. "mirror" is currently the only supported value.
+# mode = "mirror"
+
+[ingest]
+# Maximum rows collected before a sink flushes a batch to ClickHouse.
+batch_size = 4000
+
+# Maximum serialized JSONEachRow batch size, in bytes, before flushing.
+max_batch_bytes = 8388608
+
+# Maximum time, in seconds, that a non-empty sink batch waits before flushing.
+flush_interval_seconds = 0.5
+
+# Directory for ingest checkpoints and local ingestor state.
+state_dir = "~/.moraine/ingestor"
+
+# On service start, enumerate matching files and ingest anything newer than
+# stored checkpoints before continuing with live watch events.
+backfill_on_start = true
+
+# Maximum number of source files processed concurrently during enumeration,
+# backfill, and replay work.
+max_file_workers = 8
+
+# Maximum number of pending batches allowed between processors and sink tasks.
+max_inflight_batches = 16
+
+# Milliseconds to coalesce filesystem notifications for the same tracked file.
+debounce_ms = 50
+
+# Seconds between reconciliation scans that catch missed watcher events,
+# deleted files, and lagging backend replay opportunities.
+reconcile_interval_seconds = 30.0
+
+# Seconds between ingest heartbeat writes.
+heartbeat_interval_seconds = 5.0
+
+[[ingest.sources]]
+# Stable source name shown in logs, checkpoints, heartbeats, and health output.
+name = "codex"
+
+# Normalizer to use for records from this source.
+harness = "codex"
+
+# Set false to keep the source configured but skip ingesting it.
+enabled = true
+
+# Glob for files this source ingests. "~" expands while loading config.
+glob = "~/.codex/sessions/**/*.jsonl"
+
+# Directory watched for filesystem changes. If empty, Moraine derives it from
+# the glob prefix before the first wildcard.
+watch_root = "~/.codex/sessions"
+
+# On-disk format. Use "jsonl", "session_json", "cursor_sqlite", or
+# "opencode_sqlite". Empty or omitted means Moraine infers from harness+glob.
+format = "jsonl"
+
+[[ingest.sources]]
+# Claude Code JSONL project session files.
+name = "claude"
+harness = "claude-code"
+enabled = true
+glob = "~/.claude/projects/**/*.jsonl"
+watch_root = "~/.claude/projects"
+format = "jsonl"
+
+[[ingest.sources]]
+# Kimi CLI wire JSONL session files.
+name = "kimi-cli"
+harness = "kimi-cli"
+enabled = true
+glob = "~/.kimi/sessions/**/wire.jsonl"
+watch_root = "~/.kimi/sessions"
+format = "jsonl"
+
+[[ingest.sources]]
+# OpenCode SQLite conversation databases, read-only.
+name = "opencode"
+harness = "opencode"
+enabled = true
+glob = "~/.local/share/opencode/opencode*.db"
+watch_root = "~/.local/share/opencode"
+format = "opencode_sqlite"
+
+[[ingest.sources]]
+# Cursor Agent JSONL transcripts.
+name = "cursor"
+harness = "cursor"
+enabled = true
+glob = "~/.cursor/projects/*/agent-transcripts/**/*.jsonl"
+watch_root = "~/.cursor/projects"
+format = "jsonl"
+
+[[ingest.sources]]
+# Cursor IDE chat history stored in state.vscdb SQLite databases. On Linux,
+# use ~/.config/Cursor/User for glob and watch_root.
+name = "cursor-sqlite"
+harness = "cursor"
+enabled = true
+glob = "~/Library/Application Support/Cursor/User/**/state.vscdb"
+watch_root = "~/Library/Application Support/Cursor/User"
+format = "cursor_sqlite"
+
+[[ingest.sources]]
+# Pi Coding Agent JSONL session files.
+name = "pi"
+harness = "pi-coding-agent"
+enabled = true
+glob = "~/.pi/agent/sessions/**/*.jsonl"
+watch_root = "~/.pi/agent/sessions"
+format = "jsonl"
+
+[[ingest.sources]]
+# Hermes live session JSON files rewritten in place.
+name = "hermes"
+harness = "hermes"
+enabled = true
+glob = "~/.hermes/sessions/session_*.json"
+watch_root = "~/.hermes/sessions"
+format = "session_json"
+
+# Optional Hermes offline trajectory JSONL source. Uncomment and adjust the
+# path when a trajectory batch runner writes ShareGPT-compatible JSONL.
+#
+# [[ingest.sources]]
+# name = "hermes-trajectories"
+# harness = "hermes"
+# enabled = true
+# glob = "~/trajectories/**/*.jsonl"
+# watch_root = "~/trajectories"
+# format = "jsonl"
+
+[mcp]
+# Default maximum number of search/list rows returned by MCP tools when a
+# request does not provide an explicit limit.
+max_results = 25
+
+# Characters of text preview included per result row.
+preview_chars = 320
+
+# Default number of records included before a matched event when opening or
+# searching context.
+default_context_before = 3
+
+# Default number of records included after a matched event when opening or
+# searching context.
+default_context_after = 3
+
+# Include tool-call and tool-result events by default in MCP responses.
+default_include_tool_events = false
+
+# Exclude Moraine's own Codex MCP traffic by default to reduce self-noise.
+default_exclude_codex_mcp = true
+
+# Warm query metadata during MCP initialize. This can lower first-search
+# latency but increases startup work.
+prewarm_on_initialize = false
+
+# Write MCP request logs asynchronously. This keeps tool calls responsive while
+# still recording observability rows.
+async_log_writes = true
+
+# MCP protocol version advertised by the server.
+protocol_version = "2024-11-05"
+
+# Prefer the shared central MCP server when running "moraine run mcp". If the
+# socket is unavailable, Moraine falls back to an embedded stdio server.
+use_central_server = true
+
+# Launch the shared central MCP server when "moraine up" starts services.
+start_central_on_up = true
+
+# Unix socket path for the central MCP server. A bare filename resolves under
+# runtime.pids_dir; an absolute path is used as-is.
+central_socket_path = "mcp.sock"
+
+# Milliseconds a proxy client waits for the central socket before falling back
+# to embedded mode.
+central_connect_timeout_ms = 250
+
+[bm25]
+# BM25 term-frequency saturation. Larger values give repeated terms more
+# influence; most installs should keep the default.
+k1 = 1.2
+
+# BM25 length normalization. 0 disables length normalization; 1 applies full
+# normalization.
+b = 0.75
+
+# Default minimum BM25 score used when a request omits min_score.
+default_min_score = 0.0
+
+# Default minimum number of query terms that should match.
+default_min_should_match = 1
+
+# Maximum query terms kept after tokenization.
+max_query_terms = 32
+
+[monitor]
+# Interface the monitor HTTP server binds. Use 127.0.0.1 for local-only access.
+host = "127.0.0.1"
+
+# Monitor HTTP port.
+port = 8080
+
+[runtime]
+# Root directory for Moraine runtime state.
+root_dir = "~/.moraine"
+
+# Log directory. Relative paths resolve under runtime.root_dir.
+logs_dir = "logs"
+
+# PID and socket directory. Relative paths resolve under runtime.root_dir.
+pids_dir = "run"
+
+# Directory containing service binaries such as moraine-ingest,
+# moraine-monitor, and moraine-mcp.
+service_bin_dir = "~/.local/bin"
+
+# Directory for the managed ClickHouse installation.
+managed_clickhouse_dir = "~/.local/lib/moraine/clickhouse/current"
+
+# Seconds to wait for managed ClickHouse to become healthy during startup.
+clickhouse_start_timeout_seconds = 30.0
+
+# Milliseconds between service health checks while waiting for startup.
+healthcheck_interval_ms = 500
+
+# Automatically install the managed ClickHouse binary when needed.
+clickhouse_auto_install = true
+
+# Managed ClickHouse release tag expected by this Moraine build.
+clickhouse_version = "v25.12.5.44-stable"
+
+# Launch the monitor service when "moraine up" starts services.
+start_monitor_on_up = true
+
+# Deprecated compatibility flag. Existing configs may keep it; new configs
+# should use mcp.start_central_on_up.
+start_mcp_on_up = false


### PR DESCRIPTION
## Description

**What.** Completes the configuration reference and adds a fully commented TOML file for every supported config key.

**Why.** Users need one reviewable place to understand the complete Moraine config surface, including defaults, routing, ingest sources, MCP behavior, search tuning, monitor bind settings, and runtime paths.

This adds `docs/full-config.toml` as a copyable, commented reference and links it from `docs/configuration.md`. The configuration page now includes a top-level section map plus field/default/purpose tables for the normal config sections. While validating the docs, this also aligns `mcp.async_log_writes` serde omission behavior with the shipped template and documented default so partial `[mcp]` tables keep async logging enabled unless explicitly disabled.

## Usage

Read the configuration docs and open the linked full reference:

```text
docs/configuration.md -> docs/full-config.toml
```

Users can copy from the fully commented TOML when building a custom `~/.moraine/config.toml`.

## Changelog

- Adds a fully commented Moraine configuration TOML reference.
- Expands configuration documentation to cover every normal config section and key.
- Fixes partial `[mcp]` config loading so omitted `async_log_writes` defaults to `true`, matching the documented and shipped-template value.

## Operational Impact

No migrations or service lifecycle changes. Existing partial `[mcp]` configs that omit `async_log_writes` now keep asynchronous MCP log writes enabled by default; users can still set `async_log_writes = false` explicitly.

## Validation

Validated the new config reference by loading it through `cargo run -p moraine --locked -- --config docs/full-config.toml config get clickhouse.url`, which printed `http://127.0.0.1:8123`. Ran `cargo test -p moraine-config --locked`, `cargo fmt --all -- --check`, `git diff --check`, and `make docs-build` successfully; the generated site includes `site/full-config.toml` and links to it from `site/configuration.html`. The pre-commit hook also ran `make fmt` and the repository's strict clippy baseline successfully during commit. Sandbox QA was not run because this change does not touch ingest/MCP-core/monitor/schema or stack lifecycle code.
