### PR TITLE
feat(setup): enable harnesses by default

### DIFF
--- a/apps/moraine/src/cli.rs
+++ b/apps/moraine/src/cli.rs
@@ -191,7 +191,7 @@ pub(crate) struct ConfigGetArgs {
 
 #[derive(Debug, Args)]
 pub(crate) struct SetupArgs {
-    /// Accept non-interactive defaults. Does not enable MCP targets by itself.
+    /// Accept non-interactive defaults, including all supported MCP/plugin targets.
     #[arg(long)]
     pub(crate) yes: bool,
     /// Show planned changes without writing files or running external commands.

--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -70,8 +70,13 @@ fn run_setup(
         if config_allows_mcp {
             let selections = setup_target_selections(args, interactive, runner)?;
             if selections.apply_ingest && !args.skip_config && config.status == SetupStatus::Ok {
-                match apply_ingest_selections_to_config(&target.path, &selections.targets) {
-                    Ok(update) => config.apply_ingest_update(update),
+                let ingest_update = if args.dry_run {
+                    preview_ingest_selections_for_config(&target.path, &selections.targets)
+                } else {
+                    apply_ingest_selections_to_config(&target.path, &selections.targets)
+                };
+                match ingest_update {
+                    Ok(update) => config.apply_ingest_update(update, args.dry_run),
                     Err(exc) => {
                         config = ConfigReport::error(
                             &target.path,
@@ -489,7 +494,17 @@ impl IngestSelectionUpdate {
         if !self.has_changes() {
             return "ingest sources already matched selection".to_string();
         }
+        format!("ingest sources updated: {}", self.change_summary())
+    }
 
+    fn planned_summary(self) -> String {
+        if !self.has_changes() {
+            return "ingest sources already matched selection".to_string();
+        }
+        format!("ingest sources would be updated: {}", self.change_summary())
+    }
+
+    fn change_summary(self) -> String {
         let mut parts = Vec::new();
         if self.added_sources == 1 {
             parts.push("1 added".to_string());
@@ -511,24 +526,36 @@ impl IngestSelectionUpdate {
         } else if self.updated_sources > 1 {
             parts.push(format!("{} repaired", self.updated_sources));
         }
-        format!("ingest sources updated: {}", parts.join(", "))
+        parts.join(", ")
     }
+}
+
+fn preview_ingest_selections_for_config(
+    path: &Path,
+    selections: &[SetupTargetSelection],
+) -> Result<IngestSelectionUpdate> {
+    let mut document = read_config_document(path)?;
+    apply_ingest_selections_to_document(&mut document, selections)
 }
 
 fn apply_ingest_selections_to_config(
     path: &Path,
     selections: &[SetupTargetSelection],
 ) -> Result<IngestSelectionUpdate> {
-    let content =
-        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
-    let mut document = content
-        .parse::<DocumentMut>()
-        .with_context(|| format!("{} is not valid TOML", path.display()))?;
+    let mut document = read_config_document(path)?;
     let update = apply_ingest_selections_to_document(&mut document, selections)?;
     if update.has_changes() {
         write_toml_atomic(path, &document.to_string())?;
     }
     Ok(update)
+}
+
+fn read_config_document(path: &Path) -> Result<DocumentMut> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    content
+        .parse::<DocumentMut>()
+        .with_context(|| format!("{} is not valid TOML", path.display()))
 }
 
 fn apply_ingest_selections_to_document(
@@ -773,7 +800,15 @@ fn setup_target_selections(
         });
     }
 
-    if args.yes || args.dry_run || !interactive {
+    if args.yes || args.dry_run {
+        return Ok(SetupSelectionSet {
+            targets: default_setup_target_selections(),
+            apply_ingest: true,
+            confirmed_harness: true,
+        });
+    }
+
+    if !interactive {
         return Ok(SetupSelectionSet {
             targets: Vec::new(),
             apply_ingest: false,
@@ -783,6 +818,22 @@ fn setup_target_selections(
 
     let targets = harnesses::setup_targets();
     prompt_setup_target_selector(&targets, runner)
+}
+
+fn default_setup_target_selections() -> Vec<SetupTargetSelection> {
+    setup_target_selection_rows(harnesses::setup_targets())
+}
+
+fn setup_target_selection_rows(
+    targets: impl IntoIterator<Item = SetupMcpTarget>,
+) -> Vec<SetupTargetSelection> {
+    targets
+        .into_iter()
+        .map(|target| SetupTargetSelection {
+            target,
+            mode: SetupSelectionMode::IngestAndHarness,
+        })
+        .collect()
 }
 
 fn dedup_targets(targets: &[SetupMcpTarget]) -> Vec<SetupMcpTarget> {
@@ -798,14 +849,7 @@ fn prompt_setup_target_selector(
     targets: &[SetupMcpTarget],
     runner: &dyn CommandRunner,
 ) -> Result<SetupSelectionSet> {
-    let mut selections = targets
-        .iter()
-        .copied()
-        .map(|target| SetupTargetSelection {
-            target,
-            mode: SetupSelectionMode::Off,
-        })
-        .collect::<Vec<_>>();
+    let mut selections = setup_target_selection_rows(targets.iter().copied());
     let mut active = 0usize;
     let term = Term::stderr();
     let mut rendered_lines = 0usize;
@@ -887,7 +931,7 @@ fn render_setup_selector(
             .for_stderr()
             .bright()
             .black()
-            .apply_to("Space cycles none → ingest + harness → ingest only → harness only. Enter applies. Esc skips.")
+            .apply_to("All harnesses start selected. Space cycles ingest + harness → ingest only → harness only → none. Enter applies. Esc skips.")
     ))?;
     term.write_line(&format!(
         "  {}",
@@ -2001,9 +2045,22 @@ impl ConfigReport {
         }
     }
 
-    fn apply_ingest_update(&mut self, update: IngestSelectionUpdate) {
-        if update.has_changes() && self.action == "unchanged" {
-            self.action = "updated".to_string();
+    fn apply_ingest_update(&mut self, update: IngestSelectionUpdate, dry_run: bool) {
+        if update.has_changes() {
+            if dry_run || self.status == SetupStatus::Planned {
+                if self.action == "unchanged" {
+                    self.action = "would_update".to_string();
+                }
+                if self.status == SetupStatus::Ok {
+                    self.status = SetupStatus::Planned;
+                }
+                self.message = format!("{}; {}", self.message, update.planned_summary());
+                return;
+            }
+
+            if self.action == "unchanged" {
+                self.action = "updated".to_string();
+            }
         }
         self.message = format!("{}; {}", self.message, update.summary());
     }
@@ -2556,6 +2613,43 @@ mod tests {
     #[test]
     fn setup_selector_warning_discloses_host_wide_history_access() {
         assert!(HOST_WIDE_ACCESS_WARNING.contains("host-wide Moraine session history access"));
+    }
+
+    #[test]
+    fn default_target_selections_enable_ingest_and_harnesses() {
+        let selections = default_setup_target_selections();
+        assert_eq!(
+            selections
+                .iter()
+                .map(|selection| selection.target)
+                .collect::<Vec<_>>(),
+            harnesses::setup_targets()
+        );
+        assert!(selections
+            .iter()
+            .all(|selection| selection.mode == SetupSelectionMode::IngestAndHarness));
+    }
+
+    #[test]
+    fn yes_without_explicit_targets_selects_all_default_harnesses() {
+        let args = SetupArgs {
+            yes: true,
+            dry_run: false,
+            skip_config: false,
+            skip_mcp: false,
+            repair_config: false,
+            mcp_targets: Vec::new(),
+        };
+        let selections =
+            setup_target_selections(&args, false, &FakeRunner::default()).expect("selections");
+
+        assert!(selections.apply_ingest);
+        assert!(selections.confirmed_harness);
+        assert_eq!(selections.harness_targets(), harnesses::setup_targets(),);
+        assert!(selections
+            .targets
+            .iter()
+            .all(|selection| selection.mode == SetupSelectionMode::IngestAndHarness));
     }
 
     #[test]
@@ -3308,6 +3402,104 @@ watch_root = "~/custom"
             home.join(".cursor").join("mcp.json").display().to_string()
         );
         assert!(!home.exists());
+    }
+
+    #[test]
+    fn dry_run_without_explicit_targets_plans_all_default_harnesses() {
+        let args = SetupArgs {
+            yes: false,
+            dry_run: true,
+            skip_config: true,
+            skip_mcp: false,
+            repair_config: false,
+            mcp_targets: Vec::new(),
+        };
+        let mut runner = FakeRunner::default();
+        let report = run_setup(
+            &plain_output(),
+            &args,
+            ConfigTarget {
+                path: PathBuf::from("/tmp/config.toml"),
+                source: ConfigTargetSource::HomeDefault,
+            },
+            false,
+            &mut runner,
+        )
+        .expect("setup report");
+
+        assert_eq!(
+            report
+                .mcp_targets
+                .iter()
+                .map(|target| target.target)
+                .collect::<Vec<_>>(),
+            harnesses::setup_targets()
+        );
+        assert!(report
+            .mcp_targets
+            .iter()
+            .all(|target| target.status == SetupStatus::Planned));
+        assert!(runner.ran.is_empty());
+    }
+
+    #[test]
+    fn dry_run_previews_ingest_config_updates_without_writing_existing_config() {
+        let dir = temp_path("dry-run-ingest-preview");
+        fs::create_dir_all(&dir).expect("create dir");
+        let path = dir.join("config.toml");
+        let original = r#"
+[ingest]
+
+[[ingest.sources]]
+name = "codex"
+harness = "codex"
+enabled = false
+glob = "~/.codex/sessions/**/*.jsonl"
+watch_root = "~/.codex/sessions"
+"#;
+        fs::write(&path, original).expect("write config");
+        let args = SetupArgs {
+            yes: false,
+            dry_run: true,
+            skip_config: false,
+            skip_mcp: false,
+            repair_config: false,
+            mcp_targets: Vec::new(),
+        };
+        let mut runner = FakeRunner::default();
+        let report = run_setup(
+            &plain_output(),
+            &args,
+            ConfigTarget {
+                path: path.clone(),
+                source: ConfigTargetSource::HomeDefault,
+            },
+            false,
+            &mut runner,
+        )
+        .expect("setup report");
+
+        assert_eq!(report.config.status, SetupStatus::Planned);
+        assert_eq!(report.config.action, "would_update");
+        assert!(report
+            .config
+            .message
+            .contains("ingest sources would be updated"));
+        assert_eq!(fs::read_to_string(&path).expect("config content"), original);
+        assert_eq!(
+            report
+                .mcp_targets
+                .iter()
+                .map(|target| target.target)
+                .collect::<Vec<_>>(),
+            harnesses::setup_targets()
+        );
+        assert!(report
+            .mcp_targets
+            .iter()
+            .all(|target| target.status == SetupStatus::Planned));
+        assert!(runner.ran.is_empty());
+        let _ = fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/docs/agent-mcp-search/install.md
+++ b/docs/agent-mcp-search/install.md
@@ -21,11 +21,11 @@ moraine setup
 moraine up
 ```
 
-`moraine setup` installs the Claude Code and Codex plugins, registers command
-based MCP clients such as Hermes and Kimi CLI, and writes global MCP config for
-OpenCode, Cursor, and Pi Coding Agent when selected. Use the manual sections
-below for project-scoped servers, `--project-only`, or custom environment
-wiring.
+`moraine setup` starts with all supported harnesses selected for ingest plus
+plugin or MCP setup. In the interactive selector, turn off any harnesses you do
+not want before applying. Use `moraine setup --dry-run` to preview the default
+setup without writing files. Use the manual sections below for project-scoped
+servers, `--project-only`, or custom environment wiring.
 
 ## Claude Code plugin marketplace (recommended)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,18 +35,20 @@ config and install or update agent harness integrations:
 moraine setup
 ```
 
-In non-interactive scripts, create a missing config without registering agent
-harnesses:
+In non-interactive scripts, accept the default config and all supported agent
+harness integrations:
 
 ```bash
 moraine setup --yes
 ```
 
-To preview MCP or plugin registration without touching host agent config, pass
-explicit targets:
+Pass `--skip-mcp` when you only want config creation or repair.
+
+Preview the default config and all supported harness integrations without
+writing files or touching host agent config:
 
 ```bash
-moraine setup --dry-run --mcp-target claude-code --mcp-target codex
+moraine setup --dry-run
 ```
 
 The Claude Code and Codex plugins, plus global MCP registrations, can expose
@@ -91,25 +93,26 @@ an embedded server automatically. See
 [Agent MCP Search → Install](agent-mcp-search/install.md#shared-central-server-default).
 
 Use `moraine setup` to connect your agent harnesses. In an interactive terminal,
-setup shows a selector for detected harnesses; use the arrow keys to move, Space
-to choose integrations, and Enter to install the selected plugins or MCP
-registrations:
+setup shows all supported harnesses selected by default; use the arrow keys to
+move, Space to cycle a harness through ingest/plugin-MCP/off choices, and Enter
+to apply the selected integrations:
 
 ```bash
 moraine setup
 ```
 
-You can also target harnesses directly, which is useful for scripts or for
-rerunning setup after installing a new harness CLI:
+You can also target harness MCP/plugin setup directly, which is useful for
+rerunning setup after installing a new harness CLI. Direct targets do not change
+ingest source selections:
 
 ```bash
-moraine setup --yes --mcp-target claude-code --mcp-target codex --mcp-target hermes --mcp-target opencode --mcp-target cursor
+moraine setup --yes --mcp-target claude-code --mcp-target codex --mcp-target hermes --mcp-target kimi-cli --mcp-target opencode --mcp-target cursor --mcp-target pi-coding-agent
 ```
 
-Preview those changes without touching host agent config:
+Preview targeted MCP/plugin changes without touching host agent config:
 
 ```bash
-moraine setup --dry-run --mcp-target claude-code --mcp-target codex --mcp-target hermes --mcp-target opencode --mcp-target cursor --mcp-target pi-coding-agent
+moraine setup --dry-run --mcp-target claude-code --mcp-target codex --mcp-target hermes --mcp-target kimi-cli --mcp-target opencode --mcp-target cursor --mcp-target pi-coding-agent
 ```
 
 The Claude Code, Codex, and Hermes plugins bundle Moraine search, realtime, and


### PR DESCRIPTION
## Description

**What.** Makes `moraine setup` default every supported harness to ingest plus plugin/MCP setup.

**Why.** Guided setup should connect the full supported harness surface by default while still letting users turn individual harnesses off.

This updates the setup selection path so interactive setup, `--yes`, and default `--dry-run` all start from the same all-harness `ingest + plugin/MCP` selection. Explicit `--mcp-target` usage remains targeted MCP/plugin-only and does not change ingest source selections.

Dry-run now also reconciles ingest selections in memory so it previews existing config updates as `would_update` without writing the TOML file.

## Usage

Preview the default setup without writing files or touching host agent config:

```bash
moraine setup --dry-run
```

Accept the default config and all supported harness integrations non-interactively:

```bash
moraine setup --yes
```

Only create or repair config without MCP/plugin setup:

```bash
moraine setup --yes --skip-mcp
```

Targeted MCP/plugin-only setup is still available with explicit targets:

```bash
moraine setup --yes --mcp-target claude-code --mcp-target codex --mcp-target hermes --mcp-target kimi-cli --mcp-target opencode --mcp-target cursor --mcp-target pi-coding-agent
```

## Changelog

- `moraine setup` now defaults all supported harnesses to ingest plus plugin/MCP setup.
- `moraine setup --dry-run` previews default harness setup and ingest config changes without writing files.
- Quickstart and MCP install docs now distinguish default-all setup from targeted MCP/plugin-only setup.

## Operational Impact

This changes guided setup defaults. Running `moraine setup --yes` with no explicit targets now attempts supported harness plugin/MCP setup instead of only accepting config defaults. Users can pass `--skip-mcp` to avoid harness setup, or use the interactive selector to turn individual harnesses off.

## Review

Ran the delegated Moraine review wave across elegance, idiom, correctness, completeness, security, YAGNI, and scope. Elegance, correctness, and completeness findings were accepted and fixed; follow-up review came back clean. The remaining personas had no findings.

## Validation

Validated with `cargo fmt --all -- --check`, `git diff --check`, `cargo test -p moraine setup`, `cargo test -p moraine`, and `cargo test --workspace --locked`; all passed. The repo pre-commit hook also passed `make fmt` and the strict clippy baseline during commit.
