### PR TITLE
refactor(conversations): neutralize backend domain terms

### DIFF
--- a/bindings/python/moraine_conversations/src/lib.rs
+++ b/bindings/python/moraine_conversations/src/lib.rs
@@ -3,7 +3,7 @@ use moraine_config::ClickHouseConfig;
 use moraine_conversations::{
     ClickHouseConversationRepository, ConversationDetailOptions, ConversationListFilter,
     ConversationMode, ConversationRepository, ConversationSearchQuery, PageRequest, RepoConfig,
-    SearchEventsQuery, SearchEventsStrategy,
+    SearchEventsQuery, SearchStrategyHint,
 };
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -165,7 +165,7 @@ impl ConversationClient {
         source: Option<String>,
         search_strategy: Option<&str>,
     ) -> PyResult<String> {
-        let parsed_search_strategy = parse_search_strategy(search_strategy)?;
+        let parsed_strategy_hint = parse_strategy_hint(search_strategy)?;
         let results = self
             .rt
             .block_on(self.repo.search_events(SearchEventsQuery {
@@ -173,13 +173,14 @@ impl ConversationClient {
                 source,
                 limit,
                 session_id,
+                session_ids: None,
                 min_score,
                 min_should_match,
                 include_tool_events,
                 event_kinds: None,
                 exclude_codex_mcp,
-                disable_cache,
-                search_strategy: parsed_search_strategy,
+                bypass_cache: disable_cache,
+                strategy_hint: parsed_strategy_hint,
             }))
             .map_err(py_runtime_err)?;
 
@@ -203,14 +204,14 @@ fn parse_mode(raw: Option<&str>) -> PyResult<Option<ConversationMode>> {
     }
 }
 
-fn parse_search_strategy(raw: Option<&str>) -> PyResult<Option<SearchEventsStrategy>> {
+fn parse_strategy_hint(raw: Option<&str>) -> PyResult<Option<SearchStrategyHint>> {
     let Some(raw) = raw else {
         return Ok(None);
     };
 
     match raw {
-        "optimized" => Ok(Some(SearchEventsStrategy::Optimized)),
-        "oracle_exact" => Ok(Some(SearchEventsStrategy::OracleExact)),
+        "optimized" => Ok(Some(SearchStrategyHint::PreferPerformance)),
+        "oracle_exact" => Ok(Some(SearchStrategyHint::Exact)),
         _ => Err(PyValueError::new_err(
             "search_strategy must be one of: optimized, oracle_exact",
         )),

--- a/crates/moraine-conversations/src/clickhouse_repo/cache.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/cache.rs
@@ -99,8 +99,8 @@ impl ClickHouseConversationRepository {
                     include_tool_events: None,
                     event_kinds: None,
                     exclude_codex_mcp: None,
-                    disable_cache: Some(false),
-                    search_strategy: Some(SearchEventsStrategy::Optimized),
+                    bypass_cache: Some(false),
+                    strategy_hint: Some(SearchStrategyHint::PreferPerformance),
                 })
                 .await
             {
@@ -146,7 +146,7 @@ impl ClickHouseConversationRepository {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn search_events_cache_key(
         terms: &[String],
-        search_strategy: SearchEventsStrategy,
+        strategy_hint: SearchStrategyHint,
         include_tool_events: bool,
         event_kinds: Option<&[SearchEventKind]>,
         exclude_codex_mcp: bool,
@@ -176,7 +176,7 @@ impl ClickHouseConversationRepository {
             .unwrap_or_default();
         format!(
             "strategy={};incl_tools={include_tool_events};event_kinds={event_kind_sig};excl_codex={exclude_codex_mcp};session={};sessions={session_ids_sig};msm={min_should_match};min_score={min_score:.12};limit={limit};terms={}",
-            search_strategy.as_str(),
+            strategy_hint.as_str(),
             session_id.unwrap_or(""),
             cache_terms.join(",")
         )

--- a/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
@@ -113,9 +113,9 @@ impl ClickHouseConversationRepository {
         };
 
         let limit_plus = query.max_rows.saturating_add(1);
-        let max_execution_time = query.max_execution_time_secs.max(1).to_string();
+        let max_execution_time = query.execution_budget_secs.max(1).to_string();
         let params = [
-            ("query_id", query.query_id.as_str()),
+            ("query_id", query.cancellation_token.as_str()),
             ("max_execution_time", max_execution_time.as_str()),
             ("join_use_nulls", "1"),
         ];
@@ -290,9 +290,9 @@ impl ClickHouseConversationRepository {
         };
 
         let limit_plus = query.max_rows.saturating_add(1);
-        let max_execution_time = query.max_execution_time_secs.max(1).to_string();
+        let max_execution_time = query.execution_budget_secs.max(1).to_string();
         let params = [
-            ("query_id", query.query_id.as_str()),
+            ("query_id", query.cancellation_token.as_str()),
             ("max_execution_time", max_execution_time.as_str()),
             ("join_use_nulls", "1"),
         ];

--- a/crates/moraine-conversations/src/clickhouse_repo/mod.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/mod.rs
@@ -25,8 +25,8 @@ use crate::domain::{
     McpSessionListFilter, McpSessionListItem, McpSessionOpen, McpTurnCompact, McpTurnOpen,
     McpTurnRef, OpenContext, OpenEvent, OpenEventRequest, Page, PageRequest, RepoConfig,
     SearchEventHit, SearchEventKind, SearchEventsQuery, SearchEventsResult, SearchEventsStats,
-    SearchEventsStrategy, SearchMcpEventHit, SearchMcpEventsQuery, SearchMcpEventsResult,
-    SearchMcpEventsStats, SessionEventsDirection, SessionEventsQuery, SessionMetadata,
+    SearchMcpEventHit, SearchMcpEventsQuery, SearchMcpEventsResult, SearchMcpEventsStats,
+    SearchStrategyHint, SessionEventsDirection, SessionEventsQuery, SessionMetadata,
     SessionMetadataSearchHit, SessionMetadataSearchQuery, SessionMetadataSearchResults,
     SessionMetadataSearchStats, SessionOriginScope, TraceEvent, Turn, TurnListFilter, TurnSummary,
 };

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -1017,7 +1017,7 @@ FORMAT JSONEachRow",
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn search_events_rows_by_strategy(
         &self,
-        strategy: SearchEventsStrategy,
+        strategy_hint: SearchStrategyHint,
         terms: &[String],
         docs: u64,
         avgdl: f64,
@@ -1030,8 +1030,8 @@ FORMAT JSONEachRow",
         min_score: f64,
         limit: u16,
     ) -> RepoResult<Vec<SearchRow>> {
-        match strategy {
-            SearchEventsStrategy::Optimized => {
+        match strategy_hint {
+            SearchStrategyHint::PreferPerformance => {
                 self.search_events_rows(
                     terms,
                     docs,
@@ -1047,7 +1047,7 @@ FORMAT JSONEachRow",
                 )
                 .await
             }
-            SearchEventsStrategy::OracleExact => {
+            SearchStrategyHint::Exact => {
                 self.search_events_rows_exact_sql(
                     terms,
                     docs,
@@ -2614,8 +2614,8 @@ FORMAT JSONEachRow",
         let exclude_codex_mcp = query
             .exclude_codex_mcp
             .unwrap_or(self.cfg.default_exclude_codex_mcp);
-        let disable_cache = query.disable_cache.unwrap_or(false);
-        let effective_strategy = query.search_strategy.unwrap_or_default();
+        let bypass_cache = query.bypass_cache.unwrap_or(false);
+        let effective_strategy_hint = query.strategy_hint.unwrap_or_default();
 
         let session_id = query.session_id.clone();
         if let Some(session_id) = session_id.as_deref() {
@@ -2663,10 +2663,10 @@ FORMAT JSONEachRow",
         let avgdl = (total_doc_len as f64 / docs as f64).max(1.0);
         let fetch_limit = Self::dedupe_fetch_limit(limit);
 
-        let hits = if disable_cache {
+        let hits = if bypass_cache {
             let rows = self
                 .search_events_rows_by_strategy(
-                    effective_strategy,
+                    effective_strategy_hint,
                     &terms,
                     docs,
                     avgdl,
@@ -2685,7 +2685,7 @@ FORMAT JSONEachRow",
         } else {
             let cache_key = Self::search_events_cache_key(
                 &terms,
-                effective_strategy,
+                effective_strategy_hint,
                 include_tool_events,
                 event_kinds.as_deref(),
                 exclude_codex_mcp,
@@ -2701,7 +2701,7 @@ FORMAT JSONEachRow",
             } else {
                 let fresh_rows = self
                     .search_events_rows_by_strategy(
-                        effective_strategy,
+                        effective_strategy_hint,
                         &terms,
                         docs,
                         avgdl,

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -64,9 +64,9 @@ pub struct McpSessionListFilter {
 /// whose input path ends with `rel`, scoped and filtered per the request.
 #[derive(Debug, Clone)]
 pub struct FileAttentionQuery {
-    /// Stable identifier assigned to the ClickHouse query so MCP deadlines can
-    /// cancel the backend scan if the client-side timeout fires.
-    pub query_id: String,
+    /// Opaque cancellation token assigned by the caller so timed-out requests
+    /// can cancel in-flight backend work.
+    pub cancellation_token: String,
     /// Repo-relative tail to suffix-match against captured file paths. The tail
     /// is what unifies the same logical file across worktree roots.
     pub rel: String,
@@ -89,12 +89,12 @@ pub struct FileAttentionQuery {
     pub tool: Option<String>,
     /// Drop common pure-read touches.
     pub mutations_only: bool,
-    /// Hard cap on matched rows pulled from ClickHouse. Summary, root, and
+    /// Hard cap on matched rows returned by the backend. Summary, root, and
     /// per-session rollups are computed over this scanned set; the caller flags
     /// the result truncated when the cap is hit.
     pub max_rows: usize,
-    /// Server-side ClickHouse execution cap for this scan.
-    pub max_execution_time_secs: u64,
+    /// Execution budget available to the backend for this scan.
+    pub execution_budget_secs: u64,
 }
 
 /// One captured tool call that touched the queried file. Deserialized from a
@@ -508,25 +508,27 @@ pub struct SearchEventsQuery {
     pub event_kinds: Option<Vec<SearchEventKind>>,
     #[serde(default)]
     pub exclude_codex_mcp: Option<bool>,
-    #[serde(default)]
-    pub disable_cache: Option<bool>,
-    #[serde(default)]
-    pub search_strategy: Option<SearchEventsStrategy>,
+    #[serde(default, rename = "disable_cache")]
+    pub bypass_cache: Option<bool>,
+    /// Preferred tradeoff for this search. Backends may treat this as a hint.
+    #[serde(default, rename = "search_strategy")]
+    pub strategy_hint: Option<SearchStrategyHint>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SearchEventsStrategy {
+pub enum SearchStrategyHint {
     #[default]
-    Optimized,
-    OracleExact,
+    #[serde(rename = "optimized")]
+    PreferPerformance,
+    #[serde(rename = "oracle_exact")]
+    Exact,
 }
 
-impl SearchEventsStrategy {
+impl SearchStrategyHint {
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Optimized => "optimized",
-            Self::OracleExact => "oracle_exact",
+            Self::PreferPerformance => "optimized",
+            Self::Exact => "oracle_exact",
         }
     }
 }
@@ -954,7 +956,47 @@ fn default_page_limit() -> u16 {
 
 #[cfg(test)]
 mod tests {
-    use super::SessionOriginScope;
+    use super::{SearchEventKind, SearchEventsQuery, SearchStrategyHint, SessionOriginScope};
+
+    #[test]
+    fn search_events_query_preserves_wire_contract() {
+        const WIRE_JSON: &str = r#"{"query":"needle","source":"mcp","limit":7,"session_id":"session-a","session_ids":["session-a","session-b"],"min_score":0.25,"min_should_match":2,"include_tool_events":true,"event_kinds":["message","tool_call"],"exclude_codex_mcp":false,"disable_cache":true,"search_strategy":"optimized"}"#;
+
+        let query: SearchEventsQuery =
+            serde_json::from_str(WIRE_JSON).expect("deserialize existing MCP query contract");
+
+        assert_eq!(query.bypass_cache, Some(true));
+        assert_eq!(
+            query.strategy_hint,
+            Some(SearchStrategyHint::PreferPerformance)
+        );
+        assert_eq!(
+            query.event_kinds.as_deref(),
+            Some(&[SearchEventKind::Message, SearchEventKind::ToolCall][..])
+        );
+        assert_eq!(
+            serde_json::to_string(&query).expect("serialize MCP query contract"),
+            WIRE_JSON
+        );
+    }
+
+    #[test]
+    fn search_strategy_hint_preserves_wire_values() {
+        for (hint, wire_value) in [
+            (SearchStrategyHint::PreferPerformance, r#""optimized""#),
+            (SearchStrategyHint::Exact, r#""oracle_exact""#),
+        ] {
+            assert_eq!(
+                serde_json::to_string(&hint).expect("serialize strategy hint"),
+                wire_value
+            );
+            assert_eq!(
+                serde_json::from_str::<SearchStrategyHint>(wire_value)
+                    .expect("deserialize strategy hint"),
+                hint
+            );
+        }
+    }
 
     #[test]
     fn from_roots_normalizes_and_dedupes() {

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -13,8 +13,8 @@ pub use domain::{
     McpSessionListFilter, McpSessionListItem, McpSessionOpen, McpTurnCompact, McpTurnOpen,
     McpTurnRef, OpenContext, OpenEvent, OpenEventRequest, Page, PageRequest, RepoConfig,
     SearchEventHit, SearchEventKind, SearchEventsQuery, SearchEventsResult, SearchEventsStats,
-    SearchEventsStrategy, SearchMcpEventHit, SearchMcpEventsQuery, SearchMcpEventsResult,
-    SearchMcpEventsStats, SessionEventsDirection, SessionEventsQuery, SessionMetadata,
+    SearchMcpEventHit, SearchMcpEventsQuery, SearchMcpEventsResult, SearchMcpEventsStats,
+    SearchStrategyHint, SessionEventsDirection, SessionEventsQuery, SessionMetadata,
     SessionMetadataSearchHit, SessionMetadataSearchQuery, SessionMetadataSearchResults,
     SessionMetadataSearchStats, SessionOriginScope, TraceEvent, Turn, TurnListFilter, TurnSummary,
 };

--- a/crates/moraine-conversations/tests/repository_integration.rs
+++ b/crates/moraine-conversations/tests/repository_integration.rs
@@ -1785,7 +1785,7 @@ async fn file_attention_merges_normalized_exact_lookup_with_suffix_fallback() {
 
     let touches = repo
         .file_attention(FileAttentionQuery {
-            query_id: "test-file-attention-normalized".to_string(),
+            cancellation_token: "test-file-attention-normalized".to_string(),
             rel: "crates/foo.rs".to_string(),
             normalized_project_id: Some("project-a".to_string()),
             derive_worktree_roots: true,
@@ -1795,7 +1795,7 @@ async fn file_attention_merges_normalized_exact_lookup_with_suffix_fallback() {
             tool: None,
             mutations_only: false,
             max_rows: 10,
-            max_execution_time_secs: 3,
+            execution_budget_secs: 3,
         })
         .await
         .expect("file_attention query succeeds");
@@ -2888,8 +2888,8 @@ async fn search_events_includes_session_time_bounds() {
             include_tool_events: Some(true),
             event_kinds: None,
             exclude_codex_mcp: Some(false),
-            disable_cache: Some(true),
-            search_strategy: None,
+            bypass_cache: Some(true),
+            strategy_hint: None,
         })
         .await
         .expect("search events");
@@ -2927,8 +2927,8 @@ async fn search_events_documents_subquery_avoids_self_aliased_aggregates() {
             include_tool_events: Some(true),
             event_kinds: None,
             exclude_codex_mcp: Some(false),
-            disable_cache: Some(true),
-            search_strategy: None,
+            bypass_cache: Some(true),
+            strategy_hint: None,
         })
         .await
         .expect("search events");

--- a/crates/moraine-mcp-core/src/file_attention_v1.rs
+++ b/crates/moraine-mcp-core/src/file_attention_v1.rs
@@ -100,7 +100,7 @@ impl AppState {
 
         let query_id = file_attention_query_id();
         let repo_query = FileAttentionQuery {
-            query_id: query_id.clone(),
+            cancellation_token: query_id.clone(),
             rel: tail.rel.clone(),
             normalized_project_id: tail.project_id.clone(),
             derive_worktree_roots: tail.derive_worktree_roots,
@@ -110,7 +110,7 @@ impl AppState {
             tool: args.tool.clone(),
             mutations_only: args.mutations_only,
             max_rows: FILE_ATTENTION_SCAN_CAP,
-            max_execution_time_secs: FILE_ATTENTION_DEADLINE_MS.div_ceil(1_000),
+            execution_budget_secs: FILE_ATTENTION_DEADLINE_MS.div_ceil(1_000),
         };
 
         let touches = match timeout(


### PR DESCRIPTION
## Description

**What.** Replaces ClickHouse-specific Rust domain vocabulary with backend-neutral cancellation tokens, execution budgets, cache bypass, and strategy hints.

**Why.** Conversation retrieval contracts should describe caller intent without exposing the current storage implementation.

The Rust API now uses `cancellation_token`, `execution_budget_secs`, `bypass_cache`, `strategy_hint`, and `SearchStrategyHint::{PreferPerformance, Exact}`. Serde renames retain the existing MCP JSON keys `disable_cache` and `search_strategy`, and explicit enum renames retain `optimized` and `oracle_exact`. Mechanical repository, MCP-core, integration-test, and Python-binding callsites are migrated without Rust compatibility aliases or Python-facing API changes.

Resolves #453

## Usage

No user-facing usage change. Existing MCP and Python request field names and values remain unchanged.

## Changelog

- Makes the conversations Rust domain contract backend-neutral.
- Preserves existing MCP JSON field names and enum values byte-for-byte.
- Does not change runtime retrieval behavior.

## Validation

`cargo test -p moraine-conversations domain::tests` passed 4 tests, including an exact serialized-query byte contract and both strategy wire values. `cargo test -p moraine-conversations --lib` passed 26 tests. `cargo test -p moraine-mcp-core file_attention` passed 19 tests. Focused repository integration runs passed the file-attention test (1 test) and `search_events_` tests (2 tests). `cargo fmt --check -p moraine-conversations -p moraine-mcp-core` and `cargo fmt --check --manifest-path bindings/python/moraine_conversations/Cargo.toml` passed.

A standalone Python binding `cargo check` was attempted after migrating its callsite. It no longer reports any renamed-domain symbol or field errors, but the package remains blocked by pre-existing unrelated missing `allow_newer_server` and `sort` initializer fields.

The required seven-persona review completed. Reviewers found one stale Python-binding Rust callsite; it was migrated while preserving Python parameter names and both accepted strategy strings, then rechecked clean by the idiom, correctness, completeness, and scope reviewers.