### PR TITLE
chore(release): cut v0.6.4

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.6.3)"
+        description: "Tag to release (for example v0.6.4)"
         required: true
         type: string
       target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "moraine"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "glob",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest-core"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp-core"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor-core"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/moraine-ingest/Cargo.toml
+++ b/apps/moraine-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "Moraine ingest service binary"
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "Moraine MCP stdio server"
 

--- a/apps/moraine-monitor/Cargo.toml
+++ b/apps/moraine-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "Moraine monitor HTTP/UI service"
 

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "Unified runtime control plane for Moraine services"
 

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-clickhouse"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "Shared Moraine ClickHouse client and query helpers"
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-config"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "Shared Moraine configuration schema and loaders"
 

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-conversations"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "High-level read/query APIs for Moraine conversations"
 

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest-core"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "Core ingestion pipeline internals for Moraine"
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp-core"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "MCP protocol and tool routing core for Moraine"
 

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor-core"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "Analytics and query logic for Moraine monitor service"
 

--- a/plugins/hermes-moraine/plugin.yaml
+++ b/plugins/hermes-moraine/plugin.yaml
@@ -1,6 +1,6 @@
 manifest_version: 1
 name: moraine
-version: "0.6.3"
+version: "0.6.4"
 description: "Hermes integration for Moraine MCP session search, realtime agent awareness, sanitized bug reports, and setup diagnostics."
 author: "Moraine maintainers"
 provides_tools:

--- a/plugins/moraine/.claude-plugin/plugin.json
+++ b/plugins/moraine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "displayName": "Moraine",
   "description": "Claude Code plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {

--- a/plugins/moraine/.codex-plugin/plugin.json
+++ b/plugins/moraine/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Codex plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {
     "name": "Moraine maintainers",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ install directory precedence:
 
 examples:
   scripts/install.sh
-  MORAINE_INSTALL_VERSION=v0.6.3 scripts/install.sh
+  MORAINE_INSTALL_VERSION=v0.6.4 scripts/install.sh
   MORAINE_INSTALL_ASSET_BASE_URL=http://127.0.0.1:8080 \
     MORAINE_INSTALL_VERSION=ci-e2e scripts/install.sh
   MORAINE_INSTALL_DIR="$HOME/bin" MORAINE_INSTALL_SKIP_CLICKHOUSE=1 scripts/install.sh


### PR DESCRIPTION
## What changed

Bumps Moraine from `v0.6.3` to `v0.6.4` across the release-managed Rust crates, `Cargo.lock`, release workflow example tag, install script example, and bundled Moraine plugin manifests.

## User-facing changes since v0.6.3

- [#444](https://github.com/eric-tramel/moraine/pull/444) fixes idle Cursor/OpenCode SQLite checkpoint churn and MCP search expansion read amplification. Idle `moraine-ingest` no longer burns roughly one core on quiet Cursor databases, and search-result hydration reads far less ClickHouse data.
- [#441](https://github.com/eric-tramel/moraine/pull/441) enables default-on secret redaction before local storage and backend egress, including aggregate redaction audit counts.
- [#442](https://github.com/eric-tramel/moraine/pull/442) makes `moraine setup` default all supported harnesses to ingest plus plugin/MCP setup while preserving opt-out and targeted setup paths.
- [#439](https://github.com/eric-tramel/moraine/pull/439) fixes monitor session-list over-counting by deduping duplicate physical event rows by logical `event_uid`.
- [#440](https://github.com/eric-tramel/moraine/pull/440) completes the configuration reference and fixes partial `[mcp]` config defaults for `async_log_writes`.
- [#438](https://github.com/eric-tramel/moraine/pull/438) and [#437](https://github.com/eric-tramel/moraine/pull/437) make local checkout/plugin setup paths more reliable for Hermes users.

## Operational impact

- Pushing the annotated `v0.6.4` tag after this PR merges will run `.github/workflows/release-moraine.yml`, upload release bundles, and publish `moraine-cli` `0.6.4` to PyPI.
- The release includes already-merged migrations `022` and `023`; upgrade applies them through the normal Moraine migration path.
- Version bump only in this PR; no additional runtime behavior changes are introduced by the bump commit.

## Validation

- `git diff --check` — passed
- `cargo fmt --all -- --check` — passed
- `cargo test --workspace --locked` — passed
- Commit pre-commit hook — passed (`make fmt` and strict clippy baseline)
- Sandbox QA was attempted in sandbox `sb-2335ee`, but Docker was unresponsive: sandbox boot hung during Docker build, `docker ps` timed out after 10s, and `moraine-sandbox down sb-2335ee` removed `/tmp/moraine-sandbox-sb-2335ee` while warning that `docker compose down` returned non-zero. No host-stack QA was run in place of the sandbox.
