### PR TITLE
refactor(conversations): use repository trait in mcp-core

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
@@ -2,6 +2,14 @@ use super::*;
 
 #[async_trait]
 impl ConversationRepository for ClickHouseConversationRepository {
+    fn config(&self) -> &RepoConfig {
+        ClickHouseConversationRepository::config(self)
+    }
+
+    async fn prewarm_mcp_search_state(&self) -> RepoResult<()> {
+        ClickHouseConversationRepository::prewarm_mcp_search_state(self).await
+    }
+
     async fn list_conversations(
         &self,
         filter: ConversationListFilter,
@@ -89,10 +97,21 @@ impl ConversationRepository for ClickHouseConversationRepository {
         self.search_conversations_impl(query).await
     }
 
+    async fn search_session_metadata(
+        &self,
+        query: SessionMetadataSearchQuery,
+    ) -> RepoResult<SessionMetadataSearchResults> {
+        ClickHouseConversationRepository::search_session_metadata(self, query).await
+    }
+
     async fn file_attention(
         &self,
         query: FileAttentionQuery,
     ) -> RepoResult<Vec<FileAttentionTouch>> {
         self.file_attention_impl(query).await
+    }
+
+    async fn cancel_query(&self, query_id: &str) -> RepoResult<()> {
+        ClickHouseConversationRepository::cancel_query(self, query_id).await
     }
 }

--- a/crates/moraine-conversations/src/error.rs
+++ b/crates/moraine-conversations/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 pub type RepoResult<T> = Result<T, RepoError>;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum RepoError {
     #[error("invalid argument: {0}")]
     InvalidArgument(String),

--- a/crates/moraine-conversations/src/in_memory_repo.rs
+++ b/crates/moraine-conversations/src/in_memory_repo.rs
@@ -1,0 +1,397 @@
+use std::sync::{Mutex, MutexGuard};
+
+use async_trait::async_trait;
+
+use crate::domain::{
+    Conversation, ConversationDetailOptions, ConversationListFilter, ConversationSearchQuery,
+    ConversationSearchResults, ConversationSearchStats, ConversationSummary, FileAttentionQuery,
+    FileAttentionTouch, McpEventOpen, McpEventType, McpSessionListFilter, McpSessionListItem,
+    McpSessionOpen, McpTurnOpen, OpenContext, OpenEventRequest, Page, PageRequest, RepoConfig,
+    SearchEventsQuery, SearchEventsResult, SearchEventsStats, SearchMcpEventsQuery,
+    SearchMcpEventsResult, SearchMcpEventsStats, SessionEventsQuery, SessionMetadata,
+    SessionMetadataSearchQuery, SessionMetadataSearchResults, SessionMetadataSearchStats,
+    TraceEvent, Turn, TurnListFilter, TurnSummary,
+};
+use crate::error::RepoResult;
+use crate::repo::ConversationRepository;
+
+/// Configurable responses returned by [`InMemoryConversationRepository`].
+///
+/// An unset response uses the fake's empty or not-found default. Tests can set
+/// an `Err` response to exercise repository failure paths without a live
+/// ClickHouse server.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryConversationResponses {
+    pub list_conversations: Option<RepoResult<Page<ConversationSummary>>>,
+    pub get_conversation: Option<RepoResult<Option<Conversation>>>,
+    pub get_session_metadata: Option<RepoResult<Option<SessionMetadata>>>,
+    pub get_mcp_session: Option<RepoResult<Option<McpSessionOpen>>>,
+    pub list_mcp_sessions: Option<RepoResult<Page<McpSessionListItem>>>,
+    pub list_turns: Option<RepoResult<Page<TurnSummary>>>,
+    pub get_turn: Option<RepoResult<Option<Turn>>>,
+    pub get_mcp_turn: Option<RepoResult<Option<McpTurnOpen>>>,
+    pub open_event: Option<RepoResult<OpenContext>>,
+    pub get_mcp_event: Option<RepoResult<Option<McpEventOpen>>>,
+    pub list_session_events: Option<RepoResult<Page<TraceEvent>>>,
+    pub search_events: Option<RepoResult<SearchEventsResult>>,
+    pub search_mcp_events: Option<RepoResult<SearchMcpEventsResult>>,
+    pub search_conversations: Option<RepoResult<ConversationSearchResults>>,
+    pub search_session_metadata: Option<RepoResult<SessionMetadataSearchResults>>,
+    pub file_attention: Option<RepoResult<Vec<FileAttentionTouch>>>,
+    pub prewarm_mcp_search_state: Option<RepoResult<()>>,
+    pub cancel_query: Option<RepoResult<()>>,
+}
+
+/// Arguments observed by an [`InMemoryConversationRepository`].
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryConversationCalls {
+    pub list_conversations: Vec<(ConversationListFilter, PageRequest)>,
+    pub get_conversation: Vec<(String, ConversationDetailOptions)>,
+    pub get_session_metadata: Vec<String>,
+    pub get_mcp_session: Vec<String>,
+    pub list_mcp_sessions: Vec<(McpSessionListFilter, PageRequest)>,
+    pub list_turns: Vec<(String, TurnListFilter, PageRequest)>,
+    pub get_turn: Vec<(String, u32)>,
+    pub get_mcp_turn: Vec<(String, u32)>,
+    pub open_event: Vec<OpenEventRequest>,
+    pub get_mcp_event: Vec<String>,
+    pub list_session_events: Vec<(SessionEventsQuery, PageRequest)>,
+    pub search_events: Vec<SearchEventsQuery>,
+    pub search_mcp_events: Vec<SearchMcpEventsQuery>,
+    pub search_conversations: Vec<ConversationSearchQuery>,
+    pub search_session_metadata: Vec<SessionMetadataSearchQuery>,
+    pub file_attention: Vec<FileAttentionQuery>,
+    pub prewarm_mcp_search_state: usize,
+    pub cancel_query: Vec<String>,
+}
+
+/// In-memory, programmable implementation of [`ConversationRepository`].
+///
+/// This fake is exported from `moraine-conversations` so downstream crates can
+/// exercise repository consumers without mocking the ClickHouse HTTP wire.
+#[derive(Debug)]
+pub struct InMemoryConversationRepository {
+    config: RepoConfig,
+    responses: InMemoryConversationResponses,
+    calls: Mutex<InMemoryConversationCalls>,
+}
+
+impl InMemoryConversationRepository {
+    pub fn new(config: RepoConfig) -> Self {
+        Self::with_responses(config, InMemoryConversationResponses::default())
+    }
+
+    pub fn with_responses(config: RepoConfig, responses: InMemoryConversationResponses) -> Self {
+        Self {
+            config,
+            responses,
+            calls: Mutex::new(InMemoryConversationCalls::default()),
+        }
+    }
+
+    pub fn calls(&self) -> InMemoryConversationCalls {
+        mutex_lock(&self.calls).clone()
+    }
+
+    fn record(&self, update: impl FnOnce(&mut InMemoryConversationCalls)) {
+        update(&mut mutex_lock(&self.calls));
+    }
+
+    fn empty_search_events(&self, query: &SearchEventsQuery) -> SearchEventsResult {
+        let requested_limit = query.limit.unwrap_or(self.config.max_results).max(1);
+        SearchEventsResult {
+            query_id: "in-memory".to_string(),
+            query: query.query.clone(),
+            terms: Vec::new(),
+            stats: SearchEventsStats {
+                docs: 0,
+                avgdl: 0.0,
+                took_ms: 0,
+                result_count: 0,
+                requested_limit,
+                effective_limit: requested_limit.min(self.config.max_results),
+                limit_capped: requested_limit > self.config.max_results,
+            },
+            hits: Vec::new(),
+        }
+    }
+
+    fn empty_search_mcp_events(&self, query: &SearchMcpEventsQuery) -> SearchMcpEventsResult {
+        let requested_n_hits = query.n_hits.unwrap_or(self.config.max_results).max(1);
+        SearchMcpEventsResult {
+            query_id: "in-memory".to_string(),
+            query: query.query.clone(),
+            terms: Vec::new(),
+            event_types: query
+                .event_types
+                .clone()
+                .unwrap_or_else(McpEventType::default_search_types),
+            truncated: false,
+            stats: SearchMcpEventsStats {
+                docs: 0,
+                avgdl: 0.0,
+                took_ms: 0,
+                result_count: 0,
+                requested_n_hits,
+                effective_n_hits: requested_n_hits.min(self.config.max_results),
+                limit_capped: requested_n_hits > self.config.max_results,
+                truncated: false,
+            },
+            hits: Vec::new(),
+        }
+    }
+
+    fn empty_conversation_search(
+        &self,
+        query: &ConversationSearchQuery,
+    ) -> ConversationSearchResults {
+        let requested_limit = query.limit.unwrap_or(self.config.max_results).max(1);
+        ConversationSearchResults {
+            query_id: "in-memory".to_string(),
+            query: query.query.clone(),
+            terms: Vec::new(),
+            stats: ConversationSearchStats {
+                docs: 0,
+                avgdl: 0.0,
+                took_ms: 0,
+                result_count: 0,
+                requested_limit,
+                effective_limit: requested_limit.min(self.config.max_results),
+                limit_capped: requested_limit > self.config.max_results,
+            },
+            hits: Vec::new(),
+        }
+    }
+
+    fn empty_session_metadata_search(
+        &self,
+        query: &SessionMetadataSearchQuery,
+    ) -> SessionMetadataSearchResults {
+        let requested_limit = query.limit.unwrap_or(self.config.max_results).max(1);
+        SessionMetadataSearchResults {
+            query_id: "in-memory".to_string(),
+            query: query.query.clone(),
+            terms: Vec::new(),
+            stats: SessionMetadataSearchStats {
+                requested_limit,
+                effective_limit: requested_limit.min(self.config.max_results),
+                limit_capped: requested_limit > self.config.max_results,
+                result_count: 0,
+                took_ms: 0,
+            },
+            hits: Vec::new(),
+        }
+    }
+}
+
+impl Default for InMemoryConversationRepository {
+    fn default() -> Self {
+        Self::new(RepoConfig::default())
+    }
+}
+
+macro_rules! response_or {
+    ($self:expr, $field:ident, $default:expr) => {{
+        match &$self.responses.$field {
+            Some(result) => result.clone(),
+            None => Ok($default),
+        }
+    }};
+}
+
+#[async_trait]
+impl ConversationRepository for InMemoryConversationRepository {
+    fn config(&self) -> &RepoConfig {
+        &self.config
+    }
+
+    async fn prewarm_mcp_search_state(&self) -> RepoResult<()> {
+        self.record(|calls| calls.prewarm_mcp_search_state += 1);
+        response_or!(self, prewarm_mcp_search_state, ())
+    }
+
+    async fn list_conversations(
+        &self,
+        filter: ConversationListFilter,
+        page: PageRequest,
+    ) -> RepoResult<Page<ConversationSummary>> {
+        self.record(|calls| calls.list_conversations.push((filter, page)));
+        response_or!(
+            self,
+            list_conversations,
+            Page {
+                items: Vec::new(),
+                next_cursor: None,
+            }
+        )
+    }
+
+    async fn get_conversation(
+        &self,
+        session_id: &str,
+        opts: ConversationDetailOptions,
+    ) -> RepoResult<Option<Conversation>> {
+        self.record(|calls| calls.get_conversation.push((session_id.to_string(), opts)));
+        response_or!(self, get_conversation, None)
+    }
+
+    async fn get_session_metadata(&self, session_id: &str) -> RepoResult<Option<SessionMetadata>> {
+        self.record(|calls| calls.get_session_metadata.push(session_id.to_string()));
+        response_or!(self, get_session_metadata, None)
+    }
+
+    async fn get_mcp_session(&self, session_id: &str) -> RepoResult<Option<McpSessionOpen>> {
+        self.record(|calls| calls.get_mcp_session.push(session_id.to_string()));
+        response_or!(self, get_mcp_session, None)
+    }
+
+    async fn list_mcp_sessions(
+        &self,
+        filter: McpSessionListFilter,
+        page: PageRequest,
+    ) -> RepoResult<Page<McpSessionListItem>> {
+        self.record(|calls| calls.list_mcp_sessions.push((filter, page)));
+        response_or!(
+            self,
+            list_mcp_sessions,
+            Page {
+                items: Vec::new(),
+                next_cursor: None,
+            }
+        )
+    }
+
+    async fn list_turns(
+        &self,
+        session_id: &str,
+        filter: TurnListFilter,
+        page: PageRequest,
+    ) -> RepoResult<Page<TurnSummary>> {
+        self.record(|calls| {
+            calls
+                .list_turns
+                .push((session_id.to_string(), filter, page))
+        });
+        response_or!(
+            self,
+            list_turns,
+            Page {
+                items: Vec::new(),
+                next_cursor: None,
+            }
+        )
+    }
+
+    async fn get_turn(&self, session_id: &str, turn_seq: u32) -> RepoResult<Option<Turn>> {
+        self.record(|calls| calls.get_turn.push((session_id.to_string(), turn_seq)));
+        response_or!(self, get_turn, None)
+    }
+
+    async fn get_mcp_turn(
+        &self,
+        session_id: &str,
+        turn_seq: u32,
+    ) -> RepoResult<Option<McpTurnOpen>> {
+        self.record(|calls| calls.get_mcp_turn.push((session_id.to_string(), turn_seq)));
+        response_or!(self, get_mcp_turn, None)
+    }
+
+    async fn open_event(&self, req: OpenEventRequest) -> RepoResult<OpenContext> {
+        self.record(|calls| calls.open_event.push(req.clone()));
+        response_or!(
+            self,
+            open_event,
+            OpenContext {
+                found: false,
+                event_uid: req.event_uid,
+                session_id: String::new(),
+                target_event_order: 0,
+                turn_seq: 0,
+                before: req.before.unwrap_or(self.config.default_context_before),
+                after: req.after.unwrap_or(self.config.default_context_after),
+                events: Vec::new(),
+            }
+        )
+    }
+
+    async fn get_mcp_event(&self, event_uid: &str) -> RepoResult<Option<McpEventOpen>> {
+        self.record(|calls| calls.get_mcp_event.push(event_uid.to_string()));
+        response_or!(self, get_mcp_event, None)
+    }
+
+    async fn list_session_events(
+        &self,
+        query: SessionEventsQuery,
+        page: PageRequest,
+    ) -> RepoResult<Page<TraceEvent>> {
+        self.record(|calls| calls.list_session_events.push((query, page)));
+        response_or!(
+            self,
+            list_session_events,
+            Page {
+                items: Vec::new(),
+                next_cursor: None,
+            }
+        )
+    }
+
+    async fn search_events(&self, query: SearchEventsQuery) -> RepoResult<SearchEventsResult> {
+        self.record(|calls| calls.search_events.push(query.clone()));
+        response_or!(self, search_events, self.empty_search_events(&query))
+    }
+
+    async fn search_mcp_events(
+        &self,
+        query: SearchMcpEventsQuery,
+    ) -> RepoResult<SearchMcpEventsResult> {
+        self.record(|calls| calls.search_mcp_events.push(query.clone()));
+        response_or!(
+            self,
+            search_mcp_events,
+            self.empty_search_mcp_events(&query)
+        )
+    }
+
+    async fn search_conversations(
+        &self,
+        query: ConversationSearchQuery,
+    ) -> RepoResult<ConversationSearchResults> {
+        self.record(|calls| calls.search_conversations.push(query.clone()));
+        response_or!(
+            self,
+            search_conversations,
+            self.empty_conversation_search(&query)
+        )
+    }
+
+    async fn search_session_metadata(
+        &self,
+        query: SessionMetadataSearchQuery,
+    ) -> RepoResult<SessionMetadataSearchResults> {
+        self.record(|calls| calls.search_session_metadata.push(query.clone()));
+        response_or!(
+            self,
+            search_session_metadata,
+            self.empty_session_metadata_search(&query)
+        )
+    }
+
+    async fn file_attention(
+        &self,
+        query: FileAttentionQuery,
+    ) -> RepoResult<Vec<FileAttentionTouch>> {
+        self.record(|calls| calls.file_attention.push(query));
+        response_or!(self, file_attention, Vec::new())
+    }
+
+    async fn cancel_query(&self, query_id: &str) -> RepoResult<()> {
+        self.record(|calls| calls.cancel_query.push(query_id.to_string()));
+        response_or!(self, cancel_query, ())
+    }
+}
+
+fn mutex_lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -2,6 +2,7 @@ mod clickhouse_repo;
 mod cursor;
 mod domain;
 mod error;
+mod in_memory_repo;
 mod repo;
 
 pub use clickhouse_repo::ClickHouseConversationRepository;
@@ -19,4 +20,7 @@ pub use domain::{
     SessionMetadataSearchStats, SessionOriginScope, TraceEvent, Turn, TurnListFilter, TurnSummary,
 };
 pub use error::{RepoError, RepoResult};
+pub use in_memory_repo::{
+    InMemoryConversationCalls, InMemoryConversationRepository, InMemoryConversationResponses,
+};
 pub use repo::ConversationRepository;

--- a/crates/moraine-conversations/src/repo.rs
+++ b/crates/moraine-conversations/src/repo.rs
@@ -4,14 +4,19 @@ use crate::domain::{
     Conversation, ConversationDetailOptions, ConversationListFilter, ConversationSearchQuery,
     ConversationSearchResults, FileAttentionQuery, FileAttentionTouch, McpEventOpen,
     McpSessionListFilter, McpSessionListItem, McpSessionOpen, McpTurnOpen, OpenContext,
-    OpenEventRequest, Page, PageRequest, SearchEventsQuery, SearchEventsResult,
-    SearchMcpEventsQuery, SearchMcpEventsResult, SessionEventsQuery, SessionMetadata, TraceEvent,
-    Turn, TurnListFilter, TurnSummary,
+    OpenEventRequest, Page, PageRequest, RepoConfig, SearchEventsQuery, SearchEventsResult,
+    SearchMcpEventsQuery, SearchMcpEventsResult, SessionEventsQuery, SessionMetadata,
+    SessionMetadataSearchQuery, SessionMetadataSearchResults, TraceEvent, Turn, TurnListFilter,
+    TurnSummary,
 };
 use crate::error::RepoResult;
 
 #[async_trait]
 pub trait ConversationRepository: Send + Sync {
+    fn config(&self) -> &RepoConfig;
+
+    async fn prewarm_mcp_search_state(&self) -> RepoResult<()>;
+
     async fn list_conversations(
         &self,
         filter: ConversationListFilter,
@@ -71,8 +76,15 @@ pub trait ConversationRepository: Send + Sync {
         query: ConversationSearchQuery,
     ) -> RepoResult<ConversationSearchResults>;
 
+    async fn search_session_metadata(
+        &self,
+        query: SessionMetadataSearchQuery,
+    ) -> RepoResult<SessionMetadataSearchResults>;
+
     async fn file_attention(
         &self,
         query: FileAttentionQuery,
     ) -> RepoResult<Vec<FileAttentionTouch>>;
+
+    async fn cancel_query(&self, query_id: &str) -> RepoResult<()>;
 }

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -10,7 +10,9 @@ use anyhow::{anyhow, Context, Result};
 use moraine_clickhouse::{enforce_remote_schema_policy, ClickHouseClient};
 use moraine_config::{AppConfig, DEFAULT_BACKEND_NAME};
 pub use moraine_conversations::SessionOriginScope;
-use moraine_conversations::{ClickHouseConversationRepository, RepoConfig, RepoError};
+use moraine_conversations::{
+    ClickHouseConversationRepository, ConversationRepository, RepoConfig, RepoError,
+};
 use serde::Deserialize;
 use serde_json::{json, Value};
 #[cfg(unix)]
@@ -41,7 +43,7 @@ struct ToolCallParams {
 #[derive(Clone)]
 struct AppState {
     cfg: AppConfig,
-    repo: ClickHouseConversationRepository,
+    repo: Arc<dyn ConversationRepository>,
     prewarm_started: Arc<AtomicBool>,
 }
 
@@ -468,7 +470,8 @@ impl AppState {
             session_scope,
         };
 
-        let repo = ClickHouseConversationRepository::new(ch, repo_cfg);
+        let repo: Arc<dyn ConversationRepository> =
+            Arc::new(ClickHouseConversationRepository::new(ch, repo_cfg));
         Ok(Arc::new(AppState {
             cfg,
             repo,
@@ -925,11 +928,12 @@ pub async fn run_socket(_cfg: AppConfig, _socket_path: std::path::PathBuf) -> Re
 #[cfg(test)]
 mod tests {
     use super::*;
+    use moraine_conversations::InMemoryConversationRepository;
 
     fn test_state() -> AppState {
         let cfg = AppConfig::default();
-        let ch = ClickHouseClient::new(cfg.clickhouse.clone()).expect("clickhouse client");
-        let repo = ClickHouseConversationRepository::new(ch, RepoConfig::default());
+        let repo: Arc<dyn ConversationRepository> =
+            Arc::new(InMemoryConversationRepository::default());
         AppState {
             cfg,
             repo,

--- a/crates/moraine-mcp-core/src/list_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/list_sessions_v1.rs
@@ -9,7 +9,7 @@ use crate::contract::{
 use anyhow::{Context, Result};
 use moraine_conversations::{
     ConversationListSort as RepoListSort, ConversationMode as RepoConversationMode,
-    ConversationRepository, McpSessionListFilter, McpSessionListItem, Page, PageRequest,
+    McpSessionListFilter, McpSessionListItem, Page, PageRequest,
 };
 use serde_json::{json, Value};
 use tokio::time::{timeout, Duration};
@@ -321,7 +321,11 @@ fn format_list_sessions_error_text(payload: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use moraine_conversations::ConversationMode;
+    use moraine_config::AppConfig;
+    use moraine_conversations::{
+        ConversationMode, InMemoryConversationRepository, InMemoryConversationResponses, RepoConfig,
+    };
+    use std::sync::{atomic::AtomicBool, Arc};
 
     #[test]
     fn parses_and_canonicalizes_list_sessions_args() {
@@ -397,17 +401,8 @@ mod tests {
         assert_eq!(limit.code(), ToolErrorCode::InvalidRequest);
     }
 
-    #[test]
-    fn shapes_session_metadata_only_with_open_handle() {
-        let args = parse_list_sessions_args(
-            json!({
-                "start_datetime": "2026-04-30T09:00:00-04:00",
-                "end_datetime": "2026-04-30T13:00:00-04:00",
-                "limit": 1
-            }),
-            50,
-        )
-        .expect("valid args");
+    #[tokio::test]
+    async fn shapes_session_metadata_only_with_open_handle() {
         let page = Page {
             items: vec![McpSessionListItem {
                 session_id: "sess-open".to_string(),
@@ -426,8 +421,30 @@ mod tests {
             }],
             next_cursor: None,
         };
+        let repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            InMemoryConversationResponses {
+                list_mcp_sessions: Some(Ok(page)),
+                ..InMemoryConversationResponses::default()
+            },
+        ));
+        let state = AppState {
+            cfg: AppConfig::default(),
+            repo: repository.clone(),
+            prewarm_started: Arc::new(AtomicBool::new(false)),
+        };
 
-        let data = list_sessions_data_json(&args, &page).expect("shape data");
+        let result = state
+            .list_sessions_v1(json!({
+                "start_datetime": "2026-04-30T09:00:00-04:00",
+                "end_datetime": "2026-04-30T13:00:00-04:00",
+                "limit": 1
+            }))
+            .await
+            .expect("list sessions");
+        assert_eq!(result["isError"], json!(false));
+
+        let data = &result["structuredContent"]["data"];
         let first = &data["sessions"][0];
         assert_eq!(first["id"], json!("session:c2Vzcy1vcGVu"));
         assert_eq!(first["open"]["session_id"], first["session"]["id"]);
@@ -436,6 +453,16 @@ mod tests {
         assert!(first.get("snippet").is_none());
         assert!(first.get("events").is_none());
         assert!(first.get("payload_json").is_none());
+
+        let calls = repository.calls();
+        assert_eq!(calls.list_mcp_sessions.len(), 1);
+        let (filter, page) = &calls.list_mcp_sessions[0];
+        assert_eq!(filter.start_unix_ms, 1_777_554_000_000);
+        assert_eq!(filter.end_unix_ms, 1_777_568_400_000);
+        assert_eq!(filter.mode, None);
+        assert_eq!(filter.sort, RepoListSort::Desc);
+        assert_eq!(page.limit, 1);
+        assert_eq!(page.cursor, None);
     }
 
     #[test]

--- a/crates/moraine-mcp-core/src/open_v1.rs
+++ b/crates/moraine-mcp-core/src/open_v1.rs
@@ -5,8 +5,8 @@ use crate::contract::{
 use crate::AppState;
 use anyhow::{Context, Result};
 use moraine_conversations::{
-    ConversationRepository, McpEventOpen, McpEventRef, McpEventSummary, McpSessionOpen,
-    McpTurnCompact, McpTurnOpen, McpTurnRef, SessionMetadata, TraceEvent,
+    McpEventOpen, McpEventRef, McpEventSummary, McpSessionOpen, McpTurnCompact, McpTurnOpen,
+    McpTurnRef, SessionMetadata, TraceEvent,
 };
 use serde_json::{json, Map, Value};
 use std::time::Instant;

--- a/crates/moraine-mcp-core/src/search_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/search_sessions_v1.rs
@@ -6,8 +6,8 @@ use crate::contract::{
 };
 use anyhow::{Context, Result};
 use moraine_conversations::{
-    ConversationRepository, McpEventType as RepoMcpEventType, McpTurnOpen, RepoError,
-    SearchMcpEventHit, SearchMcpEventsQuery, SearchMcpEventsResult, SessionMetadata,
+    McpEventType as RepoMcpEventType, McpTurnOpen, RepoError, SearchMcpEventHit,
+    SearchMcpEventsQuery, SearchMcpEventsResult, SessionMetadata,
 };
 use serde_json::{json, Value};
 use std::collections::HashMap;


### PR DESCRIPTION
## Description

**What.** Completes the conversation repository seam, adds an exported in-memory fake, and makes mcp-core consume `Arc<dyn ConversationRepository>`.

**Why.** MCP consumers need a backend-neutral repository boundary and a cheap deterministic test double instead of depending on the ClickHouse HTTP wire.

- Adds the mcp-core-required config, prewarm, metadata-search, and cancellation operations to `ConversationRepository` and forwards them through the ClickHouse implementation.
- Exports `InMemoryConversationRepository` with immutable configured responses and cumulative call capture for downstream consumer tests.
- Confines the concrete ClickHouse repository in mcp-core to `AppState::build` and migrates the shared state plus a list-sessions handler test to trait-object dispatch.
- Leaves ClickHouse wire-level integration coverage in `moraine-conversations` and preserves the MCP response contracts.

## Usage

Downstream tests can construct `InMemoryConversationRepository::with_responses(RepoConfig, InMemoryConversationResponses)` and inject it as `Arc<dyn ConversationRepository>`, then inspect `calls()` to verify translated repository arguments.

No end-user usage change.

## Changelog

- Adds a backend-neutral conversation repository seam and exported in-memory fake for Rust consumers.
- No MCP wire-contract or operational behavior change.

## Validation

Ran `cargo test --locked -p moraine-conversations`: 64 passed (26 unit tests and 38 ClickHouse HTTP-wire integration tests). Ran `cargo test --locked -p moraine-mcp-core`: 64 passed, including the fake-backed list-sessions handler test that dispatches through `Arc<dyn ConversationRepository>` and verifies captured filter/page arguments.

Built the local MCP binary with `cargo build --locked -p moraine-mcp`. The unchanged `agent-smoke-e2e` flow passed through the built stdio binary: `search_sessions`, `list_sessions`, and `file_attention` each returned five correctly shaped results, and every sampled event, turn, session, listed-session, and file-attention handle reopened with the matching `data.kind`. An embedded `--project-only` run also returned valid zero-result search/list/file-attention envelopes and a clean typed `not_found` response for a nonexistent session.

The full seven-persona review (elegance, idiomatic Rust, correctness, completeness, security, YAGNI, and scope) completed on the rebased diff with no remaining findings. The accepted YAGNI finding removed mutable response/reset lifecycle APIs from the fake before final validation.

Resolves #452