### PR TITLE
feat: add identity author attribution

### DIFF
--- a/apps/moraine/src/commands/analytics_schema_v1.golden.json
+++ b/apps/moraine/src/commands/analytics_schema_v1.golden.json
@@ -20,6 +20,13 @@
       "type": "string"
     },
     {
+      "default": false,
+      "name": "author",
+      "sensitive": false,
+      "source_expression": "e.author",
+      "type": "string"
+    },
+    {
       "default": true,
       "name": "event_ts",
       "sensitive": false,

--- a/apps/moraine/src/commands/schema.rs
+++ b/apps/moraine/src/commands/schema.rs
@@ -81,6 +81,7 @@ pub(super) const EVENT_COLUMNS: &[EventColumn] = &[
         true,
         false,
     ),
+    col("author", "e.author", "e.author", "string", false, false),
     col(
         "event_ts",
         "CLI format of e.event_unix_ms",

--- a/config/moraine.toml
+++ b/config/moraine.toml
@@ -28,6 +28,11 @@ wait_for_async_insert = true
 # backend = "team-ch"
 # mode = "mirror"               # default; the only supported mode
 
+[identity]
+# Stable person identity stamped on raw_events/events. Leave empty for
+# local-only installs. Required for mirroring to non-default backends.
+author = ""
+
 [redaction]
 # Secret redaction is default-on for all ingestion. This flag is honored only
 # from $HOME/.moraine/config.toml, and only for the local/default backend;

--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -753,6 +753,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             name: "023_search_documents_event_uid_bloom.sql",
             sql: include_str!("../../../sql/023_search_documents_event_uid_bloom.sql"),
         },
+        Migration {
+            version: "024",
+            name: "024_add_event_author.sql",
+            sql: include_str!("../../../sql/024_add_event_author.sql"),
+        },
     ]
 }
 

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -103,6 +103,13 @@ pub struct RedactionConfig {
     pub dangerously_skip_secret_redaction_ignored: bool,
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IdentityConfig {
+    #[serde(default)]
+    pub author: String,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct IngestConfig {
@@ -246,6 +253,8 @@ pub struct AppConfig {
     #[serde(default)]
     pub routes: Vec<RouteConfig>,
     #[serde(default)]
+    pub identity: IdentityConfig,
+    #[serde(default)]
     pub redaction: RedactionConfig,
     #[serde(default)]
     pub ingest: IngestConfig,
@@ -317,6 +326,7 @@ impl Default for AppConfig {
             clickhouse,
             backends,
             routes: Vec::new(),
+            identity: IdentityConfig::default(),
             redaction: RedactionConfig::default(),
             ingest: IngestConfig::default(),
             mcp: McpConfig::default(),
@@ -1088,8 +1098,13 @@ fn normalize_config(mut cfg: AppConfig) -> Result<AppConfig> {
 
     normalize_backends_and_routes(&mut cfg)?;
     normalize_redaction(&mut cfg)?;
+    normalize_identity(&mut cfg);
 
     Ok(cfg)
+}
+
+fn normalize_identity(cfg: &mut AppConfig) {
+    cfg.identity.author = cfg.identity.author.trim().to_string();
 }
 
 fn normalize_redaction(cfg: &mut AppConfig) -> Result<()> {
@@ -1511,8 +1526,48 @@ ruleset = "custom"
         let cfg = load_config(&path).expect("minimal config should load with defaults");
         std::fs::remove_file(&path).ok();
         assert_eq!(cfg.clickhouse.url, "http://127.0.0.1:8123");
+        assert_eq!(cfg.identity.author, "");
         assert!(!cfg.mcp.prewarm_on_initialize);
         assert!(!cfg.ingest.sources.is_empty());
+    }
+
+    #[test]
+    fn identity_author_defaults_to_empty() {
+        let path = write_temp_config("", "identity-defaults");
+        let cfg = load_config(&path).expect("empty config should load with defaults");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(cfg.identity.author, "");
+    }
+
+    #[test]
+    fn identity_author_parses_and_trims() {
+        let path = write_temp_config(
+            r#"
+[identity]
+author = "  alice@example.com  "
+"#,
+            "identity-author",
+        );
+        let cfg = load_config(&path).expect("identity config should load");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(cfg.identity.author, "alice@example.com");
+    }
+
+    #[test]
+    fn identity_author_whitespace_only_normalizes_to_empty() {
+        let path = write_temp_config(
+            r#"
+[identity]
+author = "    "
+"#,
+            "identity-author-empty",
+        );
+        let cfg = load_config(&path).expect("whitespace identity should load");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(cfg.identity.author, "");
     }
 
     #[test]

--- a/crates/moraine-ingest-core/src/lib.rs
+++ b/crates/moraine-ingest-core/src/lib.rs
@@ -16,7 +16,7 @@ use crate::dispatch::{enqueue_work, run_work_item, spawn_debounce_task};
 use crate::model::RowBatch;
 use crate::reconcile::spawn_reconcile_task;
 use crate::redaction::{RedactionAudit, SecretRedactor};
-use crate::sink::{spawn_sink_task, SinkRole};
+use crate::sink::{spawn_sink_task, SinkAuthorConfig, SinkRole};
 use crate::tee::{
     spawn_tee_router, RedactionContext, RouteResolver, SharedRouteResolver, StatusRegistry,
 };
@@ -126,6 +126,21 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
         .backends
         .keys()
         .any(|name| name != DEFAULT_BACKEND_NAME);
+    let raw_events_author_column = table_column_available(&clickhouse, "raw_events", "author")
+        .await
+        .context("failed to inspect raw_events author column")?;
+    let events_author_column = table_column_available(&clickhouse, "events", "author")
+        .await
+        .context("failed to inspect events author column")?;
+    if !raw_events_author_column || !events_author_column {
+        warn!(
+            raw_events_author_column,
+            events_author_column,
+            "raw_events/events are missing the author column (migration 024); \
+             author attribution will be omitted for missing local/default columns until \
+             `moraine db migrate` runs and this ingest service restarts"
+        );
+    }
     let heartbeat_backend_column = if has_named_backends {
         let available = heartbeat_column_available(&clickhouse, "backend_sinks")
             .await
@@ -199,6 +214,11 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
         metrics.clone(),
         default_sink_rx,
         checkpoint_cursor_columns,
+        SinkAuthorConfig::new(
+            config.identity.author.clone(),
+            raw_events_author_column,
+            events_author_column,
+        ),
         SinkRole::Default {
             dispatch: dispatch.clone(),
             backends: backend_statuses.clone(),
@@ -365,28 +385,23 @@ struct CheckpointRow {
 /// added by migration 015. Selecting them unconditionally would abort startup
 /// for every source on a database that has not run `moraine db migrate` yet.
 async fn checkpoint_cursor_columns_available(clickhouse: &ClickHouseClient) -> Result<bool> {
-    #[derive(Deserialize)]
-    struct CountRow {
-        column_count: u64,
-    }
-
-    let query = format!(
-        "SELECT toUInt64(count()) AS column_count \
-         FROM system.columns \
-         WHERE database = '{}' AND table = 'ingest_checkpoints' AND name = 'cursor_json'",
-        clickhouse.config().database.replace('\'', "\\'")
-    );
-    let rows: Vec<CountRow> = clickhouse.query_rows(&query, None).await?;
-    Ok(rows
-        .first()
-        .map(|row| row.column_count > 0)
-        .unwrap_or(false))
+    table_column_available(clickhouse, "ingest_checkpoints", "cursor_json").await
 }
 
 /// Returns whether `ingest_heartbeats` carries an optional heartbeat column.
 /// Inserting optional columns unconditionally would break every heartbeat on a
 /// database that has not run the corresponding `moraine db migrate` yet.
 async fn heartbeat_column_available(clickhouse: &ClickHouseClient, column: &str) -> Result<bool> {
+    table_column_available(clickhouse, "ingest_heartbeats", column).await
+}
+
+/// Returns whether a table carries a column. Optional-write paths use this at
+/// startup because ClickHouse JSONEachRow rejects unknown fields at insert time.
+async fn table_column_available(
+    clickhouse: &ClickHouseClient,
+    table: &str,
+    column: &str,
+) -> Result<bool> {
     #[derive(Deserialize)]
     struct CountRow {
         column_count: u64,
@@ -395,8 +410,9 @@ async fn heartbeat_column_available(clickhouse: &ClickHouseClient, column: &str)
     let query = format!(
         "SELECT toUInt64(count()) AS column_count \
          FROM system.columns \
-         WHERE database = '{}' AND table = 'ingest_heartbeats' AND name = '{}'",
+         WHERE database = '{}' AND table = '{}' AND name = '{}'",
         clickhouse.config().database.replace('\'', "\\'"),
+        table.replace('\'', "\\'"),
         column.replace('\'', "\\'")
     );
     let rows: Vec<CountRow> = clickhouse.query_rows(&query, None).await?;

--- a/crates/moraine-ingest-core/src/model.rs
+++ b/crates/moraine-ingest-core/src/model.rs
@@ -96,6 +96,47 @@ impl RowBatch {
         self.approx_bytes = self.approx_bytes();
     }
 
+    /// Stamp the configured author onto raw/event rows, the only event tables
+    /// carrying migration-024 `author` columns.
+    pub(crate) fn stamp_author(
+        &mut self,
+        author: &str,
+        raw_events_column: bool,
+        events_column: bool,
+    ) {
+        if author.is_empty() {
+            return;
+        }
+
+        let mut stamped = 0usize;
+        let mut recompute = false;
+
+        if raw_events_column {
+            let stats = stamp_author_rows(&mut self.raw_rows, author);
+            stamped = stamped.saturating_add(stats.inserted);
+            recompute |= stats.replaced;
+        } else {
+            recompute |= strip_author_rows(&mut self.raw_rows);
+        }
+
+        if events_column {
+            let stats = stamp_author_rows(&mut self.event_rows, author);
+            stamped = stamped.saturating_add(stats.inserted);
+            recompute |= stats.replaced;
+        } else {
+            recompute |= strip_author_rows(&mut self.event_rows);
+        }
+
+        if recompute {
+            self.recompute_approx_bytes();
+        } else if self.approx_bytes > 0 {
+            let per_row_bytes = r#""author":"","#.len().saturating_add(author.len());
+            self.approx_bytes = self
+                .approx_bytes
+                .saturating_add(stamped.saturating_mul(per_row_bytes));
+        }
+    }
+
     pub fn push_raw_row(&mut self, row: Value) {
         self.approx_bytes = self
             .approx_bytes
@@ -192,4 +233,117 @@ fn approx_json_row_bytes(row: &Value) -> usize {
     serde_json::to_vec(row)
         .map(|bytes| bytes.len().saturating_add(1))
         .unwrap_or(1)
+}
+
+struct AuthorStampStats {
+    inserted: usize,
+    replaced: bool,
+}
+
+fn stamp_author_rows(rows: &mut [Value], author: &str) -> AuthorStampStats {
+    let mut stats = AuthorStampStats {
+        inserted: 0,
+        replaced: false,
+    };
+
+    for row in rows {
+        let Some(obj) = row.as_object_mut() else {
+            continue;
+        };
+        if obj
+            .insert("author".to_string(), Value::String(author.to_string()))
+            .is_some()
+        {
+            stats.replaced = true;
+        } else {
+            stats.inserted = stats.inserted.saturating_add(1);
+        }
+    }
+
+    stats
+}
+
+fn strip_author_rows(rows: &mut [Value]) -> bool {
+    let mut removed = false;
+    for row in rows {
+        let Some(obj) = row.as_object_mut() else {
+            continue;
+        };
+        removed |= obj.remove("author").is_some();
+    }
+    removed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn batch_with_all_row_kinds() -> RowBatch {
+        let mut batch = RowBatch::default();
+        batch.push_raw_row(json!({"event_uid": "raw-1"}));
+        batch.extend_event_rows(vec![json!({"event_uid": "event-1"})]);
+        batch.extend_link_rows(vec![json!({"event_uid": "link-1"})]);
+        batch.extend_tool_rows(vec![json!({"event_uid": "tool-1"})]);
+        batch.push_error_row(json!({"error_kind": "parse"}));
+        batch
+    }
+
+    #[test]
+    fn stamp_author_covers_raw_and_event_rows_only() {
+        let mut batch = batch_with_all_row_kinds();
+
+        batch.stamp_author("alice@example.com", true, true);
+
+        assert_eq!(
+            batch.raw_rows[0].get("author").and_then(Value::as_str),
+            Some("alice@example.com")
+        );
+        assert_eq!(
+            batch.event_rows[0].get("author").and_then(Value::as_str),
+            Some("alice@example.com")
+        );
+        assert!(batch.link_rows[0].get("author").is_none());
+        assert!(batch.tool_rows[0].get("author").is_none());
+        assert!(batch.error_rows[0].get("author").is_none());
+    }
+
+    #[test]
+    fn stamp_author_strips_per_table_when_default_schema_lacks_column() {
+        let mut batch = RowBatch::default();
+        batch.push_raw_row(json!({"event_uid": "raw-1", "author": "old"}));
+        batch.extend_event_rows(vec![json!({"event_uid": "event-1", "author": "old"})]);
+
+        batch.stamp_author("alice@example.com", false, true);
+
+        assert!(batch.raw_rows[0].get("author").is_none());
+        assert_eq!(
+            batch.event_rows[0].get("author").and_then(Value::as_str),
+            Some("alice@example.com")
+        );
+    }
+
+    #[test]
+    fn stamp_author_with_empty_identity_is_a_no_op() {
+        let mut batch = batch_with_all_row_kinds();
+        let before_bytes = batch.approx_bytes();
+
+        batch.stamp_author("", true, true);
+
+        assert!(batch.raw_rows[0].get("author").is_none());
+        assert!(batch.event_rows[0].get("author").is_none());
+        assert_eq!(batch.approx_bytes(), before_bytes);
+    }
+
+    #[test]
+    fn stamp_author_advances_cached_batch_size_by_insert_delta() {
+        let author = "alice@example.com";
+        let mut batch = batch_with_all_row_kinds();
+        let before = batch.approx_bytes();
+
+        batch.stamp_author(author, true, true);
+
+        let expected_delta = 2 * (r#""author":"","#.len() + author.len());
+        assert_eq!(batch.approx_bytes(), before + expected_delta);
+    }
 }

--- a/crates/moraine-ingest-core/src/sink.rs
+++ b/crates/moraine-ingest-core/src/sink.rs
@@ -1,6 +1,6 @@
 use crate::checkpoint::merge_checkpoint;
 use crate::heartbeat::host_name;
-use crate::model::Checkpoint;
+use crate::model::{Checkpoint, RowBatch};
 use crate::redaction::{RedactionAudit, SecretRedactor};
 use crate::sources::shared::truncate_chars;
 use crate::tee::{
@@ -82,29 +82,10 @@ impl SinkAuthorConfig {
     pub(crate) fn fully_supported(author: String) -> Self {
         Self::new(author, true, true)
     }
-}
 
-fn stamp_author_rows(rows: &mut [Value], author: &str, column_supported: bool) {
-    for row in rows {
-        let Some(obj) = row.as_object_mut() else {
-            continue;
-        };
-        if column_supported {
-            obj.insert("author".to_string(), Value::String(author.to_string()));
-        } else {
-            obj.remove("author");
-        }
+    fn apply_to_batch(&self, batch: &mut RowBatch) {
+        batch.stamp_author(&self.author, self.raw_events_column, self.events_column);
     }
-}
-
-fn apply_author_to_batch(batch: &mut crate::model::RowBatch, author: &SinkAuthorConfig) {
-    stamp_author_rows(
-        &mut batch.raw_rows,
-        &author.author,
-        author.raw_events_column,
-    );
-    stamp_author_rows(&mut batch.event_rows, &author.author, author.events_column);
-    batch.recompute_approx_bytes();
 }
 
 /// Backend-role health bookkeeping after a flush attempt; no-op for the
@@ -330,7 +311,7 @@ pub(crate) fn spawn_sink_task(
                                 }
                                 SinkRole::Default { .. } => batch,
                             };
-                            apply_author_to_batch(&mut batch, &author);
+                            author.apply_to_batch(&mut batch);
                             pending_batch_bytes =
                                 pending_batch_bytes.saturating_add(batch.approx_bytes());
                             raw_rows.extend(batch.raw_rows);
@@ -1324,10 +1305,7 @@ mod tests {
         batch.extend_tool_rows(vec![json!({"event_uid": "tool-1"})]);
         batch.push_error_row(json!({"error_kind": "parse"}));
 
-        apply_author_to_batch(
-            &mut batch,
-            &SinkAuthorConfig::fully_supported("alice@example.com".to_string()),
-        );
+        batch.stamp_author("alice@example.com", true, true);
 
         assert_eq!(
             batch.raw_rows[0].get("author").and_then(Value::as_str),
@@ -1348,10 +1326,7 @@ mod tests {
         batch.push_raw_row(json!({"event_uid": "raw-1", "author": "old"}));
         batch.extend_event_rows(vec![json!({"event_uid": "event-1", "author": "old"})]);
 
-        apply_author_to_batch(
-            &mut batch,
-            &SinkAuthorConfig::new("alice@example.com".to_string(), false, true),
-        );
+        batch.stamp_author("alice@example.com", false, true);
 
         assert!(batch.raw_rows[0].get("author").is_none());
         assert_eq!(
@@ -1361,24 +1336,15 @@ mod tests {
     }
 
     #[test]
-    fn empty_author_is_stamped_when_schema_supports_it() {
+    fn empty_author_is_a_no_op_even_when_schema_supports_it() {
         let mut batch = RowBatch::default();
         batch.push_raw_row(json!({"event_uid": "raw-1"}));
         batch.extend_event_rows(vec![json!({"event_uid": "event-1"})]);
 
-        apply_author_to_batch(
-            &mut batch,
-            &SinkAuthorConfig::fully_supported(String::new()),
-        );
+        batch.stamp_author("", true, true);
 
-        assert_eq!(
-            batch.raw_rows[0].get("author").and_then(Value::as_str),
-            Some("")
-        );
-        assert_eq!(
-            batch.event_rows[0].get("author").and_then(Value::as_str),
-            Some("")
-        );
+        assert!(batch.raw_rows[0].get("author").is_none());
+        assert!(batch.event_rows[0].get("author").is_none());
     }
 
     const CLICKHOUSE_OVERSIZED_JSON_OBJECT_ERROR: &str =

--- a/crates/moraine-ingest-core/src/sink.rs
+++ b/crates/moraine-ingest-core/src/sink.rs
@@ -63,6 +63,50 @@ pub(crate) enum SinkRole {
     },
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct SinkAuthorConfig {
+    author: String,
+    raw_events_column: bool,
+    events_column: bool,
+}
+
+impl SinkAuthorConfig {
+    pub(crate) fn new(author: String, raw_events_column: bool, events_column: bool) -> Self {
+        Self {
+            author,
+            raw_events_column,
+            events_column,
+        }
+    }
+
+    pub(crate) fn fully_supported(author: String) -> Self {
+        Self::new(author, true, true)
+    }
+}
+
+fn stamp_author_rows(rows: &mut [Value], author: &str, column_supported: bool) {
+    for row in rows {
+        let Some(obj) = row.as_object_mut() else {
+            continue;
+        };
+        if column_supported {
+            obj.insert("author".to_string(), Value::String(author.to_string()));
+        } else {
+            obj.remove("author");
+        }
+    }
+}
+
+fn apply_author_to_batch(batch: &mut crate::model::RowBatch, author: &SinkAuthorConfig) {
+    stamp_author_rows(
+        &mut batch.raw_rows,
+        &author.author,
+        author.raw_events_column,
+    );
+    stamp_author_rows(&mut batch.event_rows, &author.author, author.events_column);
+    batch.recompute_approx_bytes();
+}
+
 /// Backend-role health bookkeeping after a flush attempt; no-op for the
 /// default sink. Recovery requires a drained queue so one successful flush
 /// mid-backlog does not trigger a replay storm.
@@ -179,6 +223,7 @@ pub(crate) fn spawn_sink_task(
     metrics: Arc<Metrics>,
     mut rx: mpsc::Receiver<SinkMessage>,
     checkpoint_cursor_columns: bool,
+    author: SinkAuthorConfig,
     role: SinkRole,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -267,7 +312,7 @@ pub(crate) fn spawn_sink_task(
                         Some(SinkMessage::Batch(batch)) => {
                             // Mirror sinks only buffer the sessions routed to
                             // them; the default sink takes batches whole.
-                            let batch = match &role {
+                            let mut batch = match &role {
                                 SinkRole::Backend {
                                     cell,
                                     resolver,
@@ -285,6 +330,7 @@ pub(crate) fn spawn_sink_task(
                                 }
                                 SinkRole::Default { .. } => batch,
                             };
+                            apply_author_to_batch(&mut batch, &author);
                             pending_batch_bytes =
                                 pending_batch_bytes.saturating_add(batch.approx_bytes());
                             raw_rows.extend(batch.raw_rows);
@@ -1269,6 +1315,72 @@ mod tests {
         }
     }
 
+    #[test]
+    fn author_is_stamped_only_on_raw_and_event_rows() {
+        let mut batch = RowBatch::default();
+        batch.push_raw_row(json!({"event_uid": "raw-1"}));
+        batch.extend_event_rows(vec![json!({"event_uid": "event-1"})]);
+        batch.extend_link_rows(vec![json!({"event_uid": "link-1"})]);
+        batch.extend_tool_rows(vec![json!({"event_uid": "tool-1"})]);
+        batch.push_error_row(json!({"error_kind": "parse"}));
+
+        apply_author_to_batch(
+            &mut batch,
+            &SinkAuthorConfig::fully_supported("alice@example.com".to_string()),
+        );
+
+        assert_eq!(
+            batch.raw_rows[0].get("author").and_then(Value::as_str),
+            Some("alice@example.com")
+        );
+        assert_eq!(
+            batch.event_rows[0].get("author").and_then(Value::as_str),
+            Some("alice@example.com")
+        );
+        assert!(batch.link_rows[0].get("author").is_none());
+        assert!(batch.tool_rows[0].get("author").is_none());
+        assert!(batch.error_rows[0].get("author").is_none());
+    }
+
+    #[test]
+    fn author_is_stripped_per_table_when_default_schema_lacks_column() {
+        let mut batch = RowBatch::default();
+        batch.push_raw_row(json!({"event_uid": "raw-1", "author": "old"}));
+        batch.extend_event_rows(vec![json!({"event_uid": "event-1", "author": "old"})]);
+
+        apply_author_to_batch(
+            &mut batch,
+            &SinkAuthorConfig::new("alice@example.com".to_string(), false, true),
+        );
+
+        assert!(batch.raw_rows[0].get("author").is_none());
+        assert_eq!(
+            batch.event_rows[0].get("author").and_then(Value::as_str),
+            Some("alice@example.com")
+        );
+    }
+
+    #[test]
+    fn empty_author_is_stamped_when_schema_supports_it() {
+        let mut batch = RowBatch::default();
+        batch.push_raw_row(json!({"event_uid": "raw-1"}));
+        batch.extend_event_rows(vec![json!({"event_uid": "event-1"})]);
+
+        apply_author_to_batch(
+            &mut batch,
+            &SinkAuthorConfig::fully_supported(String::new()),
+        );
+
+        assert_eq!(
+            batch.raw_rows[0].get("author").and_then(Value::as_str),
+            Some("")
+        );
+        assert_eq!(
+            batch.event_rows[0].get("author").and_then(Value::as_str),
+            Some("")
+        );
+    }
+
     const CLICKHOUSE_OVERSIZED_JSON_OBJECT_ERROR: &str =
         "Code: 117. DB::Exception: Size of JSON object at position 104890103 is extremely large. \
          Expected not greater than 10485760 bytes, but current is 104890103 bytes per row. \
@@ -1296,6 +1408,7 @@ mod tests {
             metrics,
             rx,
             true,
+            SinkAuthorConfig::fully_supported(String::new()),
             default_role(),
         );
 
@@ -1992,6 +2105,7 @@ mod tests {
             metrics,
             rx,
             true,
+            SinkAuthorConfig::fully_supported(String::new()),
             SinkRole::Backend {
                 cell: Arc::new(BackendSinkCell::new("team-ch")),
                 resolver,

--- a/crates/moraine-ingest-core/src/tee.rs
+++ b/crates/moraine-ingest-core/src/tee.rs
@@ -16,7 +16,7 @@ use crate::dispatch::process_file;
 use crate::heartbeat::host_name;
 use crate::model::{Checkpoint, RowBatch};
 use crate::redaction::{RedactionAudit, SecretRedactor};
-use crate::sink::{spawn_sink_task, SinkRole};
+use crate::sink::{spawn_sink_task, SinkAuthorConfig, SinkRole};
 use crate::watch::enumerate_tracked_files;
 use crate::{Metrics, SinkMessage, WorkItem};
 use moraine_clickhouse::{enforce_remote_schema_policy, ClickHouseClient};
@@ -46,6 +46,8 @@ pub(crate) enum BackendSinkStatus {
     Unreachable,
     /// Schema skew policy rejected the backend; terminal until restart.
     DisabledSkew,
+    /// Identity is required before mirroring to a non-default backend.
+    DisabledMissingIdentityAuthor,
 }
 
 impl BackendSinkStatus {
@@ -56,6 +58,7 @@ impl BackendSinkStatus {
             Self::Lagging => "lagging",
             Self::Unreachable => "unreachable",
             Self::DisabledSkew => "disabled_skew",
+            Self::DisabledMissingIdentityAuthor => "disabled_missing_identity_author",
         }
     }
 }
@@ -359,9 +362,14 @@ pub(crate) fn filter_batch_for_backend(
     out
 }
 
-struct BackendHandle {
-    tx: mpsc::Sender<SinkMessage>,
-    cell: Arc<BackendSinkCell>,
+enum BackendHandle {
+    Active {
+        tx: mpsc::Sender<SinkMessage>,
+        cell: Arc<BackendSinkCell>,
+    },
+    Disabled {
+        cell: Arc<BackendSinkCell>,
+    },
 }
 
 #[derive(Clone)]
@@ -410,18 +418,18 @@ pub(crate) fn spawn_tee_router(
         let mut handles = HashMap::<String, BackendHandle>::new();
 
         // Backends named by home-config routes start eagerly so handshake
-        // failures surface at startup. Backends referenced only by repo
-        // `.moraine.toml` files are constructed on first resolution — we
-        // cannot know at startup which configured backends repos will name,
-        // and eagerly replaying never-routed backends would write
-        // checkpoints into databases the user never routed to.
-        let eager: BTreeSet<String> = context
+        // failures surface at startup. Repo `.moraine.toml` routes are
+        // discovered with a read-only source pass first: this lets retained
+        // files trigger backend replay after identity is configured, without
+        // writing checkpoints to every configured-but-never-routed backend.
+        let mut eager: BTreeSet<String> = context
             .config
             .routes
             .iter()
             .map(|route| route.backend.clone())
             .filter(|name| name != DEFAULT_BACKEND_NAME)
             .collect();
+        eager.extend(discover_startup_backend_targets(&context).await);
         for name in eager {
             ensure_backend(&name, &context, &mut handles);
         }
@@ -463,6 +471,94 @@ fn redact_default_batch_if_enabled(
     redaction.audit.record(&report);
 }
 
+async fn discover_startup_backend_targets(context: &TeeRouterContext) -> BTreeSet<String> {
+    let mut targets = BTreeSet::new();
+    if !context
+        .config
+        .backends
+        .keys()
+        .any(|name| name != DEFAULT_BACKEND_NAME)
+    {
+        return targets;
+    }
+
+    let metrics = Arc::new(Metrics::default());
+    for source in context.sources.iter() {
+        let files = match enumerate_tracked_files(&source.glob, &source.format) {
+            Ok(files) => files,
+            Err(exc) => {
+                warn!(
+                    source = %source.name,
+                    "startup backend discovery enumerate failed: {exc}"
+                );
+                continue;
+            }
+        };
+
+        for path in files {
+            match discover_file_backend_targets(context, source, path, metrics.clone()).await {
+                Ok(file_targets) => targets.extend(file_targets),
+                Err(exc) => warn!(
+                    source = %source.name,
+                    "startup backend discovery failed: {exc}"
+                ),
+            }
+        }
+    }
+    targets
+}
+
+async fn discover_file_backend_targets(
+    context: &TeeRouterContext,
+    source: &IngestSource,
+    path: String,
+    metrics: Arc<Metrics>,
+) -> Result<BTreeSet<String>, anyhow::Error> {
+    let checkpoints = Arc::new(RwLock::new(HashMap::<String, Checkpoint>::new()));
+    let poll_state = crate::sqlite_poll::VolatilePollMap::new();
+    let (tx, mut rx) = mpsc::channel::<SinkMessage>(16);
+    let work = WorkItem {
+        source_name: source.name.clone(),
+        harness: source.harness.clone(),
+        format: source.format.clone(),
+        path,
+    };
+    let process = process_file(
+        &context.config,
+        &work,
+        checkpoints,
+        &poll_state,
+        tx,
+        &metrics,
+    );
+    tokio::pin!(process);
+
+    let mut targets = BTreeSet::new();
+    let process_result = loop {
+        tokio::select! {
+            result = &mut process => break result,
+            Some(SinkMessage::Batch(batch)) = rx.recv() => {
+                let mut resolver = context
+                    .resolver
+                    .lock()
+                    .expect("route resolver mutex poisoned");
+                targets.extend(collect_targets(&batch, &mut resolver));
+            }
+        }
+    };
+
+    while let Ok(SinkMessage::Batch(batch)) = rx.try_recv() {
+        let mut resolver = context
+            .resolver
+            .lock()
+            .expect("route resolver mutex poisoned");
+        targets.extend(collect_targets(&batch, &mut resolver));
+    }
+
+    process_result?;
+    Ok(targets)
+}
+
 /// Looks up (or lazily constructs) the handle for a named backend. Returns
 /// `None` only for names without a `[backends.*]` entry, which the resolver
 /// already refuses to produce — this is a defensive double-check.
@@ -472,16 +568,31 @@ fn ensure_backend<'a>(
     handles: &'a mut HashMap<String, BackendHandle>,
 ) -> Option<&'a BackendHandle> {
     if !handles.contains_key(name) {
-        let backend_cfg = context.config.backends.get(name)?.clone();
         let cell = Arc::new(BackendSinkCell::new(name));
+        if !context.config.backends.contains_key(name) {
+            return None;
+        }
+
         let queue_capacity = context.config.ingest.max_inflight_batches.max(1);
-        let (tx, backend_rx) = mpsc::channel::<SinkMessage>(queue_capacity);
 
         context
             .registry
             .lock()
             .expect("backend registry mutex poisoned")
             .insert(name.to_string(), cell.clone());
+
+        if context.config.identity.author.is_empty() {
+            cell.set_status(BackendSinkStatus::DisabledMissingIdentityAuthor);
+            warn!(
+                backend = name,
+                "mirror sink disabled: [identity].author is required for non-default backends"
+            );
+            handles.insert(name.to_string(), BackendHandle::Disabled { cell });
+            return handles.get(name);
+        }
+
+        let backend_cfg = context.config.backends.get(name)?.clone();
+        let (tx, backend_rx) = mpsc::channel::<SinkMessage>(queue_capacity);
 
         info!(backend = name, "starting mirror sink for backend");
         spawn_backend_supervisor(
@@ -492,36 +603,46 @@ fn ensure_backend<'a>(
             context.clone(),
         );
 
-        handles.insert(name.to_string(), BackendHandle { tx, cell });
+        handles.insert(name.to_string(), BackendHandle::Active { tx, cell });
     }
     handles.get(name)
 }
 
 fn forward_to_backend(handle: &BackendHandle, batch: &RowBatch) {
-    if !handle.cell.is_live() || handle.cell.status() != BackendSinkStatus::Ok {
+    let BackendHandle::Active { tx, cell } = handle else {
+        if let BackendHandle::Disabled { cell } = handle {
+            debug_assert_eq!(
+                cell.status(),
+                BackendSinkStatus::DisabledMissingIdentityAuthor
+            );
+        }
+        return;
+    };
+
+    if !cell.is_live() || cell.status() != BackendSinkStatus::Ok {
         // Not accepting (connecting / lagging / unreachable / disabled):
         // drop the mirror copy. Replay recovers it from the source file.
-        handle.cell.record_drop();
+        cell.record_drop();
         return;
     }
 
-    match handle.tx.try_send(SinkMessage::Batch(batch.clone())) {
+    match tx.try_send(SinkMessage::Batch(batch.clone())) {
         Ok(()) => {}
         Err(mpsc::error::TrySendError::Full(_)) => {
-            handle.cell.record_drop();
-            if handle.cell.mark_overflow() {
+            cell.record_drop();
+            if cell.mark_overflow() {
                 warn!(
-                    backend = handle.cell.name(),
+                    backend = cell.name(),
                     "mirror queue full; backend marked lagging and live mirroring paused \
                      (catch-up replay will recover the gap once it drains)"
                 );
             }
         }
         Err(mpsc::error::TrySendError::Closed(_)) => {
-            handle.cell.record_drop();
-            if handle.cell.mark_flush_failure() {
+            cell.record_drop();
+            if cell.mark_flush_failure() {
                 warn!(
-                    backend = handle.cell.name(),
+                    backend = cell.name(),
                     "mirror sink channel closed unexpectedly; backend marked unreachable"
                 );
             }
@@ -615,6 +736,7 @@ fn spawn_backend_supervisor(
             metrics.clone(),
             backend_rx,
             true,
+            SinkAuthorConfig::fully_supported(context.config.identity.author.clone()),
             SinkRole::Backend {
                 cell: cell.clone(),
                 resolver: context.resolver.clone(),
@@ -827,6 +949,57 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn startup_discovery_finds_repo_referenced_backend_without_home_route() {
+        let path = unique_replay_file("repo-discovery");
+        fs::write(
+            &path,
+            json!({
+                "type": "user",
+                "timestamp": "2026-04-18T20:43:51.069Z",
+                "uuid": "u1",
+                "sessionId": "repo-session",
+                "cwd": "/elsewhere/project",
+                "message": {"role": "user", "content": "hello"}
+            })
+            .to_string(),
+        )
+        .expect("write discovery fixture");
+
+        let mut config = (*team_config()).clone();
+        config.routes.clear();
+        let config = Arc::new(config);
+        let resolver: SharedRouteResolver =
+            Arc::new(Mutex::new(resolver_with_lookup(config.clone(), |dir| {
+                assert_eq!(dir, "/elsewhere/project");
+                Some("team-ch".to_string())
+            })));
+        let context = TeeRouterContext {
+            config,
+            sources: Arc::new(vec![IngestSource {
+                name: "claude".to_string(),
+                harness: "claude-code".to_string(),
+                enabled: true,
+                glob: path.to_string_lossy().to_string(),
+                watch_root: std::env::temp_dir().to_string_lossy().to_string(),
+                format: "jsonl".to_string(),
+            }]),
+            resolver,
+            registry: Arc::new(Mutex::new(BTreeMap::new())),
+            redaction: RedactionContext::new(test_redactor(), test_redaction_audit()),
+        };
+
+        let targets = discover_startup_backend_targets(&context).await;
+
+        assert_eq!(
+            targets,
+            BTreeSet::from(["team-ch".to_string()]),
+            "startup discovery starts repo-routed backends so replay can backfill retained files"
+        );
+
+        let _ = fs::remove_file(path);
+    }
+
     #[test]
     fn unknown_repo_backend_warns_once_and_resolves_to_default_only() {
         let mut resolver =
@@ -1019,23 +1192,43 @@ mod tests {
     }
 
     #[test]
+    fn disabled_missing_identity_author_is_terminal() {
+        let cell = BackendSinkCell::new("team-ch");
+        cell.set_status(BackendSinkStatus::DisabledMissingIdentityAuthor);
+
+        assert!(!cell.mark_overflow());
+        assert!(!cell.mark_flush_failure());
+        assert!(!cell.mark_recovered());
+        assert_eq!(
+            cell.status(),
+            BackendSinkStatus::DisabledMissingIdentityAuthor
+        );
+        assert_eq!(cell.status().as_str(), "disabled_missing_identity_author");
+    }
+
+    #[test]
     fn backend_sinks_json_is_deterministic_and_absent_when_empty() {
         let registry: StatusRegistry = Arc::new(Mutex::new(BTreeMap::new()));
         assert_eq!(backend_sinks_json(&registry), None);
 
         let lagging = Arc::new(BackendSinkCell::new("b-lagging"));
         lagging.set_status(BackendSinkStatus::Lagging);
+        let disabled = Arc::new(BackendSinkCell::new("c-disabled"));
+        disabled.set_status(BackendSinkStatus::DisabledMissingIdentityAuthor);
         let ok = Arc::new(BackendSinkCell::new("a-ok"));
         ok.set_status(BackendSinkStatus::Ok);
         {
             let mut cells = registry.lock().expect("registry mutex poisoned");
             cells.insert("b-lagging".to_string(), lagging);
+            cells.insert("c-disabled".to_string(), disabled);
             cells.insert("a-ok".to_string(), ok);
         }
 
         assert_eq!(
             backend_sinks_json(&registry).as_deref(),
-            Some(r#"{"a-ok":"ok","b-lagging":"lagging"}"#)
+            Some(
+                r#"{"a-ok":"ok","b-lagging":"lagging","c-disabled":"disabled_missing_identity_author"}"#
+            )
         );
     }
 
@@ -1045,7 +1238,7 @@ mod tests {
         let cell = Arc::new(BackendSinkCell::new("team-ch"));
         cell.set_status(BackendSinkStatus::Ok);
         cell.mark_live();
-        let handle = BackendHandle {
+        let handle = BackendHandle::Active {
             tx,
             cell: cell.clone(),
         };
@@ -1068,7 +1261,7 @@ mod tests {
     async fn forward_skips_backends_that_are_not_live() {
         let (tx, mut backend_rx) = mpsc::channel::<SinkMessage>(4);
         let cell = Arc::new(BackendSinkCell::new("team-ch"));
-        let handle = BackendHandle {
+        let handle = BackendHandle::Active {
             tx,
             cell: cell.clone(),
         };
@@ -1082,6 +1275,49 @@ mod tests {
             BackendSinkStatus::Connecting,
             "dropping while connecting is not an overflow"
         );
+    }
+
+    #[test]
+    fn forward_disabled_backend_is_noop_without_drop_accounting() {
+        let cell = Arc::new(BackendSinkCell::new("team-ch"));
+        cell.set_status(BackendSinkStatus::DisabledMissingIdentityAuthor);
+        let handle = BackendHandle::Disabled { cell: cell.clone() };
+
+        forward_to_backend(&handle, &mixed_session_batch());
+
+        assert_eq!(cell.dropped_batches(), 0);
+        assert_eq!(
+            cell.status(),
+            BackendSinkStatus::DisabledMissingIdentityAuthor
+        );
+    }
+
+    #[test]
+    fn ensure_backend_caches_disabled_missing_author_handle() {
+        let config = team_config();
+        assert!(config.identity.author.is_empty());
+        let resolver: SharedRouteResolver =
+            Arc::new(Mutex::new(RouteResolver::new(config.clone())));
+        let context = test_router_context(config, resolver);
+        let mut handles = HashMap::<String, BackendHandle>::new();
+
+        let first = ensure_backend("team-ch", &context, &mut handles)
+            .expect("configured backend should produce a disabled handle");
+        assert!(matches!(first, BackendHandle::Disabled { .. }));
+        assert_eq!(handles.len(), 1);
+
+        let second = ensure_backend("team-ch", &context, &mut handles)
+            .expect("cached disabled handle should be returned");
+        assert!(matches!(second, BackendHandle::Disabled { .. }));
+        assert_eq!(handles.len(), 1);
+
+        let registry = context.registry.lock().expect("registry mutex poisoned");
+        let cell = registry.get("team-ch").expect("registered disabled cell");
+        assert_eq!(
+            cell.status(),
+            BackendSinkStatus::DisabledMissingIdentityAuthor
+        );
+        assert!(!cell.is_live());
     }
 
     async fn wait_for_status(

--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -148,6 +148,7 @@ async fn api_health(State(state): State<AppState>) -> Response {
     match state.clickhouse.ping().await {
         Ok(()) => match state.clickhouse.version().await {
             Ok(version) => {
+                let ingestor = query_health_heartbeat_or_absent(&state).await;
                 let body = json!({
                     "ok": true,
                     "url": state.clickhouse.config().url,
@@ -155,6 +156,7 @@ async fn api_health(State(state): State<AppState>) -> Response {
                     "version": version,
                     "ping_ms": (Instant::elapsed(&start).as_secs_f64() * 1000.0),
                     "connections": connection_stats,
+                    "ingestor": ingestor,
                 });
                 json_response(body, StatusCode::OK)
             }
@@ -214,11 +216,9 @@ async fn api_status(State(state): State<AppState>) -> Response {
 
     let estimated_total_rows = tables.iter().map(|table| table.rows).sum::<u64>();
     let heartbeat = if db_exists {
-        query_heartbeat(&state).await.unwrap_or_else(|_| {
-            json!({"present": false, "alive": false, "latest": Value::Null, "age_seconds": Value::Null})
-        })
+        query_heartbeat_or_absent(&state).await
     } else {
-        json!({"present": false, "alive": false, "latest": Value::Null, "age_seconds": Value::Null})
+        heartbeat_absent()
     };
 
     let clickhouse_ping = if db_exists {
@@ -1402,6 +1402,53 @@ async fn query_heartbeat(state: &AppState) -> Result<Value> {
     }))
 }
 
+fn heartbeat_absent() -> Value {
+    json!({
+        "present": false,
+        "alive": false,
+        "latest": Value::Null,
+        "age_seconds": Value::Null,
+    })
+}
+
+async fn query_heartbeat_or_absent(state: &AppState) -> Value {
+    query_heartbeat(state)
+        .await
+        .unwrap_or_else(|_| heartbeat_absent())
+}
+
+fn health_heartbeat(heartbeat: Value) -> Value {
+    let latest = heartbeat
+        .get("latest")
+        .and_then(Value::as_object)
+        .map(|obj| {
+            json!({
+                "backend_sinks": obj
+                    .get("backend_sinks")
+                    .cloned()
+                    .unwrap_or_else(|| json!({})),
+            })
+        })
+        .unwrap_or(Value::Null);
+
+    json!({
+        "present": heartbeat
+            .get("present")
+            .cloned()
+            .unwrap_or(Value::Bool(false)),
+        "alive": heartbeat
+            .get("alive")
+            .cloned()
+            .unwrap_or(Value::Bool(false)),
+        "latest": latest,
+        "age_seconds": heartbeat.get("age_seconds").cloned().unwrap_or(Value::Null),
+    })
+}
+
+async fn query_health_heartbeat_or_absent(state: &AppState) -> Value {
+    health_heartbeat(query_heartbeat_or_absent(state).await)
+}
+
 async fn query_clickhouse_connections(state: &AppState) -> Result<Value> {
     #[derive(serde::Deserialize)]
     struct MetricRow {
@@ -1662,6 +1709,10 @@ fn value_to_i64(value: &Value) -> Option<i64> {
 mod tests {
     use super::*;
     use anyhow::anyhow;
+    use axum::{body::to_bytes, extract::Query, http::StatusCode, routing::post};
+    use moraine_clickhouse::ClickHouseClient;
+    use moraine_config::ClickHouseConfig;
+    use std::collections::HashMap;
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1709,6 +1760,70 @@ mod tests {
 
     fn compact_sql(query: &str) -> String {
         query.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    async fn health_mock_handler(Query(params): Query<HashMap<String, String>>) -> String {
+        let query = params.get("query").cloned().unwrap_or_default();
+        if query.trim() == "SELECT 1" {
+            return "1".to_string();
+        }
+        if query.contains("version()") {
+            return json!({"data": [{"version": "25.1.1"}]}).to_string();
+        }
+        if query.contains("system.metrics") {
+            return json!({"data": []}).to_string();
+        }
+        if query.contains("system.columns") && query.contains("ingest_heartbeats") {
+            return json!({"data": [{"name": "backend_sinks"}]}).to_string();
+        }
+        if query.contains("ingest_heartbeats") {
+            let now_ms = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_millis() as u64;
+            return json!({
+                "data": [{
+                    "ts": "2026-07-07 20:00:00.000",
+                    "ts_unix_ms": now_ms,
+                    "host": "host-a",
+                    "service_version": "0.6.4",
+                    "queue_depth": 0,
+                    "files_active": 0,
+                    "files_watched": 1,
+                    "rows_raw_written": 2,
+                    "rows_events_written": 2,
+                    "rows_errors_written": 0,
+                    "flush_latency_ms": 1,
+                    "append_to_visible_p50_ms": 1,
+                    "append_to_visible_p95_ms": 2,
+                    "last_error": "",
+                    "backend_sinks": "{\"team-ch\":\"disabled_missing_identity_author\"}"
+                }]
+            })
+            .to_string();
+        }
+        json!({"data": []}).to_string()
+    }
+
+    async fn mock_health_state() -> AppState {
+        let app = Router::new().route("/", post(health_mock_handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock clickhouse");
+        let addr = listener.local_addr().expect("mock addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let cfg = ClickHouseConfig {
+            url: format!("http://{}", addr),
+            timeout_seconds: 1.0,
+            ..Default::default()
+        };
+        AppState {
+            clickhouse: ClickHouseClient::new(cfg).expect("mock client"),
+            static_dir: PathBuf::new(),
+        }
     }
 
     #[test]
@@ -1859,6 +1974,47 @@ mod tests {
         assert_eq!(payload["version"], json!("24.8"));
         assert_eq!(payload["ping_ms"], json!(8.25));
         assert_eq!(payload["error"], json!("ping failed"));
+    }
+
+    #[tokio::test]
+    async fn query_heartbeat_decodes_disabled_backend_status() {
+        let state = mock_health_state().await;
+        let heartbeat = query_heartbeat(&state).await.expect("heartbeat");
+
+        assert_eq!(
+            heartbeat["latest"]["backend_sinks"]["team-ch"],
+            json!("disabled_missing_identity_author")
+        );
+        assert_eq!(heartbeat["present"], json!(true));
+        assert_eq!(heartbeat["alive"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn api_health_includes_ingestor_without_affecting_health_status() {
+        let state = mock_health_state().await;
+        let response = api_health(axum::extract::State(state)).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let payload: Value = serde_json::from_slice(&body).expect("health json");
+        assert_eq!(payload["ok"], json!(true));
+        assert_eq!(
+            payload["ingestor"]["latest"]["backend_sinks"]["team-ch"],
+            json!("disabled_missing_identity_author")
+        );
+        let latest = payload["ingestor"]["latest"]
+            .as_object()
+            .expect("latest object");
+        assert!(
+            !latest.contains_key("last_error"),
+            "/api/health should expose mirror status without full heartbeat internals"
+        );
+        assert!(
+            !latest.contains_key("host"),
+            "/api/health should expose mirror status without full heartbeat internals"
+        );
     }
 
     #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,7 @@ future keys.
 | `[clickhouse]` | Default ClickHouse backend used by local ingest, monitor, MCP, and migrations. |
 | `[backends.<name>]` | Optional named ClickHouse backend for project mirroring and routed MCP. |
 | `[[routes]]` | Optional ordered working-directory routes to named backends. |
+| `[identity]` | Explicit person identity stamped on ingested raw/events rows. |
 | `[ingest]` | Ingest batching, backfill, watcher, checkpoint, and heartbeat settings. |
 | `[[ingest.sources]]` | Watched agent trace sources. |
 | `[mcp]` | MCP retrieval defaults and shared central server settings. |
@@ -67,6 +68,28 @@ enabled = true
 glob = "~/.codex/sessions/**/*.jsonl"
 watch_root = "~/.codex/sessions"
 ```
+
+## Identity
+
+`[identity]` configures the stable person identity stamped on newly ingested
+`raw_events` and `events` rows:
+
+```toml
+[identity]
+author = "alice@example.com"
+```
+
+The value is free-form by design; email-shaped strings are conventional but
+not enforced. Moraine never infers this identity from git, `$USER`,
+`$HOSTNAME`, the machine host, or the working directory. Missing and
+whitespace-only values normalize to empty.
+
+Local/default-only installs may leave `author` empty. If any route targets a
+non-default backend and `author` is empty, that mirror is disabled for the
+process and reported as `disabled_missing_identity_author`; default ingest
+continues. After setting `author`, restart the ingest service. Retained source
+files are then replayed to the mirror using the configured author; files
+deleted before the mirror catches up cannot be recovered by this replay path.
 
 ## ClickHouse
 
@@ -195,11 +218,14 @@ window effectively empty (the working directory rides the records
 themselves, or is recovered from the session header), so in practice it
 only affects traces that carry no working directory at all.
 
-Per-backend mirror status — `connecting`, `ok`, `lagging`, `unreachable`, or
-`disabled_skew` — is written to ingest heartbeats as a `backend_sinks` map
-and surfaced through the monitor's `/api/health`. This uses a column added by
-migration 017; until `moraine db migrate` runs (and ingest restarts), ingest
-warns and omits the field rather than failing heartbeats.
+Per-backend mirror status — `connecting`, `ok`, `lagging`, `unreachable`,
+`disabled_skew`, or `disabled_missing_identity_author` — is written to ingest
+heartbeats as a `backend_sinks` map and surfaced through the monitor's
+`/api/health`. This uses a column added by migration 017; until
+`moraine db migrate` runs (and ingest restarts), ingest warns and omits the
+field rather than failing heartbeats. `disabled_missing_identity_author` means
+`[identity].author` is empty; set it and restart ingest before mirroring to
+team backends.
 
 ### Schema version handshake
 

--- a/docs/full-config.toml
+++ b/docs/full-config.toml
@@ -70,6 +70,12 @@ allow_newer_server = false
 # # Routing mode. "mirror" is currently the only supported value.
 # mode = "mirror"
 
+[identity]
+# Stable person identity stamped on raw_events/events. Leave empty for
+# local-only installs. Required for mirroring to non-default backends; when
+# empty, routed mirror sinks report disabled_missing_identity_author.
+author = ""
+
 [ingest]
 # Maximum rows collected before a sink flushes a batch to ClickHouse.
 batch_size = 4000

--- a/sql/001_schema.sql
+++ b/sql/001_schema.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS moraine.raw_events (
   record_ts String,
   top_type LowCardinality(String),
   session_id String,
+  author String DEFAULT '',
   raw_json String,
   raw_json_hash UInt64,
   event_uid String
@@ -25,6 +26,7 @@ CREATE TABLE IF NOT EXISTS moraine.events (
   ingested_at DateTime64(3) DEFAULT now64(3),
   event_uid String,
   session_id String,
+  author String DEFAULT '',
   session_date Date,
   source_name LowCardinality(String),
   harness LowCardinality(String),

--- a/sql/024_add_event_author.sql
+++ b/sql/024_add_event_author.sql
@@ -1,0 +1,12 @@
+-- Stable person identity that produced each ingested record. This is distinct
+-- from checkpoint `host`: one author can write from multiple machines, while
+-- host continues to scope mirror checkpoints per machine.
+--
+-- Every statement below is individually idempotent: the migration runner
+-- re-executes the whole file if any statement fails mid-way.
+
+ALTER TABLE moraine.raw_events
+  ADD COLUMN IF NOT EXISTS author String DEFAULT '';
+
+ALTER TABLE moraine.events
+  ADD COLUMN IF NOT EXISTS author String DEFAULT '';

--- a/web/monitor/src/lib/types/api.ts
+++ b/web/monitor/src/lib/types/api.ts
@@ -16,6 +16,7 @@ export interface HealthResponse {
   version?: string | null;
   ping_ms?: number | null;
   connections?: ConnectionStats;
+  ingestor?: IngestorStatus;
   error?: string;
 }
 


### PR DESCRIPTION
## Description

**What.** Adds explicit person identity attribution for ingested Moraine rows.

**Why.** Shared team backends need a stable `author` column before later RBAC, team usability, and deletion work can distinguish people from machines.

This PR adds `[identity].author`, stores it on `raw_events` and `events`, and keeps the value explicit-only: unset config stays empty, with no git, environment, username, or hostname inference. The default/local sink continues to ingest with an empty author, while named mirror sinks refuse to start when author is empty and report `disabled_missing_identity_author` through backend sink health.

The ingest path stamps author at sink intake so live batches and backend catch-up replay use the same behavior. Default sinks probe `raw_events.author` and `events.author` independently and strip unsupported fields for pre-024 local schemas; backend sinks still rely on the existing remote schema handshake. Repo-level `.moraine.toml` routes are discovered from retained source files at startup without writing remote rows or checkpoints, so setting author and restarting can start the backend replay path for repo-routed sessions.

## Usage

Configure a stable person identity once per install:

```toml
[identity]
author = "alice@example.com"
```

Local-only installs may leave `author = ""`. If a route targets a non-default backend while author is empty, the default sink keeps ingesting locally and the mirror status is reported as `disabled_missing_identity_author`.

## Changelog

- Adds migration `024_add_event_author.sql` and fresh-schema `author String DEFAULT ''` columns on `raw_events` and `events`.
- Adds explicit `[identity].author` config, config templates, and documentation.
- Stamps configured author on raw/event rows without changing search-index tables, event ids, payload JSON, or checkpoint identity.
- Disables named mirror sinks with empty author and exposes the status in monitor health.
- Advertises `events.author` in the analytics schema while keeping default export columns unchanged.

## Operational Impact

Operators should run `moraine db migrate` before relying on local/default author writes. Direct ingest against a pre-024 local schema remains compatible by stripping unsupported author fields until migration and restart.

Team mirror backends must already have migration 024 applied, as with other non-default backend schema changes. Retained source files remain the replay source for disabled-then-enabled mirror backfill; files deleted before replay cannot be recovered for that backend.

## Validation

Ran successfully:

```bash
cargo fmt --all -- --check
cargo test --workspace --locked
make clippy
make docs-build
cd web/monitor && bun install --frozen-lockfile
cd web/monitor && bun run typecheck
cd web/monitor && bun run build
```

Focused checks also passed for the new paths:

```bash
cargo test -p moraine-config identity --locked
cargo test -p moraine-clickhouse schema_skew --locked
cargo test -p moraine-ingest-core author --locked
cargo test -p moraine-ingest-core disabled_missing --locked
cargo test -p moraine-ingest-core startup_discovery --locked
cargo test -p moraine-monitor-core api_health_includes_ingestor --locked
cargo test -p moraine analytics_schema_json_matches_golden --locked
```

Ran the delegated Moraine code-review wave across elegance, idiom, correctness, completeness, security, YAGNI, and scope. Two findings were accepted and fixed: `/api/health` now exposes only minimal ingestor backend status, and repo-routed retained files now discover backends at startup so replay can start after author is configured. Follow-up review confirmed both were resolved.

Sandbox QA was attempted but blocked by Docker responsiveness. `scripts/dev/sandbox/moraine-sandbox up --quiet` allocated `sb-10a682` and then hung during Docker runtime build; Docker inspection commands also blocked. Cleanup with `scripts/dev/sandbox/moraine-sandbox down sb-10a682` warned that `docker compose down` returned non-zero but removed `/tmp/moraine-sandbox-sb-10a682`. No sandbox stack checks were able to run.

Closes #381.
