### PR TITLE
fix(clickhouse): supervise managed server crashes

### DIFF
--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -6,7 +6,7 @@ description = "Unified runtime control plane for Moraine services"
 
 [dependencies]
 anyhow = "1.0"
-tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "time", "process", "signal"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }

--- a/apps/moraine/src/cli.rs
+++ b/apps/moraine/src/cli.rs
@@ -162,6 +162,8 @@ pub(crate) enum ClickhouseCommand {
     Install(ClickhouseInstallArgs),
     Status,
     Uninstall,
+    #[command(hide = true)]
+    Supervise,
 }
 
 #[derive(Debug, Args)]
@@ -260,6 +262,17 @@ mod tests {
             }
             _ => panic!("expected clickhouse install command"),
         }
+    }
+
+    #[test]
+    fn clap_parses_internal_clickhouse_supervisor() {
+        let cli = Cli::parse_from(["moraine", "clickhouse", "supervise"]);
+        assert!(matches!(
+            cli.command,
+            CliCommand::Clickhouse(ClickhouseArgs {
+                command: ClickhouseCommand::Supervise,
+            })
+        ));
     }
 
     #[test]

--- a/apps/moraine/src/commands.rs
+++ b/apps/moraine/src/commands.rs
@@ -18,7 +18,7 @@ use crate::cli::{
 };
 use crate::managed_clickhouse::{
     cmd_clickhouse_install, cmd_clickhouse_status, cmd_clickhouse_uninstall,
-    run_foreground_clickhouse,
+    run_foreground_clickhouse, run_supervised_clickhouse,
 };
 use crate::paths::{load_cfg, runtime_paths};
 use crate::process::{require_service_binary, service_args_with_defaults};
@@ -123,6 +123,7 @@ pub(crate) async fn dispatch(cli: Cli, output: CliOutput) -> Result<ExitCode> {
                     render_clickhouse_status(&output, &snapshot)?;
                     Ok(ExitCode::SUCCESS)
                 }
+                ClickhouseCommand::Supervise => run_supervised_clickhouse(&cfg, &paths).await,
                 ClickhouseCommand::Uninstall => {
                     let removed = cmd_clickhouse_uninstall(&paths)?;
                     if output.is_json() {

--- a/apps/moraine/src/commands/logs.rs
+++ b/apps/moraine/src/commands/logs.rs
@@ -1,10 +1,10 @@
 use anyhow::{Context, Result};
 use std::fs;
 use std::io::{Read, Seek, SeekFrom};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::paths::RuntimePaths;
-use crate::process::log_path;
+use crate::process::{clickhouse_supervisor_log_path, log_path};
 use crate::render::{LogsSnapshot, ServiceLogSection};
 use crate::service::Service;
 
@@ -68,6 +68,17 @@ fn tail_lines(path: &Path, lines: usize) -> Result<Vec<String>> {
     Ok(collected)
 }
 
+fn service_log_paths(paths: &RuntimePaths, service: Service) -> Vec<PathBuf> {
+    if service == Service::ClickHouse {
+        vec![
+            clickhouse_supervisor_log_path(paths),
+            log_path(paths, service),
+        ]
+    } else {
+        vec![log_path(paths, service)]
+    }
+}
+
 pub(super) fn collect_logs(
     paths: &RuntimePaths,
     service: Option<Service>,
@@ -85,23 +96,24 @@ pub(super) fn collect_logs(
 
     let mut sections = Vec::new();
     for svc in targets {
-        let path = log_path(paths, svc);
-        let path_string = path.display().to_string();
-        if !path.exists() {
+        for path in service_log_paths(paths, svc) {
+            let path_string = path.display().to_string();
+            if !path.exists() {
+                sections.push(ServiceLogSection {
+                    service: svc,
+                    path: path_string,
+                    exists: false,
+                    lines: Vec::new(),
+                });
+                continue;
+            }
             sections.push(ServiceLogSection {
                 service: svc,
                 path: path_string,
-                exists: false,
-                lines: Vec::new(),
+                exists: true,
+                lines: tail_lines(&path, lines)?,
             });
-            continue;
         }
-        sections.push(ServiceLogSection {
-            service: svc,
-            path: path_string,
-            exists: true,
-            lines: tail_lines(&path, lines)?,
-        });
     }
 
     Ok(LogsSnapshot {
@@ -113,6 +125,7 @@ pub(super) fn collect_logs(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use moraine_config::AppConfig;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -152,6 +165,31 @@ mod tests {
         let two = tail_lines(&path, 2).expect("tail two lines");
         assert_eq!(two, vec!["middle".to_string(), "tail".to_string()]);
 
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn clickhouse_logs_include_supervisor_and_server_sections() {
+        let root = temp_dir("clickhouse-log-sections");
+        let mut cfg = AppConfig::default();
+        cfg.runtime.root_dir = root.join("runtime").display().to_string();
+        cfg.runtime.logs_dir = root.join("logs").display().to_string();
+        let paths = crate::paths::runtime_paths(&cfg);
+        fs::create_dir_all(&paths.logs_dir).expect("logs dir");
+        fs::create_dir_all(paths.clickhouse_root.join("log")).expect("clickhouse log dir");
+        let supervisor = clickhouse_supervisor_log_path(&paths);
+        let server = log_path(&paths, Service::ClickHouse);
+        fs::write(&supervisor, "state=exhausted\n").expect("supervisor log");
+        fs::write(&server, "server line\n").expect("server log");
+
+        let snapshot =
+            collect_logs(&paths, Some(Service::ClickHouse), 10).expect("collect clickhouse logs");
+
+        assert_eq!(snapshot.sections.len(), 2);
+        assert_eq!(snapshot.sections[0].path, supervisor.display().to_string());
+        assert_eq!(snapshot.sections[0].lines, ["state=exhausted"]);
+        assert_eq!(snapshot.sections[1].path, server.display().to_string());
+        assert_eq!(snapshot.sections[1].lines, ["server line"]);
         let _ = fs::remove_dir_all(root);
     }
 }

--- a/apps/moraine/src/commands/up.rs
+++ b/apps/moraine/src/commands/up.rs
@@ -32,7 +32,7 @@ async fn start_selected_services(
     preflight_required_service_binaries(&services_to_start, paths)?;
     ensure_runtime_dirs(paths)?;
 
-    let clickhouse = start_clickhouse(cfg, paths).await?;
+    let clickhouse = start_clickhouse(config_path, cfg, paths).await?;
     let migrations = cmd_db_migrate(cfg).await?;
 
     let mut started_services = Vec::new();

--- a/apps/moraine/src/managed_clickhouse.rs
+++ b/apps/moraine/src/managed_clickhouse.rs
@@ -3,20 +3,24 @@ use moraine_clickhouse::ClickHouseClient;
 use moraine_config::AppConfig;
 use reqwest::{Client, Url};
 use sha2::{Digest, Sha256};
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitCode, Stdio};
+use std::process::{Command, ExitCode, ExitStatus, Stdio};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tokio::time::{sleep, Instant};
+use tokio::process::{Child, Command as TokioCommand};
+use tokio::time::{sleep, timeout, Instant};
 
 #[cfg(unix)]
-use std::os::unix::fs::{symlink, PermissionsExt};
+use std::os::unix::{
+    fs::{symlink, PermissionsExt},
+    process::ExitStatusExt,
+};
 
 use crate::paths::{ensure_runtime_dirs, RuntimePaths};
 use crate::process::{
-    cleanup_legacy_clickhouse_pipe_log, log_path, pid_path, service_running, write_pid,
-    StartOutcome, StartState,
+    cleanup_legacy_clickhouse_pipe_log, clickhouse_supervisor_log_path, pid_path,
+    remove_pid_if_matches, service_running, write_pid, StartOutcome, StartState,
 };
 use crate::render::ClickhouseStatusSnapshot;
 use crate::service::Service;
@@ -530,36 +534,425 @@ fn prompt_install_clickhouse(version: &str) -> Result<bool> {
 
 async fn wait_for_clickhouse(cfg: &AppConfig) -> Result<()> {
     let client = ClickHouseClient::new(cfg.clickhouse.clone())?;
-    let timeout = Duration::from_secs_f64(cfg.runtime.clickhouse_start_timeout_seconds.max(1.0));
+    let startup_timeout =
+        Duration::from_secs_f64(cfg.runtime.clickhouse_start_timeout_seconds.max(1.0));
     let interval = Duration::from_millis(cfg.runtime.healthcheck_interval_ms.max(100));
-    let start = Instant::now();
+    let deadline = Instant::now() + startup_timeout;
 
     loop {
-        if client.ping().await.is_ok() {
-            return Ok(());
-        }
-
-        if start.elapsed() >= timeout {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
             bail!(
                 "clickhouse did not become healthy within {:.1}s",
-                timeout.as_secs_f64()
+                startup_timeout.as_secs_f64()
             );
         }
 
-        sleep(interval).await;
+        if matches!(timeout(remaining, client.ping()).await, Ok(Ok(()))) {
+            return Ok(());
+        }
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            bail!(
+                "clickhouse did not become healthy within {:.1}s",
+                startup_timeout.as_secs_f64()
+            );
+        }
+        sleep(interval.min(remaining)).await;
+    }
+}
+
+const RESTART_DELAYS: [Duration; 5] = [
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(4),
+    Duration::from_secs(8),
+    Duration::from_secs(16),
+];
+const STABILITY_WINDOW: Duration = Duration::from_secs(5 * 60);
+const CHILD_SHUTDOWN_GRACE: Duration = Duration::from_secs(4);
+const SUPERVISOR_SHUTDOWN_GRACE: Duration = Duration::from_secs(8);
+
+#[derive(Clone, Copy)]
+struct SupervisorPolicy {
+    restart_delays: [Duration; 5],
+    stability_window: Duration,
+    child_shutdown_grace: Duration,
+}
+
+impl SupervisorPolicy {
+    const fn production() -> Self {
+        Self {
+            restart_delays: RESTART_DELAYS,
+            stability_window: STABILITY_WINDOW,
+            child_shutdown_grace: CHILD_SHUTDOWN_GRACE,
+        }
+    }
+}
+
+#[cfg(unix)]
+struct ShutdownSignals {
+    terminate: tokio::signal::unix::Signal,
+    interrupt: tokio::signal::unix::Signal,
+}
+
+#[cfg(unix)]
+impl ShutdownSignals {
+    fn install() -> Result<Self> {
+        use tokio::signal::unix::{signal, SignalKind};
+
+        Ok(Self {
+            terminate: signal(SignalKind::terminate())
+                .context("failed to install ClickHouse supervisor SIGTERM handler")?,
+            interrupt: signal(SignalKind::interrupt())
+                .context("failed to install ClickHouse supervisor SIGINT handler")?,
+        })
+    }
+
+    async fn recv(&mut self) {
+        tokio::select! {
+            biased;
+            _ = self.terminate.recv() => {}
+            _ = self.interrupt.recv() => {}
+        }
+    }
+}
+
+#[cfg(not(unix))]
+struct ShutdownSignals;
+
+#[cfg(not(unix))]
+impl ShutdownSignals {
+    fn install() -> Result<Self> {
+        Ok(Self)
+    }
+
+    async fn recv(&mut self) {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+enum GenerationOutcome {
+    Stopped,
+    Failed {
+        reason: String,
+        ready_uptime: Option<Duration>,
+    },
+}
+
+fn describe_exit(status: ExitStatus) -> String {
+    if let Some(code) = status.code() {
+        return format!("exit code {code}");
+    }
+
+    #[cfg(unix)]
+    if let Some(signal) = status.signal() {
+        return if status.core_dumped() {
+            format!("signal {signal} (core dumped)")
+        } else {
+            format!("signal {signal}")
+        };
+    }
+
+    "unknown exit status".to_string()
+}
+
+async fn send_terminate(pid: u32) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let status = TokioCommand::new("kill")
+            .arg("-TERM")
+            .arg(pid.to_string())
+            .status()
+            .await
+            .with_context(|| format!("failed to send SIGTERM to pid {pid}"))?;
+        if !status.success() {
+            bail!("failed to send SIGTERM to pid {pid}: {status}");
+        }
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        Ok(())
+    }
+}
+
+async fn terminate_and_reap(child: &mut Child, grace: Duration) -> Result<ExitStatus> {
+    if let Some(status) = child.try_wait().context("failed to inspect child status")? {
+        return Ok(status);
+    }
+
+    if let Some(pid) = child.id() {
+        #[cfg(unix)]
+        if let Err(err) = send_terminate(pid).await {
+            if let Some(status) = child
+                .try_wait()
+                .context("failed to inspect child after SIGTERM race")?
+            {
+                return Ok(status);
+            }
+            eprintln!("clickhouse supervisor: {err:#}; forcing child shutdown");
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = pid;
+            child
+                .start_kill()
+                .context("failed to request child shutdown")?;
+        }
+    }
+
+    match timeout(grace, child.wait()).await {
+        Ok(status) => status.context("failed waiting for child shutdown"),
+        Err(_) => {
+            child
+                .start_kill()
+                .context("failed to force-kill ClickHouse child")?;
+            child
+                .wait()
+                .await
+                .context("failed waiting for force-killed ClickHouse child")
+        }
+    }
+}
+
+fn spawn_clickhouse_generation(server_bin: &Path, config_path: &Path) -> Result<Child> {
+    let mut command = TokioCommand::new(server_bin);
+    command
+        .arg("--config-file")
+        .arg(config_path)
+        // Moraine is the sole restart owner. ClickHouse otherwise enables its
+        // own watchdog for detached stdio, hiding server exits behind a
+        // long-lived intermediate process and defeating the bounded policy.
+        .env("CLICKHOUSE_WATCHDOG_ENABLE", "0")
+        .env("CLICKHOUSE_WATCHDOG_RESTART", "0")
+        .stdin(Stdio::null())
+        .kill_on_drop(true);
+    command
+        .spawn()
+        .with_context(|| format!("failed to start {}", server_bin.display()))
+}
+
+async fn run_generation(
+    cfg: &AppConfig,
+    server_bin: &Path,
+    config_path: &Path,
+    generation: u64,
+    policy: SupervisorPolicy,
+    signals: &mut ShutdownSignals,
+) -> Result<GenerationOutcome> {
+    let mut child = match spawn_clickhouse_generation(server_bin, config_path) {
+        Ok(child) => child,
+        Err(err) => {
+            return Ok(GenerationOutcome::Failed {
+                reason: format!("{err:#}"),
+                ready_uptime: None,
+            });
+        }
+    };
+    let pid = child.id();
+    eprintln!(
+        "clickhouse supervisor: generation={generation} pid={} state=starting",
+        pid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
+    );
+
+    let readiness = wait_for_clickhouse(cfg);
+    tokio::pin!(readiness);
+    tokio::select! {
+        biased;
+        _ = signals.recv() => {
+            let status = terminate_and_reap(&mut child, policy.child_shutdown_grace).await?;
+            eprintln!(
+                "clickhouse supervisor: generation={generation} state=stopped reason={}",
+                describe_exit(status)
+            );
+            return Ok(GenerationOutcome::Stopped);
+        }
+        status = child.wait() => {
+            let status = status.context("failed waiting for ClickHouse startup exit")?;
+            return Ok(GenerationOutcome::Failed {
+                reason: format!("exited before readiness ({})", describe_exit(status)),
+                ready_uptime: None,
+            });
+        }
+        ready = &mut readiness => {
+            if let Err(err) = ready {
+                let status = terminate_and_reap(&mut child, policy.child_shutdown_grace).await?;
+                return Ok(GenerationOutcome::Failed {
+                    reason: format!("readiness failed ({err:#}); stopped child ({})", describe_exit(status)),
+                    ready_uptime: None,
+                });
+            }
+        }
+    }
+
+    if let Some(status) = child
+        .try_wait()
+        .context("failed to inspect ClickHouse after readiness")?
+    {
+        return Ok(GenerationOutcome::Failed {
+            reason: format!("exited at readiness boundary ({})", describe_exit(status)),
+            ready_uptime: None,
+        });
+    }
+
+    let ready_since = Instant::now();
+    eprintln!(
+        "clickhouse supervisor: generation={generation} pid={} state=ready",
+        pid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
+    );
+    tokio::select! {
+        biased;
+        _ = signals.recv() => {
+            let status = terminate_and_reap(&mut child, policy.child_shutdown_grace).await?;
+            eprintln!(
+                "clickhouse supervisor: generation={generation} state=stopped reason={}",
+                describe_exit(status)
+            );
+            Ok(GenerationOutcome::Stopped)
+        }
+        status = child.wait() => {
+            let status = status.context("failed waiting for ClickHouse exit")?;
+            Ok(GenerationOutcome::Failed {
+                reason: describe_exit(status),
+                ready_uptime: Some(ready_since.elapsed()),
+            })
+        }
+    }
+}
+
+fn next_failure_count(
+    consecutive_failures: usize,
+    ready_uptime: Option<Duration>,
+    stability_window: Duration,
+) -> (usize, bool) {
+    let reset = ready_uptime.is_some_and(|uptime| uptime >= stability_window);
+    (if reset { 1 } else { consecutive_failures + 1 }, reset)
+}
+
+async fn supervise_clickhouse(
+    cfg: &AppConfig,
+    server_bin: &Path,
+    config_path: &Path,
+    policy: SupervisorPolicy,
+) -> Result<ExitCode> {
+    let mut signals = ShutdownSignals::install()?;
+    let mut consecutive_failures = 0usize;
+    let mut generation = 1u64;
+
+    loop {
+        if consecutive_failures > 0 {
+            let Some(delay) = policy.restart_delays.get(consecutive_failures - 1).copied() else {
+                unreachable!("restart budget checked after every failed generation");
+            };
+            eprintln!(
+                "clickhouse supervisor: replacement={} delay_seconds={} state=backoff",
+                consecutive_failures,
+                delay.as_secs_f64()
+            );
+            tokio::select! {
+                biased;
+                _ = signals.recv() => {
+                    eprintln!("clickhouse supervisor: state=stopped reason=intentional shutdown during backoff");
+                    return Ok(ExitCode::SUCCESS);
+                }
+                _ = sleep(delay) => {}
+            }
+        }
+
+        let outcome = run_generation(
+            cfg,
+            server_bin,
+            config_path,
+            generation,
+            policy,
+            &mut signals,
+        )
+        .await?;
+        match outcome {
+            GenerationOutcome::Stopped => return Ok(ExitCode::SUCCESS),
+            GenerationOutcome::Failed {
+                reason,
+                ready_uptime,
+            } => {
+                let (next_count, reset) =
+                    next_failure_count(consecutive_failures, ready_uptime, policy.stability_window);
+                if reset {
+                    eprintln!(
+                        "clickhouse supervisor: generation={generation} state=stable-budget-reset"
+                    );
+                }
+                consecutive_failures = next_count;
+                eprintln!(
+                    "clickhouse supervisor: generation={generation} state=failed reason={reason}"
+                );
+                if consecutive_failures > policy.restart_delays.len() {
+                    eprintln!(
+                        "clickhouse supervisor: state=exhausted replacements={} final_reason={reason}",
+                        policy.restart_delays.len()
+                    );
+                    return Ok(ExitCode::from(1));
+                }
+                generation += 1;
+            }
+        }
+    }
+}
+
+async fn stop_new_supervisor(child: &mut Child, pid_file: &Path, pid: u32) -> Result<()> {
+    terminate_and_reap(child, SUPERVISOR_SHUTDOWN_GRACE).await?;
+    remove_pid_if_matches(pid_file, pid);
+    Ok(())
+}
+
+async fn wait_for_supervisor_startup(supervisor: &mut Child, cfg: &AppConfig) -> Result<()> {
+    let readiness = wait_for_clickhouse(cfg);
+    tokio::pin!(readiness);
+    tokio::select! {
+        biased;
+        status = supervisor.wait() => {
+            match status {
+                Ok(status) => Err(anyhow!(
+                    "ClickHouse supervisor exited before readiness ({})",
+                    describe_exit(status)
+                )),
+                Err(err) => Err(anyhow!(err).context(
+                    "failed waiting for ClickHouse supervisor startup"
+                )),
+            }
+        }
+        ready = &mut readiness => ready,
+    }?;
+
+    match supervisor.try_wait() {
+        Ok(Some(status)) => bail!(
+            "ClickHouse supervisor exited at readiness boundary ({})",
+            describe_exit(status)
+        ),
+        Ok(None) => Ok(()),
+        Err(err) => {
+            Err(anyhow!(err).context("failed to inspect ClickHouse supervisor after readiness"))
+        }
     }
 }
 
 pub(crate) async fn start_clickhouse(
+    config_path: &Path,
     cfg: &AppConfig,
     paths: &RuntimePaths,
 ) -> Result<StartOutcome> {
+    let supervisor_log = clickhouse_supervisor_log_path(paths);
     if let Some(pid) = service_running(paths, Service::ClickHouse) {
+        wait_for_clickhouse(cfg).await?;
         return Ok(StartOutcome {
             service: Service::ClickHouse,
             state: StartState::AlreadyRunning,
             pid: Some(pid),
-            log_path: Some(log_path(paths, Service::ClickHouse).display().to_string()),
+            log_path: Some(supervisor_log.display().to_string()),
         });
     }
 
@@ -584,27 +977,65 @@ pub(crate) async fn start_clickhouse(
     }
 
     cleanup_legacy_clickhouse_pipe_log(paths);
-
-    let server_bin = resolve_clickhouse_server_command(cfg, paths).await?;
-
+    resolve_clickhouse_server_command(cfg, paths).await?;
     materialize_clickhouse_config(cfg, paths)?;
 
-    let child = Command::new(&server_bin)
-        .arg("--config-file")
-        .arg(&paths.clickhouse_config)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+    let logfile = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&supervisor_log)
+        .with_context(|| format!("failed to open {}", supervisor_log.display()))?;
+    let logfile_err = logfile
+        .try_clone()
+        .with_context(|| format!("failed to clone {}", supervisor_log.display()))?;
+    let launcher = std::env::current_exe().context("failed to resolve current moraine binary")?;
+    let mut supervisor = TokioCommand::new(&launcher)
+        .arg("--config")
+        .arg(config_path)
+        .arg("clickhouse")
+        .arg("supervise")
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(logfile))
+        .stderr(Stdio::from(logfile_err))
         .spawn()
-        .with_context(|| format!("failed to start {}", server_bin.display()))?;
+        .with_context(|| {
+            format!(
+                "failed to start ClickHouse supervisor {}",
+                launcher.display()
+            )
+        })?;
+    let supervisor_pid = supervisor
+        .id()
+        .ok_or_else(|| anyhow!("ClickHouse supervisor did not expose a process id"))?;
+    let launcher_pid_file = pid_path(paths, Service::ClickHouse);
 
-    write_pid(&pid_path(paths, Service::ClickHouse), child.id())?;
+    if let Err(err) = write_pid(&launcher_pid_file, supervisor_pid) {
+        let cleanup =
+            stop_new_supervisor(&mut supervisor, &launcher_pid_file, supervisor_pid).await;
+        return match cleanup {
+            Ok(()) => Err(err),
+            Err(cleanup_err) => Err(err.context(format!(
+                "also failed to stop untracked ClickHouse supervisor: {cleanup_err:#}"
+            ))),
+        };
+    }
 
-    wait_for_clickhouse(cfg).await?;
+    if let Err(err) = wait_for_supervisor_startup(&mut supervisor, cfg).await {
+        let cleanup =
+            stop_new_supervisor(&mut supervisor, &launcher_pid_file, supervisor_pid).await;
+        return match cleanup {
+            Ok(()) => Err(err),
+            Err(cleanup_err) => Err(err.context(format!(
+                "also failed to stop ClickHouse supervisor after startup failure: {cleanup_err:#}"
+            ))),
+        };
+    }
+
     Ok(StartOutcome {
         service: Service::ClickHouse,
         state: StartState::Started,
-        pid: Some(child.id()),
-        log_path: Some(log_path(paths, Service::ClickHouse).display().to_string()),
+        pid: Some(supervisor_pid),
+        log_path: Some(supervisor_log.display().to_string()),
     })
 }
 
@@ -623,6 +1054,25 @@ pub(crate) async fn run_foreground_clickhouse(
         .context("failed to run clickhouse-server")?;
 
     Ok(ExitCode::from(status.code().unwrap_or(1) as u8))
+}
+
+pub(crate) async fn run_supervised_clickhouse(
+    cfg: &AppConfig,
+    paths: &RuntimePaths,
+) -> Result<ExitCode> {
+    ensure_runtime_dirs(paths)?;
+    let server_bin = resolve_clickhouse_server_command(cfg, paths).await?;
+    materialize_clickhouse_config(cfg, paths)?;
+
+    let result = supervise_clickhouse(
+        cfg,
+        &server_bin,
+        &paths.clickhouse_config,
+        SupervisorPolicy::production(),
+    )
+    .await;
+    remove_pid_if_matches(&pid_path(paths, Service::ClickHouse), std::process::id());
+    result
 }
 
 pub(crate) fn managed_clickhouse_version(paths: &RuntimePaths) -> Option<String> {
@@ -713,6 +1163,12 @@ pub(crate) fn cmd_clickhouse_uninstall(paths: &RuntimePaths) -> Result<String> {
 mod tests {
     use super::*;
     use moraine_config::AppConfig;
+    use std::net::{SocketAddr, TcpListener, TcpStream};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+    use std::thread;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn temp_dir(name: &str) -> PathBuf {
@@ -848,6 +1304,405 @@ mod tests {
         .expect("write checksum");
 
         assert_eq!(managed_clickhouse_checksum_state(&cfg, &paths), "verified");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    struct PingServer {
+        addr: SocketAddr,
+        stop: Arc<AtomicBool>,
+        thread: Option<thread::JoinHandle<()>>,
+    }
+
+    impl PingServer {
+        fn start() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind ping server");
+            listener
+                .set_nonblocking(true)
+                .expect("set ping server nonblocking");
+            let addr = listener.local_addr().expect("ping server addr");
+            let stop = Arc::new(AtomicBool::new(false));
+            let thread_stop = stop.clone();
+            let thread = thread::spawn(move || {
+                let mut request = [0_u8; 8192];
+                while !thread_stop.load(Ordering::Relaxed) {
+                    match listener.accept() {
+                        Ok((mut stream, _)) => {
+                            let _ = stream.set_read_timeout(Some(Duration::from_millis(200)));
+                            let _ = std::io::Read::read(&mut stream, &mut request);
+                            let _ = std::io::Write::write_all(
+                                &mut stream,
+                                b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n1\n",
+                            );
+                        }
+                        Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(5));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            });
+            Self {
+                addr,
+                stop,
+                thread: Some(thread),
+            }
+        }
+
+        fn url(&self) -> String {
+            format!("http://{}", self.addr)
+        }
+    }
+
+    impl Drop for PingServer {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::Relaxed);
+            let _ = TcpStream::connect(self.addr);
+            if let Some(thread) = self.thread.take() {
+                let _ = thread.join();
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn shell_quote(path: &Path) -> String {
+        format!("'{}'", path.to_string_lossy().replace('\'', "'\"'\"'"))
+    }
+
+    #[cfg(unix)]
+    fn write_fake_child_script(root: &Path, mode: &str) -> (PathBuf, PathBuf, PathBuf) {
+        let script = root.join("fake-clickhouse-server");
+        let count_file = root.join("generation-count");
+        let pid_file = root.join("raw-child.pid");
+        let test_binary = std::env::current_exe().expect("test binary");
+        let contents = format!(
+            "#!/bin/sh\n\
+             export MORAINE_TEST_CLICKHOUSE_MODE={}\n\
+             export MORAINE_TEST_CLICKHOUSE_COUNT={}\n\
+             export MORAINE_TEST_CLICKHOUSE_PID={}\n\
+             exec {} --exact managed_clickhouse::tests::fake_clickhouse_process --nocapture\n",
+            shell_quote(Path::new(mode)),
+            shell_quote(&count_file),
+            shell_quote(&pid_file),
+            shell_quote(&test_binary),
+        );
+        fs::write(&script, contents).expect("write fake child script");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755))
+            .expect("make fake child executable");
+        (script, count_file, pid_file)
+    }
+
+    fn test_config(root: &Path, url: String) -> AppConfig {
+        let mut cfg = AppConfig::default();
+        cfg.clickhouse.url = url;
+        cfg.clickhouse.timeout_seconds = 1.0;
+        cfg.runtime.root_dir = root.join("runtime").display().to_string();
+        cfg.runtime.logs_dir = root.join("runtime/logs").display().to_string();
+        cfg.runtime.pids_dir = root.join("runtime/run").display().to_string();
+        cfg.runtime.managed_clickhouse_dir = root.join("managed").display().to_string();
+        cfg.runtime.clickhouse_start_timeout_seconds = 1.0;
+        cfg.runtime.healthcheck_interval_ms = 100;
+        cfg.runtime.clickhouse_auto_install = false;
+        cfg
+    }
+
+    fn test_policy() -> SupervisorPolicy {
+        SupervisorPolicy {
+            restart_delays: [Duration::from_millis(10); 5],
+            stability_window: Duration::from_secs(1),
+            child_shutdown_grace: Duration::from_millis(200),
+        }
+    }
+
+    #[test]
+    fn fake_clickhouse_process() {
+        let Ok(mode) = std::env::var("MORAINE_TEST_CLICKHOUSE_MODE") else {
+            return;
+        };
+        let count_file =
+            PathBuf::from(std::env::var_os("MORAINE_TEST_CLICKHOUSE_COUNT").expect("count path"));
+        let pid_file =
+            PathBuf::from(std::env::var_os("MORAINE_TEST_CLICKHOUSE_PID").expect("pid path"));
+        let count = fs::read_to_string(&count_file)
+            .ok()
+            .and_then(|value| value.trim().parse::<u32>().ok())
+            .unwrap_or(0)
+            + 1;
+        fs::write(&count_file, format!("{count}\n")).expect("record generation");
+        fs::write(&pid_file, format!("{}\n", std::process::id())).expect("record child pid");
+
+        match mode.as_str() {
+            "exit" => thread::sleep(Duration::from_millis(120)),
+            "live" => loop {
+                thread::sleep(Duration::from_secs(60));
+            },
+            other => panic!("unknown fake ClickHouse mode {other}"),
+        }
+    }
+
+    #[test]
+    fn production_supervisor_policy_is_bounded() {
+        let policy = SupervisorPolicy::production();
+        assert_eq!(
+            policy.restart_delays,
+            [
+                Duration::from_secs(1),
+                Duration::from_secs(2),
+                Duration::from_secs(4),
+                Duration::from_secs(8),
+                Duration::from_secs(16),
+            ]
+        );
+        assert_eq!(policy.stability_window, Duration::from_secs(300));
+    }
+
+    #[test]
+    fn stable_ready_generation_resets_failure_budget() {
+        assert_eq!(
+            next_failure_count(4, Some(Duration::from_secs(299)), STABILITY_WINDOW),
+            (5, false)
+        );
+        assert_eq!(
+            next_failure_count(4, Some(STABILITY_WINDOW), STABILITY_WINDOW),
+            (1, true)
+        );
+    }
+
+    #[test]
+    fn materialized_config_caps_only_idle_global_threads() {
+        let root = temp_dir("thread-pool-config");
+        let cfg = test_config(&root, "http://127.0.0.1:18123".to_string());
+        let paths = crate::paths::runtime_paths(&cfg);
+        ensure_runtime_dirs(&paths).expect("runtime dirs");
+        materialize_clickhouse_config(&cfg, &paths).expect("materialize config");
+        let rendered = fs::read_to_string(&paths.clickhouse_config).expect("read config");
+
+        assert_eq!(
+            rendered
+                .matches("<max_thread_pool_free_size>64</max_thread_pool_free_size>")
+                .count(),
+            1
+        );
+        assert!(!rendered.contains("<max_thread_pool_size>"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn managed_generation_disables_clickhouse_watchdog() {
+        let root = temp_dir("watchdog-env");
+        let script = root.join("clickhouse-server");
+        let observed = root.join("watchdog-env");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nprintf '%s|%s' \"$CLICKHOUSE_WATCHDOG_ENABLE\" \
+                 \"$CLICKHOUSE_WATCHDOG_RESTART\" > {}\n",
+                shell_quote(&observed)
+            ),
+        )
+        .expect("write watchdog script");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755))
+            .expect("make watchdog script executable");
+        let config_path = root.join("config.xml");
+        fs::write(&config_path, "<clickhouse/>").expect("fake config");
+
+        let mut child =
+            spawn_clickhouse_generation(&script, &config_path).expect("spawn fake generation");
+        let status = child.wait().await.expect("wait fake generation");
+
+        assert!(status.success());
+        assert_eq!(
+            fs::read_to_string(&observed).expect("watchdog environment"),
+            "0|0"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn termination_force_kills_child_that_ignores_sigterm() {
+        let root = temp_dir("force-kill-child");
+        let script = root.join("ignore-term");
+        let ready = root.join("ready");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\ntrap '' TERM\ntouch {}\nexec sleep 60\n",
+                shell_quote(&ready)
+            ),
+        )
+        .expect("write TERM-ignoring script");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755))
+            .expect("make TERM-ignoring script executable");
+        let mut child = TokioCommand::new(&script)
+            .spawn()
+            .expect("spawn TERM-ignoring child");
+        let pid = child.id().expect("child pid");
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !ready.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "child did not install TERM handler"
+            );
+            sleep(Duration::from_millis(5)).await;
+        }
+
+        let status = terminate_and_reap(&mut child, Duration::from_millis(50))
+            .await
+            .expect("terminate child");
+
+        assert!(!status.success());
+        assert!(
+            !Command::new("kill")
+                .args(["-0", &pid.to_string()])
+                .status()
+                .expect("probe child")
+                .success(),
+            "force-killed child still running"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn startup_wait_reports_wrapper_exit_before_readiness() {
+        let root = temp_dir("wrapper-exits-before-readiness");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve unused port");
+        let port = listener.local_addr().expect("unused port").port();
+        drop(listener);
+        let cfg = test_config(&root, format!("http://127.0.0.1:{port}"));
+        let mut wrapper = TokioCommand::new("sh")
+            .args(["-c", "exit 23"])
+            .spawn()
+            .expect("spawn wrapper");
+
+        let err = wait_for_supervisor_startup(&mut wrapper, &cfg)
+            .await
+            .expect_err("wrapper exit should fail startup");
+
+        assert!(err.to_string().contains("exit code 23"), "{err:#}");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn supervisor_exhausts_after_five_replacements() {
+        let root = temp_dir("supervisor-exhaustion");
+        let ping = PingServer::start();
+        let cfg = test_config(&root, ping.url());
+        let (server_bin, count_file, _) = write_fake_child_script(&root, "exit");
+        let config_path = root.join("config.xml");
+        fs::write(&config_path, "<clickhouse/>").expect("fake config");
+
+        let exit = supervise_clickhouse(&cfg, &server_bin, &config_path, test_policy())
+            .await
+            .expect("supervisor result");
+
+        assert_eq!(exit, ExitCode::from(1));
+        assert_eq!(
+            fs::read_to_string(&count_file)
+                .expect("generation count")
+                .trim(),
+            "6"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn readiness_timeout_terminates_owned_child() {
+        let root = temp_dir("supervisor-readiness-timeout");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve unused port");
+        let port = listener.local_addr().expect("unused port").port();
+        drop(listener);
+        let cfg = test_config(&root, format!("http://127.0.0.1:{port}"));
+        let (server_bin, _, raw_pid_file) = write_fake_child_script(&root, "live");
+        let config_path = root.join("config.xml");
+        fs::write(&config_path, "<clickhouse/>").expect("fake config");
+        let mut signals = ShutdownSignals::install().expect("shutdown signals");
+
+        let outcome = run_generation(
+            &cfg,
+            &server_bin,
+            &config_path,
+            1,
+            test_policy(),
+            &mut signals,
+        )
+        .await
+        .expect("generation outcome");
+
+        assert!(matches!(
+            outcome,
+            GenerationOutcome::Failed {
+                ready_uptime: None,
+                ..
+            }
+        ));
+        let raw_pid = fs::read_to_string(&raw_pid_file)
+            .expect("raw pid")
+            .trim()
+            .to_string();
+        let running = Command::new("kill")
+            .arg("-0")
+            .arg(raw_pid)
+            .status()
+            .expect("probe raw child")
+            .success();
+        assert!(!running, "unready raw child survived timeout");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn healthy_untracked_endpoint_remains_unmanaged() {
+        let root = temp_dir("external-endpoint");
+        let ping = PingServer::start();
+        let cfg = test_config(&root, ping.url());
+        let paths = crate::paths::runtime_paths(&cfg);
+        let config_path = root.join("config.toml");
+
+        let outcome = start_clickhouse(&config_path, &cfg, &paths)
+            .await
+            .expect("healthy external endpoint");
+
+        assert!(matches!(outcome.state, StartState::AlreadyServing));
+        assert!(outcome.pid.is_none());
+        assert!(!pid_path(&paths, Service::ClickHouse).exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unhealthy_already_running_pid_is_not_stopped() {
+        let root = temp_dir("already-running-sentinel");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve unused port");
+        let port = listener.local_addr().expect("unused port").port();
+        drop(listener);
+        let cfg = test_config(&root, format!("http://127.0.0.1:{port}"));
+        let paths = crate::paths::runtime_paths(&cfg);
+        ensure_runtime_dirs(&paths).expect("runtime dirs");
+        let mut sentinel = Command::new("sleep").arg("5").spawn().expect("sentinel");
+        let sentinel_pid = sentinel.id();
+        let launcher_pid = pid_path(&paths, Service::ClickHouse);
+        write_pid(&launcher_pid, sentinel_pid).expect("sentinel pid file");
+
+        let err = start_clickhouse(&root.join("config.toml"), &cfg, &paths)
+            .await
+            .expect_err("unhealthy sentinel should fail readiness");
+
+        assert!(
+            err.to_string().contains("did not become healthy"),
+            "{err:#}"
+        );
+        assert!(sentinel.try_wait().expect("sentinel status").is_none());
+        assert_eq!(
+            fs::read_to_string(&launcher_pid)
+                .expect("preserved pid")
+                .trim(),
+            sentinel_pid.to_string()
+        );
+        let _ = sentinel.kill();
+        let _ = sentinel.wait();
         let _ = fs::remove_dir_all(root);
     }
 }

--- a/apps/moraine/src/process.rs
+++ b/apps/moraine/src/process.rs
@@ -33,6 +33,10 @@ pub(crate) fn pid_path(paths: &RuntimePaths, service: Service) -> PathBuf {
     paths.pids_dir.join(service.pid_file())
 }
 
+pub(crate) fn clickhouse_supervisor_log_path(paths: &RuntimePaths) -> PathBuf {
+    paths.logs_dir.join("clickhouse-supervisor.log")
+}
+
 fn clickhouse_internal_log_path(paths: &RuntimePaths) -> PathBuf {
     paths
         .clickhouse_root
@@ -71,6 +75,12 @@ fn read_pid(path: &Path) -> Option<u32> {
 pub(crate) fn write_pid(path: &Path, pid: u32) -> Result<()> {
     fs::write(path, format!("{}\n", pid))
         .with_context(|| format!("failed to write pid file {}", path.display()))
+}
+
+pub(crate) fn remove_pid_if_matches(path: &Path, expected_pid: u32) {
+    if read_pid(path) == Some(expected_pid) {
+        let _ = fs::remove_file(path);
+    }
 }
 
 fn is_pid_running(pid: u32) -> bool {
@@ -137,7 +147,12 @@ pub(crate) fn stop_service(paths: &RuntimePaths, service: Service) -> Result<boo
         .stderr(Stdio::null())
         .status();
 
-    for _ in 0..20 {
+    let wait_attempts = if service == Service::ClickHouse {
+        50
+    } else {
+        20
+    };
+    for _ in 0..wait_attempts {
         if !is_pid_running(pid) {
             let _ = fs::remove_file(&path);
             return Ok(true);
@@ -519,10 +534,31 @@ mod tests {
             root.join("clickhouse/log/clickhouse-server.log")
         );
         assert_eq!(
+            clickhouse_supervisor_log_path(&paths),
+            logs_dir.join("clickhouse-supervisor.log")
+        );
+        assert_eq!(
             log_path(&paths, Service::Ingest),
             logs_dir.join("ingest.log")
         );
 
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn remove_pid_if_matches_preserves_new_owner() {
+        let root = temp_dir("compare-remove-pid");
+        let path = root.join("service.pid");
+        write_pid(&path, 42).expect("write pid");
+
+        remove_pid_if_matches(&path, 41);
+        assert_eq!(
+            fs::read_to_string(&path).expect("preserved pid").trim(),
+            "42"
+        );
+
+        remove_pid_if_matches(&path, 42);
+        assert!(!path.exists());
         let _ = fs::remove_dir_all(root);
     }
 

--- a/apps/moraine/tests/clickhouse_supervision.rs
+++ b/apps/moraine/tests/clickhouse_supervision.rs
@@ -1,0 +1,220 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::net::TcpListener;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+fn temp_dir(name: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "moraine-clickhouse-supervision-{name}-{}-{stamp}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&path).expect("create temp dir");
+    path
+}
+
+fn unused_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("reserve port")
+        .local_addr()
+        .expect("reserved port address")
+        .port()
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::create_dir_all(path.parent().expect("script parent")).expect("create script parent");
+    fs::write(path, contents).expect("write script");
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("make script executable");
+}
+
+fn write_config(root: &Path, port: u16) -> PathBuf {
+    let runtime = root.join("runtime");
+    let config = root.join("config path with spaces.toml");
+    fs::write(
+        &config,
+        format!(
+            r#"[clickhouse]
+url = "http://127.0.0.1:{port}"
+database = "moraine"
+timeout_seconds = 1.0
+
+[mcp]
+start_central_on_up = false
+central_socket_path = "{}"
+
+[runtime]
+root_dir = "{}"
+logs_dir = "{}"
+pids_dir = "{}"
+service_bin_dir = "{}"
+managed_clickhouse_dir = "{}"
+clickhouse_start_timeout_seconds = 1.0
+healthcheck_interval_ms = 100
+clickhouse_auto_install = false
+start_monitor_on_up = false
+start_mcp_on_up = false
+"#,
+            root.join("mcp.sock").display(),
+            runtime.display(),
+            runtime.join("logs").display(),
+            runtime.join("run").display(),
+            root.join("services").display(),
+            root.join("managed").display(),
+        ),
+    )
+    .expect("write config");
+    config
+}
+
+fn process_alive(pid: u32) -> bool {
+    Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("probe process")
+        .success()
+}
+
+fn wait_for_file(path: &Path, timeout: Duration) -> String {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(contents) = fs::read_to_string(path) {
+            if !contents.trim().is_empty() {
+                return contents;
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {}",
+            path.display()
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn wait_for_log(path: &Path, needle: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if fs::read_to_string(path)
+            .map(|contents| contents.contains(needle))
+            .unwrap_or(false)
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for `{needle}` in {}",
+            path.display()
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn wait_for_child(child: &mut Child, timeout: Duration) -> ExitStatus {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().expect("inspect child") {
+            return status;
+        }
+        assert!(Instant::now() < deadline, "timed out waiting for child");
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn failed_initial_readiness_rolls_back_supervisor_child_and_pid() {
+    let root = temp_dir("startup-rollback");
+    let raw_pid_path = root.join("raw.pid");
+    let server = root.join("managed/bin/clickhouse-server");
+    write_executable(
+        &server,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" > '{}'\nexec sleep 60\n",
+            raw_pid_path.display()
+        ),
+    );
+    let config = write_config(&root, unused_port());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_moraine"))
+        .arg("--config")
+        .arg(&config)
+        .args(["up", "--no-ingest"])
+        .output()
+        .expect("run moraine up");
+
+    assert!(!output.status.success(), "up unexpectedly succeeded");
+    let raw_pid = wait_for_file(&raw_pid_path, Duration::from_secs(2))
+        .trim()
+        .parse::<u32>()
+        .expect("raw pid");
+    assert!(
+        !process_alive(raw_pid),
+        "raw child survived startup rollback"
+    );
+    let run_dir = root.join("runtime/run");
+    assert!(!run_dir.join("clickhouse.pid").exists());
+    for service in ["ingest.pid", "monitor.pid", "mcp.pid"] {
+        assert!(
+            !run_dir.join(service).exists(),
+            "{service} should not start"
+        );
+    }
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn sigterm_during_backoff_exits_without_replacement() {
+    let root = temp_dir("backoff-shutdown");
+    let count_path = root.join("generation-count");
+    let server = root.join("managed/bin/clickhouse-server");
+    write_executable(
+        &server,
+        &format!(
+            "#!/bin/sh\ncount=0\n[ -f '{}' ] && count=$(cat '{}')\ncount=$((count + 1))\nprintf '%s\\n' \"$count\" > '{}'\nexit 42\n",
+            count_path.display(),
+            count_path.display(),
+            count_path.display()
+        ),
+    );
+    let config = write_config(&root, unused_port());
+    let supervisor_log_path = root.join("supervisor.stderr");
+    let supervisor_log = fs::File::create(&supervisor_log_path).expect("create supervisor log");
+    let supervisor_log_err = supervisor_log.try_clone().expect("clone supervisor log");
+    let mut supervisor = Command::new(env!("CARGO_BIN_EXE_moraine"))
+        .arg("--config")
+        .arg(&config)
+        .args(["clickhouse", "supervise"])
+        .stdout(Stdio::from(supervisor_log))
+        .stderr(Stdio::from(supervisor_log_err))
+        .spawn()
+        .expect("start supervisor");
+
+    wait_for_log(
+        &supervisor_log_path,
+        "state=backoff",
+        Duration::from_secs(3),
+    );
+    let status = Command::new("kill")
+        .arg(supervisor.id().to_string())
+        .status()
+        .expect("signal supervisor");
+    assert!(status.success());
+    assert!(wait_for_child(&mut supervisor, Duration::from_secs(3)).success());
+    thread::sleep(Duration::from_millis(1200));
+    assert_eq!(
+        fs::read_to_string(&count_path)
+            .expect("generation count")
+            .trim(),
+        "1"
+    );
+    let _ = fs::remove_dir_all(root);
+}

--- a/config/clickhouse.xml
+++ b/config/clickhouse.xml
@@ -21,6 +21,7 @@
 
   <max_connections>2048</max_connections>
   <max_concurrent_queries>500</max_concurrent_queries>
+  <max_thread_pool_free_size>64</max_thread_pool_free_size>
   <uncompressed_cache_size>536870912</uncompressed_cache_size>
   <mark_cache_size>536870912</mark_cache_size>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -701,8 +701,8 @@ enabled.
 | `pids_dir` | `run` | PID and socket directory. Relative paths resolve under `root_dir`. |
 | `service_bin_dir` | `~/.local/bin` | Directory containing installed service binaries. |
 | `managed_clickhouse_dir` | `~/.local/lib/moraine/clickhouse/current` | Directory for the managed ClickHouse installation. |
-| `clickhouse_start_timeout_seconds` | `30.0` | Seconds to wait for managed ClickHouse to become healthy during startup. |
-| `healthcheck_interval_ms` | `500` | Milliseconds between service health checks while waiting for startup. |
+| `clickhouse_start_timeout_seconds` | `30.0` | Seconds to wait for each managed ClickHouse process generation to become healthy, both initially and after an automatic restart. |
+| `healthcheck_interval_ms` | `500` | Milliseconds between readiness checks while a managed ClickHouse process generation starts. This is not a permanent health-poll interval after readiness. |
 | `clickhouse_auto_install` | `true` | Automatically installs the managed ClickHouse binary when needed. |
 | `clickhouse_version` | `v25.12.5.44-stable` | Managed ClickHouse release tag expected by this Moraine build. |
 | `start_monitor_on_up` | `true` | Starts the monitor service when `moraine up` starts services. |

--- a/docs/full-config.toml
+++ b/docs/full-config.toml
@@ -296,10 +296,12 @@ service_bin_dir = "~/.local/bin"
 # Directory for the managed ClickHouse installation.
 managed_clickhouse_dir = "~/.local/lib/moraine/clickhouse/current"
 
-# Seconds to wait for managed ClickHouse to become healthy during startup.
+# Seconds to wait for each managed ClickHouse process generation to become
+# healthy, both initially and after an automatic restart.
 clickhouse_start_timeout_seconds = 30.0
 
-# Milliseconds between service health checks while waiting for startup.
+# Milliseconds between readiness checks while a managed ClickHouse process
+# generation starts. This is not permanent health polling after readiness.
 healthcheck_interval_ms = 500
 
 # Automatically install the managed ClickHouse binary when needed.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -70,6 +70,17 @@ Check service health:
 moraine status
 ```
 
+For a local ClickHouse process started by `moraine up`, Moraine keeps a small
+supervisor running after startup. If ClickHouse exits unexpectedly, the
+supervisor waits 1, 2, 4, 8, then 16 seconds between at most five consecutive
+replacement attempts. Each replacement must become query-ready before recovery
+is recorded. A generation that remains ready for five uninterrupted minutes
+resets the consecutive-failure budget. After the retry budget is exhausted,
+`moraine status` reports ClickHouse stopped/unhealthy; run
+`moraine logs clickhouse` for the exit and retry history, then `moraine up` to
+start a fresh recovery budget. External ClickHouse
+endpoints are never adopted or restarted.
+
 Open the monitor UI:
 
 ```text
@@ -141,6 +152,7 @@ For manual cleanup, project-scoped setup, and other custom setup, see
 | `moraine status` | Print service and ingest health. |
 | `moraine logs` | Show recent service logs. |
 | `moraine logs ingest --lines 500` | Show recent ingest logs. |
+| `moraine logs clickhouse` | Show managed ClickHouse supervisor and server logs. |
 | `moraine db migrate` | Apply database migrations. |
 | `moraine db doctor` | Check ClickHouse connectivity and schema health. |
 | `moraine down` | Stop managed services. |


### PR DESCRIPTION
## Description

**What.** Adds a resident supervisor for Moraine-managed ClickHouse processes, with per-generation readiness checks, bounded restart backoff, safe shutdown, and durable recovery diagnostics.

**Why.** A managed ClickHouse SIGABRT left ingest, monitor, and MCP running against a dead database indefinitely because `moraine up` dropped the only child handle after startup.

- Launches a hidden `moraine clickhouse supervise` process from `moraine up`; the supervisor directly owns and reaps the raw ClickHouse process.
- Disables ClickHouse's nested watchdog so Moraine is the sole restart owner.
- Restarts unexpected exits after 1, 2, 4, 8, and 16 seconds, resets the consecutive-failure budget after five ready minutes, and exits loudly after five failed replacements.
- Health-gates every replacement before recording recovery and preserves the existing readiness-before-migrations/service-start order.
- Makes SIGTERM/SIGINT interrupt readiness, steady-state waiting, and backoff; `moraine down` terminates and reaps the raw child without resurrection.
- Preserves healthy external ClickHouse endpoints and the development sandbox sentinel as unmanaged.
- Adds a dedicated supervisor log to `moraine logs clickhouse` while preserving the server log.
- Sets managed ClickHouse `max_thread_pool_free_size` to 64 to reduce the idle-thread exposure associated with upstream ClickHouse#84761 without limiting total thread-pool capacity.

Closes #449.

## Usage

No configuration change is required. Continue to start and stop the stack normally:

```bash
moraine up
moraine status
moraine logs clickhouse
moraine down
```

If the bounded restart budget is exhausted, `moraine logs clickhouse` records the exit/retry history and a later `moraine up` starts a fresh budget.

## Bug Evidence

Before this change, `start_clickhouse` spawned ClickHouse, waited for the initial `SELECT 1`, and returned; dropping the `Child` left no resident process able to observe or recover a later crash. During the reported incident, ClickHouse stopped while ingest, monitor, and MCP remained alive and degraded until a manual `moraine up`.

The fixed path retains a resident direct parent, waits/reaps each generation, and starts replacements under one bounded policy. Focused CLI tests now cover initial-readiness rollback and shutdown during backoff. An isolated real-stack fault injection SIGKILLed the ready raw ClickHouse process and observed a different query-healthy child while the supervisor, ingest, monitor, and MCP PIDs remained unchanged.

## Operational Impact

`runtime.pids_dir/clickhouse.pid` now identifies the Moraine supervisor; ClickHouse continues to write its raw server PID under `runtime.root_dir/clickhouse/clickhouse.pid`. During a bounded backoff, status can show the supervisor running while the independent database doctor reports the endpoint unhealthy. After exhaustion, the supervisor exits and status resolves to stopped/unhealthy.

External ClickHouse endpoints are never adopted or restarted. Existing managed installations load the idle-thread setting on their next managed start.

## Changelog

- Automatically recovers unexpected managed ClickHouse exits with capped exponential backoff and crash-loop exhaustion.
- Makes managed ClickHouse shutdown and startup rollback terminate and reap owned processes.
- Adds managed ClickHouse supervisor diagnostics and documents recovery behavior.
- Caps retained idle Global Thread pool threads at 64 for managed ClickHouse.

## Validation

Ran `cargo test -p moraine --locked`; all 130 tests passed, including the new real-CLI startup rollback and backoff-shutdown tests. Ran `cargo clippy -p moraine --all-targets --locked -- -D warnings` and `cargo fmt --all -- --check` successfully. `make docs-build` completed with no issues.

For stack validation, built the exact `moraine`, ingest, monitor, and MCP binaries, then started a fresh isolated stack with managed ClickHouse 25.12.5.44. The raw server was confirmed as the supervisor's direct child. After SIGKILL, a new raw PID became query-healthy; supervisor/ingest/monitor/MCP launcher PIDs stayed unchanged. The recovered generation reported `max_thread_pool_free_size=64` with `changed=1`, while `max_thread_pool_size` remained equal to its default with `changed=0`. `moraine logs clickhouse --output json` returned both supervisor and server sections. Finally, `moraine down` stopped all services, and after 17.5 seconds no ClickHouse listener, launcher PID, raw PID, or replacement process reappeared.