### PR TITLE
feat(ingest): stamp per-person author identity on ingested rows

### DIFF
--- a/config/moraine.toml
+++ b/config/moraine.toml
@@ -28,6 +28,15 @@ wait_for_async_insert = true
 # backend = "team-ch"
 # mode = "mirror"               # default; the only supported mode
 
+# Per-person identity stamped on every ingested row as the `author` column.
+# Free-form (email-shaped by convention); use the SAME value on all your
+# machines. Never inferred from git or the environment. Optional for
+# local-only use, but REQUIRED to mirror to a non-default backend — a route
+# to a named backend with no author disables that mirror sink until the
+# author is set and the ingest service restarts.
+# [identity]
+# author = "alice@example.com"
+
 [redaction]
 # Secret redaction is default-on for all ingestion. This flag is honored only
 # from $HOME/.moraine/config.toml, and only for the local/default backend;

--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -753,6 +753,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             name: "023_search_documents_event_uid_bloom.sql",
             sql: include_str!("../../../sql/023_search_documents_event_uid_bloom.sql"),
         },
+        Migration {
+            version: "024",
+            name: "024_add_event_author.sql",
+            sql: include_str!("../../../sql/024_add_event_author.sql"),
+        },
     ]
 }
 

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -90,6 +90,29 @@ pub struct RouteConfig {
     pub mode: String,
 }
 
+/// Per-person identity stamped on ingested rows (issue #381). Explicit
+/// only: never inferred from git or the environment — a wrong-but-plausible
+/// identity on a shared machine is worse than none.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IdentityConfig {
+    /// Free-form person identifier (email-shaped by convention, not
+    /// enforced). One person uses the same value on all their machines;
+    /// `host` remains the per-machine identity. Empty means unset: fine for
+    /// local-only use, but mirror sinks to non-default backends refuse to
+    /// start without it.
+    #[serde(default)]
+    pub author: String,
+}
+
+impl IdentityConfig {
+    /// The identity actually stamped and gated on: whitespace-only values
+    /// count as unset.
+    pub fn resolved_author(&self) -> &str {
+        self.author.trim()
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RedactionConfig {
@@ -246,6 +269,8 @@ pub struct AppConfig {
     #[serde(default)]
     pub routes: Vec<RouteConfig>,
     #[serde(default)]
+    pub identity: IdentityConfig,
+    #[serde(default)]
     pub redaction: RedactionConfig,
     #[serde(default)]
     pub ingest: IngestConfig,
@@ -317,6 +342,7 @@ impl Default for AppConfig {
             clickhouse,
             backends,
             routes: Vec::new(),
+            identity: IdentityConfig::default(),
             redaction: RedactionConfig::default(),
             ingest: IngestConfig::default(),
             mcp: McpConfig::default(),
@@ -1225,6 +1251,50 @@ mod tests {
         ));
         std::fs::write(&path, contents).expect("write temp config");
         path
+    }
+
+    #[test]
+    fn identity_author_defaults_to_empty_when_absent() {
+        let path = write_temp_config("", "identity-absent");
+        let cfg = load_config(&path).expect("config without [identity] should load");
+
+        assert_eq!(cfg.identity.author, "");
+        assert_eq!(cfg.identity.resolved_author(), "");
+
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn identity_author_parses_when_set() {
+        let path = write_temp_config(
+            r#"
+[identity]
+author = "alice@example.com"
+"#,
+            "identity-set",
+        );
+        let cfg = load_config(&path).expect("config with [identity] should load");
+
+        assert_eq!(cfg.identity.author, "alice@example.com");
+        assert_eq!(cfg.identity.resolved_author(), "alice@example.com");
+
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn identity_author_treats_whitespace_as_unset() {
+        let path = write_temp_config(
+            r#"
+[identity]
+author = "   "
+"#,
+            "identity-whitespace",
+        );
+        let cfg = load_config(&path).expect("whitespace author should load");
+
+        assert_eq!(cfg.identity.resolved_author(), "");
+
+        std::fs::remove_file(path).ok();
     }
 
     #[test]

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -100,17 +100,10 @@ pub struct IdentityConfig {
     /// enforced). One person uses the same value on all their machines;
     /// `host` remains the per-machine identity. Empty means unset: fine for
     /// local-only use, but mirror sinks to non-default backends refuse to
-    /// start without it.
+    /// start without it. Trimmed at config load, so whitespace-only values
+    /// read as unset everywhere.
     #[serde(default)]
     pub author: String,
-}
-
-impl IdentityConfig {
-    /// The identity actually stamped and gated on: whitespace-only values
-    /// count as unset.
-    pub fn resolved_author(&self) -> &str {
-        self.author.trim()
-    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1112,6 +1105,10 @@ fn normalize_config(mut cfg: AppConfig) -> Result<AppConfig> {
     cfg.mcp.central_socket_path =
         resolve_runtime_subdir(&cfg.runtime.pids_dir, &cfg.mcp.central_socket_path);
 
+    // Whitespace-only identity means unset; trimming once here keeps every
+    // consumer (mirror gate, row stamping) reading the field directly.
+    cfg.identity.author = cfg.identity.author.trim().to_string();
+
     normalize_backends_and_routes(&mut cfg)?;
     normalize_redaction(&mut cfg)?;
 
@@ -1259,7 +1256,6 @@ mod tests {
         let cfg = load_config(&path).expect("config without [identity] should load");
 
         assert_eq!(cfg.identity.author, "");
-        assert_eq!(cfg.identity.resolved_author(), "");
 
         std::fs::remove_file(path).ok();
     }
@@ -1276,13 +1272,23 @@ author = "alice@example.com"
         let cfg = load_config(&path).expect("config with [identity] should load");
 
         assert_eq!(cfg.identity.author, "alice@example.com");
-        assert_eq!(cfg.identity.resolved_author(), "alice@example.com");
 
         std::fs::remove_file(path).ok();
     }
 
     #[test]
-    fn identity_author_treats_whitespace_as_unset() {
+    fn identity_author_normalizes_whitespace_to_unset_at_load() {
+        let path = write_temp_config(
+            r#"
+[identity]
+author = "  alice@example.com  "
+"#,
+            "identity-trim",
+        );
+        let cfg = load_config(&path).expect("padded author should load");
+        assert_eq!(cfg.identity.author, "alice@example.com");
+        std::fs::remove_file(path).ok();
+
         let path = write_temp_config(
             r#"
 [identity]
@@ -1291,9 +1297,10 @@ author = "   "
             "identity-whitespace",
         );
         let cfg = load_config(&path).expect("whitespace author should load");
-
-        assert_eq!(cfg.identity.resolved_author(), "");
-
+        assert_eq!(
+            cfg.identity.author, "",
+            "whitespace-only identity must normalize to unset"
+        );
         std::fs::remove_file(path).ok();
     }
 

--- a/crates/moraine-ingest-core/src/lib.rs
+++ b/crates/moraine-ingest-core/src/lib.rs
@@ -152,6 +152,22 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
         );
     }
 
+    let author_column = if config.identity.author.is_empty() {
+        false
+    } else {
+        let available = event_author_columns_available(&clickhouse)
+            .await
+            .context("failed to inspect raw_events/events author columns")?;
+        if !available {
+            warn!(
+                "[identity].author is set but raw_events/events are missing the author column \
+                 (migration 024); rows will ingest WITHOUT attribution until \
+                 `moraine db migrate` runs and this ingest service restarts"
+            );
+        }
+        available
+    };
+
     let checkpoints = Arc::new(RwLock::new(checkpoint_map));
     let dispatch = Arc::new(Mutex::new(DispatchState::default()));
     let metrics = Arc::new(Metrics::default());
@@ -204,6 +220,7 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
             backends: backend_statuses.clone(),
             backend_sinks_column: heartbeat_backend_column,
             redactions_column: heartbeat_redactions_column,
+            author_column,
             redactions: redaction_audit.clone(),
         },
     );
@@ -403,6 +420,31 @@ async fn heartbeat_column_available(clickhouse: &ClickHouseClient, column: &str)
     Ok(rows
         .first()
         .map(|row| row.column_count > 0)
+        .unwrap_or(false))
+}
+
+/// Returns whether `raw_events` AND `events` carry the `author` column
+/// (migration 024). Stamping a configured author against a database missing
+/// the column would make every row insert fail on the unknown field, wedging
+/// the default sink in retry — so the stamp is withheld (with a loud startup
+/// warning) until the migration has run. Only consulted when an author is
+/// configured; backend mirror sinks rely on the schema handshake instead.
+async fn event_author_columns_available(clickhouse: &ClickHouseClient) -> Result<bool> {
+    #[derive(Deserialize)]
+    struct CountRow {
+        column_count: u64,
+    }
+
+    let query = format!(
+        "SELECT toUInt64(count()) AS column_count \
+         FROM system.columns \
+         WHERE database = '{}' AND table IN ('raw_events', 'events') AND name = 'author'",
+        clickhouse.config().database.replace('\'', "\\'")
+    );
+    let rows: Vec<CountRow> = clickhouse.query_rows(&query, None).await?;
+    Ok(rows
+        .first()
+        .map(|row| row.column_count >= 2)
         .unwrap_or(false))
 }
 

--- a/crates/moraine-ingest-core/src/model.rs
+++ b/crates/moraine-ingest-core/src/model.rs
@@ -106,12 +106,33 @@ impl RowBatch {
         if author.is_empty() {
             return;
         }
+        // Serialized cost of inserting `"author":"<value>",` into a
+        // non-empty object. Exact for the rows the normalizers build, and
+        // the cache is approximate by contract — a per-row delta keeps this
+        // hot path free of the whole-batch re-serialization that
+        // `recompute_approx_bytes` would do.
+        let per_row_bytes = r#""author":"","#.len() + author.len();
+        let mut stamped = 0usize;
         for row in self.raw_rows.iter_mut().chain(self.event_rows.iter_mut()) {
-            if let Value::Object(obj) = row {
-                obj.insert("author".to_string(), Value::String(author.to_string()));
+            // Rows are always JSON objects by construction (anything else
+            // could never insert via JSONEachRow).
+            if let Some(obj) = row.as_object_mut() {
+                if obj
+                    .insert("author".to_string(), Value::String(author.to_string()))
+                    .is_none()
+                {
+                    stamped += 1;
+                }
             }
         }
-        self.recompute_approx_bytes();
+        // A zero cache means "not computed yet" (rows pushed via the struct
+        // fields directly); leave it lazy — the eventual compute already
+        // sees the stamped rows.
+        if self.approx_bytes > 0 {
+            self.approx_bytes = self
+                .approx_bytes
+                .saturating_add(stamped.saturating_mul(per_row_bytes));
+        }
     }
 
     pub fn push_raw_row(&mut self, row: Value) {
@@ -249,14 +270,19 @@ mod tests {
     }
 
     #[test]
-    fn stamp_author_recomputes_the_cached_batch_size() {
+    fn stamp_author_advances_the_cached_batch_size_by_the_exact_delta() {
+        let author = "alice@example.com";
         let mut batch = batch_with_all_row_kinds();
         let before = batch.approx_bytes();
 
-        batch.stamp_author("alice@example.com");
+        batch.stamp_author(author);
 
-        assert!(
-            batch.approx_bytes() > before,
+        // One raw row + one event row stamped; each grows by the serialized
+        // `"author":"<value>",` entry.
+        let expected_delta = 2 * (r#""author":"","#.len() + author.len());
+        assert_eq!(
+            batch.approx_bytes(),
+            before + expected_delta,
             "stamped rows are larger; the cached size drives batching and must follow"
         );
     }

--- a/crates/moraine-ingest-core/src/model.rs
+++ b/crates/moraine-ingest-core/src/model.rs
@@ -96,6 +96,24 @@ impl RowBatch {
         self.approx_bytes = self.approx_bytes();
     }
 
+    /// Stamps the configured author identity onto every raw and event row —
+    /// the only row kinds whose tables carry the migration-024 `author`
+    /// column. Empty author is a no-op rather than an empty-string stamp so
+    /// identity-less installs keep inserting into default databases that
+    /// have not run migration 024 yet (the column's DEFAULT supplies the
+    /// empty value).
+    pub(crate) fn stamp_author(&mut self, author: &str) {
+        if author.is_empty() {
+            return;
+        }
+        for row in self.raw_rows.iter_mut().chain(self.event_rows.iter_mut()) {
+            if let Value::Object(obj) = row {
+                obj.insert("author".to_string(), Value::String(author.to_string()));
+            }
+        }
+        self.recompute_approx_bytes();
+    }
+
     pub fn push_raw_row(&mut self, row: Value) {
         self.approx_bytes = self
             .approx_bytes
@@ -192,4 +210,70 @@ fn approx_json_row_bytes(row: &Value) -> usize {
     serde_json::to_vec(row)
         .map(|bytes| bytes.len().saturating_add(1))
         .unwrap_or(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn batch_with_all_row_kinds() -> RowBatch {
+        let mut batch = RowBatch::default();
+        batch.push_raw_row(json!({ "session_id": "s1" }));
+        batch.extend_event_rows(vec![json!({ "session_id": "s1" })]);
+        batch.extend_link_rows(vec![json!({ "session_id": "s1" })]);
+        batch.extend_tool_rows(vec![json!({ "session_id": "s1" })]);
+        batch.push_error_row(json!({ "error_kind": "json_parse_error" }));
+        batch
+    }
+
+    #[test]
+    fn stamp_author_covers_raw_and_event_rows_only() {
+        let mut batch = batch_with_all_row_kinds();
+
+        batch.stamp_author("alice@example.com");
+
+        assert_eq!(
+            batch.raw_rows[0].get("author").and_then(Value::as_str),
+            Some("alice@example.com")
+        );
+        assert_eq!(
+            batch.event_rows[0].get("author").and_then(Value::as_str),
+            Some("alice@example.com")
+        );
+        // link/tool/error tables carry no author column (migration 024);
+        // stamping them would make their inserts reject unknown fields.
+        assert!(batch.link_rows[0].get("author").is_none());
+        assert!(batch.tool_rows[0].get("author").is_none());
+        assert!(batch.error_rows[0].get("author").is_none());
+    }
+
+    #[test]
+    fn stamp_author_recomputes_the_cached_batch_size() {
+        let mut batch = batch_with_all_row_kinds();
+        let before = batch.approx_bytes();
+
+        batch.stamp_author("alice@example.com");
+
+        assert!(
+            batch.approx_bytes() > before,
+            "stamped rows are larger; the cached size drives batching and must follow"
+        );
+    }
+
+    #[test]
+    fn stamp_author_with_empty_identity_is_a_no_op() {
+        let mut batch = batch_with_all_row_kinds();
+        let before_bytes = batch.approx_bytes();
+
+        batch.stamp_author("");
+
+        assert!(
+            batch.raw_rows[0].get("author").is_none(),
+            "an empty identity must not stamp an empty string: default databases \
+             without migration 024 must keep accepting identity-less rows"
+        );
+        assert!(batch.event_rows[0].get("author").is_none());
+        assert_eq!(batch.approx_bytes(), before_bytes);
+    }
 }

--- a/crates/moraine-ingest-core/src/sink.rs
+++ b/crates/moraine-ingest-core/src/sink.rs
@@ -200,6 +200,12 @@ pub(crate) fn spawn_sink_task(
             SinkRole::Default { .. } => String::new(),
         };
 
+        // Person identity stamped on every raw/event row (issue #381). A
+        // process constant resolved once at startup: the sink intake below
+        // is the single choke point every row passes through — live default,
+        // live mirror, and catch-up replay batches alike.
+        let author = config.identity.resolved_author().to_string();
+
         let flush_interval = duration_from_config_seconds(
             config.ingest.flush_interval_seconds,
             0.05,
@@ -267,7 +273,7 @@ pub(crate) fn spawn_sink_task(
                         Some(SinkMessage::Batch(batch)) => {
                             // Mirror sinks only buffer the sessions routed to
                             // them; the default sink takes batches whole.
-                            let batch = match &role {
+                            let mut batch = match &role {
                                 SinkRole::Backend {
                                     cell,
                                     resolver,
@@ -285,6 +291,7 @@ pub(crate) fn spawn_sink_task(
                                 }
                                 SinkRole::Default { .. } => batch,
                             };
+                            batch.stamp_author(&author);
                             pending_batch_bytes =
                                 pending_batch_bytes.saturating_add(batch.approx_bytes());
                             raw_rows.extend(batch.raw_rows);
@@ -1310,6 +1317,78 @@ mod tests {
         assert!(
             third_send.is_err(),
             "third send should block while sink retries failed flushes"
+        );
+
+        handle.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sink_intake_stamps_author_on_raw_and_event_rows() {
+        let (clickhouse, mock_state) =
+            spawn_mock_clickhouse_with_state(MockClickHouseState::default()).await;
+        let mut config = moraine_config::AppConfig::default();
+        config.identity.author = "alice@example.com".to_string();
+        config.ingest.batch_size = 1;
+        config.ingest.flush_interval_seconds = 0.05;
+        config.ingest.heartbeat_interval_seconds = 60.0;
+
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let metrics = Arc::new(Metrics::default());
+        let (tx, rx) = mpsc::channel(4);
+
+        let handle = spawn_sink_task(
+            config,
+            clickhouse,
+            checkpoints,
+            metrics,
+            rx,
+            true,
+            default_role(),
+        );
+
+        let mut batch = RowBatch::default();
+        batch.push_raw_row(json!({ "event_uid": "evt-1" }));
+        batch.extend_event_rows(vec![json!({ "event_uid": "evt-1" })]);
+        batch.extend_tool_rows(vec![json!({ "event_uid": "evt-1" })]);
+        tx.send(SinkMessage::Batch(batch))
+            .await
+            .expect("send batch");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if !mock_state.rows("raw_events").is_empty()
+                && !mock_state.rows("events").is_empty()
+                && !mock_state.rows("tool_io").is_empty()
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let raw = mock_state.rows("raw_events");
+        let events = mock_state.rows("events");
+        let tools = mock_state.rows("tool_io");
+        assert_eq!(
+            raw.first()
+                .and_then(|row| row.get("author"))
+                .and_then(Value::as_str),
+            Some("alice@example.com"),
+            "raw rows must carry the configured author"
+        );
+        assert_eq!(
+            events
+                .first()
+                .and_then(|row| row.get("author"))
+                .and_then(Value::as_str),
+            Some("alice@example.com"),
+            "event rows must carry the configured author"
+        );
+        assert!(
+            tools
+                .first()
+                .map(|row| row.get("author").is_none())
+                .unwrap_or(false),
+            "tool_io has no author column; stamping it would reject the insert"
         );
 
         handle.abort();

--- a/crates/moraine-ingest-core/src/sink.rs
+++ b/crates/moraine-ingest-core/src/sink.rs
@@ -44,6 +44,12 @@ pub(crate) enum SinkRole {
         /// Whether `ingest_heartbeats` carries the `redactions_total` column
         /// (migration 022). Redaction still runs without this audit surface.
         redactions_column: bool,
+        /// Whether `raw_events`/`events` carry the `author` column
+        /// (migration 024). Pre-024 default schemas reject unknown fields
+        /// at insert time, so a configured author is stamped only when the
+        /// column exists; backend sinks skip this flag because their schema
+        /// handshake already guarantees every bundled migration.
+        author_column: bool,
         redactions: Arc<RedactionAudit>,
     },
     /// A mirror sink for one named backend: filters intake down to the
@@ -203,8 +209,18 @@ pub(crate) fn spawn_sink_task(
         // Person identity stamped on every raw/event row (issue #381). A
         // process constant resolved once at startup: the sink intake below
         // is the single choke point every row passes through — live default,
-        // live mirror, and catch-up replay batches alike.
-        let author = config.identity.resolved_author().to_string();
+        // live mirror, and catch-up replay batches alike. The default sink
+        // withholds the stamp while its database still lacks the
+        // migration-024 column (probed at startup) so a config change can
+        // never wedge local ingest; mirror sinks only exist post-handshake,
+        // which guarantees the column.
+        let author = match &role {
+            SinkRole::Default {
+                author_column: false,
+                ..
+            } => String::new(),
+            _ => config.identity.author.clone(),
+        };
 
         let flush_interval = duration_from_config_seconds(
             config.ingest.flush_interval_seconds,
@@ -731,6 +747,7 @@ async fn emit_heartbeat(clickhouse: &ClickHouseClient, metrics: &Arc<Metrics>, r
         backends,
         backend_sinks_column,
         redactions_column,
+        author_column: _,
         redactions,
     } = role
     else {
@@ -1267,11 +1284,16 @@ mod tests {
     }
 
     fn default_role() -> SinkRole {
+        default_role_with_author_column(true)
+    }
+
+    fn default_role_with_author_column(author_column: bool) -> SinkRole {
         SinkRole::Default {
             dispatch: Arc::new(Mutex::new(DispatchState::default())),
             backends: Arc::new(Mutex::new(std::collections::BTreeMap::new())),
             backend_sinks_column: false,
             redactions_column: false,
+            author_column,
             redactions: test_redaction_audit(),
         }
     }
@@ -1391,6 +1413,120 @@ mod tests {
             "tool_io has no author column; stamping it would reject the insert"
         );
 
+        handle.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn default_sink_withholds_author_when_column_is_missing() {
+        let (clickhouse, mock_state) =
+            spawn_mock_clickhouse_with_state(MockClickHouseState::default()).await;
+        let mut config = moraine_config::AppConfig::default();
+        config.identity.author = "alice@example.com".to_string();
+        config.ingest.batch_size = 1;
+        config.ingest.flush_interval_seconds = 0.05;
+        config.ingest.heartbeat_interval_seconds = 60.0;
+
+        let (tx, rx) = mpsc::channel(4);
+        let handle = spawn_sink_task(
+            config,
+            clickhouse,
+            Arc::new(RwLock::new(HashMap::new())),
+            Arc::new(Metrics::default()),
+            rx,
+            true,
+            default_role_with_author_column(false),
+        );
+
+        let mut batch = RowBatch::default();
+        batch.push_raw_row(json!({ "event_uid": "evt-1" }));
+        tx.send(SinkMessage::Batch(batch)).await.expect("send");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && mock_state.rows("raw_events").is_empty() {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let raw = mock_state.rows("raw_events");
+        assert!(
+            raw.first()
+                .map(|row| row.get("author").is_none())
+                .unwrap_or(false),
+            "a pre-024 default schema must keep receiving unstamped rows \
+             even when an author is configured"
+        );
+        handle.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn backend_sink_intake_stamps_author_on_mirrored_rows() {
+        let (clickhouse, mock_state) =
+            spawn_mock_clickhouse_with_state(MockClickHouseState::default()).await;
+        let mut config = moraine_config::AppConfig::default();
+        config.identity.author = "alice@example.com".to_string();
+        config.backends.insert(
+            "team-ch".to_string(),
+            moraine_config::ClickHouseConfig::default(),
+        );
+        config.routes.push(moraine_config::RouteConfig {
+            dir: "/work/team/**".to_string(),
+            backend: "team-ch".to_string(),
+            mode: moraine_config::ROUTE_MODE_MIRROR.to_string(),
+        });
+        config.ingest.batch_size = 1;
+        config.ingest.flush_interval_seconds = 0.05;
+        config.ingest.heartbeat_interval_seconds = 60.0;
+
+        let resolver: SharedRouteResolver = Arc::new(Mutex::new(crate::tee::RouteResolver::new(
+            Arc::new(config.clone()),
+        )));
+        let cell = Arc::new(BackendSinkCell::new("team-ch"));
+        let role = SinkRole::Backend {
+            cell,
+            resolver,
+            replay_notify: Arc::new(Notify::new()),
+            replay_floor: Arc::new(Mutex::new(None)),
+            redactor: test_redactor(),
+            redactions: test_redaction_audit(),
+        };
+
+        let (tx, rx) = mpsc::channel(4);
+        let handle = spawn_sink_task(
+            config,
+            clickhouse,
+            Arc::new(RwLock::new(HashMap::new())),
+            Arc::new(Metrics::default()),
+            rx,
+            true,
+            role,
+        );
+
+        // One routed row (kept + stamped) and one unrouted row (filtered) —
+        // the same intake path catch-up replay batches take.
+        let mut batch = RowBatch::default();
+        batch.push_raw_row(json!({
+            "session_id": "team-session",
+            "cwd": "/work/team/project",
+            "event_uid": "evt-1"
+        }));
+        batch.push_raw_row(json!({
+            "session_id": "other-session",
+            "cwd": "/home/other",
+            "event_uid": "evt-2"
+        }));
+        tx.send(SinkMessage::Batch(batch)).await.expect("send");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && mock_state.rows("raw_events").is_empty() {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let raw = mock_state.rows("raw_events");
+        assert_eq!(raw.len(), 1, "only the routed session is mirrored");
+        assert_eq!(
+            raw[0].get("author").and_then(Value::as_str),
+            Some("alice@example.com"),
+            "mirrored rows must carry the configured author"
+        );
         handle.abort();
     }
 

--- a/crates/moraine-ingest-core/src/tee.rs
+++ b/crates/moraine-ingest-core/src/tee.rs
@@ -555,7 +555,7 @@ fn spawn_backend_supervisor(
         // network contact; terminal until restart, like schema skew. The
         // default sink is unaffected, and catch-up replay backfills this
         // backend once an author is configured.
-        if context.config.identity.resolved_author().is_empty() {
+        if context.config.identity.author.is_empty() {
             cell.set_status(BackendSinkStatus::DisabledMissingIdentity);
             error!(
                 backend = %name,
@@ -1125,6 +1125,65 @@ mod tests {
             BackendSinkStatus::Connecting,
             "dropping while connecting is not an overflow"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn router_keeps_default_path_flowing_while_identity_gate_disables_mirror() {
+        let mut config = (*team_config()).clone();
+        config.identity.author = String::new();
+        let config = Arc::new(config);
+        let resolver: SharedRouteResolver =
+            Arc::new(Mutex::new(RouteResolver::new(config.clone())));
+        let registry: StatusRegistry = Arc::new(Mutex::new(BTreeMap::new()));
+        let (router_tx, router_rx) = mpsc::channel::<SinkMessage>(4);
+        let (default_tx, mut default_rx) = mpsc::channel::<SinkMessage>(4);
+
+        let handle = spawn_tee_router(
+            config,
+            Vec::new(),
+            router_rx,
+            default_tx,
+            resolver,
+            registry.clone(),
+            RedactionContext::new(test_redactor(), test_redaction_audit()),
+        );
+
+        router_tx
+            .send(SinkMessage::Batch(mixed_session_batch()))
+            .await
+            .expect("send batch to router");
+
+        let SinkMessage::Batch(batch) = timeout(Duration::from_secs(5), default_rx.recv())
+            .await
+            .expect("default batch within timeout")
+            .expect("default batch present");
+        assert_eq!(
+            batch.raw_rows.len(),
+            2,
+            "the default sink receives the full batch while the mirror is gated"
+        );
+
+        let cell = registry
+            .lock()
+            .expect("registry mutex poisoned")
+            .get("team-ch")
+            .cloned()
+            .expect("routed backend is registered even when gated");
+        assert!(
+            wait_for_status(
+                &cell,
+                BackendSinkStatus::DisabledMissingIdentity,
+                Duration::from_secs(5)
+            )
+            .await,
+            "the routed backend must surface disabled_missing_identity"
+        );
+        assert!(
+            cell.dropped_batches() >= 1,
+            "the routed copy is dropped, not queued, while disabled"
+        );
+
+        handle.abort();
     }
 
     async fn wait_for_status(

--- a/crates/moraine-ingest-core/src/tee.rs
+++ b/crates/moraine-ingest-core/src/tee.rs
@@ -46,6 +46,11 @@ pub(crate) enum BackendSinkStatus {
     Unreachable,
     /// Schema skew policy rejected the backend; terminal until restart.
     DisabledSkew,
+    /// `[identity].author` is unset but this backend is a mirror target;
+    /// terminal until an author is configured and ingest restarts. Rows
+    /// keep landing on the default sink and catch-up replay backfills the
+    /// backend once it starts (issue #381).
+    DisabledMissingIdentity,
 }
 
 impl BackendSinkStatus {
@@ -56,6 +61,7 @@ impl BackendSinkStatus {
             Self::Lagging => "lagging",
             Self::Unreachable => "unreachable",
             Self::DisabledSkew => "disabled_skew",
+            Self::DisabledMissingIdentity => "disabled_missing_identity",
         }
     }
 }
@@ -542,6 +548,25 @@ fn spawn_backend_supervisor(
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         let name = cell.name().to_string();
+
+        // Identity is required to mirror (issue #381): rows on a shared
+        // backend that nobody can attribute would silently anonymize team
+        // data, which is worse than refusing to send it. Gated before any
+        // network contact; terminal until restart, like schema skew. The
+        // default sink is unaffected, and catch-up replay backfills this
+        // backend once an author is configured.
+        if context.config.identity.resolved_author().is_empty() {
+            cell.set_status(BackendSinkStatus::DisabledMissingIdentity);
+            error!(
+                backend = %name,
+                "mirror sink disabled: [identity].author is not set in the moraine config; \
+                 routed sessions still ingest into the default backend, and catch-up replay \
+                 will backfill this backend after you set an author and restart the ingest \
+                 service"
+            );
+            return;
+        }
+
         let allow_newer_server = backend_cfg.allow_newer_server;
         let client = match ClickHouseClient::new(backend_cfg) {
             Ok(client) => client,
@@ -785,6 +810,9 @@ mod tests {
             backend: "team-ch".to_string(),
             mode: moraine_config::ROUTE_MODE_MIRROR.to_string(),
         });
+        // Mirror targets require an identity (issue #381); supervisor tests
+        // that exercise post-gate behavior must get past the gate.
+        config.identity.author = "alice@example.com".to_string();
         Arc::new(config)
     }
 
@@ -1016,6 +1044,21 @@ mod tests {
         assert!(!cell.mark_flush_failure());
         assert!(!cell.mark_recovered());
         assert_eq!(cell.status(), BackendSinkStatus::DisabledSkew);
+    }
+
+    #[test]
+    fn disabled_missing_identity_is_terminal_and_named() {
+        let cell = BackendSinkCell::new("team-ch");
+        cell.set_status(BackendSinkStatus::DisabledMissingIdentity);
+
+        assert!(!cell.mark_overflow());
+        assert!(!cell.mark_flush_failure());
+        assert!(!cell.mark_recovered());
+        assert_eq!(cell.status(), BackendSinkStatus::DisabledMissingIdentity);
+        assert_eq!(
+            BackendSinkStatus::DisabledMissingIdentity.as_str(),
+            "disabled_missing_identity"
+        );
     }
 
     #[test]
@@ -1289,6 +1332,60 @@ mod tests {
                 .is_empty(),
             "a disabled backend must never receive writes"
         );
+        handle.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn supervisor_disables_backend_without_identity_before_any_contact() {
+        let state = SkewMockState::default();
+        let app = Router::new()
+            .route("/", post(skew_mock_handler))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind identity mock listener");
+        let addr = listener.local_addr().expect("identity mock addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let mut config = (*team_config()).clone();
+        config.identity.author = String::new();
+        let config = Arc::new(config);
+        let cell = Arc::new(BackendSinkCell::new("team-ch"));
+        let (tx, rx) = mpsc::channel::<SinkMessage>(1);
+        let resolver: SharedRouteResolver =
+            Arc::new(Mutex::new(RouteResolver::new(config.clone())));
+
+        let handle = spawn_backend_supervisor(
+            backend_cfg_for(format!("http://{}", addr)),
+            cell.clone(),
+            tx,
+            rx,
+            test_router_context(config, resolver),
+        );
+
+        assert!(
+            wait_for_status(
+                &cell,
+                BackendSinkStatus::DisabledMissingIdentity,
+                Duration::from_secs(5)
+            )
+            .await,
+            "an empty [identity].author with a mirror target must disable the sink"
+        );
+        assert!(!cell.is_live());
+        assert_eq!(
+            state.queries.load(Ordering::Relaxed),
+            0,
+            "a sink disabled for missing identity must never contact the backend \
+             (a checkpoint written while disabled would make later catch-up skip data)"
+        );
+        assert!(state
+            .write_statements
+            .lock()
+            .expect("mock writes mutex poisoned")
+            .is_empty());
         handle.abort();
     }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,7 @@ future keys.
 | `[clickhouse]` | Default ClickHouse backend used by local ingest, monitor, MCP, and migrations. |
 | `[backends.<name>]` | Optional named ClickHouse backend for project mirroring and routed MCP. |
 | `[[routes]]` | Optional ordered working-directory routes to named backends. |
+| `[identity]` | Optional per-person author identity stamped on ingested rows; required to mirror to non-default backends. |
 | `[ingest]` | Ingest batching, backfill, watcher, checkpoint, and heartbeat settings. |
 | `[[ingest.sources]]` | Watched agent trace sources. |
 | `[mcp]` | MCP retrieval defaults and shared central server settings. |
@@ -195,11 +196,40 @@ window effectively empty (the working directory rides the records
 themselves, or is recovered from the session header), so in practice it
 only affects traces that carry no working directory at all.
 
-Per-backend mirror status — `connecting`, `ok`, `lagging`, `unreachable`, or
-`disabled_skew` — is written to ingest heartbeats as a `backend_sinks` map
-and surfaced through the monitor's `/api/health`. This uses a column added by
-migration 017; until `moraine db migrate` runs (and ingest restarts), ingest
-warns and omits the field rather than failing heartbeats.
+Per-backend mirror status — `connecting`, `ok`, `lagging`, `unreachable`,
+`disabled_skew`, or `disabled_missing_identity` — is written to ingest
+heartbeats as a `backend_sinks` map and surfaced through the monitor's
+`/api/status`. This uses a column added by migration 017; until
+`moraine db migrate` runs (and ingest restarts), ingest warns and omits the
+field rather than failing heartbeats.
+
+### Identity and attribution
+
+Once several people mirror into one backend, nothing in the data says who
+produced which session. `[identity].author` fixes that: a free-form,
+per-person identifier (email-shaped by convention, not enforced) stamped on
+every ingested `raw_events`/`events` row in the `author` column (migration
+024). Use the same value on every machine you work from; the `host` column
+already tells your machines apart. Moraine never infers identity — not from
+git, not from `$USER` — because a wrong-but-plausible identity on a shared
+machine is worse than none.
+
+```toml
+[identity]
+author = "alice@example.com"
+```
+
+For local-only installs the author is optional; unset means rows carry an
+empty author and nothing changes. Mirroring is different: shared data with
+anonymous rows can't be attributed, scoped, or (later) access-controlled, so
+a route to a non-default backend **requires** an author. If one is missing,
+that mirror sink refuses to start — it logs an error at ingest startup and
+reports `disabled_missing_identity` in the heartbeat `backend_sinks` map —
+while the default backend keeps ingesting normally. Set the author and
+restart the ingest service; catch-up replay then backfills the mirror from
+the local session files, so nothing routed while the sink was disabled is
+lost (the usual caveat applies: files deleted before catch-up are lost to
+that backend).
 
 ### Schema version handshake
 
@@ -215,7 +245,7 @@ build — a strictly read-only probe — and enforces:
 | Server ahead (server-applied migrations unknown to this build) | Mirror disabled unless that backend sets `allow_newer_server = true`. Upgrade Moraine, or opt in. |
 
 For ingest mirroring, a skew failure disables that one mirror until the
-ingest service restarts and shows as `disabled_skew` in `/api/health`; the
+ingest service restarts and shows as `disabled_skew` in `/api/status`; the
 default backend is unaffected. A backend that simply does not answer retries
 the handshake periodically and shows as `unreachable`. The same handshake
 also runs when `moraine run mcp` starts in a routed directory, where it

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -231,6 +231,16 @@ the local session files, so nothing routed while the sink was disabled is
 lost (the usual caveat applies: files deleted before catch-up are lost to
 that backend).
 
+Two operational notes. First, the `author` column arrives with migration
+024: `moraine up` applies it to the default database automatically, but if
+you run services yourself, run `moraine db migrate` before restarting —
+with the column missing, ingest warns at startup and keeps writing rows
+*without* attribution until the migration runs and ingest restarts.
+Second, backfill attributes every local session file still on disk —
+including sessions recorded before any identity was configured — to the
+newly set author. On a shared or handed-down machine, review local history
+before enabling a mirror.
+
 ### Schema version handshake
 
 Moraine migrates only the default backend (`moraine db migrate`, or

--- a/docs/full-config.toml
+++ b/docs/full-config.toml
@@ -70,6 +70,23 @@ allow_newer_server = false
 # # Routing mode. "mirror" is currently the only supported value.
 # mode = "mirror"
 
+# Optional per-person identity. When set, every ingested raw_events/events row
+# carries this value in its `author` column so a shared team backend can
+# attribute sessions to the person who produced them. Free-form (email-shaped
+# by convention, not enforced); use the SAME value on every machine you work
+# from — the `host` column already distinguishes machines. Moraine never
+# infers identity from git or the environment.
+#
+# Optional for local-only installs (rows carry an empty author). REQUIRED to
+# mirror to a non-default backend: a route to a named backend with no author
+# configured disables that mirror sink (status `disabled_missing_identity` in
+# heartbeat `backend_sinks`) until the author is set and the ingest service
+# restarts; the default backend keeps ingesting normally and catch-up replay
+# backfills the mirror once identity is configured.
+#
+# [identity]
+# author = "alice@example.com"
+
 [ingest]
 # Maximum rows collected before a sink flushes a batch to ClickHouse.
 batch_size = 4000

--- a/sql/024_add_event_author.sql
+++ b/sql/024_add_event_author.sql
@@ -1,0 +1,15 @@
+-- Person identity of the installation that produced each record, stamped at
+-- ingest from `[identity].author` (issue #381). Distinct from `host`: one
+-- person's author is identical across all their machines, while host stays
+-- per-machine. Empty when the install has no identity configured — local
+-- private data needs no attribution. Not propagated into the search index
+-- tables (deferred to the team-usability phase).
+--
+-- Every statement below is individually idempotent: the migration runner
+-- re-executes the whole file if any statement fails mid-way.
+
+ALTER TABLE moraine.raw_events
+  ADD COLUMN IF NOT EXISTS author String DEFAULT '';
+
+ALTER TABLE moraine.events
+  ADD COLUMN IF NOT EXISTS author String DEFAULT '';


### PR DESCRIPTION
## Description

**What.** Adds `[identity].author` — a per-person identity stamped on every ingested `raw_events`/`events` row — and makes it required to mirror to non-default backends (migration 024).

**Why.** After the #379 tee, multiple people's sessions land in one shared ClickHouse with nothing recording who produced them; person-level attribution is the keystone for team usability, RBAC row policies, and lifecycle deletion (epic #383, Phase 1).

Closes #381.

- **Config** (`crates/moraine-config`): new `[identity]` block with a single free-form `author` key. Explicit only — never inferred from git or the environment. Whitespace-only values normalize to unset at config load, so every consumer reads the field directly.
- **Stamping** (`crates/moraine-ingest-core`): the author is resolved once at sink startup and stamped at the sink intake — the single choke point that live default ingest, live mirroring, and catch-up replay batches all pass through, covering every source format without touching the normalizers. Empty author stamps nothing (the column `DEFAULT ''` supplies the value), so identity-less installs keep working against databases that have not run migration 024. The batch byte-accounting cache advances by an exact per-row delta rather than a whole-batch re-serialization.
- **Required to mirror** (`tee.rs`): a route to a non-default backend with no author disables that mirror sink before any network contact — new terminal status `disabled_missing_identity`, a sibling of `disabled_skew` — writing neither rows nor checkpoints (so later catch-up cannot skip data), while the default sink ingests normally. Setting the author and restarting the ingest service brings the sink up and replay backfills the gap.
- **Migration guard**: if an author is configured but the default database lacks the 024 column (e.g. `moraine-ingest` run directly, bypassing `moraine up`'s auto-migrate), a startup `system.columns` probe (same pattern as the 015/017/022 probes) warns loudly and withholds the stamp instead of wedging the sink on unknown-field insert rejections. Mirror sinks always stamp — their schema handshake already guarantees the column.
- **Migration 024** (`sql/024_add_event_author.sql`): idempotent `ADD COLUMN IF NOT EXISTS author String DEFAULT ''` on `raw_events` and `events` only. Search-index propagation stays deferred per the PRD non-goals.

Two deliberate deviations from the issue text, for the record: the migration number is 024 (the PRD's "019" predates migrations 019–023 landing), and the disabled status is surfaced through the heartbeat `backend_sinks` map in **`/api/status`**, not `/api/health` — `/api/health` has always been a ClickHouse-only ping, and the pre-existing docs claiming otherwise are corrected here (the `disabled_skew` paragraph gets the same one-line endpoint fix as a rider, since half of it had to change anyway to document the new status). Follow-up, deliberately not in this PR: a stale `/api/health` reference in a `moraine-monitor-core` code comment (`lib.rs:1366`).

## Usage

```toml
[identity]
author = "alice@example.com"
```

Use the same value on every machine you work from; the `host` column continues to distinguish machines. Local-only installs can leave it unset (rows carry an empty author). With a mirror route configured and no author, ingest logs an error at startup and `/api/status` reports:

```json
"backend_sinks": {"team-ch": "disabled_missing_identity"}
```

Set the author, run migrations if you manage services yourself (`moraine db migrate`; `moraine up` does it automatically), restart ingest, and catch-up replay backfills the mirror. Note that backfill attributes every session file still on disk — including sessions recorded before the identity existed — to the configured author; review local history before enabling a mirror on a shared machine.

## Changelog

- New `[identity].author` config: per-person attribution stamped on every ingested `raw_events`/`events` row (migration 024).
- Mirroring to a non-default backend now requires a configured author; without one the mirror sink is disabled (`disabled_missing_identity` in heartbeat `backend_sinks`) until identity is set and ingest restarts. Default/local ingest is unaffected.

## Operational Impact

- Migration 024 applies automatically via `moraine up` / `moraine db migrate`; team (non-default) backends must be migrated by their operator before clients can mirror (existing handshake behavior).
- Default-only installs with no author configured: no behavior change.
- If an author is configured before the default database migrates, ingest warns at startup and rows land unattributed until migration + restart (no stall, no data loss).
- Historical local rows keep `author=''`; only the mirror path backfills attribution (it re-reads source files).
- Configs containing `[identity]` fail to load on older moraine binaries (`deny_unknown_fields`) — relevant when syncing one config across machines during a staged upgrade.

## Validation

`cargo fmt --all -- --check`, `scripts/ci/clippy-strict-baseline.sh`, and `cargo test --workspace --locked` all pass (23 test binaries). New unit coverage: config parse/normalization (absent, set, whitespace), stamp coverage boundaries (raw+event rows only; exact byte-cache delta; empty-author no-op), the supervisor identity gate (terminal status; zero HTTP contact — no rows, no checkpoints, no handshake), a router-level test pinning that the default path keeps flowing while the gate disables the mirror, and sink-intake stamping for both roles (default end-to-end against a mock ClickHouse, and backend-role filter→redact→stamp, the path replay batches take).

Live sandbox QA (`scripts/dev/sandbox/moraine-sandbox`, fresh boot on this branch) walked the full lifecycle: (1) with no identity, a claude-code fixture ingested with empty author; (2) after adding a `team-ch` backend + `/work/team/**` route with no identity, ingest logged the disable error, `/api/status` showed `disabled_missing_identity`, a second routed session landed in the default backend while the team database stayed at 0 rows / 0 events / **0 checkpoints**; (3) after setting `[identity].author` and restarting ingest, the mirror went `ok` and catch-up replay backfilled **all three** routed sessions into the team backend attributed to the configured author with host-scoped checkpoints, while new default-backend rows also carried the author and historical default rows stayed empty as documented. The two-machine half of the cross-machine acceptance criterion is not reproducible in a single-host sandbox; it holds by construction (the author is a per-install config constant, and per-machine `host` scoping is #379 behavior, re-verified live via the host-scoped team checkpoints).
