### PR TITLE
feat(ingest): redact secrets before storage and egress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,7 @@ dependencies = [
 name = "moraine-ingest-core"
 version = "0.6.3"
 dependencies = [
+ "aho-corasick",
  "anyhow",
  "axum",
  "chrono",

--- a/config/moraine.toml
+++ b/config/moraine.toml
@@ -28,6 +28,14 @@ wait_for_async_insert = true
 # backend = "team-ch"
 # mode = "mirror"               # default; the only supported mode
 
+[redaction]
+# Secret redaction is default-on for all ingestion. This flag is honored only
+# from $HOME/.moraine/config.toml, and only for the local/default backend;
+# mirror egress to named backends is always redacted.
+# dangerously_skip_secret_redaction = true
+ruleset = "builtin"
+# extra_patterns = ["acme_internal_[A-Za-z0-9]{32}"]
+
 [ingest]
 batch_size = 4000
 max_batch_bytes = 8388608

--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -743,6 +743,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             name: "021_file_attention_normalization.sql",
             sql: include_str!("../../../sql/021_file_attention_normalization.sql"),
         },
+        Migration {
+            version: "022",
+            name: "022_heartbeat_redaction_counts.sql",
+            sql: include_str!("../../../sql/022_heartbeat_redaction_counts.sql"),
+        },
     ]
 }
 

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -92,6 +92,19 @@ pub struct RouteConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct RedactionConfig {
+    #[serde(default)]
+    pub dangerously_skip_secret_redaction: bool,
+    #[serde(default = "default_redaction_ruleset")]
+    pub ruleset: String,
+    #[serde(default)]
+    pub extra_patterns: Vec<String>,
+    #[serde(skip)]
+    pub dangerously_skip_secret_redaction_ignored: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct IngestConfig {
     #[serde(default = "default_sources")]
     pub sources: Vec<IngestSource>,
@@ -233,6 +246,8 @@ pub struct AppConfig {
     #[serde(default)]
     pub routes: Vec<RouteConfig>,
     #[serde(default)]
+    pub redaction: RedactionConfig,
+    #[serde(default)]
     pub ingest: IngestConfig,
     #[serde(default)]
     pub mcp: McpConfig,
@@ -302,6 +317,7 @@ impl Default for AppConfig {
             clickhouse,
             backends,
             routes: Vec::new(),
+            redaction: RedactionConfig::default(),
             ingest: IngestConfig::default(),
             mcp: McpConfig::default(),
             bm25: Bm25Config::default(),
@@ -325,6 +341,17 @@ impl Default for IngestConfig {
             debounce_ms: default_debounce_ms(),
             reconcile_interval_seconds: default_reconcile_interval_seconds(),
             heartbeat_interval_seconds: default_heartbeat_interval_seconds(),
+        }
+    }
+}
+
+impl Default for RedactionConfig {
+    fn default() -> Self {
+        Self {
+            dangerously_skip_secret_redaction: false,
+            ruleset: default_redaction_ruleset(),
+            extra_patterns: Vec::new(),
+            dangerously_skip_secret_redaction_ignored: false,
         }
     }
 }
@@ -735,6 +762,10 @@ fn default_route_mode() -> String {
     ROUTE_MODE_MIRROR.to_string()
 }
 
+fn default_redaction_ruleset() -> String {
+    "builtin".to_string()
+}
+
 fn default_k1() -> f64 {
     1.2
 }
@@ -1056,14 +1087,49 @@ fn normalize_config(mut cfg: AppConfig) -> Result<AppConfig> {
         resolve_runtime_subdir(&cfg.runtime.pids_dir, &cfg.mcp.central_socket_path);
 
     normalize_backends_and_routes(&mut cfg)?;
+    normalize_redaction(&mut cfg)?;
 
     Ok(cfg)
 }
 
-pub fn load_config(path: impl AsRef<Path>) -> Result<AppConfig> {
-    let content = std::fs::read_to_string(path.as_ref())
-        .with_context(|| format!("failed to read config {}", path.as_ref().display()))?;
-    let cfg: AppConfig = toml::from_str(&content).context("failed to parse TOML config")?;
+fn normalize_redaction(cfg: &mut AppConfig) -> Result<()> {
+    cfg.redaction.ruleset = cfg.redaction.ruleset.trim().to_ascii_lowercase();
+    if cfg.redaction.ruleset.is_empty() {
+        cfg.redaction.ruleset = default_redaction_ruleset();
+    }
+    if cfg.redaction.ruleset != "builtin" {
+        return Err(anyhow::anyhow!(
+            "invalid redaction.ruleset `{}`; only `builtin` is supported",
+            cfg.redaction.ruleset
+        ));
+    }
+    cfg.redaction.extra_patterns = cfg
+        .redaction
+        .extra_patterns
+        .iter()
+        .map(|pattern| pattern.trim().to_string())
+        .filter(|pattern| !pattern.is_empty())
+        .collect();
+    Ok(())
+}
+
+fn paths_refer_to_same_file(path: &Path, other: &Path) -> bool {
+    match (std::fs::canonicalize(path), std::fs::canonicalize(other)) {
+        (Ok(path), Ok(other)) => path == other,
+        _ => path == other,
+    }
+}
+
+fn path_is_home_config(path: &Path, home_path: Option<&Path>) -> bool {
+    home_path
+        .map(|home| paths_refer_to_same_file(path, home))
+        .unwrap_or(false)
+}
+
+fn load_config_with_home_path(path: &Path, home_path: Option<PathBuf>) -> Result<AppConfig> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read config {}", path.display()))?;
+    let mut cfg: AppConfig = toml::from_str(&content).context("failed to parse TOML config")?;
     // The struct-level parse cannot tell an explicit `[clickhouse]` block
     // from its serde default, so the both-declared ambiguity is detected on
     // the raw TOML document instead.
@@ -1078,7 +1144,19 @@ pub fn load_config(path: impl AsRef<Path>) -> Result<AppConfig> {
             "config declares both [clickhouse] and [backends.default]; they are aliases for the same backend — keep exactly one"
         ));
     }
+
+    if cfg.redaction.dangerously_skip_secret_redaction
+        && !path_is_home_config(path, home_path.as_deref())
+    {
+        cfg.redaction.dangerously_skip_secret_redaction = false;
+        cfg.redaction.dangerously_skip_secret_redaction_ignored = true;
+    }
+
     normalize_config(cfg)
+}
+
+pub fn load_config(path: impl AsRef<Path>) -> Result<AppConfig> {
+    load_config_with_home_path(path.as_ref(), home_config_path())
 }
 
 /// Name of the optional repo-level backend reference file. It carries a
@@ -1147,6 +1225,94 @@ mod tests {
         ));
         std::fs::write(&path, contents).expect("write temp config");
         path
+    }
+
+    #[test]
+    fn redaction_defaults_to_enabled() {
+        let path = write_temp_config("", "redaction-defaults");
+        let cfg = load_config(&path).expect("empty config should load with defaults");
+
+        assert!(!cfg.redaction.dangerously_skip_secret_redaction);
+        assert_eq!(cfg.redaction.ruleset, "builtin");
+        assert!(cfg.redaction.extra_patterns.is_empty());
+        assert!(!cfg.redaction.dangerously_skip_secret_redaction_ignored);
+
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn redaction_skip_is_honored_from_home_config_path() {
+        let path = write_temp_config(
+            r#"
+[redaction]
+dangerously_skip_secret_redaction = true
+"#,
+            "redaction-home-skip",
+        );
+        let cfg = load_config_with_home_path(&path, Some(path.clone()))
+            .expect("home config skip should load");
+
+        assert!(cfg.redaction.dangerously_skip_secret_redaction);
+        assert!(!cfg.redaction.dangerously_skip_secret_redaction_ignored);
+
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn redaction_skip_is_ignored_outside_home_config_path() {
+        let path = write_temp_config(
+            r#"
+[redaction]
+dangerously_skip_secret_redaction = true
+"#,
+            "redaction-repo-skip",
+        );
+        let home = std::env::temp_dir().join("moraine-config-home-does-not-match.toml");
+        let cfg = load_config_with_home_path(&path, Some(home))
+            .expect("non-home config skip should be ignored");
+
+        assert!(!cfg.redaction.dangerously_skip_secret_redaction);
+        assert!(cfg.redaction.dangerously_skip_secret_redaction_ignored);
+
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn redaction_rejects_allowlist_policy_key() {
+        let path = write_temp_config(
+            r#"
+[redaction]
+allowlist = ["AKIAEXAMPLEEXAMPLE12"]
+"#,
+            "redaction-allowlist",
+        );
+        let err = load_config(&path).expect_err("unknown redaction keys should fail");
+
+        assert!(
+            format!("{err:#}").contains("unknown field `allowlist`"),
+            "error names unknown redaction key: {err:#}"
+        );
+
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn redaction_rejects_unknown_ruleset() {
+        let path = write_temp_config(
+            r#"
+[redaction]
+ruleset = "custom"
+"#,
+            "redaction-ruleset",
+        );
+        let err = load_config(&path).expect_err("unknown ruleset should fail");
+
+        assert!(
+            format!("{err:#}").contains("invalid redaction.ruleset"),
+            "error names redaction ruleset: {err:#}"
+        );
+
+        std::fs::remove_file(path).ok();
     }
 
     #[test]

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -6,6 +6,7 @@ description = "Core ingestion pipeline internals for Moraine"
 
 [dependencies]
 anyhow = "1.0"
+aho-corasick = "1.1"
 glob = "0.3"
 notify = "7.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/moraine-ingest-core/src/lib.rs
+++ b/crates/moraine-ingest-core/src/lib.rs
@@ -4,6 +4,7 @@ mod heartbeat;
 pub mod model;
 pub mod normalize;
 mod reconcile;
+mod redaction;
 mod sink;
 mod sources;
 pub mod sqlite_poll;
@@ -14,8 +15,11 @@ use crate::checkpoint::checkpoint_key;
 use crate::dispatch::{enqueue_work, run_work_item, spawn_debounce_task};
 use crate::model::RowBatch;
 use crate::reconcile::spawn_reconcile_task;
+use crate::redaction::{RedactionAudit, SecretRedactor};
 use crate::sink::{spawn_sink_task, SinkRole};
-use crate::tee::{spawn_tee_router, RouteResolver, SharedRouteResolver, StatusRegistry};
+use crate::tee::{
+    spawn_tee_router, RedactionContext, RouteResolver, SharedRouteResolver, StatusRegistry,
+};
 use crate::watch::{enumerate_tracked_files, spawn_watcher_threads};
 use anyhow::{Context, Result};
 use moraine_clickhouse::ClickHouseClient;
@@ -123,7 +127,7 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
         .keys()
         .any(|name| name != DEFAULT_BACKEND_NAME);
     let heartbeat_backend_column = if has_named_backends {
-        let available = heartbeat_backend_sinks_column_available(&clickhouse)
+        let available = heartbeat_column_available(&clickhouse, "backend_sinks")
             .await
             .context("failed to inspect ingest_heartbeats columns")?;
         if !available {
@@ -137,10 +141,35 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
     } else {
         false
     };
+    let heartbeat_redactions_column = heartbeat_column_available(&clickhouse, "redactions_total")
+        .await
+        .context("failed to inspect ingest_heartbeats redaction columns")?;
+    if !heartbeat_redactions_column {
+        warn!(
+            "ingest_heartbeats is missing the redactions_total column (migration 022); \
+             redaction audit counts will not appear in heartbeats until \
+             `moraine db migrate` runs and this ingest service restarts"
+        );
+    }
 
     let checkpoints = Arc::new(RwLock::new(checkpoint_map));
     let dispatch = Arc::new(Mutex::new(DispatchState::default()));
     let metrics = Arc::new(Metrics::default());
+    let redactor = Arc::new(
+        SecretRedactor::new(&config.redaction).context("failed to initialize secret redaction")?,
+    );
+    let redaction_audit = Arc::new(RedactionAudit::default());
+    if config.redaction.dangerously_skip_secret_redaction_ignored {
+        warn!(
+            "ignoring redaction.dangerously_skip_secret_redaction from non-home config; only \
+             $HOME/.moraine/config.toml may disable local secret redaction"
+        );
+    }
+    if config.redaction.dangerously_skip_secret_redaction {
+        warn!(
+            "local/default secret redaction disabled by home config; mirror backend egress remains redacted"
+        );
+    }
 
     let process_queue_capacity = config
         .ingest
@@ -174,6 +203,8 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
             dispatch: dispatch.clone(),
             backends: backend_statuses.clone(),
             backend_sinks_column: heartbeat_backend_column,
+            redactions_column: heartbeat_redactions_column,
+            redactions: redaction_audit.clone(),
         },
     );
 
@@ -184,6 +215,7 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
         default_sink_tx,
         resolver,
         backend_statuses,
+        RedactionContext::new(redactor, redaction_audit),
     );
 
     let sem = Arc::new(Semaphore::new(config.ingest.max_file_workers.max(1)));
@@ -345,10 +377,10 @@ async fn checkpoint_cursor_columns_available(clickhouse: &ClickHouseClient) -> R
         .unwrap_or(false))
 }
 
-/// Returns whether `ingest_heartbeats` carries the `backend_sinks` column
-/// added by migration 017. Inserting it unconditionally would break every
-/// heartbeat on a database that has not run `moraine db migrate` yet.
-async fn heartbeat_backend_sinks_column_available(clickhouse: &ClickHouseClient) -> Result<bool> {
+/// Returns whether `ingest_heartbeats` carries an optional heartbeat column.
+/// Inserting optional columns unconditionally would break every heartbeat on a
+/// database that has not run the corresponding `moraine db migrate` yet.
+async fn heartbeat_column_available(clickhouse: &ClickHouseClient, column: &str) -> Result<bool> {
     #[derive(Deserialize)]
     struct CountRow {
         column_count: u64,
@@ -357,8 +389,9 @@ async fn heartbeat_backend_sinks_column_available(clickhouse: &ClickHouseClient)
     let query = format!(
         "SELECT toUInt64(count()) AS column_count \
          FROM system.columns \
-         WHERE database = '{}' AND table = 'ingest_heartbeats' AND name = 'backend_sinks'",
-        clickhouse.config().database.replace('\'', "\\'")
+         WHERE database = '{}' AND table = 'ingest_heartbeats' AND name = '{}'",
+        clickhouse.config().database.replace('\'', "\\'"),
+        column.replace('\'', "\\'")
     );
     let rows: Vec<CountRow> = clickhouse.query_rows(&query, None).await?;
     Ok(rows

--- a/crates/moraine-ingest-core/src/model.rs
+++ b/crates/moraine-ingest-core/src/model.rs
@@ -91,6 +91,11 @@ impl RowBatch {
                 .sum::<usize>()
     }
 
+    pub(crate) fn recompute_approx_bytes(&mut self) {
+        self.approx_bytes = 0;
+        self.approx_bytes = self.approx_bytes();
+    }
+
     pub fn push_raw_row(&mut self, row: Value) {
         self.approx_bytes = self
             .approx_bytes

--- a/crates/moraine-ingest-core/src/redaction.rs
+++ b/crates/moraine-ingest-core/src/redaction.rs
@@ -1,0 +1,1037 @@
+use crate::model::RowBatch;
+use crate::sources::shared::{io_hash, raw_hash, truncate_chars, PREVIEW_LIMIT};
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
+use anyhow::{Context, Result};
+use moraine_config::RedactionConfig;
+use regex::bytes::{Regex, RegexSet};
+use serde_json::{json, Map, Value};
+use std::cmp::Reverse;
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+#[derive(Clone, Copy, Debug)]
+enum EntropyGate {
+    None,
+    GenericCredential,
+}
+
+#[derive(Clone, Debug)]
+struct Rule {
+    id: String,
+    pattern: String,
+    regex: Regex,
+    keywords: Vec<String>,
+    secret_group: usize,
+    entropy_gate: EntropyGate,
+    min_len: usize,
+    priority: usize,
+}
+
+#[derive(Debug)]
+struct KeywordPrefilter {
+    matcher: AhoCorasick,
+    rules_by_pattern: Vec<Vec<usize>>,
+    always_scan_rules: Vec<usize>,
+}
+
+#[derive(Clone, Debug)]
+struct RedactionSpan {
+    start: usize,
+    end: usize,
+    rule_id: String,
+    priority: usize,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct ScrubbedText {
+    pub(crate) text: String,
+    pub(crate) counts: BTreeMap<String, u64>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct BatchRedactionReport {
+    pub(crate) total: u64,
+    pub(crate) per_rule: BTreeMap<String, u64>,
+}
+
+#[derive(Debug)]
+pub(crate) struct SecretRedactor {
+    rules: Vec<Rule>,
+    prefilter: Option<KeywordPrefilter>,
+    regex_set: RegexSet,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct RedactionAudit {
+    counts: Mutex<BTreeMap<String, u64>>,
+}
+
+impl SecretRedactor {
+    pub(crate) fn new(config: &RedactionConfig) -> Result<Self> {
+        if config.ruleset != "builtin" {
+            return Err(anyhow::anyhow!(
+                "invalid redaction.ruleset `{}`; only `builtin` is supported",
+                config.ruleset
+            ));
+        }
+
+        let specs = builtin_rules()?;
+        let mut rules = specs
+            .iter()
+            .enumerate()
+            .map(|(priority, spec)| spec.compile(priority))
+            .collect::<Result<Vec<_>>>()?;
+        for (idx, pattern) in config.extra_patterns.iter().enumerate() {
+            let id = format!("extra-pattern-{}", idx + 1);
+            rules.push(Rule {
+                id: id.clone(),
+                pattern: pattern.clone(),
+                regex: Regex::new(pattern).with_context(|| {
+                    format!("failed to compile redaction.extra_patterns[{idx}] for {id}")
+                })?,
+                keywords: Vec::new(),
+                secret_group: 0,
+                entropy_gate: EntropyGate::None,
+                min_len: 1,
+                priority: rules.len(),
+            });
+        }
+        let regex_set = RegexSet::new(rules.iter().map(|rule| rule.pattern.as_str()))
+            .context("failed to compile redaction regex set")?;
+        let prefilter = build_prefilter(&rules)?;
+
+        Ok(Self {
+            rules,
+            prefilter,
+            regex_set,
+        })
+    }
+
+    pub(crate) fn redact_batch(&self, batch: &mut RowBatch) -> BatchRedactionReport {
+        let mut report = BatchRedactionReport::default();
+
+        for row in &mut batch.raw_rows {
+            let counts = self.redact_raw_row(row);
+            report.record(counts);
+        }
+        for row in &mut batch.event_rows {
+            let counts = self.redact_event_row(row);
+            report.record(counts);
+        }
+        for row in &mut batch.tool_rows {
+            let counts = self.redact_tool_row(row);
+            report.record(counts);
+        }
+        for row in &mut batch.error_rows {
+            let counts = self.redact_error_row(row);
+            report.record(counts);
+        }
+
+        batch.recompute_approx_bytes();
+        report
+    }
+
+    pub(crate) fn scrub_text(&self, text: &str) -> ScrubbedText {
+        let spans = self.non_overlapping_spans(text);
+        if spans.is_empty() {
+            return ScrubbedText {
+                text: text.to_string(),
+                counts: BTreeMap::new(),
+            };
+        }
+
+        let mut out = String::with_capacity(text.len());
+        let mut last = 0usize;
+        let mut counts = BTreeMap::<String, u64>::new();
+        for span in spans {
+            out.push_str(&text[last..span.start]);
+            out.push_str("[REDACTED:");
+            out.push_str(&span.rule_id);
+            out.push(']');
+            last = span.end;
+            *counts.entry(span.rule_id).or_default() += 1;
+        }
+        out.push_str(&text[last..]);
+
+        ScrubbedText { text: out, counts }
+    }
+
+    fn non_overlapping_spans(&self, text: &str) -> Vec<RedactionSpan> {
+        let placeholder_ranges = placeholder_ranges(text);
+        let candidate_rules = self.prefilter_candidates(text);
+        if candidate_rules.iter().all(|candidate| !candidate) {
+            return Vec::new();
+        }
+
+        let set_matches = self.regex_set.matches(text.as_bytes());
+        let mut spans = Vec::<RedactionSpan>::new();
+
+        for rule_idx in set_matches.iter() {
+            if !candidate_rules[rule_idx] {
+                continue;
+            }
+            let rule = &self.rules[rule_idx];
+
+            for captures in rule.regex.captures_iter(text.as_bytes()) {
+                let Some(secret) = captures.get(rule.secret_group) else {
+                    continue;
+                };
+                if span_overlaps(&placeholder_ranges, secret.start(), secret.end()) {
+                    continue;
+                }
+                let Ok(candidate) = std::str::from_utf8(secret.as_bytes()) else {
+                    continue;
+                };
+                if !self.should_redact(rule, candidate) {
+                    continue;
+                }
+                spans.push(RedactionSpan {
+                    start: secret.start(),
+                    end: secret.end(),
+                    rule_id: rule.id.clone(),
+                    priority: rule.priority,
+                });
+            }
+        }
+
+        spans.sort_by_key(|span| {
+            (
+                span.start,
+                Reverse(span.end.saturating_sub(span.start)),
+                span.priority,
+            )
+        });
+
+        let mut kept = Vec::<RedactionSpan>::new();
+        let mut occupied_until = 0usize;
+        for span in spans {
+            if span.start < occupied_until {
+                continue;
+            }
+            occupied_until = span.end;
+            kept.push(span);
+        }
+        kept
+    }
+
+    fn should_redact(&self, rule: &Rule, candidate: &str) -> bool {
+        if candidate.len() < rule.min_len || candidate.contains("[REDACTED:") {
+            return false;
+        }
+
+        match rule.entropy_gate {
+            EntropyGate::None => true,
+            EntropyGate::GenericCredential => generic_candidate_is_secret(candidate),
+        }
+    }
+
+    fn prefilter_candidates(&self, text: &str) -> Vec<bool> {
+        let mut candidates = vec![false; self.rules.len()];
+        let Some(prefilter) = &self.prefilter else {
+            candidates.fill(true);
+            return candidates;
+        };
+
+        for rule_idx in &prefilter.always_scan_rules {
+            candidates[*rule_idx] = true;
+        }
+        for mat in prefilter.matcher.find_overlapping_iter(text.as_bytes()) {
+            for rule_idx in &prefilter.rules_by_pattern[mat.pattern().as_usize()] {
+                candidates[*rule_idx] = true;
+            }
+        }
+
+        candidates
+    }
+
+    fn redact_raw_row(&self, row: &mut Value) -> BTreeMap<String, u64> {
+        let mut counts = BTreeMap::new();
+        let Some(obj) = row.as_object_mut() else {
+            return counts;
+        };
+
+        let raw_changed = redact_string_field(self, obj, "raw_json", &mut counts);
+        if raw_changed {
+            if let Some(raw_json) = obj.get("raw_json").and_then(Value::as_str) {
+                obj.insert("raw_json_hash".to_string(), json!(raw_hash(raw_json)));
+            }
+        }
+        counts
+    }
+
+    fn redact_event_row(&self, row: &mut Value) -> BTreeMap<String, u64> {
+        let mut counts = BTreeMap::new();
+        let Some(obj) = row.as_object_mut() else {
+            return counts;
+        };
+
+        let text_changed = redact_string_field(self, obj, "text_content", &mut counts);
+        redact_string_field(self, obj, "payload_json", &mut counts);
+
+        if text_changed {
+            if let Some(text_content) = obj.get("text_content").and_then(Value::as_str) {
+                obj.insert(
+                    "text_preview".to_string(),
+                    Value::String(truncate_chars(text_content, PREVIEW_LIMIT)),
+                );
+            }
+        } else {
+            redact_string_field(self, obj, "text_preview", &mut counts);
+        }
+
+        counts
+    }
+
+    fn redact_tool_row(&self, row: &mut Value) -> BTreeMap<String, u64> {
+        let mut counts = BTreeMap::new();
+        let Some(obj) = row.as_object_mut() else {
+            return counts;
+        };
+
+        let input_changed = redact_string_field(self, obj, "input_json", &mut counts);
+        let output_json_changed = redact_string_field(self, obj, "output_json", &mut counts);
+        let output_text_changed = redact_string_field(self, obj, "output_text", &mut counts);
+
+        if input_changed {
+            if let Some(input_json) = obj
+                .get("input_json")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+            {
+                obj.insert("input_bytes".to_string(), json!(input_json.len() as u32));
+                obj.insert(
+                    "input_preview".to_string(),
+                    Value::String(truncate_chars(&input_json, PREVIEW_LIMIT)),
+                );
+            }
+        } else {
+            redact_string_field(self, obj, "input_preview", &mut counts);
+        }
+
+        if output_text_changed {
+            if let Some(output_text) = obj
+                .get("output_text")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+            {
+                obj.insert(
+                    "output_preview".to_string(),
+                    Value::String(truncate_chars(&output_text, PREVIEW_LIMIT)),
+                );
+            }
+        } else {
+            redact_string_field(self, obj, "output_preview", &mut counts);
+        }
+
+        if output_json_changed {
+            if let Some(output_json) = obj
+                .get("output_json")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+            {
+                obj.insert("output_bytes".to_string(), json!(output_json.len() as u32));
+            }
+        }
+
+        if input_changed || output_json_changed {
+            let input_json = obj.get("input_json").and_then(Value::as_str).unwrap_or("");
+            let output_json = obj.get("output_json").and_then(Value::as_str).unwrap_or("");
+            obj.insert(
+                "io_hash".to_string(),
+                json!(io_hash(input_json, output_json)),
+            );
+        }
+
+        counts
+    }
+
+    fn redact_error_row(&self, row: &mut Value) -> BTreeMap<String, u64> {
+        let mut counts = BTreeMap::new();
+        let Some(obj) = row.as_object_mut() else {
+            return counts;
+        };
+
+        redact_string_field(self, obj, "raw_fragment", &mut counts);
+        counts
+    }
+}
+
+impl RedactionAudit {
+    pub(crate) fn record(&self, report: &BatchRedactionReport) {
+        if report.total == 0 {
+            return;
+        }
+
+        {
+            let mut counts = self.counts.lock().expect("redaction audit mutex poisoned");
+            for (rule, count) in &report.per_rule {
+                *counts.entry(rule.clone()).or_default() += *count;
+            }
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> BTreeMap<String, u64> {
+        self.counts
+            .lock()
+            .expect("redaction audit mutex poisoned")
+            .clone()
+    }
+}
+
+impl BatchRedactionReport {
+    fn record(&mut self, counts: BTreeMap<String, u64>) {
+        let row_total: u64 = counts.values().copied().sum();
+        if row_total == 0 {
+            return;
+        }
+
+        for (rule, count) in &counts {
+            *self.per_rule.entry(rule.clone()).or_default() += *count;
+        }
+        self.total += row_total;
+    }
+}
+
+fn redact_string_field(
+    redactor: &SecretRedactor,
+    obj: &mut Map<String, Value>,
+    field: &str,
+    counts: &mut BTreeMap<String, u64>,
+) -> bool {
+    let Some(Value::String(value)) = obj.get_mut(field) else {
+        return false;
+    };
+    if value.is_empty() {
+        return false;
+    }
+
+    let scrubbed = redactor.scrub_text(value);
+    if scrubbed.counts.is_empty() {
+        return false;
+    }
+
+    *value = scrubbed.text;
+    merge_counts(counts, scrubbed.counts);
+    true
+}
+
+fn merge_counts(into: &mut BTreeMap<String, u64>, counts: BTreeMap<String, u64>) {
+    for (rule, count) in counts {
+        *into.entry(rule).or_default() += count;
+    }
+}
+
+fn build_prefilter(rules: &[Rule]) -> Result<Option<KeywordPrefilter>> {
+    let mut keyword_ids = BTreeMap::<String, usize>::new();
+    let mut keywords = Vec::<String>::new();
+    let mut rules_by_pattern = Vec::<Vec<usize>>::new();
+    let mut always_scan_rules = Vec::<usize>::new();
+
+    for (rule_idx, rule) in rules.iter().enumerate() {
+        if rule.keywords.is_empty() {
+            always_scan_rules.push(rule_idx);
+            continue;
+        }
+        for keyword in &rule.keywords {
+            let keyword = keyword.trim().to_ascii_lowercase();
+            if keyword.is_empty() {
+                continue;
+            }
+            let keyword_idx = if let Some(keyword_idx) = keyword_ids.get(&keyword) {
+                *keyword_idx
+            } else {
+                let keyword_idx = keywords.len();
+                keyword_ids.insert(keyword.clone(), keyword_idx);
+                keywords.push(keyword);
+                rules_by_pattern.push(Vec::new());
+                keyword_idx
+            };
+            rules_by_pattern[keyword_idx].push(rule_idx);
+        }
+    }
+
+    if keywords.is_empty() {
+        return Ok(None);
+    }
+
+    let matcher = AhoCorasickBuilder::new()
+        .ascii_case_insensitive(true)
+        .build(&keywords)
+        .context("failed to compile redaction keyword prefilter")?;
+    Ok(Some(KeywordPrefilter {
+        matcher,
+        rules_by_pattern,
+        always_scan_rules,
+    }))
+}
+
+fn placeholder_ranges(text: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut search_start = 0usize;
+    while let Some(relative_start) = text[search_start..].find("[REDACTED:") {
+        let start = search_start + relative_start;
+        let Some(relative_end) = text[start..].find(']') else {
+            break;
+        };
+        let end = start + relative_end + 1;
+        ranges.push((start, end));
+        search_start = end;
+    }
+    ranges
+}
+
+fn span_overlaps(ranges: &[(usize, usize)], start: usize, end: usize) -> bool {
+    ranges
+        .iter()
+        .any(|(range_start, range_end)| start < *range_end && end > *range_start)
+}
+
+fn builtin_rules() -> Result<Vec<RuleSpec>> {
+    let specs = [
+        RuleSpec::literal(
+            "aws-access-token",
+            r"\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z2-7]{16})\b",
+            &["a3t", "akia", "asia", "abia", "acca"],
+        ),
+        RuleSpec::literal(
+            "github-token",
+            r"\bgh[pousr]_[0-9A-Za-z_]{36,255}\b",
+            &["ghp_", "gho_", "ghu_", "ghs_", "ghr_"],
+        ),
+        RuleSpec::literal(
+            "github-fine-grained-token",
+            r"\bgithub_pat_[0-9A-Za-z_]{82,255}\b",
+            &["github_pat_"],
+        ),
+        RuleSpec::literal(
+            "gitlab-token",
+            r"\b(?:glpat|glft|glcbt|glsoat|gldt)-[0-9A-Za-z_-]{20,}\b",
+            &["glpat-", "glft-", "glcbt-", "glsoat-", "gldt-"],
+        ),
+        RuleSpec::literal(
+            "slack-token",
+            r"\bxox[pbarose]-[0-9A-Za-z-]{10,}\b",
+            &[
+                "xoxp-", "xoxb-", "xoxa-", "xoxr-", "xoxo-", "xoxe-", "xoxs-",
+            ],
+        ),
+        RuleSpec::literal(
+            "slack-webhook",
+            r"https://hooks\.slack\.com/services/[0-9A-Za-z/_+-]{20,}",
+            &["hooks.slack.com/services"],
+        ),
+        RuleSpec::literal("google-api-key", r"\bAIza[0-9A-Za-z_-]{35}\b", &["aiza"]),
+        RuleSpec::literal(
+            "google-oauth-token",
+            r"\bya29\.[0-9A-Za-z_-]{20,}\b",
+            &["ya29."],
+        ),
+        RuleSpec::literal(
+            "pem-private-key",
+            r"(?s)-----BEGIN (?:[A-Z0-9]+ )?PRIVATE KEY-----.*?-----END (?:[A-Z0-9]+ )?PRIVATE KEY-----",
+            &["private key"],
+        ),
+        RuleSpec::literal(
+            "openssh-private-key",
+            r"(?s)-----BEGIN OPENSSH PRIVATE KEY-----.*?-----END OPENSSH PRIVATE KEY-----",
+            &["openssh private key"],
+        ),
+        RuleSpec::literal(
+            "jwt",
+            r"\beyJ[0-9A-Za-z_-]{5,}\.eyJ[0-9A-Za-z_-]{5,}\.[0-9A-Za-z_-]*\b",
+            &["eyj"],
+        ),
+        RuleSpec::literal(
+            "stripe-token",
+            r"\b(?:sk|rk|pk)_(?:test|live)_[0-9A-Za-z]{10,}\b",
+            &[
+                "sk_test_", "sk_live_", "rk_test_", "rk_live_", "pk_test_", "pk_live_",
+            ],
+        ),
+        RuleSpec::literal(
+            "stripe-webhook-secret",
+            r"\bwhsec_[0-9A-Za-z]{20,}\b",
+            &["whsec_"],
+        ),
+        RuleSpec::literal(
+            "anthropic-api-key",
+            r"\bsk-ant-[0-9A-Za-z_-]{20,}\b",
+            &["sk-ant-"],
+        ),
+        RuleSpec::literal(
+            "openai-api-key",
+            r"\bsk-(?:proj-)?[0-9A-Za-z_-]{20,}\b",
+            &["sk-", "sk-proj-"],
+        ),
+        RuleSpec::literal("huggingface-token", r"\bhf_[0-9A-Za-z]{30,}\b", &["hf_"]),
+        RuleSpec::literal(
+            "sendgrid-api-key",
+            r"\bSG\.[0-9A-Za-z_-]{20,}\.[0-9A-Za-z_-]{20,}\b",
+            &["sg."],
+        ),
+        RuleSpec::literal(
+            "discord-webhook",
+            r"https://discord(?:app)?\.com/api/webhooks/[0-9]{6,}/[0-9A-Za-z_-]{20,}",
+            &["discord.com/api/webhooks", "discordapp.com/api/webhooks"],
+        ),
+        RuleSpec::literal("npm-token", r"\bnpm_[0-9A-Za-z]{30,}\b", &["npm_"]),
+        RuleSpec::literal("pypi-token", r"\bpypi-[0-9A-Za-z_-]{30,}\b", &["pypi-"]),
+        RuleSpec::literal(
+            "digitalocean-token",
+            r"\bdop_v1_[0-9a-f]{64}\b",
+            &["dop_v1_"],
+        ),
+        RuleSpec::literal("databricks-token", r"\bdapi[0-9a-f]{32}\b", &["dapi"]),
+        RuleSpec::literal(
+            "dockerhub-token",
+            r"\bdckr_pat_[0-9A-Za-z_-]{20,}\b",
+            &["dckr_pat_"],
+        ),
+        RuleSpec::literal(
+            "linear-api-key",
+            r"\blin_api_[0-9A-Za-z]{30,}\b",
+            &["lin_api_"],
+        ),
+        RuleSpec::literal("notion-token", r"\bsecret_[0-9A-Za-z]{30,}\b", &["secret_"]),
+        RuleSpec::generic(
+            "generic-api-key",
+            r#"(?i)\b(?:api[_-]?key|access[_-]?token|auth(?:orization)?|bearer|client[_-]?secret|credential|passwd|password|private[_-]?key|secret|token)\b["']?\s*[:=]\s*["']?([0-9A-Za-z_./+=-]{20,})["']?"#,
+            &[
+                "api",
+                "access",
+                "auth",
+                "bearer",
+                "client",
+                "credential",
+                "passwd",
+                "password",
+                "private",
+                "secret",
+                "token",
+            ],
+            1,
+        ),
+    ];
+
+    Ok(Vec::from(specs))
+}
+
+#[derive(Clone, Copy, Debug)]
+struct RuleSpec {
+    id: &'static str,
+    pattern: &'static str,
+    keywords: &'static [&'static str],
+    secret_group: usize,
+    entropy_gate: EntropyGate,
+    min_len: usize,
+}
+
+impl RuleSpec {
+    const fn literal(
+        id: &'static str,
+        pattern: &'static str,
+        keywords: &'static [&'static str],
+    ) -> Self {
+        Self {
+            id,
+            pattern,
+            keywords,
+            secret_group: 0,
+            entropy_gate: EntropyGate::None,
+            min_len: 1,
+        }
+    }
+
+    const fn generic(
+        id: &'static str,
+        pattern: &'static str,
+        keywords: &'static [&'static str],
+        secret_group: usize,
+    ) -> Self {
+        Self {
+            id,
+            pattern,
+            keywords,
+            secret_group,
+            entropy_gate: EntropyGate::GenericCredential,
+            min_len: 20,
+        }
+    }
+
+    fn compile(&self, priority: usize) -> Result<Rule> {
+        Ok(Rule {
+            id: self.id.to_string(),
+            pattern: self.pattern.to_string(),
+            regex: Regex::new(self.pattern)
+                .with_context(|| format!("failed to compile builtin redaction rule {}", self.id))?,
+            keywords: self
+                .keywords
+                .iter()
+                .map(|keyword| keyword.to_ascii_lowercase())
+                .collect(),
+            secret_group: self.secret_group,
+            entropy_gate: self.entropy_gate,
+            min_len: self.min_len,
+            priority,
+        })
+    }
+}
+
+fn generic_candidate_is_secret(candidate: &str) -> bool {
+    let trimmed = candidate.trim_matches(|c: char| matches!(c, '"' | '\'' | '`' | ',' | ';'));
+    if trimmed.len() < 20 || is_structural_false_positive(trimmed) {
+        return false;
+    }
+
+    let entropy = shannon_entropy(trimmed);
+    if is_hex(trimmed) {
+        return entropy - all_digit_hex_penalty(trimmed) > 3.0;
+    }
+    if is_base64ish(trimmed) {
+        return entropy > 4.5;
+    }
+    entropy > 3.5
+}
+
+fn shannon_entropy(value: &str) -> f64 {
+    let mut counts = [0usize; 256];
+    let bytes = value.as_bytes();
+    if bytes.is_empty() {
+        return 0.0;
+    }
+    for byte in bytes {
+        counts[*byte as usize] += 1;
+    }
+    let len = bytes.len() as f64;
+    counts
+        .iter()
+        .copied()
+        .filter(|count| *count > 0)
+        .map(|count| {
+            let p = count as f64 / len;
+            -p * p.log2()
+        })
+        .sum()
+}
+
+fn is_hex(value: &str) -> bool {
+    value.len() >= 20 && value.as_bytes().iter().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_base64ish(value: &str) -> bool {
+    value.len() >= 20
+        && value.as_bytes().iter().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(*byte, b'+' | b'/' | b'_' | b'-' | b'=')
+        })
+}
+
+fn all_digit_hex_penalty(value: &str) -> f64 {
+    if value.as_bytes().iter().all(|byte| byte.is_ascii_digit()) {
+        1.2 / (value.len() as f64).log2()
+    } else {
+        0.0
+    }
+}
+
+fn is_structural_false_positive(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    let stopwords = [
+        "example",
+        "placeholder",
+        "changeme",
+        "notasecret",
+        "not-a-secret",
+        "dummy",
+        "sample",
+        "redacted",
+        "password",
+        "secret",
+        "token",
+    ];
+    if stopwords.iter().any(|word| lower.contains(word)) {
+        return true;
+    }
+
+    let mut chars = lower.chars();
+    let Some(first) = chars.next() else {
+        return true;
+    };
+    if chars.all(|ch| ch == first) {
+        return true;
+    }
+
+    let alnum: String = lower
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect();
+    matches!(
+        alnum.as_str(),
+        "abcdefghijklmnopqrstuvwxyz"
+            | "zyxwvutsrqponmlkjihgfedcba"
+            | "01234567890123456789"
+            | "12345678901234567890"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use moraine_config::RedactionConfig;
+
+    fn redactor() -> SecretRedactor {
+        SecretRedactor::new(&RedactionConfig::default()).expect("builtin redactor compiles")
+    }
+
+    fn fixture(parts: &[&str]) -> String {
+        parts.concat()
+    }
+
+    #[test]
+    fn redacts_specific_secret_families() {
+        let redactor = redactor();
+        let input = format!(
+            "{} {} {} {} {} {}",
+            fixture(&["aws=", "AKIAIOSFODNN7EXAMPLE"]),
+            fixture(&["ghp_", "abcdefghijklmnopqrstuvwxyzABCDE12345"]),
+            fixture(&["glpat-", "abcdefABCDEF12345678"]),
+            fixture(&["xoxb-", "123456789012-ABCDEFGHIJKL"]),
+            fixture(&["AIza", "0123456789abcdefghijklmnopqrstuvwxy"]),
+            fixture(&["sk_live_", "abcdefghijklmnop"])
+        );
+
+        let scrubbed = redactor.scrub_text(&input);
+
+        assert!(scrubbed.text.contains("[REDACTED:aws-access-token]"));
+        assert!(scrubbed.text.contains("[REDACTED:github-token]"));
+        assert!(scrubbed.text.contains("[REDACTED:gitlab-token]"));
+        assert!(scrubbed.text.contains("[REDACTED:slack-token]"));
+        assert!(scrubbed.text.contains("[REDACTED:google-api-key]"));
+        assert!(scrubbed.text.contains("[REDACTED:stripe-token]"));
+    }
+
+    #[test]
+    fn redacts_common_service_token_prefixes() {
+        let redactor = redactor();
+        let input = format!(
+            "{} {} {} {} {} {} {} {} {} {} {} {} {}",
+            fixture(&["sk-ant-", "AbCdEfGhIjKlMnOpQrStUvWxYz1234567890"]),
+            fixture(&["sk-proj-", "AbCdEfGhIjKlMnOpQrStUvWxYz1234567890"]),
+            fixture(&["hf_", "abcdefghijklmnopqrstuvwxyzABCDEFGH"]),
+            fixture(&[
+                "SG.",
+                "ABCDEFGHIJKLMNOPQRSTUV",
+                ".abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNO",
+            ]),
+            fixture(&[
+                "https://hooks.slack.com/",
+                "services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+            ]),
+            fixture(&[
+                "https://discord.com/api/",
+                "webhooks/123456789012345678/AbCdEfGhIjKlMnOpQrStUvWxYz1234567890",
+            ]),
+            fixture(&["npm_", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJ"]),
+            fixture(&["pypi-", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJ"]),
+            fixture(&[
+                "dop_v1_",
+                "0123456789abcdef0123456789abcdef",
+                "0123456789abcdef0123456789abcdef",
+            ]),
+            fixture(&["dapi", "0123456789abcdef0123456789abcdef"]),
+            fixture(&["dckr_pat_", "AbCdEfGhIjKlMnOpQrStUvWxYz1234567890"]),
+            fixture(&["lin_api_", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJ"]),
+            fixture(&["secret_", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJ"])
+        );
+
+        let scrubbed = redactor.scrub_text(&input);
+
+        for rule in [
+            "anthropic-api-key",
+            "openai-api-key",
+            "huggingface-token",
+            "sendgrid-api-key",
+            "slack-webhook",
+            "discord-webhook",
+            "npm-token",
+            "pypi-token",
+            "digitalocean-token",
+            "databricks-token",
+            "dockerhub-token",
+            "linear-api-key",
+            "notion-token",
+        ] {
+            assert!(
+                scrubbed.text.contains(&format!("[REDACTED:{rule}]")),
+                "missing redaction for {rule}: {}",
+                scrubbed.text
+            );
+        }
+    }
+
+    #[test]
+    fn redacts_pem_and_jwt() {
+        let redactor = redactor();
+        let input = "-----BEGIN PRIVATE KEY-----\nabc123\n-----END PRIVATE KEY----- jwt=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature";
+
+        let scrubbed = redactor.scrub_text(input);
+
+        assert!(scrubbed.text.contains("[REDACTED:pem-private-key]"));
+        assert!(scrubbed.text.contains("[REDACTED:jwt]"));
+    }
+
+    #[test]
+    fn generic_assignment_uses_entropy_gate() {
+        let redactor = redactor();
+        let scrubbed = redactor.scrub_text(
+            r#"password = "passwordpasswordpassword" token = "Vb9pQx7Lm2Nf8Rs4Ty6Ua0Kc3Wd5Ez""#,
+        );
+
+        assert!(scrubbed.text.contains("passwordpasswordpassword"));
+        assert!(scrubbed
+            .text
+            .contains(r#"token = "[REDACTED:generic-api-key]""#));
+    }
+
+    #[test]
+    fn scrub_is_idempotent() {
+        let redactor = redactor();
+        let once = redactor.scrub_text("token = Vb9pQx7Lm2Nf8Rs4Ty6Ua0Kc3Wd5Ez");
+        let twice = redactor.scrub_text(&once.text);
+
+        assert_eq!(once.text, twice.text);
+        assert!(twice.counts.is_empty());
+    }
+
+    #[test]
+    fn placeholders_are_protected_from_future_rules() {
+        let redactor = redactor();
+        let scrubbed = redactor.scrub_text("[REDACTED:github-token]");
+
+        assert_eq!(scrubbed.text, "[REDACTED:github-token]");
+        assert!(scrubbed.counts.is_empty());
+    }
+
+    #[test]
+    fn extra_pattern_redacts_and_stays_idempotent() {
+        let config = RedactionConfig {
+            extra_patterns: vec![r"acme_internal_[0-9A-Za-z]{32}".to_string()],
+            ..RedactionConfig::default()
+        };
+        let redactor = SecretRedactor::new(&config).expect("redactor compiles");
+        let once = redactor.scrub_text("token=acme_internal_0123456789abcdef0123456789abcdef");
+        let twice = redactor.scrub_text(&once.text);
+
+        assert_eq!(once.text, "token=[REDACTED:extra-pattern-1]");
+        assert_eq!(once.text, twice.text);
+        assert!(twice.counts.is_empty());
+    }
+
+    #[test]
+    fn bad_extra_pattern_is_startup_error() {
+        let config = RedactionConfig {
+            extra_patterns: vec!["(".to_string()],
+            ..RedactionConfig::default()
+        };
+        let err = SecretRedactor::new(&config).expect_err("invalid regex should fail");
+
+        assert!(format!("{err:#}").contains("extra_patterns[0]"));
+    }
+
+    #[test]
+    fn large_secret_free_text_returns_without_matches() {
+        let redactor = redactor();
+        let input = "z".repeat(2 * 1024 * 1024);
+
+        let scrubbed = redactor.scrub_text(&input);
+
+        assert_eq!(scrubbed.text.len(), input.len());
+        assert!(scrubbed.counts.is_empty());
+    }
+
+    #[test]
+    fn redacts_batch_fields_and_recomputes_derived_values() {
+        let redactor = redactor();
+        let original_raw = r#"{"token":"ghp_abcdefghijklmnopqrstuvwxyzABCDE12345"}"#;
+        let original_input =
+            r#"{"api_key":"AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVv1234567890+/"}"#;
+        let mut batch = RowBatch::default();
+        batch.push_raw_row(json!({
+            "session_id": "s1",
+            "raw_json": original_raw,
+            "raw_json_hash": raw_hash(original_raw)
+        }));
+        batch.extend_event_rows([json!({
+            "session_id": "s1",
+            "text_content": "ghp_abcdefghijklmnopqrstuvwxyzABCDE12345",
+            "text_preview": "ghp_abcdefghijklmnopqrstuvwxyzABCDE12345",
+            "payload_json": "{}"
+        })]);
+        batch.extend_tool_rows([json!({
+            "session_id": "s1",
+            "input_json": original_input,
+            "output_json": "{}",
+            "output_text": "ghp_abcdefghijklmnopqrstuvwxyzABCDE12345",
+            "input_bytes": original_input.len() as u32,
+            "output_bytes": 2u32,
+            "input_preview": original_input,
+            "output_preview": "ghp_abcdefghijklmnopqrstuvwxyzABCDE12345",
+            "io_hash": io_hash(original_input, "{}")
+        })]);
+        batch.push_error_row(json!({
+            "session_id": "s1",
+            "raw_fragment": "malformed ghp_abcdefghijklmnopqrstuvwxyzABCDE12345"
+        }));
+
+        let report = redactor.redact_batch(&mut batch);
+
+        assert!(report.total >= 5);
+        let raw = &batch.raw_rows[0];
+        let redacted_raw = raw.get("raw_json").and_then(Value::as_str).unwrap();
+        assert!(redacted_raw.contains("[REDACTED:github-token]"));
+        assert_eq!(
+            raw.get("raw_json_hash").and_then(Value::as_u64),
+            Some(raw_hash(redacted_raw))
+        );
+
+        let event = &batch.event_rows[0];
+        assert_eq!(
+            event.get("text_preview").and_then(Value::as_str),
+            Some("[REDACTED:github-token]")
+        );
+
+        let tool = &batch.tool_rows[0];
+        let input = tool.get("input_json").and_then(Value::as_str).unwrap();
+        let output_json = tool.get("output_json").and_then(Value::as_str).unwrap();
+        assert!(input.contains("[REDACTED:generic-api-key]"));
+        assert_eq!(
+            tool.get("io_hash").and_then(Value::as_u64),
+            Some(io_hash(input, output_json))
+        );
+        assert_eq!(
+            tool.get("input_bytes").and_then(Value::as_u64),
+            Some(input.len() as u64)
+        );
+        assert_eq!(
+            tool.get("output_preview").and_then(Value::as_str),
+            Some("[REDACTED:github-token]")
+        );
+
+        let error = &batch.error_rows[0];
+        assert_eq!(
+            error.get("raw_fragment").and_then(Value::as_str),
+            Some("malformed [REDACTED:github-token]")
+        );
+    }
+
+    #[test]
+    fn audit_accumulates_rule_counts() {
+        let audit = RedactionAudit::default();
+        let mut report = BatchRedactionReport::default();
+        report.per_rule.insert("github-token".to_string(), 2);
+        report.total = 2;
+
+        audit.record(&report);
+
+        assert_eq!(audit.snapshot().get("github-token"), Some(&2));
+    }
+}

--- a/crates/moraine-ingest-core/src/sink.rs
+++ b/crates/moraine-ingest-core/src/sink.rs
@@ -1,6 +1,7 @@
 use crate::checkpoint::merge_checkpoint;
 use crate::heartbeat::host_name;
 use crate::model::Checkpoint;
+use crate::redaction::{RedactionAudit, SecretRedactor};
 use crate::sources::shared::truncate_chars;
 use crate::tee::{
     backend_sinks_json, filter_batch_for_backend, BackendSinkCell, ReplayFloor,
@@ -40,6 +41,10 @@ pub(crate) enum SinkRole {
         /// (migration 017). Pre-017 schemas reject unknown columns at insert
         /// time, so the field is attached only when the column exists.
         backend_sinks_column: bool,
+        /// Whether `ingest_heartbeats` carries the `redactions_total` column
+        /// (migration 022). Redaction still runs without this audit surface.
+        redactions_column: bool,
+        redactions: Arc<RedactionAudit>,
     },
     /// A mirror sink for one named backend: filters intake down to the
     /// sessions routed to it and reports flush health on its status cell.
@@ -53,6 +58,8 @@ pub(crate) enum SinkRole {
         /// transition (see `note_flush_outcome` for why it must be taken
         /// here, inside the sink task, and not when the supervisor wakes).
         replay_floor: ReplayFloor,
+        redactor: Arc<SecretRedactor>,
+        redactions: Arc<RedactionAudit>,
     },
 }
 
@@ -261,10 +268,20 @@ pub(crate) fn spawn_sink_task(
                             // Mirror sinks only buffer the sessions routed to
                             // them; the default sink takes batches whole.
                             let batch = match &role {
-                                SinkRole::Backend { cell, resolver, .. } => {
+                                SinkRole::Backend {
+                                    cell,
+                                    resolver,
+                                    redactor,
+                                    redactions,
+                                    ..
+                                } => {
                                     let mut resolver =
                                         resolver.lock().expect("route resolver mutex poisoned");
-                                    filter_batch_for_backend(&batch, cell.name(), &mut resolver)
+                                    let mut batch =
+                                        filter_batch_for_backend(&batch, cell.name(), &mut resolver);
+                                    let report = redactor.redact_batch(&mut batch);
+                                    redactions.record(&report);
+                                    batch
                                 }
                                 SinkRole::Default { .. } => batch,
                             };
@@ -706,6 +723,8 @@ async fn emit_heartbeat(clickhouse: &ClickHouseClient, metrics: &Arc<Metrics>, r
         dispatch,
         backends,
         backend_sinks_column,
+        redactions_column,
+        redactions,
     } = role
     else {
         return;
@@ -751,6 +770,16 @@ async fn emit_heartbeat(clickhouse: &ClickHouseClient, metrics: &Arc<Metrics>, r
         if let Some(statuses) = backend_sinks_json(backends) {
             if let Some(obj) = heartbeat.as_object_mut() {
                 obj.insert("backend_sinks".to_string(), json!(statuses));
+            }
+        }
+    }
+
+    if *redactions_column {
+        let counts = redactions.snapshot();
+        if !counts.is_empty() {
+            if let Some(obj) = heartbeat.as_object_mut() {
+                let counts_json = serde_json::to_string(&counts).unwrap_or_default();
+                obj.insert("redactions_total".to_string(), Value::String(counts_json));
             }
         }
     }
@@ -1098,6 +1127,8 @@ mod tests {
             Some("ingest_errors")
         } else if query.contains("`ingest_checkpoints`") {
             Some("ingest_checkpoints")
+        } else if query.contains("`ingest_heartbeats`") {
+            Some("ingest_heartbeats")
         } else if query.contains("`events`") {
             Some("events")
         } else {
@@ -1217,11 +1248,24 @@ mod tests {
         SinkMessage::Batch(batch)
     }
 
+    fn test_redactor() -> Arc<SecretRedactor> {
+        Arc::new(
+            SecretRedactor::new(&moraine_config::RedactionConfig::default())
+                .expect("test redactor compiles"),
+        )
+    }
+
+    fn test_redaction_audit() -> Arc<RedactionAudit> {
+        Arc::new(RedactionAudit::default())
+    }
+
     fn default_role() -> SinkRole {
         SinkRole::Default {
             dispatch: Arc::new(Mutex::new(DispatchState::default())),
             backends: Arc::new(Mutex::new(std::collections::BTreeMap::new())),
             backend_sinks_column: false,
+            redactions_column: false,
+            redactions: test_redaction_audit(),
         }
     }
 
@@ -1938,6 +1982,7 @@ mod tests {
         config.ingest.heartbeat_interval_seconds = 60.0;
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
         let metrics = Arc::new(Metrics::default());
+        let redactions = test_redaction_audit();
         let (tx, rx) = mpsc::channel::<SinkMessage>(8);
 
         let handle = spawn_sink_task(
@@ -1952,19 +1997,26 @@ mod tests {
                 resolver,
                 replay_notify: Arc::new(Notify::new()),
                 replay_floor: Arc::new(Mutex::new(None)),
+                redactor: test_redactor(),
+                redactions: redactions.clone(),
             },
         );
 
+        let raw_secret = "ghp_abcdefghijklmnopqrstuvwxyzABCDE12345";
         let mut batch = RowBatch::default();
         batch.push_raw_row(json!({
             "session_id": "team-session",
             "cwd": "/work/team/project",
             "record_ts": "2026-02-17T00:00:01.000Z",
+            "raw_json": format!("{{\"token\":\"{raw_secret}\"}}"),
+            "raw_json_hash": 1u64,
         }));
         batch.push_raw_row(json!({
             "session_id": "other-session",
             "cwd": "/home/other",
             "record_ts": "2026-02-17T00:00:01.000Z",
+            "raw_json": format!("{{\"token\":\"{raw_secret}\"}}"),
+            "raw_json_hash": 1u64,
         }));
         batch.checkpoint = Some(sample_checkpoint());
         tx.send(SinkMessage::Batch(batch))
@@ -1982,6 +2034,16 @@ mod tests {
         assert_eq!(
             raw_rows[0].get("session_id").and_then(Value::as_str),
             Some("team-session")
+        );
+        assert_eq!(
+            raw_rows[0].get("raw_json").and_then(Value::as_str),
+            Some("{\"token\":\"[REDACTED:github-token]\"}"),
+            "backend sink backstop redacts the remote copy after route filtering"
+        );
+        assert_eq!(
+            redactions.snapshot().get("github-token"),
+            Some(&1),
+            "backend redactions are counted without secret values"
         );
         let checkpoint_rows = mock_state.rows("ingest_checkpoints");
         assert_eq!(
@@ -2070,6 +2132,8 @@ mod tests {
             )))),
             replay_notify: replay_notify.clone(),
             replay_floor: replay_floor.clone(),
+            redactor: test_redactor(),
+            redactions: test_redaction_audit(),
         };
 
         let checkpoint = sample_checkpoint(); // offset 100

--- a/crates/moraine-ingest-core/src/sources/shared.rs
+++ b/crates/moraine-ingest-core/src/sources/shared.rs
@@ -869,7 +869,7 @@ pub(crate) fn raw_hash(raw_json: &str) -> u64 {
     u64::from_str_radix(&hex[..16], 16).unwrap_or(0)
 }
 
-fn io_hash(input_json: &str, output_json: &str) -> u64 {
+pub(crate) fn io_hash(input_json: &str, output_json: &str) -> u64 {
     raw_hash(&format!("{}\n{}", input_json, output_json))
 }
 

--- a/crates/moraine-ingest-core/src/tee.rs
+++ b/crates/moraine-ingest-core/src/tee.rs
@@ -15,6 +15,7 @@
 use crate::dispatch::process_file;
 use crate::heartbeat::host_name;
 use crate::model::{Checkpoint, RowBatch};
+use crate::redaction::{RedactionAudit, SecretRedactor};
 use crate::sink::{spawn_sink_task, SinkRole};
 use crate::watch::enumerate_tracked_files;
 use crate::{Metrics, SinkMessage, WorkItem};
@@ -363,6 +364,27 @@ struct BackendHandle {
     cell: Arc<BackendSinkCell>,
 }
 
+#[derive(Clone)]
+pub(crate) struct RedactionContext {
+    redactor: Arc<SecretRedactor>,
+    audit: Arc<RedactionAudit>,
+}
+
+impl RedactionContext {
+    pub(crate) fn new(redactor: Arc<SecretRedactor>, audit: Arc<RedactionAudit>) -> Self {
+        Self { redactor, audit }
+    }
+}
+
+#[derive(Clone)]
+struct TeeRouterContext {
+    config: Arc<AppConfig>,
+    sources: Arc<Vec<IngestSource>>,
+    resolver: SharedRouteResolver,
+    registry: StatusRegistry,
+    redaction: RedactionContext,
+}
+
 /// Routes every batch from the processors to the default sink (always,
 /// awaited — the existing backpressure) and tees full batches toward mirror
 /// backends via `try_send` (never awaited — a slow remote cannot stall the
@@ -375,8 +397,16 @@ pub(crate) fn spawn_tee_router(
     default_tx: mpsc::Sender<SinkMessage>,
     resolver: SharedRouteResolver,
     registry: StatusRegistry,
+    redaction: RedactionContext,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
+        let context = TeeRouterContext {
+            config,
+            sources: Arc::new(sources),
+            resolver,
+            registry,
+            redaction,
+        };
         let mut handles = HashMap::<String, BackendHandle>::new();
 
         // Backends named by home-config routes start eagerly so handshake
@@ -385,26 +415,30 @@ pub(crate) fn spawn_tee_router(
         // cannot know at startup which configured backends repos will name,
         // and eagerly replaying never-routed backends would write
         // checkpoints into databases the user never routed to.
-        let eager: BTreeSet<String> = config
+        let eager: BTreeSet<String> = context
+            .config
             .routes
             .iter()
             .map(|route| route.backend.clone())
             .filter(|name| name != DEFAULT_BACKEND_NAME)
             .collect();
         for name in eager {
-            ensure_backend(&name, &config, &sources, &resolver, &registry, &mut handles);
+            ensure_backend(&name, &context, &mut handles);
         }
 
-        while let Some(SinkMessage::Batch(batch)) = rx.recv().await {
+        while let Some(SinkMessage::Batch(mut batch)) = rx.recv().await {
+            redact_default_batch_if_enabled(&context.config, &context.redaction, &mut batch);
+
             let targets = {
-                let mut resolver = resolver.lock().expect("route resolver mutex poisoned");
+                let mut resolver = context
+                    .resolver
+                    .lock()
+                    .expect("route resolver mutex poisoned");
                 collect_targets(&batch, &mut resolver)
             };
 
             for name in &targets {
-                if let Some(handle) =
-                    ensure_backend(name, &config, &sources, &resolver, &registry, &mut handles)
-                {
+                if let Some(handle) = ensure_backend(name, &context, &mut handles) {
                     forward_to_backend(handle, &batch);
                 }
             }
@@ -416,37 +450,46 @@ pub(crate) fn spawn_tee_router(
     })
 }
 
+fn redact_default_batch_if_enabled(
+    config: &AppConfig,
+    redaction: &RedactionContext,
+    batch: &mut RowBatch,
+) {
+    if config.redaction.dangerously_skip_secret_redaction {
+        return;
+    }
+
+    let report = redaction.redactor.redact_batch(batch);
+    redaction.audit.record(&report);
+}
+
 /// Looks up (or lazily constructs) the handle for a named backend. Returns
 /// `None` only for names without a `[backends.*]` entry, which the resolver
 /// already refuses to produce — this is a defensive double-check.
 fn ensure_backend<'a>(
     name: &str,
-    config: &Arc<AppConfig>,
-    sources: &[IngestSource],
-    resolver: &SharedRouteResolver,
-    registry: &StatusRegistry,
+    context: &TeeRouterContext,
     handles: &'a mut HashMap<String, BackendHandle>,
 ) -> Option<&'a BackendHandle> {
     if !handles.contains_key(name) {
-        let backend_cfg = config.backends.get(name)?.clone();
+        let backend_cfg = context.config.backends.get(name)?.clone();
         let cell = Arc::new(BackendSinkCell::new(name));
-        let queue_capacity = config.ingest.max_inflight_batches.max(1);
+        let queue_capacity = context.config.ingest.max_inflight_batches.max(1);
         let (tx, backend_rx) = mpsc::channel::<SinkMessage>(queue_capacity);
 
-        registry
+        context
+            .registry
             .lock()
             .expect("backend registry mutex poisoned")
             .insert(name.to_string(), cell.clone());
 
         info!(backend = name, "starting mirror sink for backend");
         spawn_backend_supervisor(
-            config.clone(),
             backend_cfg,
-            sources.to_vec(),
             cell.clone(),
             tx.clone(),
             backend_rx,
-            resolver.clone(),
+            context.clone(),
         );
 
         handles.insert(name.to_string(), BackendHandle { tx, cell });
@@ -491,13 +534,11 @@ fn forward_to_backend(handle: &BackendHandle, batch: &RowBatch) {
 /// load from the backend's own database, sink task spawn, then catch-up
 /// replay passes re-armed on every recovery.
 fn spawn_backend_supervisor(
-    config: Arc<AppConfig>,
     backend_cfg: ClickHouseConfig,
-    sources: Vec<IngestSource>,
     cell: Arc<BackendSinkCell>,
     replay_tx: mpsc::Sender<SinkMessage>,
     backend_rx: mpsc::Receiver<SinkMessage>,
-    resolver: SharedRouteResolver,
+    context: TeeRouterContext,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         let name = cell.name().to_string();
@@ -568,7 +609,7 @@ fn spawn_backend_supervisor(
         let replay_notify = Arc::new(Notify::new());
         let replay_floor: ReplayFloor = Arc::new(Mutex::new(None));
         spawn_sink_task(
-            config.as_ref().clone(),
+            context.config.as_ref().clone(),
             client,
             checkpoints.clone(),
             metrics.clone(),
@@ -576,9 +617,11 @@ fn spawn_backend_supervisor(
             true,
             SinkRole::Backend {
                 cell: cell.clone(),
-                resolver,
+                resolver: context.resolver.clone(),
                 replay_notify: replay_notify.clone(),
                 replay_floor: replay_floor.clone(),
+                redactor: context.redaction.redactor.clone(),
+                redactions: context.redaction.audit.clone(),
             },
         );
 
@@ -595,8 +638,8 @@ fn spawn_backend_supervisor(
         let mut reported_lost = HashSet::<String>::new();
         loop {
             run_replay_pass(
-                &config,
-                &sources,
+                &context.config,
+                context.sources.as_slice(),
                 &floor,
                 &replay_tx,
                 &metrics,
@@ -721,8 +764,10 @@ mod tests {
 
     fn team_config() -> Arc<AppConfig> {
         let mut config = AppConfig::default();
-        let mut team = ClickHouseConfig::default();
-        team.database = "moraine_team".to_string();
+        let team = ClickHouseConfig {
+            database: "moraine_team".to_string(),
+            ..Default::default()
+        };
         config.backends.insert("team-ch".to_string(), team);
         config.routes.push(moraine_config::RouteConfig {
             dir: "/work/team/**".to_string(),
@@ -1044,26 +1089,97 @@ mod tests {
     }
 
     fn backend_cfg_for(url: String) -> ClickHouseConfig {
-        let mut cfg = ClickHouseConfig::default();
-        cfg.url = url;
-        cfg.timeout_seconds = 1.0;
-        cfg
+        ClickHouseConfig {
+            url,
+            timeout_seconds: 1.0,
+            ..Default::default()
+        }
+    }
+
+    fn test_redactor() -> Arc<SecretRedactor> {
+        Arc::new(
+            SecretRedactor::new(&moraine_config::RedactionConfig::default())
+                .expect("test redactor compiles"),
+        )
+    }
+
+    fn test_redaction_audit() -> Arc<RedactionAudit> {
+        Arc::new(RedactionAudit::default())
+    }
+
+    fn test_router_context(
+        config: Arc<AppConfig>,
+        resolver: SharedRouteResolver,
+    ) -> TeeRouterContext {
+        TeeRouterContext {
+            config,
+            sources: Arc::new(Vec::new()),
+            resolver,
+            registry: Arc::new(Mutex::new(BTreeMap::new())),
+            redaction: RedactionContext::new(test_redactor(), test_redaction_audit()),
+        }
+    }
+
+    fn secret_batch() -> RowBatch {
+        let mut batch = RowBatch::default();
+        batch.push_raw_row(serde_json::json!({
+            "session_id": "session-a",
+            "cwd": "/work/team/project",
+            "raw_json": "{\"token\":\"ghp_abcdefghijklmnopqrstuvwxyzABCDE12345\"}",
+            "raw_json_hash": 1u64,
+        }));
+        batch
+    }
+
+    #[test]
+    fn default_gate_redacts_when_enabled() {
+        let config = AppConfig::default();
+        let redactor = test_redactor();
+        let redactions = test_redaction_audit();
+        let redaction = RedactionContext::new(redactor, redactions.clone());
+        let mut batch = secret_batch();
+
+        redact_default_batch_if_enabled(&config, &redaction, &mut batch);
+
+        assert_eq!(
+            batch.raw_rows[0].get("raw_json").and_then(Value::as_str),
+            Some("{\"token\":\"[REDACTED:github-token]\"}")
+        );
+        assert_eq!(redactions.snapshot().get("github-token"), Some(&1));
+    }
+
+    #[test]
+    fn default_gate_honors_local_skip() {
+        let mut config = AppConfig::default();
+        config.redaction.dangerously_skip_secret_redaction = true;
+        let redactor = test_redactor();
+        let redactions = test_redaction_audit();
+        let redaction = RedactionContext::new(redactor, redactions.clone());
+        let mut batch = secret_batch();
+
+        redact_default_batch_if_enabled(&config, &redaction, &mut batch);
+
+        assert_eq!(
+            batch.raw_rows[0].get("raw_json").and_then(Value::as_str),
+            Some("{\"token\":\"ghp_abcdefghijklmnopqrstuvwxyzABCDE12345\"}")
+        );
+        assert!(redactions.snapshot().is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn supervisor_marks_unreachable_backend_without_going_live() {
         let cell = Arc::new(BackendSinkCell::new("team-ch"));
         let (tx, rx) = mpsc::channel::<SinkMessage>(1);
-        let resolver: SharedRouteResolver = Arc::new(Mutex::new(RouteResolver::new(team_config())));
+        let config = team_config();
+        let resolver: SharedRouteResolver =
+            Arc::new(Mutex::new(RouteResolver::new(config.clone())));
 
         let handle = spawn_backend_supervisor(
-            team_config(),
             backend_cfg_for("http://127.0.0.1:1".to_string()),
-            Vec::new(),
             cell.clone(),
             tx,
             rx,
-            resolver,
+            test_router_context(config, resolver),
         );
 
         assert!(
@@ -1132,16 +1248,16 @@ mod tests {
 
         let cell = Arc::new(BackendSinkCell::new("team-ch"));
         let (tx, rx) = mpsc::channel::<SinkMessage>(1);
-        let resolver: SharedRouteResolver = Arc::new(Mutex::new(RouteResolver::new(team_config())));
+        let config = team_config();
+        let resolver: SharedRouteResolver =
+            Arc::new(Mutex::new(RouteResolver::new(config.clone())));
 
         let handle = spawn_backend_supervisor(
-            team_config(),
             backend_cfg_for(format!("http://{}", addr)), // allow_newer_server = false
-            Vec::new(),
             cell.clone(),
             tx,
             rx,
-            resolver,
+            test_router_context(config, resolver),
         );
 
         assert!(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -205,6 +205,35 @@ backend's health/schema first. As with ingest routes, a repo `.moraine.toml`
 naming an unconfigured backend logs a warning and keeps the default
 behavior.
 
+## Secret Redaction
+
+Secret redaction is enabled by default for every ingested row. Moraine scans
+the secret-bearing string fields in raw events, normalized events, and tool
+I/O, then replaces matched secrets with typed placeholders such as
+`[REDACTED:github-token]`. Derived previews and hashes are recomputed from
+the redacted content.
+
+```toml
+[redaction]
+ruleset = "builtin"
+# extra_patterns = ["acme_internal_[A-Za-z0-9]{32}"]
+# dangerously_skip_secret_redaction = true
+```
+
+`dangerously_skip_secret_redaction = true` is honored only from
+`$HOME/.moraine/config.toml`. It disables redaction for the local/default
+backend only; mirror egress to named backends is always redacted. The same
+flag in a repo or checkout config is ignored with a warning so a cloned
+repository cannot weaken local capture settings.
+
+The builtin ruleset covers common API keys, provider tokens, private-key
+blocks, JWTs, and high-entropy generic credential assignments. `extra_patterns`
+adds local Rust regular expressions that redact the full matched span with
+`[REDACTED:extra-pattern-N]`; invalid patterns are a startup error. Redaction
+counts are written to ingest heartbeats in `redactions_total` after migration
+022; before that migration, redaction still runs and ingest logs that the
+heartbeat audit column is not available.
+
 ## Ingest Sources
 
 Each `[[ingest.sources]]` entry describes one watched source:

--- a/sql/022_heartbeat_redaction_counts.sql
+++ b/sql/022_heartbeat_redaction_counts.sql
@@ -1,0 +1,6 @@
+-- Aggregate secret-redaction counts on ingest heartbeats, encoded as a JSON
+-- object `{rule_id: count}`. Redaction itself does not require this column:
+-- ingest probes for it at startup and omits the audit surface until migrated.
+
+ALTER TABLE moraine.ingest_heartbeats
+  ADD COLUMN IF NOT EXISTS redactions_total String DEFAULT '';


### PR DESCRIPTION
## Summary

Implements default-on secret redaction for Moraine ingestion. Session rows are scrubbed before the default/local sink by the tee router, and mirror/backend egress gets a second non-skippable redaction pass after route filtering.

The redactor covers built-in token families, private key material, JWTs, common service token prefixes, configurable additive `extra_patterns`, entropy/min-length/stopword filters, and idempotent typed placeholders like `[REDACTED:github-token]`.

## Behavior

- Adds `[redaction]` config with `ruleset = "builtin"`, additive `extra_patterns`, and local-only `dangerously_skip_secret_redaction`.
- Honors the skip flag only from the trusted home config path; repo/non-home config attempts are ignored and warned about.
- Keeps remote backend egress redacted even when local capture is explicitly skipped.
- Redacts `raw_events.raw_json`, `events.payload_json`, `events.text_content`, `tool_io.input_json`, `tool_io.output_json`, `tool_io.output_text`, and `ingest_errors.raw_fragment`.
- Recomputes derived hashes/previews/byte counts for scrubbed rows.
- Adds aggregate per-rule audit counts to heartbeat payloads via migration 022 (`ingest_heartbeats.redactions_total`).

## Coverage Against Open Issues

This PR covers the Phase 2 secret-redaction slice from #383 and #382:

- Default-on redaction before local/default storage.
- Trusted-home-config-only local opt-out via `dangerously_skip_secret_redaction`.
- Non-skippable mirror/backend egress redaction backstop.
- The two-gate shape requested by #382: tee-router default gate plus backend-sink backstop after route filtering.
- Secret surfaces named by #382, plus `ingest_errors.raw_fragment` so oversized/error quarantine rows do not bypass redaction.
- Typed, idempotent placeholders; bad rulesets or invalid `extra_patterns` fail startup.
- Per-rule aggregate audit counts without secret values.

Not covered here:

- #381 Identity & Attribution remains open; per-record `{rule, count}` audit attribution to `author` is deferred until identity exists. This PR intentionally records aggregate counts only.
- #383 experimental-mode acknowledgement/loud-warning guardrails, RBAC/monitor auth, team usability, and lifecycle/deletion phases remain separate epic work.
- Redaction dry-run/preview mode and ruleset refresh cadence remain #383/#382 follow-up questions.
- No live secret verification, reversible redaction, encryption/tokenization, or PII/NER redaction is introduced.

## Operational Impact

- Behavior change: newly ingested local rows are redacted by default.
- Migration 022 adds `redactions_total String DEFAULT ''` to `ingest_heartbeats`; ingest logs a warning until `moraine db migrate` is run and the service restarts.
- Bad redaction rulesets or invalid `extra_patterns` fail startup.
- Identity-attributed per-record audit is intentionally deferred until the Identity work from the issue’s soft dependency is available; this PR records aggregate counts only.
- No live verification or reversible redaction is introduced.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --locked`
- `make docs-build`
- repo-managed pre-commit hook: fmt + strict clippy baseline passed during commit
- sandbox `sb-ca1b58` (removed): targeted redaction/config/router/backend/migration tests passed
- sandbox stack smoke: `scripts/ci/e2e-stack.sh` passed with sandbox-only path overrides for Linux service binaries and prebuilt monitor assets
- sandbox monitor health check returned ok against ClickHouse 25.12.5.44

Closes #382
