### PR TITLE
fix(ingest): stop no-op sqlite checkpoint churn and search expansion read amplification

### DIFF
--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -748,6 +748,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             name: "022_heartbeat_redaction_counts.sql",
             sql: include_str!("../../../sql/022_heartbeat_redaction_counts.sql"),
         },
+        Migration {
+            version: "023",
+            name: "023_search_documents_event_uid_bloom.sql",
+            sql: include_str!("../../../sql/023_search_documents_event_uid_bloom.sql"),
+        },
     ]
 }
 

--- a/crates/moraine-conversations/src/clickhouse_repo/cache.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/cache.rs
@@ -15,7 +15,12 @@ pub(super) const TERM_POSTINGS_FAST_PATH_MAX_ROWS_PER_TERM: u64 =
 pub(super) const TERM_POSTINGS_FAST_PATH_RATIO_MIN_DOCS: u64 = 10_000;
 pub(super) const TERM_POSTINGS_FAST_PATH_MAX_DOC_RATIO_NUMERATOR: u64 = 1;
 pub(super) const TERM_POSTINGS_FAST_PATH_MAX_DOC_RATIO_DENOMINATOR: u64 = 4;
-pub(super) const SEARCH_DOC_EXTRA_CACHE_TTL: Duration = Duration::from_secs(15);
+// 60s (issue #443): hydrated doc rows are near-immutable — an event_uid's
+// content only moves when a mutable source (cursor bubble) re-emits it — and
+// agents issue bursts of overlapping searches, so a short TTL re-reads the
+// same fat search_documents granules over and over. The cost of staleness is
+// a preview up to a minute old, never a wrong hit.
+pub(super) const SEARCH_DOC_EXTRA_CACHE_TTL: Duration = Duration::from_secs(60);
 pub(super) const SEARCH_DOC_EXTRA_CACHE_MAX_ENTRIES: usize = 65536;
 
 #[derive(Debug, Clone)]

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -565,39 +565,20 @@ FORMAT JSONEachRow",
         }
         let documents_table = self.table_ref("search_documents");
         let event_uids_array = sql_array_strings(event_uids);
-        let codex_expr = if use_document_codex_flag {
-            "d.has_codex_mcp"
-        } else {
-            "toUInt8(positionCaseInsensitiveUTF8(d.payload_json, 'codex-mcp') > 0)"
-        };
         let text_content_limit = usize::from(self.cfg.preview_chars).saturating_mul(4);
         let payload_json_limit = usize::from(self.cfg.preview_chars).saturating_mul(8);
-        let documents_source_sql = if use_document_codex_flag {
-            format!(
-                "(SELECT
-  t.event_uid AS event_uid,
-  any(t.session_id) AS session_id,
-  any(t.record_ts) AS event_time,
-  any(t.source_name) AS source_name,
-  any(t.harness) AS harness,
-  any(t.inference_provider) AS inference_provider,
-  any(t.event_class) AS event_class,
-  any(t.payload_type) AS payload_type,
-  any(t.actor_role) AS actor_role,
-  any(t.name) AS name,
-  any(t.phase) AS phase,
-  any(t.source_ref) AS source_ref,
-  any(t.doc_len) AS doc_len,
-  any(t.text_content) AS text_content,
-  any(t.payload_json) AS payload_json,
-  toUInt8(any(t.has_codex_mcp)) AS has_codex_mcp
-FROM {documents_table} AS t
-WHERE t.event_uid IN {event_uids_array}
-GROUP BY t.event_uid)"
-            )
+        // Truncate the fat columns inside the aggregation (issue #443): the
+        // GROUP BY state then holds at most `*_limit` characters per uid
+        // instead of full multi-MB payload blobs. The codex fallback still
+        // scans every full payload value, but as a boolean aggregate rather
+        // than a held string.
+        let codex_inner_expr = if use_document_codex_flag {
+            "toUInt8(any(t.has_codex_mcp))"
         } else {
-            format!(
-                "(SELECT
+            "toUInt8(max(toUInt8(positionCaseInsensitiveUTF8(t.payload_json, 'codex-mcp') > 0)))"
+        };
+        let documents_source_sql = format!(
+            "(SELECT
   t.event_uid AS event_uid,
   any(t.session_id) AS session_id,
   any(t.record_ts) AS event_time,
@@ -611,14 +592,13 @@ GROUP BY t.event_uid)"
   any(t.phase) AS phase,
   any(t.source_ref) AS source_ref,
   any(t.doc_len) AS doc_len,
-  any(t.text_content) AS text_content,
-  any(t.payload_json) AS payload_json,
-  toUInt8(0) AS has_codex_mcp
+  any(leftUTF8(t.text_content, {text_content_limit})) AS text_content,
+  any(leftUTF8(t.payload_json, {payload_json_limit})) AS payload_json,
+  {codex_inner_expr} AS has_codex_mcp
 FROM {documents_table} AS t
 WHERE t.event_uid IN {event_uids_array}
 GROUP BY t.event_uid)"
-            )
-        };
+        );
 
         Ok(format!(
             "SELECT
@@ -636,15 +616,12 @@ GROUP BY t.event_uid)"
   d.source_ref AS source_ref,
   d.doc_len AS doc_len,
   leftUTF8(d.text_content, {preview}) AS text_preview,
-  leftUTF8(d.text_content, {text_content_limit}) AS text_content,
-  leftUTF8(d.payload_json, {payload_json_limit}) AS payload_json,
-  {codex_expr} AS has_codex_mcp
+  d.text_content AS text_content,
+  d.payload_json AS payload_json,
+  d.has_codex_mcp AS has_codex_mcp
 FROM {documents_source_sql} AS d
 FORMAT JSONEachRow",
             preview = self.cfg.preview_chars,
-            text_content_limit = text_content_limit,
-            payload_json_limit = payload_json_limit,
-            codex_expr = codex_expr,
             documents_source_sql = documents_source_sql,
         ))
     }
@@ -2099,19 +2076,21 @@ FORMAT JSONEachRow",
         let event_uids_sql = sql_array_strings(event_uids);
         let text_content_limit = usize::from(self.cfg.preview_chars).saturating_mul(4);
         let payload_json_limit = usize::from(self.cfg.preview_chars).saturating_mul(8);
+        // Truncate inside the aggregation (issue #443) so the GROUP BY state
+        // holds bounded strings, not full payload blobs.
         let sql = format!(
             "SELECT
   event_uid,
   leftUTF8(text_content_raw, {preview}) AS snippet,
-  leftUTF8(text_content_raw, {text_content_limit}) AS text_content,
-  leftUTF8(payload_json_raw, {payload_json_limit}) AS payload_json,
+  text_content_raw AS text_content,
+  payload_json_raw AS payload_json,
   event_class_raw AS event_class,
   actor_role_raw AS actor_role
 FROM (
   SELECT
     event_uid,
-    any(text_content) AS text_content_raw,
-    any(payload_json) AS payload_json_raw,
+    any(leftUTF8(text_content, {text_content_limit})) AS text_content_raw,
+    any(leftUTF8(payload_json, {payload_json_limit})) AS payload_json_raw,
     any(event_class) AS event_class_raw,
     any(actor_role) AS actor_role_raw
   FROM {documents_table}

--- a/crates/moraine-ingest-core/src/dispatch.rs
+++ b/crates/moraine-ingest-core/src/dispatch.rs
@@ -2,6 +2,7 @@ use crate::checkpoint::checkpoint_key;
 use crate::model::{Checkpoint, NormalizedRecord, RowBatch};
 use crate::normalize::{normalize_record, normalize_record_with_ts_hint};
 use crate::sources::shared::{format_record_ts, parse_record_ts};
+use crate::sqlite_poll::VolatilePollMap;
 use crate::{DispatchState, Metrics, SinkMessage, WorkItem};
 use anyhow::{Context, Result};
 use moraine_config::{
@@ -591,6 +592,7 @@ pub(crate) async fn run_work_item(
     work: WorkItem,
     permit: OwnedSemaphorePermit,
     checkpoints: Arc<RwLock<HashMap<String, Checkpoint>>>,
+    poll_state: VolatilePollMap,
     sink_tx: mpsc::Sender<crate::SinkMessage>,
     process_tx: mpsc::Sender<WorkItem>,
     dispatch: Arc<Mutex<DispatchState>>,
@@ -598,7 +600,9 @@ pub(crate) async fn run_work_item(
 ) {
     let key = work.key();
 
-    if let Err(exc) = process_file(&config, &work, checkpoints, sink_tx, &metrics).await {
+    if let Err(exc) =
+        process_file(&config, &work, checkpoints, &poll_state, sink_tx, &metrics).await
+    {
         error!(
             "failed processing {}:{}: {exc}",
             work.source_name, work.path
@@ -626,6 +630,7 @@ pub(crate) async fn process_file(
     config: &AppConfig,
     work: &WorkItem,
     checkpoints: Arc<RwLock<HashMap<String, Checkpoint>>>,
+    poll_state: &VolatilePollMap,
     sink_tx: mpsc::Sender<SinkMessage>,
     metrics: &Arc<Metrics>,
 ) -> Result<()> {
@@ -637,6 +642,7 @@ pub(crate) async fn process_file(
             config,
             work,
             checkpoints,
+            poll_state,
             sink_tx,
             metrics,
         )
@@ -647,6 +653,7 @@ pub(crate) async fn process_file(
             config,
             work,
             checkpoints,
+            poll_state,
             sink_tx,
             metrics,
         )
@@ -1345,6 +1352,7 @@ mod tests {
         SESSION_JSON_GENERATION, SESSION_JSON_INODE,
     };
     use crate::model::Checkpoint;
+    use crate::sqlite_poll::VolatilePollMap;
     use crate::{DispatchState, Metrics, SinkMessage, WorkItem};
     use serde_json::{json, Value};
     use std::collections::HashMap;
@@ -1523,6 +1531,7 @@ mod tests {
             work,
             permit,
             checkpoints,
+            VolatilePollMap::new(),
             sink_tx,
             process_tx,
             dispatch,
@@ -1788,9 +1797,16 @@ mod tests {
             path: source_file,
         };
 
-        process_file(&config, &work, checkpoints, sink_tx, &metrics)
-            .await
-            .expect("legacy codex file should process");
+        process_file(
+            &config,
+            &work,
+            checkpoints,
+            &VolatilePollMap::new(),
+            sink_tx,
+            &metrics,
+        )
+        .await
+        .expect("legacy codex file should process");
 
         let batches = drain_batches(&mut sink_rx).await;
         assert_eq!(batches.len(), 1);
@@ -1880,9 +1896,16 @@ mod tests {
         let metrics = Arc::new(Metrics::default());
         let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(16);
 
-        process_file(&config, &work, checkpoints, sink_tx, &metrics)
-            .await
-            .expect("resumed codex file should process");
+        process_file(
+            &config,
+            &work,
+            checkpoints,
+            &VolatilePollMap::new(),
+            sink_tx,
+            &metrics,
+        )
+        .await
+        .expect("resumed codex file should process");
 
         let batches = drain_batches(&mut sink_rx).await;
         assert_eq!(batches.len(), 1);
@@ -1945,9 +1968,16 @@ mod tests {
             path: source_file,
         };
 
-        process_file(&config, &work, checkpoints, sink_tx, &metrics)
-            .await
-            .expect("claude file should process");
+        process_file(
+            &config,
+            &work,
+            checkpoints,
+            &VolatilePollMap::new(),
+            sink_tx,
+            &metrics,
+        )
+        .await
+        .expect("claude file should process");
 
         let batches = drain_batches(&mut sink_rx).await;
         assert_eq!(batches.len(), 1);
@@ -2006,9 +2036,16 @@ mod tests {
             path: source_file,
         };
 
-        process_file(&config, &work, checkpoints, sink_tx, &metrics)
-            .await
-            .expect("pi fixture should process around malformed line");
+        process_file(
+            &config,
+            &work,
+            checkpoints,
+            &VolatilePollMap::new(),
+            sink_tx,
+            &metrics,
+        )
+        .await
+        .expect("pi fixture should process around malformed line");
 
         let batches = drain_batches(&mut sink_rx).await;
         assert_eq!(batches.len(), 1);
@@ -2088,9 +2125,16 @@ mod tests {
             path: source_file.clone(),
         };
 
-        process_file(&config, &work, checkpoints, sink_tx, &metrics)
-            .await
-            .expect("oversized codex file should process around the large line");
+        process_file(
+            &config,
+            &work,
+            checkpoints,
+            &VolatilePollMap::new(),
+            sink_tx,
+            &metrics,
+        )
+        .await
+        .expect("oversized codex file should process around the large line");
 
         let batches = drain_batches(&mut sink_rx).await;
         assert!(!batches.is_empty(), "expected at least one sink batch");
@@ -2241,9 +2285,16 @@ mod tests {
             path: source_file.clone(),
         };
 
-        process_file(&config, &work, checkpoints, sink_tx, &metrics)
-            .await
-            .expect("expanded-row codex file should process around the unsafe row");
+        process_file(
+            &config,
+            &work,
+            checkpoints,
+            &VolatilePollMap::new(),
+            sink_tx,
+            &metrics,
+        )
+        .await
+        .expect("expanded-row codex file should process around the unsafe row");
 
         let batches = drain_batches(&mut sink_rx).await;
         assert!(!batches.is_empty(), "expected at least one sink batch");

--- a/crates/moraine-ingest-core/src/lib.rs
+++ b/crates/moraine-ingest-core/src/lib.rs
@@ -219,10 +219,15 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
     );
 
     let sem = Arc::new(Semaphore::new(config.ingest.max_file_workers.max(1)));
+    // Per-pipeline volatile sqlite poll state (issue #443): shared by every
+    // work item, dropped with the pipeline so restarts start from durable
+    // state only.
+    let sqlite_poll_state = crate::sqlite_poll::VolatilePollMap::new();
     let processor_handle = {
         let process_tx_clone = process_tx.clone();
         let sink_tx_clone = sink_tx.clone();
         let checkpoints_clone = checkpoints.clone();
+        let poll_state_clone = sqlite_poll_state.clone();
         let dispatch_clone = dispatch.clone();
         let sem_clone = sem.clone();
         let metrics_clone = metrics.clone();
@@ -249,6 +254,7 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
                     work,
                     permit,
                     checkpoints_clone.clone(),
+                    poll_state_clone.clone(),
                     sink_tx_clone.clone(),
                     process_tx_clone.clone(),
                     dispatch_clone.clone(),

--- a/crates/moraine-ingest-core/src/sqlite_poll.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, warn};
@@ -78,7 +78,7 @@ const ERROR_KIND_SCHEMA: &str = "sqlite_schema_mismatch";
 const ERROR_KIND_TOO_LARGE: &str = "sqlite_cursor_too_large";
 const ERROR_KIND_SCAN: &str = "sqlite_scan_error";
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
 struct StatFingerprint {
     db_len: u64,
     db_mtime_ns: u64,
@@ -89,7 +89,7 @@ struct StatFingerprint {
 }
 
 /// Persisted poll cursor (the checkpoint's `cursor_json` payload).
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 struct CursorState {
     version: u32,
     format: String,
@@ -152,80 +152,98 @@ const NOOP_RESCAN_MIN_INTERVAL: Duration = Duration::from_secs(15);
 /// ClickHouse CPU at idle, so scans that change nothing durable record the
 /// stat fingerprint they covered here instead of in `ingest_checkpoints`.
 /// Losing this map on restart costs one redundant no-op scan per database.
-struct VolatilePollState {
+/// Entries for databases that vanish from disk are never evicted; growth is
+/// bounded by the number of distinct watched database paths.
+struct VolatilePollEntry {
     source_generation: u32,
     stat: StatFingerprint,
     consecutive_noop_scans: u32,
     last_scan_at: Instant,
 }
 
-static VOLATILE_POLL_STATE: LazyLock<Mutex<HashMap<String, VolatilePollState>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-fn volatile_poll_state() -> std::sync::MutexGuard<'static, HashMap<String, VolatilePollState>> {
-    VOLATILE_POLL_STATE
-        .lock()
-        .expect("volatile poll state mutex poisoned")
+/// One map per ingest pipeline, created in `run_ingestor` and threaded
+/// alongside the committed-checkpoint map — never process-global, so a
+/// pipeline always starts from durable state only.
+#[derive(Clone, Default)]
+pub(crate) struct VolatilePollMap {
+    entries: Arc<Mutex<HashMap<String, VolatilePollEntry>>>,
 }
 
-/// True when a poll should be skipped without scanning: either the last no-op
-/// scan already covered the current stat fingerprint (the durable checkpoint
-/// is intentionally stale after a no-op scan), or the database is stat-noisy
-/// and still inside its rescan backoff window.
-fn should_skip_noop_poll(
-    cp_key: &str,
-    source_generation: u32,
-    current_stat: &StatFingerprint,
-) -> bool {
-    let map = volatile_poll_state();
-    let Some(entry) = map.get(cp_key) else {
-        return false;
-    };
-    if entry.source_generation != source_generation {
-        return false;
+impl VolatilePollMap {
+    pub(crate) fn new() -> Self {
+        Self::default()
     }
-    if entry.stat == *current_stat {
-        return true;
-    }
-    entry.consecutive_noop_scans >= NOOP_SCAN_BACKOFF_THRESHOLD
-        && entry.last_scan_at.elapsed() < NOOP_RESCAN_MIN_INTERVAL
-}
 
-/// Record a scan that changed nothing durable: remember the stat fingerprint
-/// it covered and extend the no-op streak.
-fn record_noop_scan(cp_key: &str, source_generation: u32, stat: StatFingerprint) {
-    let mut map = volatile_poll_state();
-    let consecutive_noop_scans = match map.get(cp_key) {
-        Some(entry) if entry.source_generation == source_generation => {
-            entry.consecutive_noop_scans.saturating_add(1)
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, VolatilePollEntry>> {
+        self.entries
+            .lock()
+            .expect("volatile poll state mutex poisoned")
+    }
+
+    /// True when a poll should be skipped without scanning: either the last
+    /// no-op scan already covered the current stat fingerprint (the durable
+    /// checkpoint is intentionally stale after a no-op scan), or the database
+    /// is stat-noisy and still inside its rescan backoff window.
+    fn should_skip_poll(
+        &self,
+        cp_key: &str,
+        source_generation: u32,
+        current_stat: &StatFingerprint,
+    ) -> bool {
+        let map = self.lock();
+        let Some(entry) = map.get(cp_key) else {
+            return false;
+        };
+        if entry.source_generation != source_generation {
+            return false;
         }
-        _ => 1,
-    };
-    map.insert(
-        cp_key.to_string(),
-        VolatilePollState {
-            source_generation,
-            stat,
-            consecutive_noop_scans,
-            last_scan_at: Instant::now(),
-        },
-    );
-}
+        if entry.stat == *current_stat {
+            return true;
+        }
+        entry.consecutive_noop_scans >= NOOP_SCAN_BACKOFF_THRESHOLD
+            && entry.last_scan_at.elapsed() < NOOP_RESCAN_MIN_INTERVAL
+    }
 
-/// Forget volatile state after a scan that persisted a durable checkpoint:
-/// the checkpoint now carries the authoritative cursor, and crash recovery
-/// must never be suppressed by stale volatile state.
-fn clear_noop_poll_state(cp_key: &str) {
-    volatile_poll_state().remove(cp_key);
-}
-
-/// A failed scan refreshes the backoff clock of an existing no-op streak so a
-/// persistently failing stat-noisy database retries on the throttled cadence
-/// instead of every reconcile tick. Without a streak this is a no-op and the
-/// failure retries exactly as before.
-fn record_failed_scan(cp_key: &str) {
-    if let Some(entry) = volatile_poll_state().get_mut(cp_key) {
+    /// Record a scan that changed nothing durable: remember the stat
+    /// fingerprint it covered and extend the no-op streak.
+    fn record_noop_scan(&self, cp_key: &str, source_generation: u32, stat: StatFingerprint) {
+        let mut map = self.lock();
+        let entry = map
+            .entry(cp_key.to_string())
+            .and_modify(|entry| {
+                if entry.source_generation != source_generation {
+                    entry.consecutive_noop_scans = 0;
+                }
+            })
+            .or_insert(VolatilePollEntry {
+                source_generation,
+                stat,
+                consecutive_noop_scans: 0,
+                last_scan_at: Instant::now(),
+            });
+        entry.source_generation = source_generation;
+        entry.stat = stat;
+        entry.consecutive_noop_scans = entry.consecutive_noop_scans.saturating_add(1);
         entry.last_scan_at = Instant::now();
+    }
+
+    /// Forget volatile state after a scan that persisted a durable *data*
+    /// checkpoint: that checkpoint now carries the authoritative cursor, and
+    /// crash recovery must never be suppressed by stale volatile state.
+    /// Error-marker checkpoints deliberately do not clear — the failure path
+    /// keeps the entry and refreshes its clock via `record_failed_scan`.
+    fn clear(&self, cp_key: &str) {
+        self.lock().remove(cp_key);
+    }
+
+    /// A failed scan refreshes the backoff clock of an existing no-op streak
+    /// so a persistently failing stat-noisy database retries on the throttled
+    /// cadence instead of every reconcile tick. Without a streak this is a
+    /// no-op and the failure retries exactly as before.
+    fn record_failed_scan(&self, cp_key: &str) {
+        if let Some(entry) = self.lock().get_mut(cp_key) {
+            entry.last_scan_at = Instant::now();
+        }
     }
 }
 
@@ -315,6 +333,7 @@ pub(crate) async fn process_cursor_sqlite_db(
     config: &AppConfig,
     work: &WorkItem,
     checkpoints: Arc<RwLock<HashMap<String, Checkpoint>>>,
+    poll_state: &VolatilePollMap,
     sink_tx: mpsc::Sender<SinkMessage>,
     metrics: &Arc<Metrics>,
 ) -> Result<()> {
@@ -367,7 +386,7 @@ pub(crate) async fn process_cursor_sqlite_db(
 
     // Volatile short-circuit + rescan backoff (issue #443): no-op scans leave
     // the durable checkpoint untouched, so their coverage lives here instead.
-    if should_skip_noop_poll(&cp_key, checkpoint.source_generation, &current_stat) {
+    if poll_state.should_skip_poll(&cp_key, checkpoint.source_generation, &current_stat) {
         return Ok(());
     }
 
@@ -384,25 +403,30 @@ pub(crate) async fn process_cursor_sqlite_db(
             schema_fingerprint,
             relevant_keys,
         } => {
-            new_state.stat = current_stat.clone();
+            new_state.stat = current_stat;
             new_state.last_error = String::new();
 
             // A no-op scan: only the stat fingerprint moved — no record was
-            // emitted and nothing the durable checkpoint carries (hash
-            // cursor, schema, key count, error marker) changed. Persisting a
-            // checkpoint here would append an `ingest_checkpoints` row per
-            // WAL touch forever (issue #443); record the covered stat in
-            // volatile state instead and send nothing.
+            // emitted and nothing the durable checkpoint carries changed.
+            // Persisting a checkpoint here would append an
+            // `ingest_checkpoints` row per WAL touch forever (issue #443);
+            // record the covered stat in volatile state instead and send
+            // nothing. The comparison is structural (stat normalized away)
+            // so any future `CursorState` field is durable by default.
+            let prior_state_covered = {
+                let mut prior = state.clone();
+                prior.stat = new_state.stat;
+                prior
+            };
             let scan_is_noop = had_committed
                 && !generation_changed
                 && records.is_empty()
-                && state.last_error.is_empty()
                 && checkpoint.status == "active"
-                && new_state.kv_hashes == state.kv_hashes
+                && new_state == prior_state_covered
                 && schema_fingerprint == checkpoint.schema_fingerprint
                 && relevant_keys == checkpoint.last_line_no;
             if scan_is_noop {
-                record_noop_scan(&cp_key, checkpoint.source_generation, new_state.stat);
+                poll_state.record_noop_scan(&cp_key, checkpoint.source_generation, new_state.stat);
                 return Ok(());
             }
 
@@ -479,7 +503,7 @@ pub(crate) async fn process_cursor_sqlite_db(
                 .send(SinkMessage::Batch(batch))
                 .await
                 .context("sink channel closed while sending final cursor_sqlite batch")?;
-            clear_noop_poll_state(&cp_key);
+            poll_state.clear(&cp_key);
 
             if emitted > 0 {
                 debug!(
@@ -494,7 +518,7 @@ pub(crate) async fn process_cursor_sqlite_db(
             error_kind,
             error_text,
         } => {
-            record_failed_scan(&cp_key);
+            poll_state.record_failed_scan(&cp_key);
 
             // A repeat of the failure already marked in the committed
             // checkpoint sends nothing: the marker is durable, and reconcile
@@ -1437,13 +1461,28 @@ mod tests {
         work: &WorkItem,
         checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
     ) -> Vec<RowBatch> {
+        run_poll_with_state(work, checkpoints, &VolatilePollMap::new()).await
+    }
+
+    async fn run_poll_with_state(
+        work: &WorkItem,
+        checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
+        poll_state: &VolatilePollMap,
+    ) -> Vec<RowBatch> {
         let config = moraine_config::AppConfig::default();
         let metrics = Arc::new(Metrics::default());
         let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(64);
 
-        process_cursor_sqlite_db(&config, work, checkpoints.clone(), sink_tx, &metrics)
-            .await
-            .expect("cursor_sqlite poll should succeed");
+        process_cursor_sqlite_db(
+            &config,
+            work,
+            checkpoints.clone(),
+            poll_state,
+            sink_tx,
+            &metrics,
+        )
+        .await
+        .expect("cursor_sqlite poll should succeed");
         let batches = drain_batches(&mut sink_rx).await;
 
         // Apply the final checkpoint exactly like the sink would after a
@@ -1577,8 +1616,9 @@ mod tests {
         let db = seed_fixture_db(&path);
         let work = sqlite_work(&path);
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
 
-        let first = run_poll(&work, &checkpoints).await;
+        let first = run_poll_with_state(&work, &checkpoints, &poll_state).await;
         assert!(!first.is_empty());
         let cp_key = checkpoint_key(&work.source_name, &work.path);
         let baseline = checkpoints
@@ -1592,7 +1632,7 @@ mod tests {
         // stat fingerprint moves but no relevant key changes.
         put(&db, "agentKv:blob:0000", &json!({"opaque": "blob"}));
 
-        let second = run_poll(&work, &checkpoints).await;
+        let second = run_poll_with_state(&work, &checkpoints, &poll_state).await;
         assert!(
             second.is_empty(),
             "a no-op scan must send nothing durable; got {} batches",
@@ -1601,7 +1641,7 @@ mod tests {
 
         // The same stat fingerprint is now covered by volatile state, so a
         // re-poll without further writes also sends nothing.
-        let third = run_poll(&work, &checkpoints).await;
+        let third = run_poll_with_state(&work, &checkpoints, &poll_state).await;
         assert!(
             third.is_empty(),
             "volatile stat coverage must short-circuit"
@@ -1614,7 +1654,7 @@ mod tests {
             &format!("bubbleId:{COMPOSER_ID}:{TOOL_BUBBLE_ID}"),
             &tool_bubble_value("completed", true),
         );
-        let fourth = run_poll(&work, &checkpoints).await;
+        let fourth = run_poll_with_state(&work, &checkpoints, &poll_state).await;
         let rows = all_event_rows(&fourth);
         assert_eq!(event_uid_by_kind(&rows, "tool_result").len(), 1);
         let cp = fourth
@@ -1632,6 +1672,7 @@ mod tests {
 
     #[test]
     fn noop_backoff_state_machine() {
+        let map = VolatilePollMap::new();
         let key = "cursor-sqlite-test:noop-backoff-state-machine";
         let stat = |db_len: u64| StatFingerprint {
             db_len,
@@ -1639,34 +1680,52 @@ mod tests {
         };
 
         assert!(
-            !should_skip_noop_poll(key, 1, &stat(1)),
+            !map.should_skip_poll(key, 1, &stat(1)),
             "no volatile state yet"
         );
-
-        record_noop_scan(key, 1, stat(1));
+        map.record_failed_scan(key);
         assert!(
-            should_skip_noop_poll(key, 1, &stat(1)),
+            !map.should_skip_poll(key, 1, &stat(1)),
+            "a failed scan without a streak leaves retries unthrottled"
+        );
+
+        map.record_noop_scan(key, 1, stat(1));
+        assert!(
+            map.should_skip_poll(key, 1, &stat(1)),
             "covered stat skips without a scan"
         );
         assert!(
-            !should_skip_noop_poll(key, 1, &stat(2)),
+            !map.should_skip_poll(key, 1, &stat(2)),
             "below the streak threshold a fresh stat scans immediately"
         );
 
-        record_noop_scan(key, 1, stat(2));
-        record_noop_scan(key, 1, stat(3));
+        map.record_noop_scan(key, 1, stat(2));
+        map.record_noop_scan(key, 1, stat(3));
         assert!(
-            should_skip_noop_poll(key, 1, &stat(4)),
+            map.should_skip_poll(key, 1, &stat(4)),
             "at the streak threshold fresh stats are throttled"
         );
         assert!(
-            !should_skip_noop_poll(key, 2, &stat(4)),
+            !map.should_skip_poll(key, 2, &stat(4)),
             "a new generation ignores stale volatile state"
         );
 
-        clear_noop_poll_state(key);
+        // A failed scan on an established streak refreshes the backoff clock
+        // (streak and coverage untouched), keeping a persistently failing
+        // stat-noisy database on the throttled cadence.
+        map.record_failed_scan(key);
         assert!(
-            !should_skip_noop_poll(key, 1, &stat(4)),
+            map.should_skip_poll(key, 1, &stat(5)),
+            "failed scan keeps the throttle window open"
+        );
+        assert!(
+            map.should_skip_poll(key, 1, &stat(3)),
+            "failed scan does not invalidate the covered stat"
+        );
+
+        map.clear(key);
+        assert!(
+            !map.should_skip_poll(key, 1, &stat(4)),
             "a durable checkpoint write clears the throttle"
         );
     }

--- a/crates/moraine-ingest-core/src/sqlite_poll.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll.rs
@@ -38,7 +38,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, warn};
 
@@ -129,6 +130,102 @@ impl CursorState {
 
     fn serialize(&self) -> String {
         serde_json::to_string(self).unwrap_or_default()
+    }
+}
+
+/// After this many consecutive no-op scans, a database is considered
+/// stat-noisy and rescans are throttled to `NOOP_RESCAN_MIN_INTERVAL`.
+/// Below the threshold every stat change scans immediately, so ordinary
+/// write→poll flows (and tests) never wait on the throttle.
+const NOOP_SCAN_BACKOFF_THRESHOLD: u32 = 3;
+
+/// Minimum interval between full scans of a stat-noisy database. This bounds
+/// pickup latency: after an idle stretch the first relevant write can wait up
+/// to this long, but the scan it triggers resets the streak, so an actively
+/// streaming session tails in real time again.
+const NOOP_RESCAN_MIN_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Volatile per-database poll state (issue #443). Cursor touches its DB, WAL,
+/// and SHM sidecars continuously (heartbeats, `ItemTable` writes) without
+/// changing any transcript-relevant key. Persisting a durable checkpoint — or
+/// even re-hashing every relevant value — on each touch pins ingest and
+/// ClickHouse CPU at idle, so scans that change nothing durable record the
+/// stat fingerprint they covered here instead of in `ingest_checkpoints`.
+/// Losing this map on restart costs one redundant no-op scan per database.
+struct VolatilePollState {
+    source_generation: u32,
+    stat: StatFingerprint,
+    consecutive_noop_scans: u32,
+    last_scan_at: Instant,
+}
+
+static VOLATILE_POLL_STATE: LazyLock<Mutex<HashMap<String, VolatilePollState>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn volatile_poll_state() -> std::sync::MutexGuard<'static, HashMap<String, VolatilePollState>> {
+    VOLATILE_POLL_STATE
+        .lock()
+        .expect("volatile poll state mutex poisoned")
+}
+
+/// True when a poll should be skipped without scanning: either the last no-op
+/// scan already covered the current stat fingerprint (the durable checkpoint
+/// is intentionally stale after a no-op scan), or the database is stat-noisy
+/// and still inside its rescan backoff window.
+fn should_skip_noop_poll(
+    cp_key: &str,
+    source_generation: u32,
+    current_stat: &StatFingerprint,
+) -> bool {
+    let map = volatile_poll_state();
+    let Some(entry) = map.get(cp_key) else {
+        return false;
+    };
+    if entry.source_generation != source_generation {
+        return false;
+    }
+    if entry.stat == *current_stat {
+        return true;
+    }
+    entry.consecutive_noop_scans >= NOOP_SCAN_BACKOFF_THRESHOLD
+        && entry.last_scan_at.elapsed() < NOOP_RESCAN_MIN_INTERVAL
+}
+
+/// Record a scan that changed nothing durable: remember the stat fingerprint
+/// it covered and extend the no-op streak.
+fn record_noop_scan(cp_key: &str, source_generation: u32, stat: StatFingerprint) {
+    let mut map = volatile_poll_state();
+    let consecutive_noop_scans = match map.get(cp_key) {
+        Some(entry) if entry.source_generation == source_generation => {
+            entry.consecutive_noop_scans.saturating_add(1)
+        }
+        _ => 1,
+    };
+    map.insert(
+        cp_key.to_string(),
+        VolatilePollState {
+            source_generation,
+            stat,
+            consecutive_noop_scans,
+            last_scan_at: Instant::now(),
+        },
+    );
+}
+
+/// Forget volatile state after a scan that persisted a durable checkpoint:
+/// the checkpoint now carries the authoritative cursor, and crash recovery
+/// must never be suppressed by stale volatile state.
+fn clear_noop_poll_state(cp_key: &str) {
+    volatile_poll_state().remove(cp_key);
+}
+
+/// A failed scan refreshes the backoff clock of an existing no-op streak so a
+/// persistently failing stat-noisy database retries on the throttled cadence
+/// instead of every reconcile tick. Without a streak this is a no-op and the
+/// failure retries exactly as before.
+fn record_failed_scan(cp_key: &str) {
+    if let Some(entry) = volatile_poll_state().get_mut(cp_key) {
+        entry.last_scan_at = Instant::now();
     }
 }
 
@@ -239,6 +336,7 @@ pub(crate) async fn process_cursor_sqlite_db(
 
     let cp_key = checkpoint_key(&work.source_name, &source_file);
     let committed = { checkpoints.read().await.get(&cp_key).cloned() };
+    let had_committed = committed.is_some();
 
     let mut checkpoint = committed.unwrap_or(Checkpoint {
         source_name: work.source_name.clone(),
@@ -254,7 +352,8 @@ pub(crate) async fn process_cursor_sqlite_db(
     // A replaced database file is a new generation: every logical identity
     // (and therefore every event UID) starts over, and the hash cursor is
     // meaningless for the new file's contents.
-    if checkpoint.source_inode != inode {
+    let generation_changed = checkpoint.source_inode != inode;
+    if generation_changed {
         checkpoint.source_inode = inode;
         checkpoint.source_generation = checkpoint.source_generation.saturating_add(1).max(1);
         state = CursorState::fresh();
@@ -263,6 +362,12 @@ pub(crate) async fn process_cursor_sqlite_db(
     // Cheap no-change short-circuit: nothing touched the database or its WAL
     // sidecars since the last successful poll.
     if state.stat == current_stat && state.last_error.is_empty() {
+        return Ok(());
+    }
+
+    // Volatile short-circuit + rescan backoff (issue #443): no-op scans leave
+    // the durable checkpoint untouched, so their coverage lives here instead.
+    if should_skip_noop_poll(&cp_key, checkpoint.source_generation, &current_stat) {
         return Ok(());
     }
 
@@ -279,8 +384,27 @@ pub(crate) async fn process_cursor_sqlite_db(
             schema_fingerprint,
             relevant_keys,
         } => {
-            new_state.stat = current_stat;
+            new_state.stat = current_stat.clone();
             new_state.last_error = String::new();
+
+            // A no-op scan: only the stat fingerprint moved — no record was
+            // emitted and nothing the durable checkpoint carries (hash
+            // cursor, schema, key count, error marker) changed. Persisting a
+            // checkpoint here would append an `ingest_checkpoints` row per
+            // WAL touch forever (issue #443); record the covered stat in
+            // volatile state instead and send nothing.
+            let scan_is_noop = had_committed
+                && !generation_changed
+                && records.is_empty()
+                && state.last_error.is_empty()
+                && checkpoint.status == "active"
+                && new_state.kv_hashes == state.kv_hashes
+                && schema_fingerprint == checkpoint.schema_fingerprint
+                && relevant_keys == checkpoint.last_line_no;
+            if scan_is_noop {
+                record_noop_scan(&cp_key, checkpoint.source_generation, new_state.stat);
+                return Ok(());
+            }
 
             let mut batch = RowBatch::default();
             for synthetic in &records {
@@ -355,6 +479,7 @@ pub(crate) async fn process_cursor_sqlite_db(
                 .send(SinkMessage::Batch(batch))
                 .await
                 .context("sink channel closed while sending final cursor_sqlite batch")?;
+            clear_noop_poll_state(&cp_key);
 
             if emitted > 0 {
                 debug!(
@@ -369,6 +494,8 @@ pub(crate) async fn process_cursor_sqlite_db(
             error_kind,
             error_text,
         } => {
+            record_failed_scan(&cp_key);
+
             // A repeat of the failure already marked in the committed
             // checkpoint sends nothing: the marker is durable, and reconcile
             // re-polls every tick — re-sending an identical checkpoint would
@@ -1442,6 +1569,106 @@ mod tests {
         );
 
         cleanup(&path);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn irrelevant_write_scans_but_persists_no_checkpoint() {
+        let path = unique_db_path("noop-checkpoint");
+        let db = seed_fixture_db(&path);
+        let work = sqlite_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+
+        let first = run_poll(&work, &checkpoints).await;
+        assert!(!first.is_empty());
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let baseline = checkpoints
+            .read()
+            .await
+            .get(&cp_key)
+            .cloned()
+            .expect("committed checkpoint after first poll");
+
+        // Cursor constantly rewrites non-transcript keys (issue #443): the
+        // stat fingerprint moves but no relevant key changes.
+        put(&db, "agentKv:blob:0000", &json!({"opaque": "blob"}));
+
+        let second = run_poll(&work, &checkpoints).await;
+        assert!(
+            second.is_empty(),
+            "a no-op scan must send nothing durable; got {} batches",
+            second.len()
+        );
+
+        // The same stat fingerprint is now covered by volatile state, so a
+        // re-poll without further writes also sends nothing.
+        let third = run_poll(&work, &checkpoints).await;
+        assert!(
+            third.is_empty(),
+            "volatile stat coverage must short-circuit"
+        );
+
+        // A relevant write below the backoff threshold is picked up
+        // immediately and persists a durable checkpoint again.
+        put(
+            &db,
+            &format!("bubbleId:{COMPOSER_ID}:{TOOL_BUBBLE_ID}"),
+            &tool_bubble_value("completed", true),
+        );
+        let fourth = run_poll(&work, &checkpoints).await;
+        let rows = all_event_rows(&fourth);
+        assert_eq!(event_uid_by_kind(&rows, "tool_result").len(), 1);
+        let cp = fourth
+            .last()
+            .and_then(|batch| batch.checkpoint.clone())
+            .expect("relevant change persists a checkpoint");
+        assert_eq!(
+            cp.last_offset,
+            baseline.last_offset + 1,
+            "poll sequence advances once for the relevant change, not per WAL touch"
+        );
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn noop_backoff_state_machine() {
+        let key = "cursor-sqlite-test:noop-backoff-state-machine";
+        let stat = |db_len: u64| StatFingerprint {
+            db_len,
+            ..Default::default()
+        };
+
+        assert!(
+            !should_skip_noop_poll(key, 1, &stat(1)),
+            "no volatile state yet"
+        );
+
+        record_noop_scan(key, 1, stat(1));
+        assert!(
+            should_skip_noop_poll(key, 1, &stat(1)),
+            "covered stat skips without a scan"
+        );
+        assert!(
+            !should_skip_noop_poll(key, 1, &stat(2)),
+            "below the streak threshold a fresh stat scans immediately"
+        );
+
+        record_noop_scan(key, 1, stat(2));
+        record_noop_scan(key, 1, stat(3));
+        assert!(
+            should_skip_noop_poll(key, 1, &stat(4)),
+            "at the streak threshold fresh stats are throttled"
+        );
+        assert!(
+            !should_skip_noop_poll(key, 2, &stat(4)),
+            "a new generation ignores stale volatile state"
+        );
+
+        clear_noop_poll_state(key);
+        assert!(
+            !should_skip_noop_poll(key, 1, &stat(4)),
+            "a durable checkpoint write clears the throttle"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/moraine-ingest-core/src/sqlite_poll/opencode.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/opencode.rs
@@ -14,7 +14,8 @@ use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, warn};
 
 use super::{
-    hash_str, open_read_only, stat_fingerprint, truncate_chars_local, StatFingerprint,
+    clear_noop_poll_state, hash_str, open_read_only, record_failed_scan, record_noop_scan,
+    should_skip_noop_poll, stat_fingerprint, truncate_chars_local, StatFingerprint,
     SyntheticRecord, CURSOR_STATE_VERSION, ERROR_KIND_OPEN, ERROR_KIND_SCAN, ERROR_KIND_SCHEMA,
     ERROR_KIND_TOO_LARGE, SCAN_PAGE_MAX_BYTES, SCAN_PAGE_SIZE,
 };
@@ -172,6 +173,7 @@ pub(crate) async fn process_opencode_sqlite_db(
 
     let cp_key = checkpoint_key(&work.source_name, &source_file);
     let committed = { checkpoints.read().await.get(&cp_key).cloned() };
+    let had_committed = committed.is_some();
 
     let mut checkpoint = committed.unwrap_or(Checkpoint {
         source_name: work.source_name.clone(),
@@ -186,7 +188,8 @@ pub(crate) async fn process_opencode_sqlite_db(
 
     // A replaced database file is a new generation: logical identities (and so
     // event UIDs) restart, and the old event cursor no longer applies.
-    if checkpoint.source_inode != inode {
+    let generation_changed = checkpoint.source_inode != inode;
+    if generation_changed {
         checkpoint.source_inode = inode;
         checkpoint.source_generation = checkpoint.source_generation.saturating_add(1).max(1);
         state = OpenCodeState::fresh();
@@ -196,6 +199,12 @@ pub(crate) async fn process_opencode_sqlite_db(
     // sidecars since the last poll. `event_scan_complete` also forces one real
     // scan after upgrading from the earlier projection cursor state.
     if state.stat == current_stat && state.last_error.is_empty() && state.event_scan_complete {
+        return Ok(());
+    }
+
+    // Volatile short-circuit + rescan backoff (issue #443): no-op scans leave
+    // the durable checkpoint untouched, so their coverage lives here instead.
+    if should_skip_noop_poll(&cp_key, checkpoint.source_generation, &current_stat) {
         return Ok(());
     }
 
@@ -213,8 +222,27 @@ pub(crate) async fn process_opencode_sqlite_db(
             schema_fingerprint,
             relevant_rows,
         } => {
-            new_state.stat = current_stat;
+            new_state.stat = current_stat.clone();
             new_state.last_error = String::new();
+
+            // A no-op scan: only the stat fingerprint moved — no record was
+            // emitted and nothing the durable checkpoint carries (event
+            // cursor, schema, error marker) changed. Persisting a checkpoint
+            // here would append an `ingest_checkpoints` row per WAL touch
+            // forever (issue #443); record the covered stat in volatile
+            // state instead and send nothing.
+            let scan_is_noop = had_committed
+                && !generation_changed
+                && records.is_empty()
+                && state.last_error.is_empty()
+                && checkpoint.status == "active"
+                && state.event_scan_complete
+                && new_state.aggregate_sequences == state.aggregate_sequences
+                && schema_fingerprint == checkpoint.schema_fingerprint;
+            if scan_is_noop {
+                record_noop_scan(&cp_key, checkpoint.source_generation, new_state.stat);
+                return Ok(());
+            }
 
             let mut batch = RowBatch::default();
             for synthetic in &records {
@@ -280,6 +308,7 @@ pub(crate) async fn process_opencode_sqlite_db(
                 .send(SinkMessage::Batch(batch))
                 .await
                 .context("sink channel closed while sending final opencode_sqlite batch")?;
+            clear_noop_poll_state(&cp_key);
 
             if emitted > 0 {
                 debug!(
@@ -294,6 +323,8 @@ pub(crate) async fn process_opencode_sqlite_db(
             error_kind,
             error_text,
         } => {
+            record_failed_scan(&cp_key);
+
             // Emit each failure mode once per state change, not once per
             // reconcile tick: the marker is durable and reconcile re-polls every
             // tick, so re-sending it would append an identical error forever.

--- a/crates/moraine-ingest-core/src/sqlite_poll/opencode.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/opencode.rs
@@ -14,10 +14,9 @@ use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, warn};
 
 use super::{
-    clear_noop_poll_state, hash_str, open_read_only, record_failed_scan, record_noop_scan,
-    should_skip_noop_poll, stat_fingerprint, truncate_chars_local, StatFingerprint,
-    SyntheticRecord, CURSOR_STATE_VERSION, ERROR_KIND_OPEN, ERROR_KIND_SCAN, ERROR_KIND_SCHEMA,
-    ERROR_KIND_TOO_LARGE, SCAN_PAGE_MAX_BYTES, SCAN_PAGE_SIZE,
+    hash_str, open_read_only, stat_fingerprint, truncate_chars_local, StatFingerprint,
+    SyntheticRecord, VolatilePollMap, CURSOR_STATE_VERSION, ERROR_KIND_OPEN, ERROR_KIND_SCAN,
+    ERROR_KIND_SCHEMA, ERROR_KIND_TOO_LARGE, SCAN_PAGE_MAX_BYTES, SCAN_PAGE_SIZE,
 };
 
 const MAX_OPENCODE_RELEVANT_ROWS: u64 = 10_000;
@@ -47,7 +46,7 @@ struct OpenCodeMessageContext {
     directory: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 struct OpenCodeState {
     version: u32,
     format: String,
@@ -152,6 +151,7 @@ pub(crate) async fn process_opencode_sqlite_db(
     config: &AppConfig,
     work: &WorkItem,
     checkpoints: Arc<RwLock<HashMap<String, Checkpoint>>>,
+    poll_state: &VolatilePollMap,
     sink_tx: mpsc::Sender<SinkMessage>,
     metrics: &Arc<Metrics>,
 ) -> Result<()> {
@@ -204,7 +204,7 @@ pub(crate) async fn process_opencode_sqlite_db(
 
     // Volatile short-circuit + rescan backoff (issue #443): no-op scans leave
     // the durable checkpoint untouched, so their coverage lives here instead.
-    if should_skip_noop_poll(&cp_key, checkpoint.source_generation, &current_stat) {
+    if poll_state.should_skip_poll(&cp_key, checkpoint.source_generation, &current_stat) {
         return Ok(());
     }
 
@@ -222,25 +222,29 @@ pub(crate) async fn process_opencode_sqlite_db(
             schema_fingerprint,
             relevant_rows,
         } => {
-            new_state.stat = current_stat.clone();
+            new_state.stat = current_stat;
             new_state.last_error = String::new();
 
             // A no-op scan: only the stat fingerprint moved — no record was
-            // emitted and nothing the durable checkpoint carries (event
-            // cursor, schema, error marker) changed. Persisting a checkpoint
-            // here would append an `ingest_checkpoints` row per WAL touch
-            // forever (issue #443); record the covered stat in volatile
-            // state instead and send nothing.
+            // emitted and nothing the durable checkpoint carries changed.
+            // Persisting a checkpoint here would append an
+            // `ingest_checkpoints` row per WAL touch forever (issue #443);
+            // record the covered stat in volatile state instead and send
+            // nothing. The comparison is structural (stat normalized away)
+            // so any future `OpenCodeState` field is durable by default.
+            let prior_state_covered = {
+                let mut prior = state.clone();
+                prior.stat = new_state.stat;
+                prior
+            };
             let scan_is_noop = had_committed
                 && !generation_changed
                 && records.is_empty()
-                && state.last_error.is_empty()
                 && checkpoint.status == "active"
-                && state.event_scan_complete
-                && new_state.aggregate_sequences == state.aggregate_sequences
+                && new_state == prior_state_covered
                 && schema_fingerprint == checkpoint.schema_fingerprint;
             if scan_is_noop {
-                record_noop_scan(&cp_key, checkpoint.source_generation, new_state.stat);
+                poll_state.record_noop_scan(&cp_key, checkpoint.source_generation, new_state.stat);
                 return Ok(());
             }
 
@@ -308,7 +312,7 @@ pub(crate) async fn process_opencode_sqlite_db(
                 .send(SinkMessage::Batch(batch))
                 .await
                 .context("sink channel closed while sending final opencode_sqlite batch")?;
-            clear_noop_poll_state(&cp_key);
+            poll_state.clear(&cp_key);
 
             if emitted > 0 {
                 debug!(
@@ -323,7 +327,7 @@ pub(crate) async fn process_opencode_sqlite_db(
             error_kind,
             error_text,
         } => {
-            record_failed_scan(&cp_key);
+            poll_state.record_failed_scan(&cp_key);
 
             // Emit each failure mode once per state change, not once per
             // reconcile tick: the marker is durable and reconcile re-polls every

--- a/crates/moraine-ingest-core/src/sqlite_poll/opencode/tests.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/opencode/tests.rs
@@ -506,13 +506,28 @@ async fn run_opencode_poll(
     work: &WorkItem,
     checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
 ) -> Vec<RowBatch> {
+    run_opencode_poll_with_state(work, checkpoints, &VolatilePollMap::new()).await
+}
+
+async fn run_opencode_poll_with_state(
+    work: &WorkItem,
+    checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
+    poll_state: &VolatilePollMap,
+) -> Vec<RowBatch> {
     let config = moraine_config::AppConfig::default();
     let metrics = Arc::new(Metrics::default());
     let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(64);
 
-    process_opencode_sqlite_db(&config, work, checkpoints.clone(), sink_tx, &metrics)
-        .await
-        .expect("opencode_sqlite poll should succeed");
+    process_opencode_sqlite_db(
+        &config,
+        work,
+        checkpoints.clone(),
+        poll_state,
+        sink_tx,
+        &metrics,
+    )
+    .await
+    .expect("opencode_sqlite poll should succeed");
     let batches = drain_batches(&mut sink_rx).await;
 
     if let Some(cp) = batches.last().and_then(|batch| batch.checkpoint.clone()) {

--- a/crates/moraine-ingest-core/src/sqlite_poll/opencode/tests.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/opencode/tests.rs
@@ -911,6 +911,52 @@ async fn opencode_sqlite_unchanged_db_is_a_noop_then_mutation_reemits_row() {
     cleanup(&path);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn opencode_sqlite_irrelevant_write_persists_no_checkpoint() {
+    let path = unique_opencode_db_path("noop-checkpoint");
+    let db = seed_opencode_db(&path);
+    let work = opencode_sqlite_work(&path);
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+
+    let first = run_opencode_poll(&work, &checkpoints).await;
+    assert!(!first.is_empty());
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let baseline = checkpoints
+        .read()
+        .await
+        .get(&cp_key)
+        .cloned()
+        .expect("committed checkpoint after first poll");
+
+    // A write that never touches the event tables (issue #443): the stat
+    // fingerprint moves but the event cursor cannot advance.
+    db.execute(
+        "INSERT INTO credential (id, value, time_created, time_updated) \
+         VALUES ('cred_noise', 'rotated', 1780000004000, 1780000004000)",
+        [],
+    )
+    .expect("write non-event row");
+
+    let second = run_opencode_poll(&work, &checkpoints).await;
+    assert!(
+        second.is_empty(),
+        "a no-op scan must send nothing durable; got {} batches",
+        second.len()
+    );
+    let after = checkpoints
+        .read()
+        .await
+        .get(&cp_key)
+        .cloned()
+        .expect("checkpoint survives no-op poll");
+    assert_eq!(
+        baseline.last_offset, after.last_offset,
+        "no-op scan must not advance the poll sequence"
+    );
+
+    cleanup(&path);
+}
+
 #[test]
 fn opencode_sqlite_scan_paginates_past_single_event_page() {
     let path = unique_opencode_db_path("many-events");

--- a/crates/moraine-ingest-core/src/tee.rs
+++ b/crates/moraine-ingest-core/src/tee.rs
@@ -722,6 +722,9 @@ async fn run_replay_pass(
             }
         }
 
+        // Replay reads against this backend's own floor, not the live
+        // pipeline's, so it gets a fresh volatile map: every file scans.
+        let poll_state = crate::sqlite_poll::VolatilePollMap::new();
         for path in files {
             let work = WorkItem {
                 source_name: source.name.clone(),
@@ -731,7 +734,15 @@ async fn run_replay_pass(
             };
             // Sends are awaited: replay backpressure is bounded by the
             // backend's own queue and never touches the default path.
-            if let Err(exc) = process_file(config, &work, floor.clone(), tx.clone(), metrics).await
+            if let Err(exc) = process_file(
+                config,
+                &work,
+                floor.clone(),
+                &poll_state,
+                tx.clone(),
+                metrics,
+            )
+            .await
             {
                 warn!(
                     backend,

--- a/docs/development/ingest-sources.md
+++ b/docs/development/ingest-sources.md
@@ -164,6 +164,20 @@ Mechanics that differ from file-backed sources:
   `sqlite_scan_error`. The cursor records the last reported kind so a
   persistent failure is emitted once rather than on every reconcile tick, and
   the data cursor is left untouched so the next poll retries.
+- **Volatile no-op poll state (issue #443).** Cursor touches its DB/WAL/SHM
+  sidecars continuously without changing any transcript-relevant key. A scan
+  that emits no records and changes nothing else the durable checkpoint
+  carries persists *nothing*: the stat fingerprint it covered is recorded
+  only in a per-pipeline in-memory map (`sqlite_poll::VolatilePollMap`), so
+  the durable checkpoint's `cursor_json` stat is expected to lag the file on
+  a quiet database — that staleness is intentional, not a bug. After three
+  consecutive no-op scans the database is treated as stat-noisy and rescans
+  are throttled to one per 15 s (a failed scan refreshes that clock); any
+  scan that finds real changes persists a checkpoint, clears the volatile
+  entry, and restores immediate pickup. Worst-case pickup latency for the
+  first relevant write after an idle stretch is one throttle window
+  (~15–30 s including the reconcile tick); a process restart merely costs
+  one redundant no-op scan per database.
 
 Fixtures: `fixtures/cursor/state-vscdb-kv.jsonl` stores `cursorDiskKV` rows as
 JSONL (`key`/`value` pairs), and `fixtures/opencode/session.jsonl` stores the

--- a/sql/023_search_documents_event_uid_bloom.sql
+++ b/sql/023_search_documents_event_uid_bloom.sql
@@ -1,0 +1,19 @@
+-- Issue #443: MCP search-result expansion hydrates rows by exact `event_uid`
+-- (`WHERE event_uid IN [...]`). `search_documents` is ORDER BY (event_uid),
+-- but the sparse primary index can only narrow each lookup to one granule per
+-- part — and because event_uids are uniformly distributed hashes, nearly every
+-- part's [min, max] key range "could" contain every uid, so each expansion
+-- reads a fat-column granule (text_content/payload_json) from every part
+-- whether or not the uid is present there. During the incident this amplified
+-- to hundreds of MiB read per expansion call. A per-granule bloom filter lets
+-- ClickHouse skip the granules that do not actually contain the uid, which is
+-- most of them: a uid lives in exactly one part once merges settle.
+ALTER TABLE moraine.search_documents
+  ADD INDEX IF NOT EXISTS idx_search_documents_event_uid_bloom event_uid TYPE bloom_filter(0.01) GRANULARITY 1;
+
+-- Build the index for existing parts in the background; new parts index at
+-- insert/merge time. Deliberately not `mutations_sync = 1`: materializing over
+-- a large table must not block startup migrations, and queries are merely
+-- unaccelerated (not wrong) until the mutation finishes.
+ALTER TABLE moraine.search_documents
+  MATERIALIZE INDEX idx_search_documents_event_uid_bloom;


### PR DESCRIPTION
## Description

**What.** Stops the `cursor_sqlite`/`opencode_sqlite` pollers from persisting a durable checkpoint on every no-op scan, throttles rescans of stat-noisy databases, and cuts MCP search-expansion read amplification on `search_documents`.

**Why.** Cursor touches `state.vscdb` and its WAL/SHM sidecars continuously (heartbeats, `ItemTable` writes) without changing any transcript-relevant key. Every touch triggered a full hash scan that appended a fresh `ingest_checkpoints` row and bumped `last_offset`, pinning `moraine-ingest` at ~1 core and driving continuous ClickHouse insert/merge pressure at idle (#443). Independently, expansion of known `event_uid` hits read a fat-column granule from nearly every `search_documents` part per uid.

Ingest half (`crates/moraine-ingest-core/src/sqlite_poll.rs`, `sqlite_poll/opencode.rs`):

- A scan that emits no records and changes nothing the durable checkpoint carries persists nothing. The stat fingerprint it covered is recorded in a per-pipeline in-memory `VolatilePollMap` (created in `run_ingestor`, threaded through `process_file` like the checkpoint map; the tee catch-up replay gets a fresh map per pass). The durable checkpoint's `cursor_json` stat is therefore expected to lag the file on a quiet database; a restart costs one redundant no-op scan per database.
- The no-op verdict is structural: the scanned state is compared against the prior state with only the stat fingerprint normalized away, so any future durable state field forces a persist by default.
- After 3 consecutive no-op scans a database is treated as stat-noisy and rescans are throttled to one per 15s. Any scan that finds real changes persists a checkpoint, clears the volatile entry, and restores immediate pickup; worst-case pickup latency for the first relevant write after an idle stretch is ~15–30s including the reconcile tick.
- Failed scans on an established no-op streak refresh the throttle clock, so a persistently failing stat-noisy database retries on the throttled cadence instead of every tick (a change to failure retry cadence in that narrow case; failures without a streak retry exactly as before).
- The same treatment deliberately extends to `opencode_sqlite`, which shares the poll engine and the same defect class, though it was not the reported source.

Search half (`sql/023`, `crates/moraine-conversations`):

- Migration 023 adds a per-granule `bloom_filter` skip index on `search_documents.event_uid`. The table is `ORDER BY (event_uid)`, but uids are uniformly distributed hashes, so the sparse primary index marks a granule in nearly every part for every looked-up uid whether present or not; the bloom filter skips the absent ones.
- The hydrate/snippet queries truncate `text_content`/`payload_json` inside the inner `any()` aggregation, so GROUP BY state holds bounded strings instead of full multi-MB blobs.
- The per-uid doc-extra cache TTL rises 15s → 60s: hydrated rows are near-immutable and agents issue bursts of overlapping searches. This is a user-visible freshness change — previews of a mutated (e.g. streaming Cursor) event can be up to a minute stale, never wrong.

## Usage

No user action required. The migration applies automatically on the next stack start; the index materializes for existing parts in the background (queries are unaccelerated, not wrong, until it completes). No configuration surface was added.

## Changelog

- `cursor_sqlite`/`opencode_sqlite` no longer write an `ingest_checkpoints` row per WAL touch on idle databases; idle `moraine-ingest` CPU drops from ~1 core to ~0%.
- New ClickHouse migration `023_search_documents_event_uid_bloom.sql` (additive skip index + async materialize).
- MCP search-result expansion reads ~20x fewer bytes per call; search previews may be up to 60s stale for freshly mutated events (was 15s).

## Bug Evidence

Before, on the reporting host (Cursor running, ~no live sessions): `moraine-ingest` at 104–106% CPU sustained, 2,378 `ingest_checkpoints` inserts in 10 minutes, `last_offset` climbing ~4/s across 7 `state.vscdb` files with `last_line_no = 0`.

Root cause: `process_cursor_sqlite_db` unconditionally built a checkpoint with `last_offset + 1` after every scan — including scans triggered purely by DB/WAL/SHM stat changes that emitted zero records — and the stat short-circuit could never hold because Cursor touches those files continuously.

After (same host, tip build installed, stack restarted): `moraine-ingest` at 0.0–0.1% CPU across repeated samples, ClickHouse 2–7%, zero `cursor-sqlite` checkpoint rows written in 5 minutes of idle observation, and the new tests (`irrelevant_write_scans_but_persists_no_checkpoint`, `opencode_sqlite_irrelevant_write_persists_no_checkpoint`, `noop_backoff_state_machine`) pin the behavior.

## Performance

Live host, ~7 months of `search_documents` history, measured via `system.query_log` (`read_bytes`, `QueryFinish` rows):

| Metric | Baseline | This PR | Delta |
| --- | ---: | ---: | ---: |
| expansion query avg read | 363.6 MiB | 17.7 MiB (128 uids, 25 ms, 7.4 MiB peak mem) | ~20x less |
| idle `moraine-ingest` CPU | 104–106% | 0.0–0.1% | ~1 core freed |
| `ingest_checkpoints` inserts | 2,378 / 10 min | 0 cursor-sqlite rows / 5 min | eliminated |

Baseline read figure is the average over the incident-era expansion queries retained in `system.query_log`; the PR figure is a hydrate-shaped query for 128 random real uids after `MATERIALIZE INDEX` completed.

## Operational Impact

- Migration 023 runs on upgrade: `ADD INDEX IF NOT EXISTS` plus an async `MATERIALIZE INDEX` mutation over existing `search_documents` parts. Rollback is dropping the index; no code path depends on it.
- Durable checkpoint `cursor_json` stat fingerprints now intentionally lag quiet sqlite databases (documented in `docs/development/ingest-sources.md`).
- Worst-case pickup latency for the first relevant Cursor/OpenCode write after an idle stretch is one throttle window (~15–30s); active sessions are unaffected.

## Validation

Ran `cargo test --workspace --locked` (all suites green, 172 ingest-core tests including the three new ones), `cargo fmt --all -- --check`, and the CI clippy strict baseline (`-Dwarnings` with the baseline allows) — clean. The dev sandbox could not boot for this change (Docker daemon on the host was wedged; both buildx builders in error state), so stack validation ran against the live host stack that was actively reproducing the incident: `make install`, `moraine down && moraine up`, then verified migration 023 in `schema_migrations` and `system.data_skipping_indices`, mutation completion in `system.mutations`, the CPU/insert numbers above, and the read-bytes measurement above. A seven-persona delegated review wave (elegance, idiom, correctness, completeness, security, YAGNI, scope) ran with all findings resolved or explicitly dispositioned; CI e2e should gate merge as usual.

Closes #443.
