### PR TITLE
feat(conversations): add shared analytics read surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,6 +1192,7 @@ dependencies = [
  "moraine-clickhouse",
  "moraine-config",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -20,5 +20,6 @@ moraine-clickhouse = { path = "../moraine-clickhouse" }
 
 [dev-dependencies]
 axum = "0.7"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1.40", features = ["macros", "rt-multi-thread", "net"] }
 moraine-config = { path = "../moraine-config" }

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -20,6 +20,6 @@ moraine-clickhouse = { path = "../moraine-clickhouse" }
 
 [dev-dependencies]
 axum = "0.7"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
-tokio = { version = "1.40", features = ["macros", "rt-multi-thread", "net"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+tokio = { version = "1.40", features = ["macros", "rt-multi-thread", "net", "time", "test-util"] }
 moraine-config = { path = "../moraine-config" }

--- a/crates/moraine-conversations/src/clickhouse_repo/analytics.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/analytics.rs
@@ -1,43 +1,6 @@
 use super::*;
 
 #[derive(Debug, Deserialize)]
-struct SessionAnalyticsSummaryRow {
-    session_id: String,
-    first_event_time: String,
-    first_event_unix_ms: i64,
-    last_event_time: String,
-    last_event_unix_ms: i64,
-    total_turns: u32,
-    total_events: u64,
-    user_messages: u64,
-    assistant_messages: u64,
-    tool_calls: u64,
-    tool_results: u64,
-    mode: String,
-    #[serde(default)]
-    session_slug: String,
-    #[serde(default)]
-    session_summary: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct SessionAnalyticsTurnRow {
-    session_id: String,
-    turn_seq: u32,
-    turn_id: String,
-    started_at: String,
-    started_at_unix_ms: i64,
-    ended_at: String,
-    ended_at_unix_ms: i64,
-    total_events: u64,
-    user_messages: u64,
-    assistant_messages: u64,
-    tool_calls: u64,
-    tool_results: u64,
-    reasoning_items: u64,
-}
-
-#[derive(Debug, Deserialize)]
 struct SessionAnalyticsEventRow {
     session_id: String,
     event_order: u64,
@@ -171,8 +134,8 @@ ORDER BY s.last_event_time DESC, s.session_id DESC
 LIMIT {limit}
 FORMAT JSONEachRow"
         );
-        let summary_rows: Vec<SessionAnalyticsSummaryRow> =
-            self.map_backend(self.ch.query_rows(&summary_query, None).await)?;
+        let summary_rows: Vec<ConversationSummaryRow> =
+            self.map_backend(self.query_rows(&summary_query, None).await)?;
         if summary_rows.is_empty() {
             return Ok(Vec::new());
         }
@@ -203,8 +166,8 @@ WHERE session_id IN {session_ids_sql}
 ORDER BY session_id ASC, turn_seq ASC
 FORMAT JSONEachRow"
         );
-        let turn_rows: Vec<SessionAnalyticsTurnRow> =
-            self.map_backend(self.ch.query_rows(&turns_query, None).await)?;
+        let turn_rows: Vec<TurnSummaryRow> =
+            self.map_backend(self.query_rows(&turns_query, None).await)?;
 
         let events_query = format!(
             "SELECT
@@ -227,9 +190,9 @@ FORMAT JSONEachRow"
   toUInt32(ifNull(e.cache_write_tokens, 0)) AS cache_write_tokens,
   t.token_usage_buckets AS token_usage_buckets,
   t.token_usage_native_units AS token_usage_native_units,
-  substring(ifNull(e.text_preview, ''), 1, 2000) AS text_preview,
-  substring(ifNull(t.text_content, ''), 1, 2000) AS text_content,
-  if(t.event_class = 'tool_call', substring(JSONExtractRaw(t.payload_json, 'input'), 1, 2000), '') AS tool_args_json,
+  substringUTF8(ifNull(e.text_preview, ''), 1, 2000) AS text_preview,
+  substringUTF8(ifNull(t.text_content, ''), 1, 2000) AS text_content,
+  if(t.event_class = 'tool_call', substringUTF8(JSONExtractRaw(t.payload_json, 'input'), 1, 2000), '') AS tool_args_json,
   ifNull(e.harness, '') AS harness,
   ifNull(e.source_name, '') AS source_name,
   ifNull(e.trace_id, '') AS trace_id
@@ -240,7 +203,7 @@ ORDER BY t.session_id ASC, t.event_order ASC
 FORMAT JSONEachRow"
         );
         let event_rows: Vec<SessionAnalyticsEventRow> =
-            self.map_backend(self.ch.query_rows(&events_query, None).await)?;
+            self.map_backend(self.query_rows(&events_query, None).await)?;
 
         Ok(assemble_sessions(summary_rows, turn_rows, event_rows))
     }
@@ -285,7 +248,7 @@ WHERE intDiv(toUnixTimestamp64Milli(e.event_ts), 1000) >= greatest(database_now_
 FORMAT JSONEachRow"
         );
         let anchors: Vec<AnalyticsAnchorRow> =
-            self.map_backend(self.ch.query_rows(&anchor_query, None).await)?;
+            self.map_backend(self.query_rows(&anchor_query, None).await)?;
         let anchor = anchors
             .into_iter()
             .next()
@@ -349,7 +312,7 @@ ORDER BY bucket_unix ASC, model ASC, endpoint_kind ASC, bucket ASC
 FORMAT JSONEachRow"
         );
         let token_rows: Vec<AnalyticsTokenRow> =
-            self.map_backend(self.ch.query_rows(&token_query, None).await)?;
+            self.map_backend(self.query_rows(&token_query, None).await)?;
 
         let turns_query = format!(
             "SELECT
@@ -365,7 +328,7 @@ ORDER BY bucket_unix ASC, model ASC
 FORMAT JSONEachRow"
         );
         let turn_rows: Vec<AnalyticsTurnRow> =
-            self.map_backend(self.ch.query_rows(&turns_query, None).await)?;
+            self.map_backend(self.query_rows(&turns_query, None).await)?;
 
         let concurrency_query = format!(
             "SELECT
@@ -389,7 +352,7 @@ ORDER BY bucket_unix ASC
 FORMAT JSONEachRow"
         );
         let concurrency_rows: Vec<AnalyticsConcurrencyRow> =
-            self.map_backend(self.ch.query_rows(&concurrency_query, None).await)?;
+            self.map_backend(self.query_rows(&concurrency_query, None).await)?;
 
         Ok(AnalyticsSnapshot {
             window: AnalyticsWindow {
@@ -470,11 +433,11 @@ FROM {canonical_events} AS e
 WHERE e.payload_type = 'web_search_call'
    OR (e.payload_type = 'tool_use' AND e.tool_name IN ('WebSearch', 'WebFetch'))
    OR e.payload_type = 'search_results_received'
-ORDER BY e.event_ts DESC
+ORDER BY e.event_ts DESC, e.event_uid DESC
 LIMIT {limit}
 FORMAT JSONEachRow"
         );
-        let rows: Vec<WebSearchRow> = self.map_backend(self.ch.query_rows(&query, None).await)?;
+        let rows: Vec<WebSearchRow> = self.map_backend(self.query_rows(&query, None).await)?;
         Ok(rows
             .into_iter()
             .map(|row| WebSearchEvent {
@@ -493,11 +456,11 @@ FORMAT JSONEachRow"
 }
 
 fn assemble_sessions(
-    summary_rows: Vec<SessionAnalyticsSummaryRow>,
-    turn_rows: Vec<SessionAnalyticsTurnRow>,
+    summary_rows: Vec<ConversationSummaryRow>,
+    turn_rows: Vec<TurnSummaryRow>,
     event_rows: Vec<SessionAnalyticsEventRow>,
 ) -> Vec<SessionAnalytics> {
-    let mut turns_by_session = HashMap::<String, Vec<SessionAnalyticsTurnRow>>::new();
+    let mut turns_by_session = HashMap::<String, Vec<TurnSummaryRow>>::new();
     for turn in turn_rows {
         turns_by_session
             .entry(turn.session_id.clone())
@@ -516,9 +479,8 @@ fn assemble_sessions(
     summary_rows
         .into_iter()
         .map(|row| {
-            let mut events = events_by_session
-                .remove(&row.session_id)
-                .unwrap_or_default();
+            let session_id = row.session_id.clone();
+            let mut events = events_by_session.remove(&session_id).unwrap_or_default();
             events.sort_by_key(|event| event.event_order);
             let harness = first_nonempty(&events, |event| &event.harness);
             let source_name = first_nonempty(&events, |event| &event.source_name);
@@ -536,7 +498,7 @@ fn assemble_sessions(
             models.sort_unstable();
             models.dedup();
 
-            let mut session_turns = turns_by_session.remove(&row.session_id).unwrap_or_default();
+            let mut session_turns = turns_by_session.remove(&session_id).unwrap_or_default();
             session_turns.sort_by_key(|turn| turn.turn_seq);
             let mut events_by_turn = HashMap::<u32, Vec<SessionAnalyticsEventRow>>::new();
             for event in events {
@@ -554,22 +516,7 @@ fn assemble_sessions(
                 .collect();
 
             SessionAnalytics {
-                summary: ConversationSummary {
-                    session_id: row.session_id,
-                    first_event_time: row.first_event_time,
-                    first_event_unix_ms: row.first_event_unix_ms,
-                    last_event_time: row.last_event_time,
-                    last_event_unix_ms: row.last_event_unix_ms,
-                    total_turns: row.total_turns,
-                    total_events: row.total_events,
-                    user_messages: row.user_messages,
-                    assistant_messages: row.assistant_messages,
-                    tool_calls: row.tool_calls,
-                    tool_results: row.tool_results,
-                    mode: ClickHouseConversationRepository::parse_mode(&row.mode),
-                    session_slug: non_empty_string(row.session_slug),
-                    session_summary: non_empty_string(row.session_summary),
-                },
+                summary: ClickHouseConversationRepository::map_conversation_row(row),
                 harness,
                 source_name,
                 models,
@@ -581,10 +528,8 @@ fn assemble_sessions(
         .collect()
 }
 
-fn assemble_turn(
-    row: SessionAnalyticsTurnRow,
-    mut events: Vec<SessionAnalyticsEventRow>,
-) -> SessionTurn {
+fn assemble_turn(row: TurnSummaryRow, mut events: Vec<SessionAnalyticsEventRow>) -> SessionTurn {
+    let summary = ClickHouseConversationRepository::map_turn_row(row);
     events.sort_by_key(|event| event.event_order);
     let model = events
         .iter()
@@ -648,6 +593,8 @@ fn assemble_turn(
                 } else {
                     event.tool_name.clone()
                 },
+                latency_ms: (event.latency_ms > 0).then_some(event.latency_ms),
+                is_error: event.tool_error != 0,
                 call_id: event.call_id,
                 arguments: parse_tool_arguments(&event.tool_args_json),
                 result: None,
@@ -680,21 +627,7 @@ fn assemble_turn(
     }
 
     SessionTurn {
-        summary: TurnSummary {
-            session_id: row.session_id,
-            turn_seq: row.turn_seq,
-            turn_id: row.turn_id,
-            started_at: row.started_at,
-            started_at_unix_ms: row.started_at_unix_ms,
-            ended_at: row.ended_at,
-            ended_at_unix_ms: row.ended_at_unix_ms,
-            total_events: row.total_events,
-            user_messages: row.user_messages,
-            assistant_messages: row.assistant_messages,
-            tool_calls: row.tool_calls,
-            tool_results: row.tool_results,
-            reasoning_items: row.reasoning_items,
-        },
+        summary,
         model,
         token_usage_buckets: turn_buckets,
         steps,
@@ -813,8 +746,8 @@ mod tests {
         }
     }
 
-    fn turn_row() -> SessionAnalyticsTurnRow {
-        SessionAnalyticsTurnRow {
+    fn turn_row() -> TurnSummaryRow {
+        TurnSummaryRow {
             session_id: "session".to_string(),
             turn_seq: 1,
             turn_id: "turn".to_string(),
@@ -842,6 +775,24 @@ mod tests {
         row.token_usage_buckets.insert("reasoning".to_string(), 7);
         assert_eq!(event_token_buckets(&row).get("reasoning"), Some(&7));
         assert!(!event_token_buckets(&row).contains_key("input_text"));
+    }
+
+    #[test]
+    fn unmatched_tool_call_preserves_call_latency_and_error() {
+        let mut call = event(1, "tool_call", "call");
+        call.latency_ms = 17;
+        call.tool_error = 1;
+
+        let turn = assemble_turn(turn_row(), vec![call]);
+        assert!(matches!(
+            &turn.steps[0],
+            SessionStep::ToolCall {
+                latency_ms: Some(17),
+                is_error: true,
+                result: None,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/moraine-conversations/src/clickhouse_repo/analytics.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/analytics.rs
@@ -1,0 +1,889 @@
+use super::*;
+
+#[derive(Debug, Deserialize)]
+struct SessionAnalyticsSummaryRow {
+    session_id: String,
+    first_event_time: String,
+    first_event_unix_ms: i64,
+    last_event_time: String,
+    last_event_unix_ms: i64,
+    total_turns: u32,
+    total_events: u64,
+    user_messages: u64,
+    assistant_messages: u64,
+    tool_calls: u64,
+    tool_results: u64,
+    mode: String,
+    #[serde(default)]
+    session_slug: String,
+    #[serde(default)]
+    session_summary: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionAnalyticsTurnRow {
+    session_id: String,
+    turn_seq: u32,
+    turn_id: String,
+    started_at: String,
+    started_at_unix_ms: i64,
+    ended_at: String,
+    ended_at_unix_ms: i64,
+    total_events: u64,
+    user_messages: u64,
+    assistant_messages: u64,
+    tool_calls: u64,
+    tool_results: u64,
+    reasoning_items: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionAnalyticsEventRow {
+    session_id: String,
+    event_order: u64,
+    turn_seq: u32,
+    event_unix_ms: i64,
+    event_class: String,
+    actor_role: String,
+    payload_type: String,
+    call_id: String,
+    tool_name: String,
+    tool_error: u8,
+    latency_ms: u32,
+    model: String,
+    endpoint_kind: String,
+    input_tokens: u32,
+    output_tokens: u32,
+    cache_read_tokens: u32,
+    cache_write_tokens: u32,
+    #[serde(default)]
+    token_usage_buckets: BTreeMap<String, u64>,
+    #[serde(default)]
+    token_usage_native_units: BTreeMap<String, f64>,
+    text_preview: String,
+    text_content: String,
+    tool_args_json: String,
+    harness: String,
+    source_name: String,
+    trace_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnalyticsAnchorRow {
+    scan_from_unix: u64,
+    scan_to_unix: u64,
+    display_to_unix: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnalyticsTokenRow {
+    bucket_unix: u64,
+    model: String,
+    endpoint_kind: String,
+    bucket: String,
+    tokens: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnalyticsTurnRow {
+    bucket_unix: u64,
+    model: String,
+    turns: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnalyticsConcurrencyRow {
+    bucket_unix: u64,
+    concurrent_sessions: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct WebSearchRow {
+    event_time: String,
+    harness: String,
+    source_name: String,
+    session_id: String,
+    model: String,
+    action: String,
+    search_query: String,
+    result_url: String,
+    source_ref: String,
+}
+
+impl ClickHouseConversationRepository {
+    pub(super) async fn list_session_analytics_impl(
+        &self,
+        query: SessionAnalyticsQuery,
+    ) -> RepoResult<Vec<SessionAnalytics>> {
+        let session_summary = self.table_ref("v_session_summary");
+        let turn_summary = self.table_ref("v_turn_summary");
+        let trace = self.table_ref("v_conversation_trace");
+        let canonical_events = canonical_events_source(&self.table_ref("events"));
+        let mode_subquery = self.mode_subquery();
+        let lookback_clause = query
+            .lookback
+            .window_seconds()
+            .map(|seconds| {
+                format!("\n  AND s.last_event_time >= now() - INTERVAL {seconds} SECOND")
+            })
+            .unwrap_or_default();
+        let limit = query.normalized_limit();
+
+        let summary_query = format!(
+            "SELECT
+  s.session_id AS session_id,
+  toString(s.first_event_time) AS first_event_time,
+  toInt64(toUnixTimestamp64Milli(s.first_event_time)) AS first_event_unix_ms,
+  toString(s.last_event_time) AS last_event_time,
+  toInt64(toUnixTimestamp64Milli(s.last_event_time)) AS last_event_unix_ms,
+  toUInt32(s.total_turns) AS total_turns,
+  toUInt64(s.total_events) AS total_events,
+  toUInt64(s.user_messages) AS user_messages,
+  toUInt64(s.assistant_messages) AS assistant_messages,
+  toUInt64(s.tool_calls) AS tool_calls,
+  toUInt64(s.tool_results) AS tool_results,
+  ifNull(m.mode, 'chat') AS mode,
+  ifNull(meta.session_slug, '') AS session_slug,
+  ifNull(meta.session_summary, '') AS session_summary
+FROM {session_summary} AS s
+LEFT JOIN ({mode_subquery}) AS m ON m.session_id = s.session_id
+LEFT JOIN (
+  SELECT
+    session_id,
+    ifNull(argMax(nullIf(JSONExtractString(payload_json, 'slug'), ''), tuple(event_ts, event_uid)), '') AS session_slug,
+    ifNull(
+      argMax(
+        coalesce(
+          nullIf(JSONExtractString(payload_json, 'summary'), ''),
+          nullIf(JSONExtractString(payload_json, 'title'), ''),
+          nullIf(JSONExtractString(payload_json, 'name'), '')
+        ),
+        tuple(event_ts, event_uid)
+      ),
+      ''
+    ) AS session_summary
+  FROM {canonical_events} AS meta_events
+  WHERE meta_events.event_kind = 'session_meta'
+  GROUP BY session_id
+) AS meta ON meta.session_id = s.session_id
+WHERE notEmpty(trimBoth(s.session_id)){lookback_clause}
+ORDER BY s.last_event_time DESC, s.session_id DESC
+LIMIT {limit}
+FORMAT JSONEachRow"
+        );
+        let summary_rows: Vec<SessionAnalyticsSummaryRow> =
+            self.map_backend(self.ch.query_rows(&summary_query, None).await)?;
+        if summary_rows.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let session_ids = summary_rows
+            .iter()
+            .map(|row| row.session_id.clone())
+            .collect::<Vec<_>>();
+        let session_ids_sql = sql_array_strings(&session_ids);
+
+        let turns_query = format!(
+            "SELECT
+  session_id,
+  toUInt32(turn_seq) AS turn_seq,
+  ifNull(turn_id, '') AS turn_id,
+  toString(started_at) AS started_at,
+  toInt64(toUnixTimestamp64Milli(parseDateTime64BestEffort(toString(started_at), 3))) AS started_at_unix_ms,
+  toString(ended_at) AS ended_at,
+  toInt64(toUnixTimestamp64Milli(parseDateTime64BestEffort(toString(ended_at), 3))) AS ended_at_unix_ms,
+  toUInt64(total_events) AS total_events,
+  toUInt64(user_messages) AS user_messages,
+  toUInt64(assistant_messages) AS assistant_messages,
+  toUInt64(tool_calls) AS tool_calls,
+  toUInt64(tool_results) AS tool_results,
+  toUInt64(reasoning_items) AS reasoning_items
+FROM {turn_summary}
+WHERE session_id IN {session_ids_sql}
+ORDER BY session_id ASC, turn_seq ASC
+FORMAT JSONEachRow"
+        );
+        let turn_rows: Vec<SessionAnalyticsTurnRow> =
+            self.map_backend(self.ch.query_rows(&turns_query, None).await)?;
+
+        let events_query = format!(
+            "SELECT
+  t.session_id AS session_id,
+  toUInt64(t.event_order) AS event_order,
+  toUInt32(t.turn_seq) AS turn_seq,
+  toInt64(toUnixTimestamp64Milli(t.event_time)) AS event_unix_ms,
+  t.event_class AS event_class,
+  t.actor_role AS actor_role,
+  t.payload_type AS payload_type,
+  ifNull(t.call_id, '') AS call_id,
+  ifNull(t.name, '') AS tool_name,
+  toUInt8(ifNull(e.tool_error, 0)) AS tool_error,
+  toUInt32(ifNull(e.latency_ms, 0)) AS latency_ms,
+  ifNull(e.model, '') AS model,
+  ifNull(t.endpoint_kind, '') AS endpoint_kind,
+  toUInt32(ifNull(e.input_tokens, 0)) AS input_tokens,
+  toUInt32(ifNull(e.output_tokens, 0)) AS output_tokens,
+  toUInt32(ifNull(e.cache_read_tokens, 0)) AS cache_read_tokens,
+  toUInt32(ifNull(e.cache_write_tokens, 0)) AS cache_write_tokens,
+  t.token_usage_buckets AS token_usage_buckets,
+  t.token_usage_native_units AS token_usage_native_units,
+  substring(ifNull(e.text_preview, ''), 1, 2000) AS text_preview,
+  substring(ifNull(t.text_content, ''), 1, 2000) AS text_content,
+  if(t.event_class = 'tool_call', substring(JSONExtractRaw(t.payload_json, 'input'), 1, 2000), '') AS tool_args_json,
+  ifNull(e.harness, '') AS harness,
+  ifNull(e.source_name, '') AS source_name,
+  ifNull(e.trace_id, '') AS trace_id
+FROM {trace} AS t
+LEFT JOIN {canonical_events} AS e ON e.event_uid = t.event_uid
+WHERE t.session_id IN {session_ids_sql}
+ORDER BY t.session_id ASC, t.event_order ASC
+FORMAT JSONEachRow"
+        );
+        let event_rows: Vec<SessionAnalyticsEventRow> =
+            self.map_backend(self.ch.query_rows(&events_query, None).await)?;
+
+        Ok(assemble_sessions(summary_rows, turn_rows, event_rows))
+    }
+
+    pub(super) async fn analytics_series_impl(
+        &self,
+        range: AnalyticsRange,
+    ) -> RepoResult<AnalyticsSnapshot> {
+        let slot = &self.analytics_cache[analytics_range_index(range)];
+        let mut entry = slot.lock().await;
+        let now = Instant::now();
+        if let Some(cached) = entry.as_ref().filter(|cached| cached.is_fresh(now)) {
+            return Ok(cached.snapshot.clone());
+        }
+
+        let snapshot = self.load_analytics_snapshot(range).await?;
+        *entry = Some(AnalyticsCacheEntry {
+            snapshot: snapshot.clone(),
+            fetched_at: Instant::now(),
+        });
+        Ok(snapshot)
+    }
+
+    async fn load_analytics_snapshot(
+        &self,
+        range: AnalyticsRange,
+    ) -> RepoResult<AnalyticsSnapshot> {
+        let canonical_events = canonical_events_source(&self.table_ref("events"));
+        let window_seconds = range.window_seconds();
+        let bucket_seconds = range.bucket_seconds();
+        let anchor_query = format!(
+            "WITH
+  toInt64(toUnixTimestamp(now())) AS database_now_unix,
+  greatest(database_now_unix - toInt64({window_seconds}), toInt64(0)) AS scan_from_unix
+SELECT
+  toUInt64(scan_from_unix) AS scan_from_unix,
+  toUInt64(database_now_unix) AS scan_to_unix,
+  toUInt64(if(count() = 0, database_now_unix, max(intDiv(toUnixTimestamp64Milli(e.event_ts), 1000)))) AS display_to_unix
+FROM {canonical_events} AS e
+WHERE intDiv(toUnixTimestamp64Milli(e.event_ts), 1000) >= scan_from_unix
+  AND intDiv(toUnixTimestamp64Milli(e.event_ts), 1000) <= database_now_unix
+  AND notEmpty(trimBoth(e.model))
+  AND lowerUTF8(trimBoth(e.model)) != '<synthetic>'
+FORMAT JSONEachRow"
+        );
+        let anchors: Vec<AnalyticsAnchorRow> =
+            self.map_backend(self.ch.query_rows(&anchor_query, None).await)?;
+        let anchor = anchors
+            .into_iter()
+            .next()
+            .ok_or_else(|| RepoError::backend("analytics anchor query returned no row"))?;
+        let event_bounds = format!(
+            "intDiv(toUnixTimestamp64Milli(e.event_ts), 1000) >= {} AND intDiv(toUnixTimestamp64Milli(e.event_ts), 1000) <= {}",
+            anchor.scan_from_unix, anchor.scan_to_unix
+        );
+        let model_expr = "if(lowerUTF8(trimBoth(e.model)) = 'codex', 'gpt-5.3-codex-xhigh', lowerUTF8(trimBoth(e.model)))";
+        let eligible_model =
+            "notEmpty(trimBoth(e.model)) AND lowerUTF8(trimBoth(e.model)) != '<synthetic>'";
+
+        let token_query = format!(
+            "SELECT
+  bucket_unix,
+  model,
+  endpoint_kind,
+  bucket,
+  toUInt64(sum(tokens)) AS tokens
+FROM (
+  SELECT
+    bucket_unix,
+    model,
+    endpoint_kind,
+    bucket,
+    toUInt64(max(tokens_per_event)) AS tokens
+  FROM (
+    SELECT
+      toUInt64(toUnixTimestamp(toStartOfInterval(e.event_ts, INTERVAL {bucket_seconds} SECOND))) AS bucket_unix,
+      {model_expr} AS model,
+      e.endpoint_kind AS endpoint_kind,
+      e.session_id AS session_id,
+      e.request_id AS request_id,
+      bucket,
+      toUInt64(tokens_per_event) AS tokens_per_event
+    FROM {canonical_events} AS e
+    ARRAY JOIN mapKeys(e.token_usage_buckets) AS bucket, mapValues(e.token_usage_buckets) AS tokens_per_event
+    WHERE {event_bounds}
+      AND {eligible_model}
+      AND tokens_per_event > 0
+      AND e.harness = 'claude-code'
+      AND notEmpty(trimBoth(e.request_id))
+  )
+  GROUP BY bucket_unix, model, endpoint_kind, session_id, request_id, bucket
+  UNION ALL
+  SELECT
+    toUInt64(toUnixTimestamp(toStartOfInterval(e.event_ts, INTERVAL {bucket_seconds} SECOND))) AS bucket_unix,
+    {model_expr} AS model,
+    e.endpoint_kind AS endpoint_kind,
+    bucket,
+    toUInt64(tokens_per_event) AS tokens
+  FROM {canonical_events} AS e
+  ARRAY JOIN mapKeys(e.token_usage_buckets) AS bucket, mapValues(e.token_usage_buckets) AS tokens_per_event
+  WHERE {event_bounds}
+    AND {eligible_model}
+    AND tokens_per_event > 0
+    AND NOT (e.harness = 'claude-code' AND notEmpty(trimBoth(e.request_id)))
+)
+GROUP BY bucket_unix, model, endpoint_kind, bucket
+ORDER BY bucket_unix ASC, model ASC, endpoint_kind ASC, bucket ASC
+FORMAT JSONEachRow"
+        );
+        let token_rows: Vec<AnalyticsTokenRow> =
+            self.map_backend(self.ch.query_rows(&token_query, None).await)?;
+
+        let turns_query = format!(
+            "SELECT
+  toUInt64(toUnixTimestamp(toStartOfInterval(e.event_ts, INTERVAL {bucket_seconds} SECOND))) AS bucket_unix,
+  {model_expr} AS model,
+  toUInt64(uniqExact(tuple(e.session_id, e.request_id))) AS turns
+FROM {canonical_events} AS e
+WHERE {event_bounds}
+  AND {eligible_model}
+  AND notEmpty(trimBoth(e.request_id))
+GROUP BY bucket_unix, model
+ORDER BY bucket_unix ASC, model ASC
+FORMAT JSONEachRow"
+        );
+        let turn_rows: Vec<AnalyticsTurnRow> =
+            self.map_backend(self.ch.query_rows(&turns_query, None).await)?;
+
+        let concurrency_query = format!(
+            "SELECT
+  bucket_unix,
+  toUInt64(uniqExact(session_stream_key)) AS concurrent_sessions
+FROM (
+  SELECT
+    toUInt64(toUnixTimestamp(toStartOfInterval(e.event_ts, INTERVAL {bucket_seconds} SECOND))) AS bucket_unix,
+    if(
+      e.harness = 'claude-code' AND notEmpty(trimBoth(e.agent_run_id)),
+      concat(e.session_id, '::', e.agent_run_id),
+      e.session_id
+    ) AS session_stream_key
+  FROM {canonical_events} AS e
+  WHERE {event_bounds}
+    AND notEmpty(trimBoth(e.session_id))
+    AND arraySum(mapValues(e.token_usage_buckets)) > 0
+)
+GROUP BY bucket_unix
+ORDER BY bucket_unix ASC
+FORMAT JSONEachRow"
+        );
+        let concurrency_rows: Vec<AnalyticsConcurrencyRow> =
+            self.map_backend(self.ch.query_rows(&concurrency_query, None).await)?;
+
+        Ok(AnalyticsSnapshot {
+            window: AnalyticsWindow {
+                range,
+                window_seconds,
+                bucket_seconds,
+                from_unix: anchor
+                    .display_to_unix
+                    .saturating_sub(u64::from(window_seconds)),
+                to_unix: anchor.display_to_unix,
+            },
+            tokens: token_rows
+                .into_iter()
+                .map(|row| AnalyticsTokenPoint {
+                    bucket_unix: row.bucket_unix,
+                    model: row.model,
+                    endpoint_kind: row.endpoint_kind,
+                    bucket: row.bucket,
+                    tokens: row.tokens,
+                })
+                .collect(),
+            turns: turn_rows
+                .into_iter()
+                .map(|row| AnalyticsTurnPoint {
+                    bucket_unix: row.bucket_unix,
+                    model: row.model,
+                    turns: row.turns,
+                })
+                .collect(),
+            concurrent_sessions: concurrency_rows
+                .into_iter()
+                .map(|row| AnalyticsConcurrencyPoint {
+                    bucket_unix: row.bucket_unix,
+                    concurrent_sessions: row.concurrent_sessions,
+                })
+                .collect(),
+        })
+    }
+
+    pub(super) async fn list_web_searches_impl(
+        &self,
+        limit: u16,
+    ) -> RepoResult<Vec<WebSearchEvent>> {
+        let canonical_events = canonical_events_source(&self.table_ref("events"));
+        let limit = limit.clamp(1, 1000);
+        let query = format!(
+            "SELECT
+  toString(e.event_ts) AS event_time,
+  e.harness AS harness,
+  e.source_name AS source_name,
+  e.session_id AS session_id,
+  lowerUTF8(trimBoth(e.model)) AS model,
+  if(
+    e.payload_type = 'web_search_call',
+    e.op_kind,
+    if(e.tool_name = 'WebFetch', 'open_page', if(e.tool_name = 'WebSearch', 'search', e.payload_type))
+  ) AS action,
+  if(
+    length(JSONExtractString(e.payload_json, 'action', 'query')) > 0,
+    JSONExtractString(e.payload_json, 'action', 'query'),
+    if(
+      length(JSONExtractString(e.payload_json, 'input', 'query')) > 0,
+      JSONExtractString(e.payload_json, 'input', 'query'),
+      if(
+        length(JSONExtractString(e.payload_json, 'data', 'query')) > 0,
+        JSONExtractString(e.payload_json, 'data', 'query'),
+        e.text_content
+      )
+    )
+  ) AS search_query,
+  if(
+    length(JSONExtractString(e.payload_json, 'action', 'url')) > 0,
+    JSONExtractString(e.payload_json, 'action', 'url'),
+    JSONExtractString(e.payload_json, 'input', 'url')
+  ) AS result_url,
+  e.source_ref AS source_ref
+FROM {canonical_events} AS e
+WHERE e.payload_type = 'web_search_call'
+   OR (e.payload_type = 'tool_use' AND e.tool_name IN ('WebSearch', 'WebFetch'))
+   OR e.payload_type = 'search_results_received'
+ORDER BY e.event_ts DESC
+LIMIT {limit}
+FORMAT JSONEachRow"
+        );
+        let rows: Vec<WebSearchRow> = self.map_backend(self.ch.query_rows(&query, None).await)?;
+        Ok(rows
+            .into_iter()
+            .map(|row| WebSearchEvent {
+                event_time: row.event_time,
+                harness: row.harness,
+                source_name: row.source_name,
+                session_id: row.session_id,
+                model: row.model,
+                action: row.action,
+                search_query: row.search_query,
+                result_url: row.result_url,
+                source_ref: row.source_ref,
+            })
+            .collect())
+    }
+}
+
+fn assemble_sessions(
+    summary_rows: Vec<SessionAnalyticsSummaryRow>,
+    turn_rows: Vec<SessionAnalyticsTurnRow>,
+    event_rows: Vec<SessionAnalyticsEventRow>,
+) -> Vec<SessionAnalytics> {
+    let mut turns_by_session = HashMap::<String, Vec<SessionAnalyticsTurnRow>>::new();
+    for turn in turn_rows {
+        turns_by_session
+            .entry(turn.session_id.clone())
+            .or_default()
+            .push(turn);
+    }
+
+    let mut events_by_session = HashMap::<String, Vec<SessionAnalyticsEventRow>>::new();
+    for event in event_rows {
+        events_by_session
+            .entry(event.session_id.clone())
+            .or_default()
+            .push(event);
+    }
+
+    summary_rows
+        .into_iter()
+        .map(|row| {
+            let mut events = events_by_session
+                .remove(&row.session_id)
+                .unwrap_or_default();
+            events.sort_by_key(|event| event.event_order);
+            let harness = first_nonempty(&events, |event| &event.harness);
+            let source_name = first_nonempty(&events, |event| &event.source_name);
+            let trace_id = first_nonempty(&events, |event| &event.trace_id);
+            let first_user_text = events
+                .iter()
+                .find(|event| event.event_class == "message" && event.actor_role == "user")
+                .map(preferred_event_text)
+                .map(|text| truncate_chars(&text, 400))
+                .unwrap_or_default();
+            let mut models = events
+                .iter()
+                .filter_map(|event| normalized_session_model(&event.model))
+                .collect::<Vec<_>>();
+            models.sort_unstable();
+            models.dedup();
+
+            let mut session_turns = turns_by_session.remove(&row.session_id).unwrap_or_default();
+            session_turns.sort_by_key(|turn| turn.turn_seq);
+            let mut events_by_turn = HashMap::<u32, Vec<SessionAnalyticsEventRow>>::new();
+            for event in events {
+                events_by_turn
+                    .entry(event.turn_seq)
+                    .or_default()
+                    .push(event);
+            }
+            let turns = session_turns
+                .into_iter()
+                .map(|turn| {
+                    let events = events_by_turn.remove(&turn.turn_seq).unwrap_or_default();
+                    assemble_turn(turn, events)
+                })
+                .collect();
+
+            SessionAnalytics {
+                summary: ConversationSummary {
+                    session_id: row.session_id,
+                    first_event_time: row.first_event_time,
+                    first_event_unix_ms: row.first_event_unix_ms,
+                    last_event_time: row.last_event_time,
+                    last_event_unix_ms: row.last_event_unix_ms,
+                    total_turns: row.total_turns,
+                    total_events: row.total_events,
+                    user_messages: row.user_messages,
+                    assistant_messages: row.assistant_messages,
+                    tool_calls: row.tool_calls,
+                    tool_results: row.tool_results,
+                    mode: ClickHouseConversationRepository::parse_mode(&row.mode),
+                    session_slug: non_empty_string(row.session_slug),
+                    session_summary: non_empty_string(row.session_summary),
+                },
+                harness,
+                source_name,
+                models,
+                trace_id,
+                first_user_text,
+                turns,
+            }
+        })
+        .collect()
+}
+
+fn assemble_turn(
+    row: SessionAnalyticsTurnRow,
+    mut events: Vec<SessionAnalyticsEventRow>,
+) -> SessionTurn {
+    events.sort_by_key(|event| event.event_order);
+    let model = events
+        .iter()
+        .find_map(|event| trimmed_session_model(&event.model))
+        .unwrap_or_default();
+    let mut turn_buckets = BTreeMap::new();
+    for event in &events {
+        merge_token_buckets(&mut turn_buckets, &event_token_buckets(event));
+    }
+
+    let mut steps = Vec::<SessionStep>::new();
+    let mut open_tool_calls = HashMap::<String, Vec<usize>>::new();
+    for event in events {
+        let is_user = event.event_class == "message" && event.actor_role == "user";
+        let is_assistant = event.actor_role == "assistant"
+            && (event.event_class == "message" || event.payload_type == "text");
+        let is_thinking = event.event_class == "reasoning" || event.payload_type == "thinking";
+        let is_tool_call = event.event_class == "tool_call" || event.payload_type == "tool_use";
+        let is_tool_result = event.event_class == "tool_result"
+            || (event.actor_role == "tool" && event.payload_type == "tool_result");
+
+        if is_user {
+            steps.push(SessionStep::User {
+                event_unix_ms: event.event_unix_ms,
+                text: preferred_event_text(&event),
+            });
+        } else if is_assistant {
+            steps.push(SessionStep::Assistant {
+                event_unix_ms: event.event_unix_ms,
+                text: preferred_event_text(&event),
+                endpoint_kind: event.endpoint_kind.clone(),
+                latency_ms: (event.latency_ms > 0).then_some(event.latency_ms),
+                token_usage_buckets: event_token_buckets(&event),
+                token_usage_native_units: event
+                    .token_usage_native_units
+                    .iter()
+                    .filter(|(_, value)| **value > 0.0)
+                    .map(|(key, value)| (key.clone(), *value))
+                    .collect(),
+            });
+        } else if is_thinking {
+            let text = preferred_event_text(&event);
+            if !text.is_empty() {
+                steps.push(SessionStep::Thinking {
+                    event_unix_ms: event.event_unix_ms,
+                    text,
+                });
+            }
+        } else if is_tool_call {
+            let step_index = steps.len();
+            if !event.call_id.is_empty() {
+                open_tool_calls
+                    .entry(event.call_id.clone())
+                    .or_default()
+                    .push(step_index);
+            }
+            steps.push(SessionStep::ToolCall {
+                event_unix_ms: event.event_unix_ms,
+                tool_name: if event.tool_name.is_empty() {
+                    "tool".to_string()
+                } else {
+                    event.tool_name.clone()
+                },
+                call_id: event.call_id,
+                arguments: parse_tool_arguments(&event.tool_args_json),
+                result: None,
+            });
+        } else if is_tool_result && !event.call_id.is_empty() {
+            let mut remove_key = false;
+            if let Some(indices) = open_tool_calls.get_mut(&event.call_id) {
+                if let Some(step_index) = indices.pop() {
+                    if let Some(SessionStep::ToolCall {
+                        event_unix_ms,
+                        result,
+                        ..
+                    }) = steps.get_mut(step_index)
+                    {
+                        let elapsed = event.event_unix_ms.saturating_sub(*event_unix_ms);
+                        *result = Some(ToolResult {
+                            event_unix_ms: event.event_unix_ms,
+                            text: preferred_event_text(&event),
+                            latency_ms: u32::try_from(elapsed).unwrap_or(u32::MAX),
+                            is_error: event.tool_error != 0,
+                        });
+                    }
+                }
+                remove_key = indices.is_empty();
+            }
+            if remove_key {
+                open_tool_calls.remove(&event.call_id);
+            }
+        }
+    }
+
+    SessionTurn {
+        summary: TurnSummary {
+            session_id: row.session_id,
+            turn_seq: row.turn_seq,
+            turn_id: row.turn_id,
+            started_at: row.started_at,
+            started_at_unix_ms: row.started_at_unix_ms,
+            ended_at: row.ended_at,
+            ended_at_unix_ms: row.ended_at_unix_ms,
+            total_events: row.total_events,
+            user_messages: row.user_messages,
+            assistant_messages: row.assistant_messages,
+            tool_calls: row.tool_calls,
+            tool_results: row.tool_results,
+            reasoning_items: row.reasoning_items,
+        },
+        model,
+        token_usage_buckets: turn_buckets,
+        steps,
+    }
+}
+
+fn event_token_buckets(event: &SessionAnalyticsEventRow) -> BTreeMap<String, u64> {
+    if event
+        .token_usage_buckets
+        .values()
+        .copied()
+        .fold(0u64, u64::saturating_add)
+        > 0
+    {
+        return event
+            .token_usage_buckets
+            .iter()
+            .filter(|(_, value)| **value > 0)
+            .map(|(key, value)| (key.clone(), *value))
+            .collect();
+    }
+
+    [
+        ("input_text", u64::from(event.input_tokens)),
+        ("output_text", u64::from(event.output_tokens)),
+        ("input_cache_read", u64::from(event.cache_read_tokens)),
+        ("input_cache_write", u64::from(event.cache_write_tokens)),
+    ]
+    .into_iter()
+    .filter(|(_, value)| *value > 0)
+    .map(|(key, value)| (key.to_string(), value))
+    .collect()
+}
+
+fn merge_token_buckets(target: &mut BTreeMap<String, u64>, source: &BTreeMap<String, u64>) {
+    for (bucket, tokens) in source {
+        let total = target.entry(bucket.clone()).or_default();
+        *total = total.saturating_add(*tokens);
+    }
+}
+
+fn preferred_event_text(event: &SessionAnalyticsEventRow) -> String {
+    let text = if event.text_content.trim().is_empty() {
+        event.text_preview.as_str()
+    } else {
+        event.text_content.as_str()
+    };
+    text.trim().to_string()
+}
+
+fn parse_tool_arguments(raw: &str) -> Value {
+    if raw.trim().is_empty() {
+        Value::Object(Default::default())
+    } else {
+        serde_json::from_str(raw).unwrap_or_else(|_| Value::Object(Default::default()))
+    }
+}
+
+fn normalized_session_model(raw: &str) -> Option<String> {
+    let normalized = raw.trim().to_ascii_lowercase();
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn trimmed_session_model(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn first_nonempty(
+    events: &[SessionAnalyticsEventRow],
+    value: impl Fn(&SessionAnalyticsEventRow) -> &String,
+) -> String {
+    events
+        .iter()
+        .map(value)
+        .find(|candidate| !candidate.trim().is_empty())
+        .map(|candidate| candidate.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(event_order: u64, event_class: &str, call_id: &str) -> SessionAnalyticsEventRow {
+        SessionAnalyticsEventRow {
+            session_id: "session".to_string(),
+            event_order,
+            turn_seq: 1,
+            event_unix_ms: i64::try_from(event_order * 100).unwrap(),
+            event_class: event_class.to_string(),
+            actor_role: String::new(),
+            payload_type: String::new(),
+            call_id: call_id.to_string(),
+            tool_name: "Read".to_string(),
+            tool_error: 0,
+            latency_ms: 0,
+            model: " CODEX ".to_string(),
+            endpoint_kind: "generation".to_string(),
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            token_usage_buckets: BTreeMap::new(),
+            token_usage_native_units: BTreeMap::new(),
+            text_preview: String::new(),
+            text_content: String::new(),
+            tool_args_json: String::new(),
+            harness: String::new(),
+            source_name: String::new(),
+            trace_id: String::new(),
+        }
+    }
+
+    fn turn_row() -> SessionAnalyticsTurnRow {
+        SessionAnalyticsTurnRow {
+            session_id: "session".to_string(),
+            turn_seq: 1,
+            turn_id: "turn".to_string(),
+            started_at: String::new(),
+            started_at_unix_ms: 0,
+            ended_at: String::new(),
+            ended_at_unix_ms: 0,
+            total_events: 99,
+            user_messages: 0,
+            assistant_messages: 0,
+            tool_calls: 2,
+            tool_results: 1,
+            reasoning_items: 0,
+        }
+    }
+
+    #[test]
+    fn scalar_tokens_fill_canonical_buckets_only_when_map_is_empty() {
+        let mut row = event(1, "message", "");
+        row.input_tokens = 5;
+        row.output_tokens = 3;
+        assert_eq!(event_token_buckets(&row).get("input_text"), Some(&5));
+        assert_eq!(event_token_buckets(&row).get("output_text"), Some(&3));
+
+        row.token_usage_buckets.insert("reasoning".to_string(), 7);
+        assert_eq!(event_token_buckets(&row).get("reasoning"), Some(&7));
+        assert!(!event_token_buckets(&row).contains_key("input_text"));
+    }
+
+    #[test]
+    fn tool_result_pairs_with_latest_unmatched_call_in_same_turn() {
+        let first = event(1, "tool_call", "call");
+        let second = event(2, "tool_call", "call");
+        let mut result = event(3, "tool_result", "call");
+        result.text_content = "done".to_string();
+
+        let turn = assemble_turn(turn_row(), vec![result, first, second]);
+        assert_eq!(turn.summary.total_events, 99);
+        let results = turn
+            .steps
+            .iter()
+            .filter_map(|step| match step {
+                SessionStep::ToolCall { result, .. } => Some(result.as_ref()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(results[0].is_none());
+        assert_eq!(results[1].expect("latest call result").text, "done");
+    }
+
+    #[test]
+    fn analytics_cache_uses_six_distinct_range_slots_and_expires_after_ttl() {
+        let indices = AnalyticsRange::ALL.map(analytics_range_index);
+        assert_eq!(indices, [0, 1, 2, 3, 4, 5]);
+
+        let now = Instant::now();
+        let fresh = AnalyticsCacheEntry {
+            snapshot: AnalyticsSnapshot::default(),
+            fetched_at: now,
+        };
+        let stale = AnalyticsCacheEntry {
+            snapshot: AnalyticsSnapshot::default(),
+            fetched_at: now
+                .checked_sub(ANALYTICS_CACHE_TTL + Duration::from_secs(1))
+                .expect("test instant"),
+        };
+        assert!(fresh.is_fresh(now));
+        assert!(!stale.is_fresh(now));
+    }
+}

--- a/crates/moraine-conversations/src/clickhouse_repo/analytics.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/analytics.rs
@@ -272,15 +272,13 @@ FORMAT JSONEachRow"
         let window_seconds = range.window_seconds();
         let bucket_seconds = range.bucket_seconds();
         let anchor_query = format!(
-            "WITH
-  toInt64(toUnixTimestamp(now())) AS database_now_unix,
-  greatest(database_now_unix - toInt64({window_seconds}), toInt64(0)) AS scan_from_unix
+            "WITH toInt64(toUnixTimestamp(now())) AS database_now_unix
 SELECT
-  toUInt64(scan_from_unix) AS scan_from_unix,
+  toUInt64(greatest(database_now_unix - toInt64({window_seconds}), toInt64(0))) AS scan_from_unix,
   toUInt64(database_now_unix) AS scan_to_unix,
   toUInt64(if(count() = 0, database_now_unix, max(intDiv(toUnixTimestamp64Milli(e.event_ts), 1000)))) AS display_to_unix
 FROM {canonical_events} AS e
-WHERE intDiv(toUnixTimestamp64Milli(e.event_ts), 1000) >= scan_from_unix
+WHERE intDiv(toUnixTimestamp64Milli(e.event_ts), 1000) >= greatest(database_now_unix - toInt64({window_seconds}), toInt64(0))
   AND intDiv(toUnixTimestamp64Milli(e.event_ts), 1000) <= database_now_unix
   AND notEmpty(trimBoth(e.model))
   AND lowerUTF8(trimBoth(e.model)) != '<synthetic>'

--- a/crates/moraine-conversations/src/clickhouse_repo/cache.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/cache.rs
@@ -1,6 +1,8 @@
 use super::*;
 
 pub(super) const BENCHMARK_REPLAY_SOURCE: &str = "benchmark-replay";
+pub(super) const ANALYTICS_CACHE_TTL: Duration = Duration::from_secs(30);
+pub(super) const ANALYTICS_RANGE_COUNT: usize = AnalyticsRange::ALL.len();
 pub(super) const CORPUS_STATS_CACHE_TTL: Duration = Duration::from_secs(30);
 pub(super) const TERM_DF_CACHE_TTL: Duration = Duration::from_secs(300);
 pub(super) const SEARCH_SCHEMA_CACHE_TTL: Duration = Duration::from_secs(60);
@@ -22,6 +24,31 @@ pub(super) const TERM_POSTINGS_FAST_PATH_MAX_DOC_RATIO_DENOMINATOR: u64 = 4;
 // a preview up to a minute old, never a wrong hit.
 pub(super) const SEARCH_DOC_EXTRA_CACHE_TTL: Duration = Duration::from_secs(60);
 pub(super) const SEARCH_DOC_EXTRA_CACHE_MAX_ENTRIES: usize = 65536;
+
+#[derive(Debug, Clone)]
+pub(super) struct AnalyticsCacheEntry {
+    pub(super) snapshot: AnalyticsSnapshot,
+    pub(super) fetched_at: Instant,
+}
+
+impl AnalyticsCacheEntry {
+    pub(super) fn is_fresh(&self, now: Instant) -> bool {
+        now.checked_duration_since(self.fetched_at)
+            .unwrap_or_default()
+            <= ANALYTICS_CACHE_TTL
+    }
+}
+
+pub(super) const fn analytics_range_index(range: AnalyticsRange) -> usize {
+    match range {
+        AnalyticsRange::FifteenMinutes => 0,
+        AnalyticsRange::OneHour => 1,
+        AnalyticsRange::SixHours => 2,
+        AnalyticsRange::TwentyFourHours => 3,
+        AnalyticsRange::SevenDays => 4,
+        AnalyticsRange::ThirtyDays => 5,
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(super) struct CorpusStatsCacheEntry {

--- a/crates/moraine-conversations/src/clickhouse_repo/cache.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/cache.rs
@@ -270,7 +270,7 @@ impl ClickHouseConversationRepository {
         );
 
         let from_stats: Vec<CorpusStatsRow> =
-            self.map_backend(self.ch.query_rows(&from_stats_query, None).await)?;
+            self.map_backend(self.query_rows(&from_stats_query, None).await)?;
 
         if let Some(row) = from_stats.first() {
             if row.docs > 0 {
@@ -285,7 +285,7 @@ impl ClickHouseConversationRepository {
             self.table_ref("search_documents")
         );
         let fallback: Vec<CorpusStatsRow> =
-            self.map_backend(self.ch.query_rows(&fallback_query, None).await)?;
+            self.map_backend(self.query_rows(&fallback_query, None).await)?;
         let resolved = if let Some(row) = fallback.first() {
             (row.docs, row.total_doc_len)
         } else {
@@ -353,7 +353,7 @@ FORMAT JSONEachRow",
             self.table_ref("search_query_log"),
             limit
         );
-        let rows: Vec<HotQueryRow> = self.map_backend(self.ch.query_rows(&query, None).await)?;
+        let rows: Vec<HotQueryRow> = self.map_backend(self.query_rows(&query, None).await)?;
         Ok(rows.into_iter().map(|row| row.raw_query).collect())
     }
 
@@ -385,7 +385,7 @@ FORMAT JSONEachRow",
         let df_query = format!(
             "SELECT term, toUInt64(uniqExact(doc_id)) AS df FROM {postings_table} WHERE term IN {missing_terms_array} GROUP BY term FORMAT JSONEachRow",
         );
-        let rows: Vec<DfRow> = self.map_backend(self.ch.query_rows(&df_query, None).await)?;
+        let rows: Vec<DfRow> = self.map_backend(self.query_rows(&df_query, None).await)?;
         for row in rows {
             map.insert(row.term, row.df);
         }

--- a/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
@@ -160,7 +160,7 @@ impl ClickHouseConversationRepository {
   FORMAT JSONEachRow",
         );
 
-        self.map_backend(self.ch.query_rows_with_params(&sql, None, &params).await)
+        self.map_backend(self.query_rows_with_params(&sql, None, &params).await)
     }
 
     async fn file_attention_suffix_impl(
@@ -337,7 +337,7 @@ impl ClickHouseConversationRepository {
   FORMAT JSONEachRow",
         );
 
-        self.map_backend(self.ch.query_rows_with_params(&sql, None, &params).await)
+        self.map_backend(self.query_rows_with_params(&sql, None, &params).await)
     }
 
     pub async fn cancel_query(&self, query_id: &str) -> RepoResult<()> {

--- a/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
@@ -62,7 +62,7 @@ impl ClickHouseConversationRepository {
         let rel = query.rel.as_str();
 
         let tool_io = self.table_ref("tool_io");
-        let events = self.table_ref("events");
+        let events_source = canonical_events_source(&self.table_ref("events"));
         let trace = self.table_ref("v_conversation_trace");
         let rel_sql = sql_quote(rel);
         let project_predicate = if query.apply_project_scope {
@@ -150,7 +150,7 @@ impl ClickHouseConversationRepository {
   ) AS tr ON tr.session_id = ti.session_id AND tr.event_uid = ti.event_uid
   ANY LEFT JOIN (
     SELECT session_id, event_uid, any(cwd) AS cwd
-    FROM {events} FINAL
+    FROM {events_source}
     WHERE (session_id, event_uid) IN (SELECT session_id, event_uid FROM matched)
     GROUP BY session_id, event_uid
   ) AS e ON e.session_id = ti.session_id AND e.event_uid = ti.event_uid
@@ -170,7 +170,7 @@ impl ClickHouseConversationRepository {
         let rel = query.rel.as_str();
 
         let tool_io = self.table_ref("tool_io");
-        let events = self.table_ref("events");
+        let events_source = canonical_events_source(&self.table_ref("events"));
         let trace = self.table_ref("v_conversation_trace");
         let rel_sql = sql_quote(rel);
         let slash_rel_sql = sql_quote(&format!("/{rel}"));
@@ -327,7 +327,7 @@ impl ClickHouseConversationRepository {
   ) AS tr ON tr.session_id = ti.session_id AND tr.event_uid = ti.event_uid
   ANY LEFT JOIN (
     SELECT session_id, event_uid, any(cwd) AS cwd
-    FROM {events} FINAL
+    FROM {events_source}
     WHERE (session_id, event_uid) IN (SELECT session_id, event_uid FROM matched)
     GROUP BY session_id, event_uid
   ) AS e ON e.session_id = ti.session_id AND e.event_uid = ti.event_uid

--- a/crates/moraine-conversations/src/clickhouse_repo/helpers.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/helpers.rs
@@ -5,7 +5,7 @@ pub(super) const MCP_INTERNAL_TOOL_NAMES_SQL: &str =
 
 impl ClickHouseConversationRepository {
     pub(super) fn mode_subquery(&self) -> String {
-        let events_table = self.table_ref("events");
+        let events_source = canonical_events_source(&self.table_ref("events"));
         format!(
             "SELECT
   session_id,
@@ -22,7 +22,7 @@ impl ClickHouseConversationRepository {
     'tool_calling',
     'chat'
   ) AS mode
-FROM {events_table}
+FROM {events_source}
 GROUP BY session_id"
         )
     }

--- a/crates/moraine-conversations/src/clickhouse_repo/list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/list.rs
@@ -30,7 +30,7 @@ impl ClickHouseConversationRepository {
         };
 
         let session_summary = self.table_ref("v_session_summary");
-        let events_table = self.table_ref("events");
+        let events_source = canonical_events_source(&self.table_ref("events"));
         let mode_subquery = self.mode_subquery();
 
         let mut where_clauses = vec!["1 = 1".to_string()];
@@ -101,7 +101,7 @@ LEFT JOIN (
       ),
       ''
     ) AS session_summary
-  FROM {events_table}
+  FROM {events_source}
   WHERE event_kind = 'session_meta'
   GROUP BY session_id
 ) AS meta ON meta.session_id = s.session_id
@@ -110,7 +110,7 @@ ORDER BY s.last_event_time {order_dir}, s.session_id {order_dir}
 LIMIT {limit_plus}
 FORMAT JSONEachRow",
             session_summary = session_summary,
-            events_table = events_table,
+            events_source = events_source,
             mode_subquery = mode_subquery,
             where_sql = where_sql,
             order_dir = order_dir,
@@ -177,7 +177,7 @@ FORMAT JSONEachRow",
         };
 
         let session_summary = self.table_ref("v_session_summary");
-        let events_table = self.table_ref("events");
+        let events_source = canonical_events_source(&self.table_ref("events"));
         let mode_subquery = self.mode_subquery();
 
         let mut where_clauses = vec![
@@ -251,7 +251,7 @@ LEFT JOIN (
       argMaxIf(payload_type, tuple(event_ts, event_uid), payload_type IN ('task_complete', 'turn_aborted')),
       ''
     ) AS latest_terminal_payload_type
-  FROM {events_table}
+  FROM {events_source}
   GROUP BY session_id
 ) AS status ON status.session_id = s.session_id
 LEFT JOIN (
@@ -290,7 +290,7 @@ LEFT JOIN (
       ),
       ''
     ) AS session_summary
-  FROM {events_table}
+  FROM {events_source}
   WHERE event_kind = 'session_meta'
   GROUP BY session_id
 ) AS meta ON meta.session_id = s.session_id
@@ -299,7 +299,7 @@ ORDER BY s.last_event_time {order_dir}, s.session_id {order_dir}
 LIMIT {limit_plus}
 FORMAT JSONEachRow",
             session_summary = session_summary,
-            events_table = events_table,
+            events_source = events_source,
             mode_subquery = mode_subquery,
             where_sql = where_sql,
             order_dir = order_dir,

--- a/crates/moraine-conversations/src/clickhouse_repo/list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/list.rs
@@ -118,7 +118,7 @@ FORMAT JSONEachRow",
         );
 
         let rows: Vec<ConversationSummaryRow> =
-            self.map_backend(self.ch.query_rows(&query, None).await)?;
+            self.map_backend(self.query_rows(&query, None).await)?;
 
         let mut items: Vec<ConversationSummary> = rows
             .iter()
@@ -306,8 +306,7 @@ FORMAT JSONEachRow",
             limit_plus = (limit as usize) + 1,
         );
 
-        let rows: Vec<McpSessionListRow> =
-            self.map_backend(self.ch.query_rows(&query, None).await)?;
+        let rows: Vec<McpSessionListRow> = self.map_backend(self.query_rows(&query, None).await)?;
 
         let mut items: Vec<McpSessionListItem> = rows
             .iter()
@@ -405,7 +404,7 @@ FORMAT JSONEachRow",
             limit_plus = (limit as usize) + 1,
         );
 
-        let rows: Vec<TurnSummaryRow> = self.map_backend(self.ch.query_rows(&query, None).await)?;
+        let rows: Vec<TurnSummaryRow> = self.map_backend(self.query_rows(&query, None).await)?;
         let items: Vec<TurnSummary> = rows
             .iter()
             .take(limit as usize)
@@ -533,8 +532,7 @@ FORMAT JSONEachRow",
             limit_plus = (limit as usize) + 1,
         );
 
-        let mut rows: Vec<TraceEventRow> =
-            self.map_backend(self.ch.query_rows(&query, None).await)?;
+        let mut rows: Vec<TraceEventRow> = self.map_backend(self.query_rows(&query, None).await)?;
         let has_more = rows.len() > limit as usize;
         if has_more {
             rows.truncate(limit as usize);

--- a/crates/moraine-conversations/src/clickhouse_repo/mod.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/mod.rs
@@ -9,7 +9,7 @@ use moraine_clickhouse::ClickHouseClient;
 use regex::Regex;
 use serde::Deserialize;
 use serde_json::{json, Value};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tracing::warn;
 use uuid::Uuid;
 
@@ -18,26 +18,31 @@ use crate::cursor::{
     TurnCursor,
 };
 use crate::domain::{
-    is_user_facing_content_event, Conversation, ConversationDetailOptions, ConversationListFilter,
-    ConversationListSort, ConversationMode, ConversationSearchHit, ConversationSearchQuery,
-    ConversationSearchResults, ConversationSearchStats, ConversationSummary, FileAttentionQuery,
-    FileAttentionTouch, McpEventOpen, McpEventRef, McpEventSummary, McpEventType,
-    McpSessionListFilter, McpSessionListItem, McpSessionOpen, McpTurnCompact, McpTurnOpen,
-    McpTurnRef, OpenContext, OpenEvent, OpenEventRequest, Page, PageRequest, RepoConfig,
-    SearchEventHit, SearchEventKind, SearchEventsQuery, SearchEventsResult, SearchEventsStats,
-    SearchMcpEventHit, SearchMcpEventsQuery, SearchMcpEventsResult, SearchMcpEventsStats,
-    SearchStrategyHint, SessionEventsDirection, SessionEventsQuery, SessionMetadata,
-    SessionMetadataSearchHit, SessionMetadataSearchQuery, SessionMetadataSearchResults,
-    SessionMetadataSearchStats, SessionOriginScope, TraceEvent, Turn, TurnListFilter, TurnSummary,
+    is_user_facing_content_event, AnalyticsConcurrencyPoint, AnalyticsRange, AnalyticsSnapshot,
+    AnalyticsTokenPoint, AnalyticsTurnPoint, AnalyticsWindow, Conversation,
+    ConversationDetailOptions, ConversationListFilter, ConversationListSort, ConversationMode,
+    ConversationSearchHit, ConversationSearchQuery, ConversationSearchResults,
+    ConversationSearchStats, ConversationSummary, FileAttentionQuery, FileAttentionTouch,
+    McpEventOpen, McpEventRef, McpEventSummary, McpEventType, McpSessionListFilter,
+    McpSessionListItem, McpSessionOpen, McpTurnCompact, McpTurnOpen, McpTurnRef, OpenContext,
+    OpenEvent, OpenEventRequest, Page, PageRequest, RepoConfig, SearchEventHit, SearchEventKind,
+    SearchEventsQuery, SearchEventsResult, SearchEventsStats, SearchMcpEventHit,
+    SearchMcpEventsQuery, SearchMcpEventsResult, SearchMcpEventsStats, SearchStrategyHint,
+    SessionAnalytics, SessionAnalyticsQuery, SessionEventsDirection, SessionEventsQuery,
+    SessionMetadata, SessionMetadataSearchHit, SessionMetadataSearchQuery,
+    SessionMetadataSearchResults, SessionMetadataSearchStats, SessionOriginScope, SessionStep,
+    SessionTurn, ToolResult, TraceEvent, Turn, TurnListFilter, TurnSummary, WebSearchEvent,
 };
 use crate::error::{RepoError, RepoResult};
 use crate::repo::ConversationRepository;
 
+mod analytics;
 mod cache;
 mod file_attention;
 mod helpers;
 mod list;
 mod open;
+mod operations;
 mod repo_impl;
 mod rows;
 mod scope;
@@ -60,6 +65,7 @@ pub struct ClickHouseConversationRepository {
     search_cache: Arc<RwLock<HashMap<String, SearchEventsCacheEntry>>>,
     term_postings_cache: Arc<RwLock<HashMap<String, TermPostingsCacheEntry>>>,
     search_doc_extra_cache: Arc<RwLock<HashMap<String, SearchDocExtraCacheEntry>>>,
+    analytics_cache: Arc<[Mutex<Option<AnalyticsCacheEntry>>; ANALYTICS_RANGE_COUNT]>,
     /// Sessions already proven to fall inside `cfg.session_scope`. A session's
     /// origin directory is its first recorded cwd and never changes, so
     /// positive results are cacheable forever. Negative results are NOT
@@ -77,6 +83,7 @@ impl ClickHouseConversationRepository {
             search_cache: Arc::new(RwLock::new(HashMap::new())),
             term_postings_cache: Arc::new(RwLock::new(HashMap::new())),
             search_doc_extra_cache: Arc::new(RwLock::new(HashMap::new())),
+            analytics_cache: Arc::new(std::array::from_fn(|_| Mutex::new(None))),
             scoped_session_cache: Arc::new(RwLock::new(std::collections::HashSet::new())),
         }
     }

--- a/crates/moraine-conversations/src/clickhouse_repo/mod.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/mod.rs
@@ -1,17 +1,21 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, OnceLock};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use ahash::AHashMap as HashMap;
 use anyhow::Result as AnyResult;
 use async_trait::async_trait;
 use moraine_clickhouse::ClickHouseClient;
 use regex::Regex;
-use serde::Deserialize;
+use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::{json, Value};
 use tokio::sync::{Mutex, RwLock};
+use tokio::time::Instant;
 use tracing::warn;
 use uuid::Uuid;
+
+const REPOSITORY_READ_SETTINGS: [(&str, &str); 1] =
+    [("do_not_merge_across_partitions_select_final", "0")];
 
 use crate::cursor::{
     decode_cursor, encode_cursor, ConversationCursor, McpSessionListCursor, SessionEventCursor,
@@ -98,6 +102,30 @@ impl ClickHouseConversationRepository {
             sql_identifier(&self.ch.config().database),
             sql_identifier(table)
         )
+    }
+
+    pub(super) async fn query_rows<T: DeserializeOwned>(
+        &self,
+        query: &str,
+        database: Option<&str>,
+    ) -> AnyResult<Vec<T>> {
+        self.ch
+            .query_rows_with_params(query, database, &REPOSITORY_READ_SETTINGS)
+            .await
+    }
+
+    pub(super) async fn query_rows_with_params<T: DeserializeOwned>(
+        &self,
+        query: &str,
+        database: Option<&str>,
+        params: &[(&str, &str)],
+    ) -> AnyResult<Vec<T>> {
+        let mut request_params = Vec::with_capacity(params.len() + REPOSITORY_READ_SETTINGS.len());
+        request_params.extend_from_slice(params);
+        request_params.extend_from_slice(&REPOSITORY_READ_SETTINGS);
+        self.ch
+            .query_rows_with_params(query, database, &request_params)
+            .await
     }
 
     pub(super) fn map_backend<T>(&self, result: AnyResult<T>) -> RepoResult<T> {

--- a/crates/moraine-conversations/src/clickhouse_repo/open.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/open.rs
@@ -119,7 +119,7 @@ FORMAT JSONEachRow",
         &self,
         session_id: &str,
     ) -> RepoResult<McpSessionInfoRow> {
-        let events_table = self.table_ref("events");
+        let events_source = canonical_events_source(&self.table_ref("events"));
         let query = format!(
             "SELECT
   ifNull(
@@ -140,7 +140,7 @@ FORMAT JSONEachRow",
       ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'name'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'), '')
     )
   ) AS session_summary
-FROM {events_table}
+FROM {events_source}
 WHERE session_id = {}
 GROUP BY session_id
 LIMIT 1
@@ -247,19 +247,18 @@ FORMAT JSONEachRow",
             }
         }
 
-        let events_table = self.table_ref("events");
-        let events_query = format!(
-            "SELECT
-  argMax(session_id, event_version) AS session_id
-FROM {events_table}
+        let trace_table = self.table_ref("v_conversation_trace");
+        let trace_query = format!(
+            "SELECT session_id
+FROM {trace_table}
 WHERE event_uid = {}
-GROUP BY event_uid
+ORDER BY event_time DESC, event_order DESC, session_id ASC
 LIMIT 1
 FORMAT JSONEachRow",
             sql_quote(event_uid),
         );
         let rows: Vec<EventSessionRow> =
-            self.map_backend(self.ch.query_rows(&events_query, None).await)?;
+            self.map_backend(self.ch.query_rows(&trace_query, None).await)?;
         Ok(rows
             .into_iter()
             .next()
@@ -267,12 +266,13 @@ FORMAT JSONEachRow",
             .filter(|session_id| !session_id.is_empty()))
     }
 
-    pub(super) async fn load_indexed_session_events_from_events(
+    pub(super) async fn load_mcp_session_events(
         &self,
         session_id: &str,
+        turn_seq: Option<u32>,
         target_full_event_uid: Option<&str>,
-    ) -> RepoResult<Vec<IndexedTraceEvent>> {
-        let events_table = self.table_ref("events");
+    ) -> RepoResult<Vec<TraceEvent>> {
+        let trace_table = self.table_ref("v_conversation_trace");
         let text_limit = usize::from(self.cfg.preview_chars).max(4);
         let payload_limit = text_limit.saturating_mul(2);
         let text_preview_expr = truncated_utf8_sql("text_content", text_limit);
@@ -286,26 +286,22 @@ FORMAT JSONEachRow",
         } else {
             (text_preview_expr, payload_preview_expr)
         };
-        // events is partitioned by toYYYYMM(ingested_at), and ReplacingMergeTree
-        // never collapses across partitions — a row re-emitted in a later month
-        // (e.g. a mutated cursor_sqlite kv row, a rewritten hermes session file)
-        // is a permanent second copy. The newest event_version per event_uid
-        // wins here so transcripts render each event exactly once.
+        let turn_filter = turn_seq
+            .map(|turn_seq| format!(" AND turn_seq = {turn_seq}"))
+            .unwrap_or_default();
         let query = format!(
-            "WITH ifNull(parseDateTime64BestEffortOrNull(record_ts), ingested_at) AS resolved_event_time
-SELECT
+            "SELECT
   session_id,
   event_uid,
-  toString(resolved_event_time) AS event_time,
-  toInt64(toUnixTimestamp64Milli(resolved_event_time)) AS event_unix_ms,
-  source_name,
-  toUInt32(turn_index) AS turn_index,
-  actor_kind AS actor_role,
-  event_kind AS event_class,
+  toUInt64(event_order) AS event_order,
+  toUInt32(turn_seq) AS turn_seq,
+  toString(event_time) AS event_time,
+  actor_role,
+  event_class,
   payload_type,
-  tool_call_id AS call_id,
-  tool_name AS name,
-  if(tool_phase != '', tool_phase, op_status) AS phase,
+  call_id,
+  name,
+  phase,
   item_id,
   source_ref,
   {text_expr} AS text_content,
@@ -314,17 +310,15 @@ SELECT
   endpoint_kind,
   token_usage_buckets,
   token_usage_native_units
-FROM {events_table}
-WHERE session_id = {}
-ORDER BY resolved_event_time, source_file, source_generation, source_offset, source_line_no, event_uid, event_version DESC
-LIMIT 1 BY event_uid
+FROM {trace_table}
+WHERE session_id = {}{turn_filter}
+ORDER BY event_order ASC, event_uid ASC
 FORMAT JSONEachRow",
             sql_quote(session_id),
         );
 
-        let rows: Vec<SessionEventSourceRow> =
-            self.map_backend(self.ch.query_rows(&query, None).await)?;
-        Ok(Self::map_indexed_session_events(rows))
+        let rows: Vec<TraceEventRow> = self.map_backend(self.ch.query_rows(&query, None).await)?;
+        Ok(rows.into_iter().map(Self::map_trace_event).collect())
     }
 
     pub(super) async fn load_events_for_turn(
@@ -389,165 +383,6 @@ FORMAT JSONEachRow",
             started_at: summary.started_at.clone(),
             ended_at: summary.ended_at.clone(),
         }
-    }
-
-    pub(super) fn summarize_indexed_turn(
-        session_id: &str,
-        turn_seq: u32,
-        events: &[IndexedTraceEvent],
-    ) -> Option<TurnSummary> {
-        let turn_events = events
-            .iter()
-            .filter(|event| event.event.turn_seq == turn_seq)
-            .collect::<Vec<_>>();
-        Self::summarize_indexed_turn_slice(session_id, turn_seq, &turn_events)
-    }
-
-    pub(super) fn summarize_indexed_turns(events: &[IndexedTraceEvent]) -> Vec<TurnSummary> {
-        let Some(first) = events.first() else {
-            return Vec::new();
-        };
-        let session_id = first.event.session_id.as_str();
-        let mut events_by_turn = BTreeMap::<u32, Vec<&IndexedTraceEvent>>::new();
-        for event in events {
-            events_by_turn
-                .entry(event.event.turn_seq)
-                .or_default()
-                .push(event);
-        }
-        events_by_turn
-            .into_iter()
-            .filter_map(|(turn_seq, turn_events)| {
-                Self::summarize_indexed_turn_slice(session_id, turn_seq, &turn_events)
-            })
-            .collect()
-    }
-
-    pub(super) fn summarize_indexed_turn_slice(
-        session_id: &str,
-        turn_seq: u32,
-        events: &[&IndexedTraceEvent],
-    ) -> Option<TurnSummary> {
-        let first = events.first()?;
-        let last = events.last()?;
-        let turn_id = events
-            .iter()
-            .find_map(|event| (!event.turn_id.is_empty()).then(|| event.turn_id.clone()))
-            .unwrap_or_default();
-        let user_messages = events
-            .iter()
-            .filter(|event| {
-                event.event.actor_role == "user" && event.event.event_class == "message"
-            })
-            .count() as u64;
-        let assistant_messages = events
-            .iter()
-            .filter(|event| {
-                event.event.actor_role == "assistant" && event.event.event_class == "message"
-            })
-            .count() as u64;
-        let tool_calls = events
-            .iter()
-            .filter(|event| event.event.event_class == "tool_call")
-            .count() as u64;
-        let tool_results = events
-            .iter()
-            .filter(|event| event.event.event_class == "tool_result")
-            .count() as u64;
-        let reasoning_items = events
-            .iter()
-            .filter(|event| event.event.event_class == "reasoning")
-            .count() as u64;
-
-        Some(TurnSummary {
-            session_id: session_id.to_string(),
-            turn_seq,
-            turn_id,
-            started_at: first.event.event_time.clone(),
-            started_at_unix_ms: first.event_unix_ms,
-            ended_at: last.event.event_time.clone(),
-            ended_at_unix_ms: last.event_unix_ms,
-            total_events: events.len() as u64,
-            user_messages,
-            assistant_messages,
-            tool_calls,
-            tool_results,
-            reasoning_items,
-        })
-    }
-
-    pub(super) fn session_metadata_from_indexed_events(
-        events: &[IndexedTraceEvent],
-    ) -> Option<SessionMetadata> {
-        let first = events.first()?;
-        let last = events.last()?;
-        let total_turns = events
-            .iter()
-            .map(|event| event.event.turn_seq)
-            .max()
-            .unwrap_or(0);
-        let tool_calls = events
-            .iter()
-            .filter(|event| event.event.event_class == "tool_call")
-            .count() as u64;
-        let tool_results = events
-            .iter()
-            .filter(|event| event.event.event_class == "tool_result")
-            .count() as u64;
-        let user_messages = events
-            .iter()
-            .filter(|event| {
-                event.event.actor_role == "user" && event.event.event_class == "message"
-            })
-            .count() as u64;
-        let assistant_messages = events
-            .iter()
-            .filter(|event| {
-                event.event.actor_role == "assistant" && event.event.event_class == "message"
-            })
-            .count() as u64;
-
-        Some(SessionMetadata {
-            session_id: first.event.session_id.clone(),
-            first_event_time: first.event.event_time.clone(),
-            first_event_unix_ms: first.event_unix_ms,
-            last_event_time: last.event.event_time.clone(),
-            last_event_unix_ms: last.event_unix_ms,
-            total_turns,
-            total_events: events.len() as u64,
-            user_messages,
-            assistant_messages,
-            tool_calls,
-            tool_results,
-            mode: Self::mode_from_indexed_events(events),
-            first_event_uid: first.event.event_uid.clone(),
-            last_event_uid: last.event.event_uid.clone(),
-            last_actor_role: last.event.actor_role.clone(),
-        })
-    }
-
-    pub(super) fn mode_from_indexed_events(events: &[IndexedTraceEvent]) -> ConversationMode {
-        if events.iter().any(|event| {
-            event.event.payload_type == "web_search_call"
-                || event.event.payload_type == "search_results_received"
-                || (event.event.payload_type == "tool_use"
-                    && matches!(event.event.name.as_str(), "WebSearch" | "WebFetch"))
-        }) {
-            return ConversationMode::WebSearch;
-        }
-        if events.iter().any(|event| {
-            event.source_name == "codex-mcp" || Self::is_mcp_internal_tool_name(&event.event.name)
-        }) {
-            return ConversationMode::McpInternal;
-        }
-        if events.iter().any(|event| {
-            event.event.event_class == "tool_call"
-                || event.event.event_class == "tool_result"
-                || event.event.payload_type == "tool_use"
-        }) {
-            return ConversationMode::ToolCalling;
-        }
-        ConversationMode::Chat
     }
 
     pub(super) fn mcp_event_summary(&self, event: &TraceEvent) -> McpEventSummary {
@@ -740,21 +575,18 @@ FORMAT JSONEachRow",
             return Ok(None);
         }
 
-        let events = self
-            .load_indexed_session_events_from_events(session_id, None)
-            .await?;
-        let Some(metadata) = Self::session_metadata_from_indexed_events(&events) else {
+        let Some(metadata) = self.load_session_metadata(session_id).await? else {
             return Ok(None);
         };
-
+        let events = self.load_mcp_session_events(session_id, None, None).await?;
         let session_info = self.load_mcp_session_info(session_id).await?;
-        let turn_summaries = Self::summarize_indexed_turns(&events);
+        let turn_summaries = self.load_turns_for_session(session_id).await?;
         let mut events_by_turn = BTreeMap::<u32, Vec<TraceEvent>>::new();
         for event in events {
             events_by_turn
-                .entry(event.event.turn_seq)
+                .entry(event.turn_seq)
                 .or_default()
-                .push(event.event);
+                .push(event);
         }
 
         let turns = turn_summaries
@@ -811,14 +643,10 @@ FORMAT JSONEachRow",
             return Ok(None);
         }
 
-        let indexed_events = self
-            .load_indexed_session_events_from_events(session_id, None)
-            .await?;
-        let Some(summary) = Self::summarize_indexed_turn(session_id, turn_seq, &indexed_events)
-        else {
+        let Some(summary) = self.load_turn_summary(session_id, turn_seq).await? else {
             return Ok(None);
         };
-        let turn_summaries = Self::summarize_indexed_turns(&indexed_events);
+        let turn_summaries = self.load_turns_for_session(session_id).await?;
         let previous_turn = turn_summaries
             .iter()
             .rev()
@@ -828,11 +656,9 @@ FORMAT JSONEachRow",
             .iter()
             .find(|summary| summary.turn_seq > turn_seq)
             .map(Self::mcp_turn_ref_from_summary);
-        let events = indexed_events
-            .into_iter()
-            .filter(|event| event.event.turn_seq == turn_seq)
-            .map(|event| event.event)
-            .collect::<Vec<_>>();
+        let events = self
+            .load_mcp_session_events(session_id, Some(turn_seq), None)
+            .await?;
 
         Ok(Some(self.mcp_turn_open(
             summary,
@@ -1061,27 +887,22 @@ FORMAT JSONEachRow",
             return Ok(None);
         }
 
-        let indexed_events = self
-            .load_indexed_session_events_from_events(&session_id, Some(event_uid))
+        let events = self
+            .load_mcp_session_events(&session_id, None, Some(event_uid))
             .await?;
-        let Some(target_index) = indexed_events
-            .iter()
-            .position(|event| event.event.event_uid == event_uid)
+        let Some(target_index) = events.iter().position(|event| event.event_uid == event_uid)
         else {
             return Ok(None);
         };
-        let event = indexed_events[target_index].event.clone();
-        let Some(parent_session) = Self::session_metadata_from_indexed_events(&indexed_events)
-        else {
+        let event = events[target_index].clone();
+        let Some(parent_session) = self.load_session_metadata(&session_id).await? else {
             return Ok(None);
         };
         let parent_session_info = self.load_mcp_session_info(&session_id).await?;
-        let Some(parent_turn) =
-            Self::summarize_indexed_turn(&session_id, event.turn_seq, &indexed_events)
-        else {
+        let Some(parent_turn) = self.load_turn_summary(&session_id, event.turn_seq).await? else {
             return Ok(None);
         };
-        let turn_summaries = Self::summarize_indexed_turns(&indexed_events);
+        let turn_summaries = self.load_turns_for_session(&session_id).await?;
         let previous_turn = turn_summaries
             .iter()
             .rev()
@@ -1093,14 +914,12 @@ FORMAT JSONEachRow",
             .map(Self::mcp_turn_ref_from_summary);
         let previous_event = target_index
             .checked_sub(1)
-            .map(|index| Self::mcp_event_ref(&indexed_events[index].event));
-        let next_event = indexed_events
-            .get(target_index + 1)
-            .map(|event| Self::mcp_event_ref(&event.event));
-        let turn_events = indexed_events
+            .map(|index| Self::mcp_event_ref(&events[index]));
+        let next_event = events.get(target_index + 1).map(Self::mcp_event_ref);
+        let turn_events = events
             .iter()
-            .filter(|indexed| indexed.event.turn_seq == event.turn_seq)
-            .map(|indexed| indexed.event.clone())
+            .filter(|candidate| candidate.turn_seq == event.turn_seq)
+            .cloned()
             .collect::<Vec<_>>();
         let event_ordinal = turn_events
             .iter()

--- a/crates/moraine-conversations/src/clickhouse_repo/open.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/open.rs
@@ -28,7 +28,7 @@ FORMAT JSONEachRow",
             sql_quote(session_id),
         );
 
-        let rows: Vec<TurnSummaryRow> = self.map_backend(self.ch.query_rows(&query, None).await)?;
+        let rows: Vec<TurnSummaryRow> = self.map_backend(self.query_rows(&query, None).await)?;
         Ok(rows.into_iter().map(Self::map_turn_row).collect())
     }
 
@@ -61,7 +61,7 @@ FORMAT JSONEachRow",
         );
 
         let rows: Vec<ConversationSummaryRow> =
-            self.map_backend(self.ch.query_rows(&query, None).await)?;
+            self.map_backend(self.query_rows(&query, None).await)?;
         Ok(rows.into_iter().next().map(Self::map_conversation_row))
     }
 
@@ -111,7 +111,7 @@ FORMAT JSONEachRow",
         );
 
         let rows: Vec<SessionMetadataRow> =
-            self.map_backend(self.ch.query_rows(&query, None).await)?;
+            self.map_backend(self.query_rows(&query, None).await)?;
         Ok(rows.into_iter().next().map(Self::map_session_metadata_row))
     }
 
@@ -148,8 +148,7 @@ FORMAT JSONEachRow",
             sql_quote(session_id),
         );
 
-        let rows: Vec<McpSessionInfoRow> =
-            self.map_backend(self.ch.query_rows(&query, None).await)?;
+        let rows: Vec<McpSessionInfoRow> = self.map_backend(self.query_rows(&query, None).await)?;
         Ok(rows.into_iter().next().unwrap_or_default())
     }
 
@@ -182,7 +181,7 @@ FORMAT JSONEachRow",
             turn_seq,
         );
 
-        let rows: Vec<TurnSummaryRow> = self.map_backend(self.ch.query_rows(&query, None).await)?;
+        let rows: Vec<TurnSummaryRow> = self.map_backend(self.query_rows(&query, None).await)?;
         Ok(rows.into_iter().next().map(Self::map_turn_row))
     }
 
@@ -220,7 +219,7 @@ FORMAT JSONEachRow",
             sql_quote(event_uid),
         );
 
-        let rows: Vec<TraceEventRow> = self.map_backend(self.ch.query_rows(&query, None).await)?;
+        let rows: Vec<TraceEventRow> = self.map_backend(self.query_rows(&query, None).await)?;
         Ok(rows.into_iter().next().map(Self::map_trace_event))
     }
 
@@ -240,7 +239,7 @@ FORMAT JSONEachRow",
             sql_quote(event_uid),
         );
         let rows: Vec<EventSessionRow> =
-            self.map_backend(self.ch.query_rows(&docs_query, None).await)?;
+            self.map_backend(self.query_rows(&docs_query, None).await)?;
         if let Some(row) = rows.into_iter().next() {
             if !row.session_id.is_empty() {
                 return Ok(Some(row.session_id));
@@ -258,7 +257,7 @@ FORMAT JSONEachRow",
             sql_quote(event_uid),
         );
         let rows: Vec<EventSessionRow> =
-            self.map_backend(self.ch.query_rows(&trace_query, None).await)?;
+            self.map_backend(self.query_rows(&trace_query, None).await)?;
         Ok(rows
             .into_iter()
             .next()
@@ -317,7 +316,7 @@ FORMAT JSONEachRow",
             sql_quote(session_id),
         );
 
-        let rows: Vec<TraceEventRow> = self.map_backend(self.ch.query_rows(&query, None).await)?;
+        let rows: Vec<TraceEventRow> = self.map_backend(self.query_rows(&query, None).await)?;
         Ok(rows.into_iter().map(Self::map_trace_event).collect())
     }
 
@@ -356,7 +355,7 @@ FORMAT JSONEachRow",
             turn_seq,
         );
 
-        let rows: Vec<TraceEventRow> = self.map_backend(self.ch.query_rows(&query, None).await)?;
+        let rows: Vec<TraceEventRow> = self.map_backend(self.query_rows(&query, None).await)?;
         Ok(rows.into_iter().map(Self::map_trace_event).collect())
     }
 
@@ -643,10 +642,14 @@ FORMAT JSONEachRow",
             return Ok(None);
         }
 
-        let Some(summary) = self.load_turn_summary(session_id, turn_seq).await? else {
+        let turn_summaries = self.load_turns_for_session(session_id).await?;
+        let Some(summary) = turn_summaries
+            .iter()
+            .find(|summary| summary.turn_seq == turn_seq)
+            .cloned()
+        else {
             return Ok(None);
         };
-        let turn_summaries = self.load_turns_for_session(session_id).await?;
         let previous_turn = turn_summaries
             .iter()
             .rev()
@@ -687,7 +690,7 @@ FORMAT JSONEachRow",
         );
 
         let targets: Vec<OpenTargetRow> =
-            self.map_backend(self.ch.query_rows(&target_query, None).await)?;
+            self.map_backend(self.query_rows(&target_query, None).await)?;
         let Some(target) = targets.first() else {
             return Ok(OpenContext {
                 found: false,
@@ -766,7 +769,7 @@ FORMAT JSONEachRow",
                 before,
             );
 
-            self.map_backend(self.ch.query_rows(&before_query, None).await)?
+            self.map_backend(self.query_rows(&before_query, None).await)?
         };
         if !include_system_events {
             before_rows.retain(|row| {
@@ -776,7 +779,7 @@ FORMAT JSONEachRow",
         before_rows.reverse();
 
         let target_rows: Vec<TraceEventRow> =
-            self.map_backend(self.ch.query_rows(&target_row_query, None).await)?;
+            self.map_backend(self.query_rows(&target_row_query, None).await)?;
 
         let mut after_rows: Vec<TraceEventRow> = if after == 0 {
             Vec::new()
@@ -813,7 +816,7 @@ FORMAT JSONEachRow",
                 after,
             );
 
-            self.map_backend(self.ch.query_rows(&after_query, None).await)?
+            self.map_backend(self.query_rows(&after_query, None).await)?
         };
         if !include_system_events {
             after_rows.retain(|row| {
@@ -899,10 +902,14 @@ FORMAT JSONEachRow",
             return Ok(None);
         };
         let parent_session_info = self.load_mcp_session_info(&session_id).await?;
-        let Some(parent_turn) = self.load_turn_summary(&session_id, event.turn_seq).await? else {
+        let turn_summaries = self.load_turns_for_session(&session_id).await?;
+        let Some(parent_turn) = turn_summaries
+            .iter()
+            .find(|summary| summary.turn_seq == event.turn_seq)
+            .cloned()
+        else {
             return Ok(None);
         };
-        let turn_summaries = self.load_turns_for_session(&session_id).await?;
         let previous_turn = turn_summaries
             .iter()
             .rev()

--- a/crates/moraine-conversations/src/clickhouse_repo/operations.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/operations.rs
@@ -75,7 +75,7 @@ impl ClickHouseConversationRepository {
              FORMAT JSONEachRow"
         );
         let columns: Vec<HeartbeatColumnRow> =
-            self.map_backend(self.ch.query_rows(&columns_query, Some("system")).await)?;
+            self.map_backend(self.query_rows(&columns_query, Some("system")).await)?;
 
         if columns.is_empty() {
             return Ok(IngestHeartbeatRead {
@@ -129,7 +129,7 @@ impl ClickHouseConversationRepository {
              FORMAT JSONEachRow"
         );
         let rows: Vec<HeartbeatRow> =
-            self.map_backend(self.ch.query_rows(&heartbeat_query, None).await)?;
+            self.map_backend(self.query_rows(&heartbeat_query, None).await)?;
         let latest = rows.into_iter().next().map(|row| IngestHeartbeat {
             ts: row.ts,
             ts_unix_ms: row.ts_unix_ms,
@@ -168,7 +168,7 @@ impl ClickHouseConversationRepository {
              FORMAT JSONEachRow"
         );
         let tables: Vec<TableMetadataRow> =
-            self.map_backend(self.ch.query_rows(&tables_query, Some("system")).await)?;
+            self.map_backend(self.query_rows(&tables_query, Some("system")).await)?;
 
         let parts_query = format!(
             "SELECT table, toUInt64(sum(rows)) AS rows\n\
@@ -233,7 +233,7 @@ impl ClickHouseConversationRepository {
              FORMAT JSONEachRow"
         );
         let schema_rows: Vec<TableSchemaRow> =
-            self.map_backend(self.ch.query_rows(&schema_query, Some("system")).await)?;
+            self.map_backend(self.query_rows(&schema_query, Some("system")).await)?;
 
         let order_by = schema_rows
             .iter()
@@ -248,7 +248,7 @@ impl ClickHouseConversationRepository {
                 "SELECT * FROM {table_ref} ORDER BY {order_by} LIMIT {limit} FORMAT JSONEachRow"
             )
         };
-        let rows: Vec<Value> = self.map_backend(self.ch.query_rows(&rows_query, None).await)?;
+        let rows: Vec<Value> = self.map_backend(self.query_rows(&rows_query, None).await)?;
         let schema = schema_rows
             .into_iter()
             .map(|column| TableColumn {

--- a/crates/moraine-conversations/src/clickhouse_repo/operations.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/operations.rs
@@ -1,0 +1,389 @@
+use super::*;
+use crate::domain::{
+    IngestHeartbeat, IngestHeartbeatRead, StoreConnectionMetrics, StoreDiagnostics, StoreHealth,
+    StoreProbe, TableColumn, TablePreview, TablePreviewQuery, TableSummaries, TableSummary,
+};
+
+#[derive(Deserialize)]
+struct HeartbeatColumnRow {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct HeartbeatRow {
+    ts: String,
+    ts_unix_ms: i64,
+    host: String,
+    service_version: String,
+    queue_depth: u64,
+    files_active: u32,
+    files_watched: u32,
+    rows_raw_written: u64,
+    rows_events_written: u64,
+    rows_errors_written: u64,
+    flush_latency_ms: u32,
+    append_to_visible_p50_ms: u32,
+    append_to_visible_p95_ms: u32,
+    last_error: String,
+    watcher_backend: Option<String>,
+    watcher_error_count: Option<u64>,
+    watcher_reset_count: Option<u64>,
+    watcher_last_reset_unix_ms: Option<u64>,
+    backend_sinks: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct TableMetadataRow {
+    name: String,
+    engine: String,
+    is_temporary: u8,
+}
+
+#[derive(Deserialize)]
+struct TablePartRowsRow {
+    table: String,
+    rows: u64,
+}
+
+#[derive(Deserialize)]
+struct TableSchemaRow {
+    name: String,
+    type_name: String,
+    default_expression: String,
+}
+
+#[derive(Deserialize)]
+struct DatabaseExistsRow {
+    exists: u8,
+}
+
+#[derive(Deserialize)]
+struct ConnectionMetricRow {
+    metric: String,
+    value: u64,
+}
+
+impl ClickHouseConversationRepository {
+    pub(super) async fn latest_ingest_heartbeat_impl(&self) -> RepoResult<IngestHeartbeatRead> {
+        let database_sql = sql_quote(&self.ch.config().database);
+        let table_sql = sql_quote("ingest_heartbeats");
+        let columns_query = format!(
+            "SELECT name\n\
+             FROM system.columns\n\
+             WHERE database = {database_sql} AND table = {table_sql}\n\
+             ORDER BY position ASC\n\
+             FORMAT JSONEachRow"
+        );
+        let columns: Vec<HeartbeatColumnRow> =
+            self.map_backend(self.ch.query_rows(&columns_query, Some("system")).await)?;
+
+        if columns.is_empty() {
+            return Ok(IngestHeartbeatRead {
+                table_present: false,
+                latest: None,
+            });
+        }
+
+        let optional_projection = |name: &str, nullable_type: &str| {
+            if columns.iter().any(|column| column.name == name) {
+                sql_identifier(name)
+            } else {
+                format!(
+                    "CAST(NULL, {}) AS {}",
+                    sql_quote(nullable_type),
+                    sql_identifier(name)
+                )
+            }
+        };
+        let watcher_backend = optional_projection("watcher_backend", "Nullable(String)");
+        let watcher_error_count = optional_projection("watcher_error_count", "Nullable(UInt64)");
+        let watcher_reset_count = optional_projection("watcher_reset_count", "Nullable(UInt64)");
+        let watcher_last_reset_unix_ms =
+            optional_projection("watcher_last_reset_unix_ms", "Nullable(UInt64)");
+        let backend_sinks = optional_projection("backend_sinks", "Nullable(String)");
+        let heartbeats = self.table_ref("ingest_heartbeats");
+        let heartbeat_query = format!(
+            "SELECT\n\
+               `ts`,\n\
+               toUnixTimestamp64Milli(`ts`) AS `ts_unix_ms`,\n\
+               `host`,\n\
+               `service_version`,\n\
+               `queue_depth`,\n\
+               `files_active`,\n\
+               `files_watched`,\n\
+               `rows_raw_written`,\n\
+               `rows_events_written`,\n\
+               `rows_errors_written`,\n\
+               `flush_latency_ms`,\n\
+               `append_to_visible_p50_ms`,\n\
+               `append_to_visible_p95_ms`,\n\
+               `last_error`,\n\
+               {watcher_backend},\n\
+               {watcher_error_count},\n\
+               {watcher_reset_count},\n\
+               {watcher_last_reset_unix_ms},\n\
+               {backend_sinks}\n\
+             FROM {heartbeats}\n\
+             ORDER BY `ts` DESC, `host` DESC\n\
+             LIMIT 1\n\
+             FORMAT JSONEachRow"
+        );
+        let rows: Vec<HeartbeatRow> =
+            self.map_backend(self.ch.query_rows(&heartbeat_query, None).await)?;
+        let latest = rows.into_iter().next().map(|row| IngestHeartbeat {
+            ts: row.ts,
+            ts_unix_ms: row.ts_unix_ms,
+            host: row.host,
+            service_version: row.service_version,
+            queue_depth: row.queue_depth,
+            files_active: row.files_active,
+            files_watched: row.files_watched,
+            rows_raw_written: row.rows_raw_written,
+            rows_events_written: row.rows_events_written,
+            rows_errors_written: row.rows_errors_written,
+            flush_latency_ms: row.flush_latency_ms,
+            append_to_visible_p50_ms: row.append_to_visible_p50_ms,
+            append_to_visible_p95_ms: row.append_to_visible_p95_ms,
+            last_error: row.last_error,
+            watcher_backend: row.watcher_backend,
+            watcher_error_count: row.watcher_error_count,
+            watcher_reset_count: row.watcher_reset_count,
+            watcher_last_reset_unix_ms: row.watcher_last_reset_unix_ms,
+            backend_sinks: decode_backend_sinks(row.backend_sinks),
+        });
+
+        Ok(IngestHeartbeatRead {
+            table_present: true,
+            latest,
+        })
+    }
+
+    pub(super) async fn list_table_summaries_impl(&self) -> RepoResult<TableSummaries> {
+        let database_sql = sql_quote(&self.ch.config().database);
+        let tables_query = format!(
+            "SELECT name, engine, toUInt8(is_temporary) AS is_temporary\n\
+             FROM system.tables\n\
+             WHERE database = {database_sql}\n\
+             ORDER BY name ASC\n\
+             FORMAT JSONEachRow"
+        );
+        let tables: Vec<TableMetadataRow> =
+            self.map_backend(self.ch.query_rows(&tables_query, Some("system")).await)?;
+
+        let parts_query = format!(
+            "SELECT table, toUInt64(sum(rows)) AS rows\n\
+             FROM system.parts\n\
+             WHERE database = {database_sql} AND active\n\
+             GROUP BY table\n\
+             ORDER BY table ASC\n\
+             FORMAT JSONEachRow"
+        );
+        let (row_counts, row_counts_error) = match self
+            .ch
+            .query_rows::<TablePartRowsRow>(&parts_query, Some("system"))
+            .await
+        {
+            Ok(parts) => (
+                parts
+                    .into_iter()
+                    .map(|part| (part.table, part.rows))
+                    .collect::<BTreeMap<_, _>>(),
+                None,
+            ),
+            Err(error) => (BTreeMap::new(), Some(error.to_string())),
+        };
+
+        let tables = tables
+            .into_iter()
+            .map(|table| {
+                let rows = row_counts.get(&table.name).copied().unwrap_or(0);
+                TableSummary {
+                    name: table.name,
+                    engine: table.engine,
+                    is_temporary: table.is_temporary != 0,
+                    rows,
+                }
+            })
+            .collect();
+
+        Ok(TableSummaries {
+            tables,
+            row_counts_error,
+        })
+    }
+
+    pub(super) async fn preview_table_impl(
+        &self,
+        query: TablePreviewQuery,
+    ) -> RepoResult<TablePreview> {
+        if !is_strict_ascii_identifier(&query.table) {
+            return Err(RepoError::invalid_argument(
+                "table must match [A-Za-z_][A-Za-z0-9_]*",
+            ));
+        }
+
+        let limit = query.normalized_limit();
+        let database_sql = sql_quote(&self.ch.config().database);
+        let table_sql = sql_quote(&query.table);
+        let schema_query = format!(
+            "SELECT name, type AS type_name, default_expression\n\
+             FROM system.columns\n\
+             WHERE database = {database_sql} AND table = {table_sql}\n\
+             ORDER BY position ASC\n\
+             FORMAT JSONEachRow"
+        );
+        let schema_rows: Vec<TableSchemaRow> =
+            self.map_backend(self.ch.query_rows(&schema_query, Some("system")).await)?;
+
+        let order_by = schema_rows
+            .iter()
+            .map(|column| sql_identifier(&column.name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let table_ref = self.table_ref(&query.table);
+        let rows_query = if order_by.is_empty() {
+            format!("SELECT * FROM {table_ref} LIMIT {limit} FORMAT JSONEachRow")
+        } else {
+            format!(
+                "SELECT * FROM {table_ref} ORDER BY {order_by} LIMIT {limit} FORMAT JSONEachRow"
+            )
+        };
+        let rows: Vec<Value> = self.map_backend(self.ch.query_rows(&rows_query, None).await)?;
+        let schema = schema_rows
+            .into_iter()
+            .map(|column| TableColumn {
+                name: column.name,
+                type_name: column.type_name,
+                default_expression: column.default_expression,
+            })
+            .collect();
+
+        Ok(TablePreview {
+            table: query.table,
+            limit,
+            schema,
+            rows,
+        })
+    }
+
+    pub(super) async fn read_store_health_impl(&self) -> RepoResult<StoreHealth> {
+        let ping_started = Instant::now();
+        let ping_result = self.ch.ping().await;
+        let ping_elapsed_ms = ping_started.elapsed().as_secs_f64() * 1_000.0;
+        let ping = match ping_result {
+            Ok(()) => StoreProbe::Available(ping_elapsed_ms),
+            Err(error) => StoreProbe::Failed {
+                message: error.to_string(),
+            },
+        };
+
+        let version = match self.ch.version().await {
+            Ok(version) => StoreProbe::Available(version),
+            Err(error) => StoreProbe::Failed {
+                message: error.to_string(),
+            },
+        };
+
+        let database_query = format!(
+            "SELECT toUInt8(count() > 0) AS exists\n\
+             FROM system.databases\n\
+             WHERE name = {}\n\
+             FORMAT JSONEachRow",
+            sql_quote(&self.ch.config().database)
+        );
+        let database_exists = match self
+            .ch
+            .query_rows::<DatabaseExistsRow>(&database_query, Some("system"))
+            .await
+        {
+            Ok(rows) => {
+                StoreProbe::Available(rows.first().map(|row| row.exists != 0).unwrap_or(false))
+            }
+            Err(error) => StoreProbe::Failed {
+                message: error.to_string(),
+            },
+        };
+
+        let connections_query = "SELECT metric, toUInt64(value) AS value\n\
+                                 FROM system.metrics\n\
+                                 WHERE metric IN ('TCPConnection', 'HTTPConnection', 'MySQLConnection', 'PostgreSQLConnection', 'InterserverConnection')\n\
+                                 ORDER BY metric ASC\n\
+                                 FORMAT JSONEachRow";
+        let connections = match self
+            .ch
+            .query_rows::<ConnectionMetricRow>(connections_query, Some("system"))
+            .await
+        {
+            Ok(rows) => {
+                let mut metrics = StoreConnectionMetrics::default();
+                for row in rows {
+                    match row.metric.as_str() {
+                        "TCPConnection" => metrics.tcp = metrics.tcp.saturating_add(row.value),
+                        "HTTPConnection" => metrics.http = metrics.http.saturating_add(row.value),
+                        "MySQLConnection" => {
+                            metrics.mysql = metrics.mysql.saturating_add(row.value)
+                        }
+                        "PostgreSQLConnection" => {
+                            metrics.postgres = metrics.postgres.saturating_add(row.value)
+                        }
+                        "InterserverConnection" => {
+                            metrics.interserver = metrics.interserver.saturating_add(row.value)
+                        }
+                        _ => {}
+                    }
+                }
+                metrics.total = metrics
+                    .tcp
+                    .saturating_add(metrics.http)
+                    .saturating_add(metrics.mysql)
+                    .saturating_add(metrics.postgres)
+                    .saturating_add(metrics.interserver);
+                StoreProbe::Available(metrics)
+            }
+            Err(error) => StoreProbe::Failed {
+                message: error.to_string(),
+            },
+        };
+
+        Ok(StoreHealth {
+            ping,
+            version,
+            database_exists,
+            connections,
+        })
+    }
+
+    pub(super) async fn read_store_diagnostics_impl(&self) -> RepoResult<StoreDiagnostics> {
+        let report = self.map_backend(self.ch.doctor_report().await)?;
+        Ok(StoreDiagnostics {
+            healthy: report.clickhouse_healthy,
+            version: report.clickhouse_version,
+            database: report.database,
+            database_exists: report.database_exists,
+            applied_schema_versions: report.applied_migrations,
+            pending_schema_versions: report.pending_migrations,
+            missing_tables: report.missing_tables,
+            errors: report.errors,
+        })
+    }
+}
+
+fn is_strict_ascii_identifier(value: &str) -> bool {
+    let Some((first, rest)) = value.as_bytes().split_first() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || *first == b'_')
+        && rest
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+}
+
+fn decode_backend_sinks(raw: Option<String>) -> Option<Value> {
+    raw.map(|raw| {
+        if raw.trim().is_empty() {
+            json!({})
+        } else {
+            serde_json::from_str(&raw).unwrap_or(Value::String(raw))
+        }
+    })
+}

--- a/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
@@ -1,4 +1,9 @@
 use super::*;
+use crate::domain::{
+    AnalyticsRange, AnalyticsSnapshot, IngestHeartbeatRead, SessionAnalytics,
+    SessionAnalyticsQuery, StoreDiagnostics, StoreHealth, TablePreview, TablePreviewQuery,
+    TableSummaries, WebSearchEvent,
+};
 
 #[async_trait]
 impl ConversationRepository for ClickHouseConversationRepository {
@@ -8,6 +13,40 @@ impl ConversationRepository for ClickHouseConversationRepository {
 
     async fn prewarm_mcp_search_state(&self) -> RepoResult<()> {
         ClickHouseConversationRepository::prewarm_mcp_search_state(self).await
+    }
+    async fn list_session_analytics(
+        &self,
+        query: SessionAnalyticsQuery,
+    ) -> RepoResult<Vec<SessionAnalytics>> {
+        self.list_session_analytics_impl(query).await
+    }
+
+    async fn analytics_series(&self, range: AnalyticsRange) -> RepoResult<AnalyticsSnapshot> {
+        self.analytics_series_impl(range).await
+    }
+
+    async fn list_web_searches(&self, limit: u16) -> RepoResult<Vec<WebSearchEvent>> {
+        self.list_web_searches_impl(limit).await
+    }
+
+    async fn latest_ingest_heartbeat(&self) -> RepoResult<IngestHeartbeatRead> {
+        self.latest_ingest_heartbeat_impl().await
+    }
+
+    async fn list_table_summaries(&self) -> RepoResult<TableSummaries> {
+        self.list_table_summaries_impl().await
+    }
+
+    async fn preview_table(&self, query: TablePreviewQuery) -> RepoResult<TablePreview> {
+        self.preview_table_impl(query).await
+    }
+
+    async fn read_store_health(&self) -> RepoResult<StoreHealth> {
+        self.read_store_health_impl().await
+    }
+
+    async fn read_store_diagnostics(&self) -> RepoResult<StoreDiagnostics> {
+        self.read_store_diagnostics_impl().await
     }
 
     async fn list_conversations(

--- a/crates/moraine-conversations/src/clickhouse_repo/rows.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/rows.rs
@@ -163,49 +163,6 @@ pub(super) struct EventSessionRow {
 }
 
 #[derive(Debug, Deserialize)]
-pub(super) struct SessionEventSourceRow {
-    pub(super) session_id: String,
-    pub(super) event_uid: String,
-    pub(super) event_time: String,
-    pub(super) event_unix_ms: i64,
-    pub(super) source_name: String,
-    pub(super) turn_index: u32,
-    pub(super) actor_role: String,
-    pub(super) event_class: String,
-    pub(super) payload_type: String,
-    #[serde(default)]
-    pub(super) call_id: String,
-    #[serde(default)]
-    pub(super) name: String,
-    #[serde(default)]
-    pub(super) phase: String,
-    #[serde(default)]
-    pub(super) item_id: String,
-    #[serde(default)]
-    pub(super) source_ref: String,
-    #[serde(default)]
-    pub(super) text_content: String,
-    #[serde(default)]
-    pub(super) payload_json: String,
-    #[serde(default)]
-    pub(super) token_usage_json: String,
-    #[serde(default)]
-    pub(super) endpoint_kind: String,
-    #[serde(default)]
-    pub(super) token_usage_buckets: BTreeMap<String, u64>,
-    #[serde(default)]
-    pub(super) token_usage_native_units: BTreeMap<String, f64>,
-}
-
-#[derive(Debug, Clone)]
-pub(super) struct IndexedTraceEvent {
-    pub(super) event: TraceEvent,
-    pub(super) event_unix_ms: i64,
-    pub(super) turn_id: String,
-    pub(super) source_name: String,
-}
-
-#[derive(Debug, Deserialize)]
 pub(super) struct OpenTargetRow {
     pub(super) session_id: String,
     pub(super) event_order: u64,
@@ -585,52 +542,5 @@ impl ClickHouseConversationRepository {
             token_usage_buckets: row.token_usage_buckets,
             token_usage_native_units: row.token_usage_native_units,
         }
-    }
-
-    pub(super) fn map_indexed_session_events(
-        rows: Vec<SessionEventSourceRow>,
-    ) -> Vec<IndexedTraceEvent> {
-        let mut fallback_turn_seq = 0u32;
-        rows.into_iter()
-            .enumerate()
-            .map(|(idx, row)| {
-                if row.actor_role == "user" && row.event_class == "message" {
-                    fallback_turn_seq = fallback_turn_seq.saturating_add(1);
-                }
-                let turn_seq = if row.turn_index > 0 {
-                    row.turn_index
-                } else {
-                    fallback_turn_seq.max(1)
-                };
-                let turn_id = row.turn_index.to_string();
-                let event = TraceEvent {
-                    session_id: row.session_id,
-                    event_uid: row.event_uid,
-                    event_order: (idx + 1) as u64,
-                    turn_seq,
-                    event_time: row.event_time,
-                    actor_role: row.actor_role,
-                    event_class: row.event_class,
-                    payload_type: row.payload_type,
-                    call_id: row.call_id,
-                    name: row.name,
-                    phase: row.phase,
-                    item_id: row.item_id,
-                    source_ref: row.source_ref,
-                    text_content: row.text_content,
-                    payload_json: row.payload_json,
-                    token_usage_json: row.token_usage_json,
-                    endpoint_kind: row.endpoint_kind,
-                    token_usage_buckets: row.token_usage_buckets,
-                    token_usage_native_units: row.token_usage_native_units,
-                };
-                IndexedTraceEvent {
-                    event,
-                    event_unix_ms: row.event_unix_ms,
-                    turn_id,
-                    source_name: row.source_name,
-                }
-            })
-            .collect()
     }
 }

--- a/crates/moraine-conversations/src/clickhouse_repo/scope.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/scope.rs
@@ -78,7 +78,7 @@ impl ClickHouseConversationRepository {
             session_id: String,
         }
 
-        let rows: Vec<SessionIdRow> = self.map_backend(self.ch.query_rows(&query, None).await)?;
+        let rows: Vec<SessionIdRow> = self.map_backend(self.query_rows(&query, None).await)?;
         let in_scope = !rows.is_empty();
         if in_scope {
             self.scoped_session_cache

--- a/crates/moraine-conversations/src/clickhouse_repo/scope.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/scope.rs
@@ -15,7 +15,7 @@ impl ClickHouseConversationRepository {
         scope: &SessionOriginScope,
         session_id: Option<&str>,
     ) -> String {
-        let events_table = self.table_ref("events");
+        let events_source = canonical_events_source(&self.table_ref("events"));
         let session_filter = session_id
             .map(|session_id| format!("session_id = {}\n      AND ", sql_quote(session_id)))
             .unwrap_or_default();
@@ -35,7 +35,7 @@ impl ClickHouseConversationRepository {
     SELECT
       session_id,
       argMin(cwd, tuple(event_ts, event_uid)) AS origin_cwd
-    FROM {events_table}
+    FROM {events_source}
     WHERE {session_filter}cwd != ''
     GROUP BY session_id
   )

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -103,7 +103,7 @@ impl ClickHouseConversationRepository {
             ));
         }
 
-        let events_table = self.table_ref("events");
+        let events_source = canonical_events_source(&self.table_ref("events"));
         let session_summary_table = self.table_ref("v_session_summary");
         let mode_subquery = self.mode_subquery();
         let terms_array_sql = sql_array_strings(terms);
@@ -211,7 +211,7 @@ FROM (
           ''
         ) AS session_summary,
         argMax(e.payload_json, tuple(e.event_ts, e.event_uid)) AS metadata_text
-      FROM {events_table} AS e
+      FROM {events_source} AS e
       WHERE e.event_kind = 'session_meta'
       GROUP BY e.session_id
     ) AS base
@@ -224,7 +224,7 @@ ORDER BY meta.score DESC, meta.session_id ASC
 LIMIT {limit}
 FORMAT JSONEachRow",
             terms_array_sql = terms_array_sql,
-            events_table = events_table,
+            events_source = events_source,
             session_summary_table = session_summary_table,
             mode_subquery = mode_subquery,
             where_sql = where_sql,
@@ -2136,18 +2136,17 @@ FORMAT JSONEachRow",
             return Ok(HashMap::new());
         }
 
-        let events_table = self.table_ref("events");
+        let session_summary_table = self.table_ref("v_session_summary");
         let session_ids_sql = sql_array_strings(&unique_session_ids);
         let sql = format!(
             "SELECT
   session_id,
-  toString(min(event_ts)) AS first_event_time,
-  toString(max(event_ts)) AS last_event_time
-FROM {events_table}
+  toString(first_event_time) AS first_event_time,
+  toString(last_event_time) AS last_event_time
+FROM {session_summary_table}
 WHERE session_id IN {session_ids_sql}
-GROUP BY session_id
 FORMAT JSONEachRow",
-            events_table = events_table,
+            session_summary_table = session_summary_table,
             session_ids_sql = session_ids_sql,
         );
 
@@ -2247,7 +2246,7 @@ FORMAT JSONEachRow",
         session_ids.dedup();
 
         let trace_table = self.table_ref("v_conversation_trace");
-        let events_table = self.table_ref("events");
+        let events_source = canonical_events_source(&self.table_ref("events"));
         let event_uids_sql = sql_array_strings(&event_uids);
         let session_ids_sql = sql_array_strings(&session_ids);
         let sql = format!(
@@ -2282,15 +2281,15 @@ FROM (
 ANY LEFT JOIN (
   SELECT
     event_uid,
-    argMax(model, event_version) AS model
-  FROM {events_table}
+    argMax(model, tuple(event_ts, event_uid)) AS model
+  FROM {events_source}
   WHERE event_uid IN {event_uids_sql}
   GROUP BY event_uid
 ) AS e ON e.event_uid = tr.event_uid
 WHERE tr.event_uid IN {event_uids_sql}
 FORMAT JSONEachRow",
             trace_table = trace_table,
-            events_table = events_table,
+            events_source = events_source,
             session_ids_sql = session_ids_sql,
             event_uids_sql = event_uids_sql,
         );
@@ -2425,7 +2424,7 @@ FORMAT JSONEachRow",
             return Ok(HashMap::new());
         }
 
-        let events_table = self.table_ref("events");
+        let events_source = canonical_events_source(&self.table_ref("events"));
         let session_ids_sql = sql_array_strings(session_ids);
         let sql = format!(
             "SELECT
@@ -2444,12 +2443,12 @@ FORMAT JSONEachRow",
     ),
     ''
   ) AS session_summary
-FROM {events_table}
+FROM {events_source}
 WHERE event_kind = 'session_meta'
   AND session_id IN {session_ids_sql}
 GROUP BY session_id
 FORMAT JSONEachRow",
-            events_table = events_table,
+            events_source = events_source,
             session_ids_sql = session_ids_sql,
         );
 

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -62,7 +62,7 @@ impl ClickHouseConversationRepository {
         )?;
 
         let rows: Vec<SessionMetadataSearchRow> =
-            self.map_backend(self.ch.query_rows(&sql, None).await)?;
+            self.map_backend(self.query_rows(&sql, None).await)?;
         let hits = rows
             .into_iter()
             .enumerate()
@@ -647,8 +647,7 @@ WHERE database = {}
 FORMAT JSONEachRow",
             sql_quote(&self.ch.config().database)
         );
-        let rows: Vec<ColumnExistsRow> =
-            self.map_backend(self.ch.query_rows(&query, None).await)?;
+        let rows: Vec<ColumnExistsRow> = self.map_backend(self.query_rows(&query, None).await)?;
         let exists = rows.first().map(|row| row.exists != 0).unwrap_or(false);
 
         let mut cache = self.stats_cache.write().await;
@@ -792,7 +791,7 @@ FORMAT JSONEachRow",
             );
 
             let fetched_rows: Vec<FetchedPostingRow> =
-                self.map_backend(self.ch.query_rows(&query, None).await)?;
+                self.map_backend(self.query_rows(&query, None).await)?;
             let mut grouped = HashMap::<String, Vec<CachedPostingRow>>::new();
             for row in fetched_rows {
                 grouped.entry(row.term).or_default().push(CachedPostingRow {
@@ -871,7 +870,7 @@ FORMAT JSONEachRow",
             let query =
                 self.build_search_events_hydrate_sql(&missing_uids, use_document_codex_flag)?;
             let fetched_rows: Vec<SearchDocExtraRow> =
-                self.map_backend(self.ch.query_rows(&query, None).await)?;
+                self.map_backend(self.query_rows(&query, None).await)?;
 
             let mut cache = self.search_doc_extra_cache.write().await;
 
@@ -1005,7 +1004,7 @@ FORMAT JSONEachRow",
         )?;
 
         let mut fallback_rows: Vec<SearchRow> =
-            self.map_backend(self.ch.query_rows(&fallback_sql, None).await)?;
+            self.map_backend(self.query_rows(&fallback_sql, None).await)?;
         fallback_rows.sort_by(|a, b| {
             b.score
                 .total_cmp(&a.score)
@@ -1120,7 +1119,7 @@ FORMAT JSONEachRow",
             limit,
         )?;
         let mut rows: Vec<SearchMcpEventRow> =
-            self.map_backend(self.ch.query_rows(&sql, None).await)?;
+            self.map_backend(self.query_rows(&sql, None).await)?;
         Self::sort_search_mcp_event_rows(&mut rows);
         Ok(rows)
     }
@@ -1842,7 +1841,7 @@ FORMAT JSONEachRow",
             mode,
         )?;
         let mut persistent_rows: Vec<ConversationCandidateRow> =
-            self.map_backend(self.ch.query_rows(&persistent_sql, None).await)?;
+            self.map_backend(self.query_rows(&persistent_sql, None).await)?;
         let truncated = persistent_rows.len() >= candidate_limit;
         if truncated {
             return Ok(ConversationCandidateSet {
@@ -1863,7 +1862,7 @@ FORMAT JSONEachRow",
             mode,
         )?;
         let recent_rows: Vec<ConversationCandidateRow> =
-            self.map_backend(self.ch.query_rows(&recent_sql, None).await)?;
+            self.map_backend(self.query_rows(&recent_sql, None).await)?;
 
         let mut by_session = HashMap::<String, (f64, u16)>::new();
         for row in persistent_rows.drain(..) {
@@ -2105,7 +2104,7 @@ FORMAT JSONEachRow",
             event_uids_sql = event_uids_sql,
         );
         let rows: Vec<ConversationSnippetRow> =
-            self.map_backend(self.ch.query_rows(&sql, None).await)?;
+            self.map_backend(self.query_rows(&sql, None).await)?;
         let mut by_uid = HashMap::new();
         for row in rows {
             let is_user_facing = is_user_facing_content_event(&row.event_class, &row.actor_role);
@@ -2151,7 +2150,7 @@ FORMAT JSONEachRow",
         );
 
         let rows: Vec<SessionTimeBoundsRow> =
-            match self.map_backend(self.ch.query_rows(&sql, None).await) {
+            match self.map_backend(self.query_rows(&sql, None).await) {
                 Ok(rows) => rows,
                 Err(err) => {
                     warn!("failed to load session time bounds: {}", err);
@@ -2279,12 +2278,9 @@ FROM (
   WHERE session_id IN {session_ids_sql}
 ) AS tr
 ANY LEFT JOIN (
-  SELECT
-    event_uid,
-    argMax(model, tuple(event_ts, event_uid)) AS model
+  SELECT event_uid, model
   FROM {events_source}
   WHERE event_uid IN {event_uids_sql}
-  GROUP BY event_uid
 ) AS e ON e.event_uid = tr.event_uid
 WHERE tr.event_uid IN {event_uids_sql}
 FORMAT JSONEachRow",
@@ -2295,7 +2291,7 @@ FORMAT JSONEachRow",
         );
 
         let rows: Vec<SearchMcpEventEnrichmentRow> =
-            self.map_backend(self.ch.query_rows(&sql, None).await)?;
+            self.map_backend(self.query_rows(&sql, None).await)?;
         let mut by_uid = HashMap::new();
         for row in rows {
             by_uid.insert(row.event_uid.clone(), row);
@@ -2453,7 +2449,7 @@ FORMAT JSONEachRow",
         );
 
         let rows: Vec<ConversationSessionMetadataRow> =
-            self.map_backend(self.ch.query_rows(&sql, None).await)?;
+            self.map_backend(self.query_rows(&sql, None).await)?;
         let mut by_session = HashMap::new();
         for row in rows {
             by_session.insert(row.session_id.clone(), row);
@@ -2999,7 +2995,7 @@ FORMAT JSONEachRow",
         )?;
 
         let rows: Vec<ConversationSearchRow> =
-            self.map_backend(self.ch.query_rows(&sql, None).await)?;
+            self.map_backend(self.query_rows(&sql, None).await)?;
         let best_event_uids = rows
             .iter()
             .filter_map(|row| {

--- a/crates/moraine-conversations/src/clickhouse_repo/sql.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/sql.rs
@@ -6,6 +6,10 @@ pub(super) fn sql_identifier(value: &str) -> String {
     format!("`{}`", value.replace('`', "``"))
 }
 
+pub(super) fn canonical_events_source(events_ref: &str) -> String {
+    format!("(SELECT * FROM {events_ref} FINAL)")
+}
+
 pub(super) fn truncated_utf8_sql(column: &str, max_chars: usize) -> String {
     let max_chars = max_chars.max(4);
     let prefix_chars = max_chars.saturating_sub(3);
@@ -25,4 +29,17 @@ pub(super) fn sql_array_f64(items: &[f64]) -> String {
         .map(|v| format!("{:.12}", v))
         .collect::<Vec<_>>();
     format!("[{}]", parts.join(","))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::canonical_events_source;
+
+    #[test]
+    fn canonical_source_wraps_final_for_outer_predicates() {
+        assert_eq!(
+            canonical_events_source("`moraine`.`events`"),
+            "(SELECT * FROM `moraine`.`events` FINAL)"
+        );
+    }
 }

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -910,6 +911,383 @@ pub struct OpenEventRequest {
     pub include_system_events: Option<bool>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum AnalyticsRange {
+    #[serde(rename = "15m")]
+    FifteenMinutes,
+    #[serde(rename = "1h")]
+    OneHour,
+    #[serde(rename = "6h")]
+    SixHours,
+    #[default]
+    #[serde(rename = "24h")]
+    TwentyFourHours,
+    #[serde(rename = "7d")]
+    SevenDays,
+    #[serde(rename = "30d")]
+    ThirtyDays,
+}
+
+impl AnalyticsRange {
+    pub const ALL: [Self; 6] = [
+        Self::FifteenMinutes,
+        Self::OneHour,
+        Self::SixHours,
+        Self::TwentyFourHours,
+        Self::SevenDays,
+        Self::ThirtyDays,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::FifteenMinutes => "15m",
+            Self::OneHour => "1h",
+            Self::SixHours => "6h",
+            Self::TwentyFourHours => "24h",
+            Self::SevenDays => "7d",
+            Self::ThirtyDays => "30d",
+        }
+    }
+
+    pub const fn window_seconds(self) -> u32 {
+        match self {
+            Self::FifteenMinutes => 15 * 60,
+            Self::OneHour => 60 * 60,
+            Self::SixHours => 6 * 60 * 60,
+            Self::TwentyFourHours => 24 * 60 * 60,
+            Self::SevenDays => 7 * 24 * 60 * 60,
+            Self::ThirtyDays => 30 * 24 * 60 * 60,
+        }
+    }
+
+    pub const fn bucket_seconds(self) -> u32 {
+        match self {
+            Self::FifteenMinutes => 60,
+            Self::OneHour => 5 * 60,
+            Self::SixHours => 15 * 60,
+            Self::TwentyFourHours => 60 * 60,
+            Self::SevenDays => 6 * 60 * 60,
+            Self::ThirtyDays => 24 * 60 * 60,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct AnalyticsWindow {
+    pub range: AnalyticsRange,
+    pub window_seconds: u32,
+    pub bucket_seconds: u32,
+    pub from_unix: u64,
+    pub to_unix: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AnalyticsTokenPoint {
+    pub bucket_unix: u64,
+    pub model: String,
+    pub endpoint_kind: String,
+    pub bucket: String,
+    pub tokens: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AnalyticsTurnPoint {
+    pub bucket_unix: u64,
+    pub model: String,
+    pub turns: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AnalyticsConcurrencyPoint {
+    pub bucket_unix: u64,
+    pub concurrent_sessions: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct AnalyticsSnapshot {
+    pub window: AnalyticsWindow,
+    pub tokens: Vec<AnalyticsTokenPoint>,
+    pub turns: Vec<AnalyticsTurnPoint>,
+    pub concurrent_sessions: Vec<AnalyticsConcurrencyPoint>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionLookback {
+    #[serde(rename = "1h")]
+    OneHour,
+    #[serde(rename = "6h")]
+    SixHours,
+    #[serde(rename = "24h")]
+    TwentyFourHours,
+    #[serde(rename = "7d")]
+    SevenDays,
+    #[default]
+    #[serde(rename = "30d")]
+    ThirtyDays,
+    #[serde(rename = "90d")]
+    NinetyDays,
+    #[serde(rename = "all")]
+    All,
+}
+
+impl SessionLookback {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::OneHour => "1h",
+            Self::SixHours => "6h",
+            Self::TwentyFourHours => "24h",
+            Self::SevenDays => "7d",
+            Self::ThirtyDays => "30d",
+            Self::NinetyDays => "90d",
+            Self::All => "all",
+        }
+    }
+
+    pub const fn window_seconds(self) -> Option<u32> {
+        match self {
+            Self::OneHour => Some(60 * 60),
+            Self::SixHours => Some(6 * 60 * 60),
+            Self::TwentyFourHours => Some(24 * 60 * 60),
+            Self::SevenDays => Some(7 * 24 * 60 * 60),
+            Self::ThirtyDays => Some(30 * 24 * 60 * 60),
+            Self::NinetyDays => Some(90 * 24 * 60 * 60),
+            Self::All => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionAnalyticsQuery {
+    #[serde(default)]
+    pub lookback: SessionLookback,
+    #[serde(default = "default_session_analytics_limit")]
+    pub limit: u16,
+}
+
+impl Default for SessionAnalyticsQuery {
+    fn default() -> Self {
+        Self {
+            lookback: SessionLookback::default(),
+            limit: default_session_analytics_limit(),
+        }
+    }
+}
+
+impl SessionAnalyticsQuery {
+    pub fn normalized_limit(&self) -> u16 {
+        self.limit.clamp(1, 200)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolResult {
+    pub event_unix_ms: i64,
+    pub text: String,
+    pub latency_ms: u32,
+    pub is_error: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SessionStep {
+    User {
+        event_unix_ms: i64,
+        text: String,
+    },
+    Assistant {
+        event_unix_ms: i64,
+        text: String,
+        endpoint_kind: String,
+        latency_ms: Option<u32>,
+        token_usage_buckets: BTreeMap<String, u64>,
+        token_usage_native_units: BTreeMap<String, f64>,
+    },
+    Thinking {
+        event_unix_ms: i64,
+        text: String,
+    },
+    ToolCall {
+        event_unix_ms: i64,
+        tool_name: String,
+        call_id: String,
+        arguments: Value,
+        result: Option<ToolResult>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionTurn {
+    pub summary: TurnSummary,
+    pub model: String,
+    pub token_usage_buckets: BTreeMap<String, u64>,
+    pub steps: Vec<SessionStep>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionAnalytics {
+    pub summary: ConversationSummary,
+    pub harness: String,
+    pub source_name: String,
+    pub models: Vec<String>,
+    pub trace_id: String,
+    pub first_user_text: String,
+    pub turns: Vec<SessionTurn>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WebSearchEvent {
+    pub event_time: String,
+    pub harness: String,
+    pub source_name: String,
+    pub session_id: String,
+    pub model: String,
+    pub action: String,
+    pub search_query: String,
+    pub result_url: String,
+    pub source_ref: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct IngestHeartbeatRead {
+    pub table_present: bool,
+    pub latest: Option<IngestHeartbeat>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IngestHeartbeat {
+    pub ts: String,
+    pub ts_unix_ms: i64,
+    pub host: String,
+    pub service_version: String,
+    pub queue_depth: u64,
+    pub files_active: u32,
+    pub files_watched: u32,
+    pub rows_raw_written: u64,
+    pub rows_events_written: u64,
+    pub rows_errors_written: u64,
+    pub flush_latency_ms: u32,
+    pub append_to_visible_p50_ms: u32,
+    pub append_to_visible_p95_ms: u32,
+    pub last_error: String,
+    #[serde(default)]
+    pub watcher_backend: Option<String>,
+    #[serde(default)]
+    pub watcher_error_count: Option<u64>,
+    #[serde(default)]
+    pub watcher_reset_count: Option<u64>,
+    #[serde(default)]
+    pub watcher_last_reset_unix_ms: Option<u64>,
+    #[serde(default)]
+    pub backend_sinks: Option<Value>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct TableSummaries {
+    pub tables: Vec<TableSummary>,
+    pub row_counts_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableSummary {
+    pub name: String,
+    pub engine: String,
+    pub is_temporary: bool,
+    pub rows: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TablePreviewQuery {
+    pub table: String,
+    #[serde(default = "default_table_preview_limit")]
+    pub limit: u16,
+}
+
+impl TablePreviewQuery {
+    pub fn normalized_limit(&self) -> u16 {
+        self.limit.clamp(1, 500)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableColumn {
+    pub name: String,
+    pub type_name: String,
+    pub default_expression: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TablePreview {
+    pub table: String,
+    pub limit: u16,
+    pub schema: Vec<TableColumn>,
+    pub rows: Vec<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoreProbe<T> {
+    Available(T),
+    Failed { message: String },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoreConnectionMetrics {
+    pub total: u64,
+    pub tcp: u64,
+    pub http: u64,
+    pub mysql: u64,
+    pub postgres: u64,
+    pub interserver: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StoreHealth {
+    /// Successful ping latency in milliseconds.
+    pub ping: StoreProbe<f64>,
+    pub version: StoreProbe<String>,
+    pub database_exists: StoreProbe<bool>,
+    pub connections: StoreProbe<StoreConnectionMetrics>,
+}
+
+impl Default for StoreHealth {
+    fn default() -> Self {
+        Self {
+            ping: StoreProbe::Failed {
+                message: "ping probe not configured".to_string(),
+            },
+            version: StoreProbe::Failed {
+                message: "version probe not configured".to_string(),
+            },
+            database_exists: StoreProbe::Failed {
+                message: "database-existence probe not configured".to_string(),
+            },
+            connections: StoreProbe::Failed {
+                message: "connection-metrics probe not configured".to_string(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoreDiagnostics {
+    pub healthy: bool,
+    pub version: Option<String>,
+    pub database: String,
+    pub database_exists: bool,
+    pub applied_schema_versions: Vec<String>,
+    pub pending_schema_versions: Vec<String>,
+    pub missing_tables: Vec<String>,
+    pub errors: Vec<String>,
+}
+
+fn default_session_analytics_limit() -> u16 {
+    50
+}
+
+fn default_table_preview_limit() -> u16 {
+    25
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RepoConfig {
     pub max_results: u16,
@@ -956,7 +1334,10 @@ fn default_page_limit() -> u16 {
 
 #[cfg(test)]
 mod tests {
-    use super::{SearchEventKind, SearchEventsQuery, SearchStrategyHint, SessionOriginScope};
+    use super::{
+        AnalyticsRange, SearchEventKind, SearchEventsQuery, SearchStrategyHint,
+        SessionAnalyticsQuery, SessionLookback, SessionOriginScope, SessionStep, TablePreviewQuery,
+    };
 
     #[test]
     fn search_events_query_preserves_wire_contract() {
@@ -1009,5 +1390,94 @@ mod tests {
     #[test]
     fn from_roots_rejects_relative_root_and_bare_slash() {
         assert!(SessionOriginScope::from_roots(["relative/path", "", "/"]).is_none());
+    }
+    #[test]
+    fn analytics_ranges_have_exact_wire_and_window_mappings() {
+        let expected = [
+            (AnalyticsRange::FifteenMinutes, "15m", 900, 60),
+            (AnalyticsRange::OneHour, "1h", 3_600, 300),
+            (AnalyticsRange::SixHours, "6h", 21_600, 900),
+            (AnalyticsRange::TwentyFourHours, "24h", 86_400, 3_600),
+            (AnalyticsRange::SevenDays, "7d", 604_800, 21_600),
+            (AnalyticsRange::ThirtyDays, "30d", 2_592_000, 86_400),
+        ];
+
+        assert_eq!(
+            AnalyticsRange::ALL.map(AnalyticsRange::as_str),
+            ["15m", "1h", "6h", "24h", "7d", "30d"]
+        );
+        for (range, wire, window_seconds, bucket_seconds) in expected {
+            assert_eq!(range.as_str(), wire);
+            assert_eq!(range.window_seconds(), window_seconds);
+            assert_eq!(range.bucket_seconds(), bucket_seconds);
+            assert_eq!(
+                serde_json::to_string(&range).expect("serialize analytics range"),
+                format!(r#""{wire}""#)
+            );
+            assert_eq!(
+                serde_json::from_str::<AnalyticsRange>(&format!(r#""{wire}""#))
+                    .expect("deserialize analytics range"),
+                range
+            );
+        }
+        assert_eq!(AnalyticsRange::default(), AnalyticsRange::TwentyFourHours);
+    }
+
+    #[test]
+    fn session_lookbacks_have_exact_windows_and_default() {
+        for (lookback, wire, window_seconds) in [
+            (SessionLookback::OneHour, "1h", Some(3_600)),
+            (SessionLookback::SixHours, "6h", Some(21_600)),
+            (SessionLookback::TwentyFourHours, "24h", Some(86_400)),
+            (SessionLookback::SevenDays, "7d", Some(604_800)),
+            (SessionLookback::ThirtyDays, "30d", Some(2_592_000)),
+            (SessionLookback::NinetyDays, "90d", Some(7_776_000)),
+            (SessionLookback::All, "all", None),
+        ] {
+            assert_eq!(lookback.as_str(), wire);
+            assert_eq!(lookback.window_seconds(), window_seconds);
+            assert_eq!(
+                serde_json::to_string(&lookback).expect("serialize session lookback"),
+                format!(r#""{wire}""#)
+            );
+        }
+        assert_eq!(SessionLookback::default(), SessionLookback::ThirtyDays);
+    }
+
+    #[test]
+    fn analytics_query_and_table_preview_limits_are_normalized() {
+        let mut sessions = SessionAnalyticsQuery::default();
+        assert_eq!(sessions.limit, 50);
+        assert_eq!(sessions.normalized_limit(), 50);
+        sessions.limit = 0;
+        assert_eq!(sessions.normalized_limit(), 1);
+        sessions.limit = u16::MAX;
+        assert_eq!(sessions.normalized_limit(), 200);
+
+        let mut preview = TablePreviewQuery {
+            table: "events".to_string(),
+            limit: 0,
+        };
+        assert_eq!(preview.normalized_limit(), 1);
+        preview.limit = u16::MAX;
+        assert_eq!(preview.normalized_limit(), 500);
+    }
+
+    #[test]
+    fn session_steps_use_a_stable_kind_tag() {
+        let value = serde_json::to_value(SessionStep::User {
+            event_unix_ms: 123,
+            text: "hello".to_string(),
+        })
+        .expect("serialize typed session step");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "kind": "user",
+                "event_unix_ms": 123,
+                "text": "hello",
+            })
+        );
     }
 }

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -929,7 +929,7 @@ pub enum AnalyticsRange {
 }
 
 impl AnalyticsRange {
-    pub const ALL: [Self; 6] = [
+    pub(crate) const ALL: [Self; 6] = [
         Self::FifteenMinutes,
         Self::OneHour,
         Self::SixHours,
@@ -949,7 +949,7 @@ impl AnalyticsRange {
         }
     }
 
-    pub const fn window_seconds(self) -> u32 {
+    pub(crate) const fn window_seconds(self) -> u32 {
         match self {
             Self::FifteenMinutes => 15 * 60,
             Self::OneHour => 60 * 60,
@@ -960,7 +960,7 @@ impl AnalyticsRange {
         }
     }
 
-    pub const fn bucket_seconds(self) -> u32 {
+    pub(crate) const fn bucket_seconds(self) -> u32 {
         match self {
             Self::FifteenMinutes => 60,
             Self::OneHour => 5 * 60,
@@ -1031,19 +1031,7 @@ pub enum SessionLookback {
 }
 
 impl SessionLookback {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::OneHour => "1h",
-            Self::SixHours => "6h",
-            Self::TwentyFourHours => "24h",
-            Self::SevenDays => "7d",
-            Self::ThirtyDays => "30d",
-            Self::NinetyDays => "90d",
-            Self::All => "all",
-        }
-    }
-
-    pub const fn window_seconds(self) -> Option<u32> {
+    pub(crate) const fn window_seconds(self) -> Option<u32> {
         match self {
             Self::OneHour => Some(60 * 60),
             Self::SixHours => Some(6 * 60 * 60),
@@ -1074,7 +1062,7 @@ impl Default for SessionAnalyticsQuery {
 }
 
 impl SessionAnalyticsQuery {
-    pub fn normalized_limit(&self) -> u16 {
+    pub(crate) fn normalized_limit(&self) -> u16 {
         self.limit.clamp(1, 200)
     }
 }
@@ -1111,6 +1099,8 @@ pub enum SessionStep {
         tool_name: String,
         call_id: String,
         arguments: Value,
+        latency_ms: Option<u32>,
+        is_error: bool,
         result: Option<ToolResult>,
     },
 }
@@ -1203,7 +1193,7 @@ pub struct TablePreviewQuery {
 }
 
 impl TablePreviewQuery {
-    pub fn normalized_limit(&self) -> u16 {
+    pub(crate) fn normalized_limit(&self) -> u16 {
         self.limit.clamp(1, 500)
     }
 }
@@ -1434,7 +1424,6 @@ mod tests {
             (SessionLookback::NinetyDays, "90d", Some(7_776_000)),
             (SessionLookback::All, "all", None),
         ] {
-            assert_eq!(lookback.as_str(), wire);
             assert_eq!(lookback.window_seconds(), window_seconds);
             assert_eq!(
                 serde_json::to_string(&lookback).expect("serialize session lookback"),

--- a/crates/moraine-conversations/src/in_memory_repo.rs
+++ b/crates/moraine-conversations/src/in_memory_repo.rs
@@ -493,7 +493,10 @@ mod tests {
     use std::sync::Arc;
 
     use crate::domain::{
-        AnalyticsRange, SessionAnalyticsQuery, SessionLookback, StoreProbe, TablePreviewQuery,
+        AnalyticsRange, AnalyticsSnapshot, AnalyticsWindow, ConversationMode, ConversationSummary,
+        IngestHeartbeatRead, SessionAnalytics, SessionAnalyticsQuery, SessionLookback,
+        StoreConnectionMetrics, StoreDiagnostics, StoreHealth, StoreProbe, TablePreview,
+        TablePreviewQuery, TableSummaries, WebSearchEvent,
     };
     use crate::error::RepoError;
 
@@ -573,6 +576,173 @@ mod tests {
         assert_eq!(calls.preview_table, vec![preview_query]);
         assert_eq!(calls.read_store_health, 1);
         assert_eq!(calls.read_store_diagnostics, 1);
+    }
+
+    #[tokio::test]
+    async fn analytics_contract_returns_configured_successes_and_accumulates_calls() {
+        let session = SessionAnalytics {
+            summary: ConversationSummary {
+                session_id: "session".to_string(),
+                first_event_time: "2026-01-01 00:00:00".to_string(),
+                first_event_unix_ms: 1,
+                last_event_time: "2026-01-01 00:00:01".to_string(),
+                last_event_unix_ms: 2,
+                total_turns: 1,
+                total_events: 2,
+                user_messages: 1,
+                assistant_messages: 1,
+                tool_calls: 0,
+                tool_results: 0,
+                mode: ConversationMode::Chat,
+                session_slug: None,
+                session_summary: None,
+            },
+            harness: "codex".to_string(),
+            source_name: "codex-jsonl".to_string(),
+            models: vec!["gpt-5".to_string()],
+            trace_id: "trace".to_string(),
+            first_user_text: "hello".to_string(),
+            turns: Vec::new(),
+        };
+        let analytics = AnalyticsSnapshot {
+            window: AnalyticsWindow {
+                range: AnalyticsRange::OneHour,
+                window_seconds: 3_600,
+                bucket_seconds: 300,
+                from_unix: 1,
+                to_unix: 2,
+            },
+            tokens: Vec::new(),
+            turns: Vec::new(),
+            concurrent_sessions: Vec::new(),
+        };
+        let web_search = WebSearchEvent {
+            event_time: "2026-01-01 00:00:00".to_string(),
+            harness: "codex".to_string(),
+            source_name: "codex-jsonl".to_string(),
+            session_id: "session".to_string(),
+            model: "gpt-5".to_string(),
+            action: "search".to_string(),
+            search_query: "rust".to_string(),
+            result_url: String::new(),
+            source_ref: "source".to_string(),
+        };
+        let heartbeat = IngestHeartbeatRead {
+            table_present: true,
+            latest: None,
+        };
+        let tables = TableSummaries {
+            tables: Vec::new(),
+            row_counts_error: Some("partial".to_string()),
+        };
+        let preview = TablePreview {
+            table: "events".to_string(),
+            limit: 7,
+            schema: Vec::new(),
+            rows: Vec::new(),
+        };
+        let health = StoreHealth {
+            ping: StoreProbe::Available(1.5),
+            version: StoreProbe::Available("25.1".to_string()),
+            database_exists: StoreProbe::Available(true),
+            connections: StoreProbe::Available(StoreConnectionMetrics::default()),
+        };
+        let diagnostics = StoreDiagnostics {
+            healthy: true,
+            database: "moraine".to_string(),
+            ..StoreDiagnostics::default()
+        };
+        let responses = InMemoryConversationResponses {
+            list_session_analytics: Some(Ok(vec![session])),
+            analytics_series: Some(Ok(analytics.clone())),
+            list_web_searches: Some(Ok(vec![web_search.clone()])),
+            latest_ingest_heartbeat: Some(Ok(heartbeat.clone())),
+            list_table_summaries: Some(Ok(tables.clone())),
+            preview_table: Some(Ok(preview.clone())),
+            read_store_health: Some(Ok(health.clone())),
+            read_store_diagnostics: Some(Ok(diagnostics.clone())),
+            ..InMemoryConversationResponses::default()
+        };
+        let fake = Arc::new(InMemoryConversationRepository::with_responses(
+            Default::default(),
+            responses,
+        ));
+        let repo: Arc<dyn ConversationRepository> = fake.clone();
+        let session_query = SessionAnalyticsQuery {
+            lookback: SessionLookback::OneHour,
+            limit: 7,
+        };
+        let preview_query = TablePreviewQuery {
+            table: "events".to_string(),
+            limit: 7,
+        };
+
+        for _ in 0..2 {
+            let sessions = repo
+                .list_session_analytics(session_query.clone())
+                .await
+                .expect("configured sessions");
+            assert_eq!(sessions[0].summary.session_id, "session");
+            assert_eq!(
+                repo.analytics_series(AnalyticsRange::OneHour)
+                    .await
+                    .expect("configured analytics"),
+                analytics
+            );
+            assert_eq!(
+                repo.list_web_searches(7)
+                    .await
+                    .expect("configured web searches"),
+                vec![web_search.clone()]
+            );
+            assert_eq!(
+                repo.latest_ingest_heartbeat()
+                    .await
+                    .expect("configured heartbeat"),
+                heartbeat
+            );
+            assert_eq!(
+                repo.list_table_summaries()
+                    .await
+                    .expect("configured table summaries"),
+                tables
+            );
+            assert_eq!(
+                repo.preview_table(preview_query.clone())
+                    .await
+                    .expect("configured preview"),
+                preview
+            );
+            assert_eq!(
+                repo.read_store_health().await.expect("configured health"),
+                health
+            );
+            assert_eq!(
+                repo.read_store_diagnostics()
+                    .await
+                    .expect("configured diagnostics"),
+                diagnostics
+            );
+        }
+
+        let calls = fake.calls();
+        assert_eq!(
+            calls.list_session_analytics,
+            vec![session_query.clone(), session_query]
+        );
+        assert_eq!(
+            calls.analytics_series,
+            vec![AnalyticsRange::OneHour, AnalyticsRange::OneHour]
+        );
+        assert_eq!(calls.list_web_searches, vec![7, 7]);
+        assert_eq!(calls.latest_ingest_heartbeat, 2);
+        assert_eq!(calls.list_table_summaries, 2);
+        assert_eq!(
+            calls.preview_table,
+            vec![preview_query.clone(), preview_query]
+        );
+        assert_eq!(calls.read_store_health, 2);
+        assert_eq!(calls.read_store_diagnostics, 2);
     }
 
     #[tokio::test]

--- a/crates/moraine-conversations/src/in_memory_repo.rs
+++ b/crates/moraine-conversations/src/in_memory_repo.rs
@@ -3,6 +3,11 @@ use std::sync::{Mutex, MutexGuard};
 use async_trait::async_trait;
 
 use crate::domain::{
+    AnalyticsRange, AnalyticsSnapshot, AnalyticsWindow, IngestHeartbeatRead, SessionAnalytics,
+    SessionAnalyticsQuery, StoreDiagnostics, StoreHealth, TablePreview, TablePreviewQuery,
+    TableSummaries, WebSearchEvent,
+};
+use crate::domain::{
     Conversation, ConversationDetailOptions, ConversationListFilter, ConversationSearchQuery,
     ConversationSearchResults, ConversationSearchStats, ConversationSummary, FileAttentionQuery,
     FileAttentionTouch, McpEventOpen, McpEventType, McpSessionListFilter, McpSessionListItem,
@@ -40,6 +45,14 @@ pub struct InMemoryConversationResponses {
     pub file_attention: Option<RepoResult<Vec<FileAttentionTouch>>>,
     pub prewarm_mcp_search_state: Option<RepoResult<()>>,
     pub cancel_query: Option<RepoResult<()>>,
+    pub list_session_analytics: Option<RepoResult<Vec<SessionAnalytics>>>,
+    pub analytics_series: Option<RepoResult<AnalyticsSnapshot>>,
+    pub list_web_searches: Option<RepoResult<Vec<WebSearchEvent>>>,
+    pub latest_ingest_heartbeat: Option<RepoResult<IngestHeartbeatRead>>,
+    pub list_table_summaries: Option<RepoResult<TableSummaries>>,
+    pub preview_table: Option<RepoResult<TablePreview>>,
+    pub read_store_health: Option<RepoResult<StoreHealth>>,
+    pub read_store_diagnostics: Option<RepoResult<StoreDiagnostics>>,
 }
 
 /// Arguments observed by an [`InMemoryConversationRepository`].
@@ -63,6 +76,14 @@ pub struct InMemoryConversationCalls {
     pub file_attention: Vec<FileAttentionQuery>,
     pub prewarm_mcp_search_state: usize,
     pub cancel_query: Vec<String>,
+    pub list_session_analytics: Vec<SessionAnalyticsQuery>,
+    pub analytics_series: Vec<AnalyticsRange>,
+    pub list_web_searches: Vec<u16>,
+    pub latest_ingest_heartbeat: usize,
+    pub list_table_summaries: usize,
+    pub preview_table: Vec<TablePreviewQuery>,
+    pub read_store_health: usize,
+    pub read_store_diagnostics: usize,
 }
 
 /// In-memory, programmable implementation of [`ConversationRepository`].
@@ -208,6 +229,77 @@ impl ConversationRepository for InMemoryConversationRepository {
     async fn prewarm_mcp_search_state(&self) -> RepoResult<()> {
         self.record(|calls| calls.prewarm_mcp_search_state += 1);
         response_or!(self, prewarm_mcp_search_state, ())
+    }
+    async fn list_session_analytics(
+        &self,
+        query: SessionAnalyticsQuery,
+    ) -> RepoResult<Vec<SessionAnalytics>> {
+        self.record(|calls| calls.list_session_analytics.push(query));
+        response_or!(self, list_session_analytics, Vec::new())
+    }
+
+    async fn analytics_series(&self, range: AnalyticsRange) -> RepoResult<AnalyticsSnapshot> {
+        self.record(|calls| calls.analytics_series.push(range));
+        response_or!(
+            self,
+            analytics_series,
+            AnalyticsSnapshot {
+                window: AnalyticsWindow {
+                    range,
+                    window_seconds: range.window_seconds(),
+                    bucket_seconds: range.bucket_seconds(),
+                    from_unix: 0,
+                    to_unix: 0,
+                },
+                tokens: Vec::new(),
+                turns: Vec::new(),
+                concurrent_sessions: Vec::new(),
+            }
+        )
+    }
+
+    async fn list_web_searches(&self, limit: u16) -> RepoResult<Vec<WebSearchEvent>> {
+        self.record(|calls| calls.list_web_searches.push(limit));
+        response_or!(self, list_web_searches, Vec::new())
+    }
+
+    async fn latest_ingest_heartbeat(&self) -> RepoResult<IngestHeartbeatRead> {
+        self.record(|calls| calls.latest_ingest_heartbeat += 1);
+        response_or!(
+            self,
+            latest_ingest_heartbeat,
+            IngestHeartbeatRead::default()
+        )
+    }
+
+    async fn list_table_summaries(&self) -> RepoResult<TableSummaries> {
+        self.record(|calls| calls.list_table_summaries += 1);
+        response_or!(self, list_table_summaries, TableSummaries::default())
+    }
+
+    async fn preview_table(&self, query: TablePreviewQuery) -> RepoResult<TablePreview> {
+        self.record(|calls| calls.preview_table.push(query.clone()));
+        let normalized_limit = query.normalized_limit();
+        response_or!(
+            self,
+            preview_table,
+            TablePreview {
+                table: query.table,
+                limit: normalized_limit,
+                schema: Vec::new(),
+                rows: Vec::new(),
+            }
+        )
+    }
+
+    async fn read_store_health(&self) -> RepoResult<StoreHealth> {
+        self.record(|calls| calls.read_store_health += 1);
+        response_or!(self, read_store_health, StoreHealth::default())
+    }
+
+    async fn read_store_diagnostics(&self) -> RepoResult<StoreDiagnostics> {
+        self.record(|calls| calls.read_store_diagnostics += 1);
+        response_or!(self, read_store_diagnostics, StoreDiagnostics::default())
     }
 
     async fn list_conversations(
@@ -394,4 +486,148 @@ fn mutex_lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     mutex
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::domain::{
+        AnalyticsRange, SessionAnalyticsQuery, SessionLookback, StoreProbe, TablePreviewQuery,
+    };
+    use crate::error::RepoError;
+
+    use super::{
+        ConversationRepository, InMemoryConversationRepository, InMemoryConversationResponses,
+    };
+
+    #[tokio::test]
+    async fn analytics_contract_defaults_and_calls_work_through_trait_object() {
+        let fake = Arc::new(InMemoryConversationRepository::default());
+        let repo: Arc<dyn ConversationRepository> = fake.clone();
+        let session_query = SessionAnalyticsQuery {
+            lookback: SessionLookback::SevenDays,
+            limit: 0,
+        };
+        let preview_query = TablePreviewQuery {
+            table: "events".to_string(),
+            limit: 0,
+        };
+
+        assert!(repo
+            .list_session_analytics(session_query.clone())
+            .await
+            .expect("default session analytics")
+            .is_empty());
+        let snapshot = repo
+            .analytics_series(AnalyticsRange::ThirtyDays)
+            .await
+            .expect("default analytics series");
+        assert_eq!(snapshot.window.range, AnalyticsRange::ThirtyDays);
+        assert_eq!(snapshot.window.window_seconds, 2_592_000);
+        assert_eq!(snapshot.window.bucket_seconds, 86_400);
+        assert!(snapshot.tokens.is_empty());
+        assert!(repo
+            .list_web_searches(0)
+            .await
+            .expect("default web searches")
+            .is_empty());
+        assert_eq!(
+            repo.latest_ingest_heartbeat()
+                .await
+                .expect("default heartbeat"),
+            Default::default()
+        );
+        assert_eq!(
+            repo.list_table_summaries()
+                .await
+                .expect("default table summaries"),
+            Default::default()
+        );
+        let preview = repo
+            .preview_table(preview_query.clone())
+            .await
+            .expect("default table preview");
+        assert_eq!(preview.table, "events");
+        assert_eq!(preview.limit, 1);
+        assert!(preview.schema.is_empty());
+        assert!(preview.rows.is_empty());
+        let health = repo
+            .read_store_health()
+            .await
+            .expect("default store health");
+        assert!(matches!(health.ping, StoreProbe::Failed { .. }));
+        assert_eq!(
+            repo.read_store_diagnostics()
+                .await
+                .expect("default store diagnostics"),
+            Default::default()
+        );
+
+        let calls = fake.calls();
+        assert_eq!(calls.list_session_analytics, vec![session_query]);
+        assert_eq!(calls.analytics_series, vec![AnalyticsRange::ThirtyDays]);
+        assert_eq!(calls.list_web_searches, vec![0]);
+        assert_eq!(calls.latest_ingest_heartbeat, 1);
+        assert_eq!(calls.list_table_summaries, 1);
+        assert_eq!(calls.preview_table, vec![preview_query]);
+        assert_eq!(calls.read_store_health, 1);
+        assert_eq!(calls.read_store_diagnostics, 1);
+    }
+
+    #[tokio::test]
+    async fn analytics_contract_returns_each_configured_error_through_trait_object() {
+        let responses = InMemoryConversationResponses {
+            list_session_analytics: Some(Err(RepoError::backend("sessions"))),
+            analytics_series: Some(Err(RepoError::backend("analytics"))),
+            list_web_searches: Some(Err(RepoError::backend("web"))),
+            latest_ingest_heartbeat: Some(Err(RepoError::backend("heartbeat"))),
+            list_table_summaries: Some(Err(RepoError::backend("tables"))),
+            preview_table: Some(Err(RepoError::backend("preview"))),
+            read_store_health: Some(Err(RepoError::backend("health"))),
+            read_store_diagnostics: Some(Err(RepoError::backend("diagnostics"))),
+            ..InMemoryConversationResponses::default()
+        };
+        let repo: Arc<dyn ConversationRepository> = Arc::new(
+            InMemoryConversationRepository::with_responses(Default::default(), responses),
+        );
+
+        assert!(matches!(
+            repo.list_session_analytics(SessionAnalyticsQuery::default())
+                .await,
+            Err(RepoError::Backend(message)) if message == "sessions"
+        ));
+        assert!(matches!(
+            repo.analytics_series(AnalyticsRange::default()).await,
+            Err(RepoError::Backend(message)) if message == "analytics"
+        ));
+        assert!(matches!(
+            repo.list_web_searches(100).await,
+            Err(RepoError::Backend(message)) if message == "web"
+        ));
+        assert!(matches!(
+            repo.latest_ingest_heartbeat().await,
+            Err(RepoError::Backend(message)) if message == "heartbeat"
+        ));
+        assert!(matches!(
+            repo.list_table_summaries().await,
+            Err(RepoError::Backend(message)) if message == "tables"
+        ));
+        assert!(matches!(
+            repo.preview_table(TablePreviewQuery {
+                table: "events".to_string(),
+                limit: 25,
+            })
+            .await,
+            Err(RepoError::Backend(message)) if message == "preview"
+        ));
+        assert!(matches!(
+            repo.read_store_health().await,
+            Err(RepoError::Backend(message)) if message == "health"
+        ));
+        assert!(matches!(
+            repo.read_store_diagnostics().await,
+            Err(RepoError::Backend(message)) if message == "diagnostics"
+        ));
+    }
 }

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -19,6 +19,13 @@ pub use domain::{
     SessionMetadataSearchHit, SessionMetadataSearchQuery, SessionMetadataSearchResults,
     SessionMetadataSearchStats, SessionOriginScope, TraceEvent, Turn, TurnListFilter, TurnSummary,
 };
+pub use domain::{
+    AnalyticsConcurrencyPoint, AnalyticsRange, AnalyticsSnapshot, AnalyticsTokenPoint,
+    AnalyticsTurnPoint, AnalyticsWindow, IngestHeartbeat, IngestHeartbeatRead, SessionAnalytics,
+    SessionAnalyticsQuery, SessionLookback, SessionStep, SessionTurn, StoreConnectionMetrics,
+    StoreDiagnostics, StoreHealth, StoreProbe, TableColumn, TablePreview, TablePreviewQuery,
+    TableSummaries, TableSummary, ToolResult, WebSearchEvent,
+};
 pub use error::{RepoError, RepoResult};
 pub use in_memory_repo::{
     InMemoryConversationCalls, InMemoryConversationRepository, InMemoryConversationResponses,

--- a/crates/moraine-conversations/src/repo.rs
+++ b/crates/moraine-conversations/src/repo.rs
@@ -1,6 +1,11 @@
 use async_trait::async_trait;
 
 use crate::domain::{
+    AnalyticsRange, AnalyticsSnapshot, IngestHeartbeatRead, SessionAnalytics,
+    SessionAnalyticsQuery, StoreDiagnostics, StoreHealth, TablePreview, TablePreviewQuery,
+    TableSummaries, WebSearchEvent,
+};
+use crate::domain::{
     Conversation, ConversationDetailOptions, ConversationListFilter, ConversationSearchQuery,
     ConversationSearchResults, FileAttentionQuery, FileAttentionTouch, McpEventOpen,
     McpSessionListFilter, McpSessionListItem, McpSessionOpen, McpTurnOpen, OpenContext,
@@ -16,6 +21,24 @@ pub trait ConversationRepository: Send + Sync {
     fn config(&self) -> &RepoConfig;
 
     async fn prewarm_mcp_search_state(&self) -> RepoResult<()>;
+    async fn list_session_analytics(
+        &self,
+        query: SessionAnalyticsQuery,
+    ) -> RepoResult<Vec<SessionAnalytics>>;
+
+    async fn analytics_series(&self, range: AnalyticsRange) -> RepoResult<AnalyticsSnapshot>;
+
+    async fn list_web_searches(&self, limit: u16) -> RepoResult<Vec<WebSearchEvent>>;
+
+    async fn latest_ingest_heartbeat(&self) -> RepoResult<IngestHeartbeatRead>;
+
+    async fn list_table_summaries(&self) -> RepoResult<TableSummaries>;
+
+    async fn preview_table(&self, query: TablePreviewQuery) -> RepoResult<TablePreview>;
+
+    async fn read_store_health(&self) -> RepoResult<StoreHealth>;
+
+    async fn read_store_diagnostics(&self) -> RepoResult<StoreDiagnostics>;
 
     async fn list_conversations(
         &self,

--- a/crates/moraine-conversations/tests/analytics_benchmark.rs
+++ b/crates/moraine-conversations/tests/analytics_benchmark.rs
@@ -1,0 +1,772 @@
+use anyhow::{anyhow, bail, Context, Result};
+use moraine_clickhouse::ClickHouseClient;
+use moraine_config::ClickHouseConfig;
+use moraine_conversations::{
+    AnalyticsRange, ClickHouseConversationRepository, ConversationRepository, RepoConfig,
+    SessionAnalyticsQuery, SessionLookback,
+};
+use reqwest::{Client, Url};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
+use std::env;
+use std::time::{Duration, Instant};
+
+const DEFAULT_SAMPLES: usize = 60;
+const DEFAULT_WARMUPS: usize = 5;
+const MAX_P95_REGRESSION_RATIO: f64 = 0.20;
+
+#[derive(Debug)]
+struct BenchmarkConfig {
+    monitor_url: String,
+    clickhouse_url: String,
+    clickhouse_database: String,
+    clickhouse_username: String,
+    clickhouse_password: String,
+    samples: usize,
+    warmups: usize,
+}
+
+impl BenchmarkConfig {
+    fn from_env() -> Result<Self> {
+        let defaults = ClickHouseConfig::default();
+        let monitor_url = required_env("MORAINE_BENCH_MONITOR_URL")?;
+        let clickhouse_url = required_env("MORAINE_BENCH_CLICKHOUSE_URL")?;
+        let clickhouse_database =
+            optional_env("MORAINE_BENCH_CLICKHOUSE_DATABASE", defaults.database)?;
+        let clickhouse_username = optional_env("MORAINE_BENCH_CLICKHOUSE_USER", defaults.username)?;
+        let clickhouse_password =
+            optional_env("MORAINE_BENCH_CLICKHOUSE_PASSWORD", defaults.password)?;
+        let samples = usize_env("MORAINE_BENCH_SAMPLES", DEFAULT_SAMPLES)?;
+        let warmups = usize_env("MORAINE_BENCH_WARMUPS", DEFAULT_WARMUPS)?;
+
+        if samples == 0 {
+            bail!("MORAINE_BENCH_SAMPLES must be at least 1");
+        }
+        if clickhouse_database.is_empty() {
+            bail!("MORAINE_BENCH_CLICKHOUSE_DATABASE must not be empty");
+        }
+
+        Url::parse(&clickhouse_url).with_context(|| {
+            format!("MORAINE_BENCH_CLICKHOUSE_URL is not a valid URL: {clickhouse_url}")
+        })?;
+
+        Ok(Self {
+            monitor_url,
+            clickhouse_url,
+            clickhouse_database,
+            clickhouse_username,
+            clickhouse_password,
+            samples,
+            warmups,
+        })
+    }
+
+    fn clickhouse_config(&self) -> ClickHouseConfig {
+        ClickHouseConfig {
+            url: self.clickhouse_url.clone(),
+            database: self.clickhouse_database.clone(),
+            username: self.clickhouse_username.clone(),
+            password: self.clickhouse_password.clone(),
+            ..ClickHouseConfig::default()
+        }
+    }
+}
+
+fn required_env(name: &str) -> Result<String> {
+    match env::var(name) {
+        Ok(value) if !value.is_empty() => Ok(value),
+        Ok(_) => bail!("{name} must not be empty"),
+        Err(env::VarError::NotPresent) => bail!("{name} is required"),
+        Err(env::VarError::NotUnicode(_)) => bail!("{name} must contain valid UTF-8"),
+    }
+}
+
+fn optional_env(name: &str, default: String) -> Result<String> {
+    match env::var(name) {
+        Ok(value) => Ok(value),
+        Err(env::VarError::NotPresent) => Ok(default),
+        Err(env::VarError::NotUnicode(_)) => bail!("{name} must contain valid UTF-8"),
+    }
+}
+
+fn usize_env(name: &str, default: usize) -> Result<usize> {
+    match env::var(name) {
+        Ok(value) => value
+            .parse::<usize>()
+            .with_context(|| format!("{name} must be a non-negative integer, got {value:?}")),
+        Err(env::VarError::NotPresent) => Ok(default),
+        Err(env::VarError::NotUnicode(_)) => bail!("{name} must contain valid UTF-8"),
+    }
+}
+
+struct BenchmarkContext {
+    http: Client,
+    monitor_analytics_url: Url,
+    monitor_sessions_url: Url,
+    clickhouse: ClickHouseClient,
+}
+
+impl BenchmarkContext {
+    fn new(config: &BenchmarkConfig) -> Result<Self> {
+        let http = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .context("failed to construct monitor HTTP client")?;
+        let monitor_analytics_url =
+            monitor_endpoint(&config.monitor_url, "/api/analytics?range=24h")?;
+        let monitor_sessions_url =
+            monitor_endpoint(&config.monitor_url, "/api/sessions?since=30d&limit=50")?;
+        let clickhouse = ClickHouseClient::new(config.clickhouse_config())
+            .context("failed to construct ClickHouse client")?;
+
+        Ok(Self {
+            http,
+            monitor_analytics_url,
+            monitor_sessions_url,
+            clickhouse,
+        })
+    }
+
+    fn fresh_repository(&self) -> ClickHouseConversationRepository {
+        ClickHouseConversationRepository::new(
+            self.clickhouse.clone(),
+            RepoConfig {
+                max_results: 50,
+                ..RepoConfig::default()
+            },
+        )
+    }
+}
+
+fn monitor_endpoint(base: &str, path_and_query: &str) -> Result<Url> {
+    let endpoint = format!("{}{}", base.trim_end_matches('/'), path_and_query);
+    Url::parse(&endpoint).with_context(|| format!("invalid monitor endpoint URL: {endpoint}"))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Arm {
+    MonitorHttp,
+    DirectRepository,
+}
+
+impl Arm {
+    const fn other(self) -> Self {
+        match self {
+            Self::MonitorHttp => Self::DirectRepository,
+            Self::DirectRepository => Self::MonitorHttp,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Scenario {
+    Analytics24h,
+    Sessions30d50,
+}
+
+impl Scenario {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Analytics24h => "analytics_24h",
+            Self::Sessions30d50 => "sessions_30d_limit_50",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum Cardinality {
+    AnalyticsSeries {
+        tokens: usize,
+        turns: usize,
+        concurrent_sessions: usize,
+    },
+    Sessions {
+        sessions: usize,
+    },
+}
+
+#[derive(Deserialize)]
+struct MonitorAnalyticsResponse {
+    ok: bool,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    series: Option<MonitorAnalyticsSeries>,
+}
+
+#[derive(Deserialize)]
+struct MonitorAnalyticsSeries {
+    tokens: Vec<Value>,
+    turns: Vec<Value>,
+    concurrent_sessions: Vec<Value>,
+}
+
+#[derive(Deserialize)]
+struct MonitorSessionsResponse {
+    ok: bool,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    sessions: Option<Vec<Value>>,
+}
+
+trait MonitorResponse: DeserializeOwned {
+    fn into_cardinality(self) -> Result<Cardinality>;
+}
+
+impl MonitorResponse for MonitorAnalyticsResponse {
+    fn into_cardinality(self) -> Result<Cardinality> {
+        if !self.ok {
+            bail!(
+                "monitor analytics response had ok=false: {}",
+                self.error.as_deref().unwrap_or("missing error message")
+            );
+        }
+        let series = self
+            .series
+            .context("monitor analytics response had ok=true but no series")?;
+        Ok(Cardinality::AnalyticsSeries {
+            tokens: series.tokens.len(),
+            turns: series.turns.len(),
+            concurrent_sessions: series.concurrent_sessions.len(),
+        })
+    }
+}
+
+impl MonitorResponse for MonitorSessionsResponse {
+    fn into_cardinality(self) -> Result<Cardinality> {
+        if !self.ok {
+            bail!(
+                "monitor sessions response had ok=false: {}",
+                self.error.as_deref().unwrap_or("missing error message")
+            );
+        }
+        let sessions = self
+            .sessions
+            .context("monitor sessions response had ok=true but no sessions")?;
+        Ok(Cardinality::Sessions {
+            sessions: sessions.len(),
+        })
+    }
+}
+
+struct TimedSample {
+    elapsed: Duration,
+    cardinality: Cardinality,
+}
+
+async fn sample_monitor<T>(client: &Client, url: &Url, label: &str) -> Result<TimedSample>
+where
+    T: MonitorResponse,
+{
+    let started = Instant::now();
+    let response = client
+        .get(url.clone())
+        .send()
+        .await
+        .with_context(|| format!("{label} request failed: {url}"))?;
+    let status = response.status();
+    let body = response
+        .bytes()
+        .await
+        .with_context(|| format!("{label} response body failed: {url}"))?;
+    let payload = serde_json::from_slice::<T>(&body).with_context(|| {
+        format!(
+            "{label} returned invalid JSON from {url}: {}",
+            String::from_utf8_lossy(&body)
+        )
+    })?;
+    if !status.is_success() {
+        bail!(
+            "{label} returned HTTP {status} from {url}: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+    let cardinality = payload.into_cardinality()?;
+
+    Ok(TimedSample {
+        elapsed: started.elapsed(),
+        cardinality,
+    })
+}
+
+async fn sample_direct_analytics(
+    repository: &ClickHouseConversationRepository,
+) -> Result<TimedSample> {
+    let started = Instant::now();
+    let snapshot = repository
+        .analytics_series(AnalyticsRange::TwentyFourHours)
+        .await
+        .context("direct analytics repository request failed")?;
+
+    Ok(TimedSample {
+        elapsed: started.elapsed(),
+        cardinality: Cardinality::AnalyticsSeries {
+            tokens: snapshot.tokens.len(),
+            turns: snapshot.turns.len(),
+            concurrent_sessions: snapshot.concurrent_sessions.len(),
+        },
+    })
+}
+
+async fn sample_direct_sessions(
+    repository: &ClickHouseConversationRepository,
+) -> Result<TimedSample> {
+    let started = Instant::now();
+    let sessions = repository
+        .list_session_analytics(SessionAnalyticsQuery {
+            lookback: SessionLookback::ThirtyDays,
+            limit: 50,
+        })
+        .await
+        .context("direct sessions repository request failed")?;
+
+    Ok(TimedSample {
+        elapsed: started.elapsed(),
+        cardinality: Cardinality::Sessions {
+            sessions: sessions.len(),
+        },
+    })
+}
+
+async fn take_sample(
+    context: &BenchmarkContext,
+    scenario: Scenario,
+    arm: Arm,
+) -> Result<TimedSample> {
+    match (scenario, arm) {
+        (Scenario::Analytics24h, Arm::MonitorHttp) => {
+            sample_monitor::<MonitorAnalyticsResponse>(
+                &context.http,
+                &context.monitor_analytics_url,
+                "monitor analytics",
+            )
+            .await
+        }
+        (Scenario::Sessions30d50, Arm::MonitorHttp) => {
+            sample_monitor::<MonitorSessionsResponse>(
+                &context.http,
+                &context.monitor_sessions_url,
+                "monitor sessions",
+            )
+            .await
+        }
+        (Scenario::Analytics24h, Arm::DirectRepository) => {
+            let repository = context.fresh_repository();
+            sample_direct_analytics(&repository).await
+        }
+        (Scenario::Sessions30d50, Arm::DirectRepository) => {
+            let repository = context.fresh_repository();
+            sample_direct_sessions(&repository).await
+        }
+    }
+}
+
+#[derive(Default)]
+struct Measurements {
+    elapsed: Vec<Duration>,
+    cardinality: Option<Cardinality>,
+}
+
+impl Measurements {
+    fn record(&mut self, sample: TimedSample, scenario: Scenario, arm: Arm) -> Result<()> {
+        if let Some(expected) = &self.cardinality {
+            if expected != &sample.cardinality {
+                bail!(
+                    "{} {:?} cardinality changed after {} successful samples: expected {:?}, got {:?}",
+                    scenario.name(),
+                    arm,
+                    self.elapsed.len(),
+                    expected,
+                    sample.cardinality
+                );
+            }
+        } else {
+            self.cardinality = Some(sample.cardinality.clone());
+        }
+        self.elapsed.push(sample.elapsed);
+        Ok(())
+    }
+
+    fn report(&self, expected_samples: usize) -> Result<ArmReport> {
+        if self.elapsed.len() != expected_samples {
+            bail!(
+                "expected exactly {expected_samples} successful samples, got {}",
+                self.elapsed.len()
+            );
+        }
+        let elapsed_ms: Vec<f64> = self
+            .elapsed
+            .iter()
+            .map(|duration| duration.as_secs_f64() * 1_000.0)
+            .collect();
+        let p50_ms = type7_percentile(&elapsed_ms, 0.50)
+            .ok_or_else(|| anyhow!("unable to compute p50 from successful samples"))?;
+        let p95_ms = type7_percentile(&elapsed_ms, 0.95)
+            .ok_or_else(|| anyhow!("unable to compute p95 from successful samples"))?;
+        let cardinality = self
+            .cardinality
+            .clone()
+            .context("successful samples had no cardinality")?;
+
+        Ok(ArmReport {
+            successful_samples: self.elapsed.len(),
+            cardinality,
+            p50_ms,
+            p95_ms,
+        })
+    }
+}
+
+#[derive(Serialize)]
+struct ArmReport {
+    successful_samples: usize,
+    cardinality: Cardinality,
+    p50_ms: f64,
+    p95_ms: f64,
+}
+
+#[derive(Serialize)]
+struct CardinalityDifference {
+    monitor_http: Cardinality,
+    direct_repository: Cardinality,
+}
+
+#[derive(Serialize)]
+struct P95Comparison {
+    direct_minus_monitor_ms: f64,
+    absolute_delta_ms: f64,
+    direct_minus_monitor_percent: f64,
+    absolute_delta_percent: f64,
+    direct_to_monitor_ratio: f64,
+    allowed_max_regression_percent: f64,
+    passed: bool,
+}
+
+#[derive(Serialize)]
+struct ScenarioReport {
+    scenario: &'static str,
+    initial_order: [Arm; 2],
+    monitor_http: ArmReport,
+    direct_repository_cold: ArmReport,
+    cardinality_match: bool,
+    semantic_cardinality_difference: Option<CardinalityDifference>,
+    p95_comparison: P95Comparison,
+    passed: bool,
+}
+
+async fn run_scenario(
+    context: &BenchmarkContext,
+    scenario: Scenario,
+    warmups: usize,
+    samples: usize,
+    initial_arm: Arm,
+) -> Result<ScenarioReport> {
+    for iteration in 0..warmups {
+        let first = if iteration % 2 == 0 {
+            initial_arm
+        } else {
+            initial_arm.other()
+        };
+        take_sample(context, scenario, first)
+            .await
+            .with_context(|| {
+                format!(
+                    "{} warmup {} {:?} failed",
+                    scenario.name(),
+                    iteration + 1,
+                    first
+                )
+            })?;
+        take_sample(context, scenario, first.other())
+            .await
+            .with_context(|| {
+                format!(
+                    "{} warmup {} {:?} failed",
+                    scenario.name(),
+                    iteration + 1,
+                    first.other()
+                )
+            })?;
+    }
+
+    let mut monitor = Measurements::default();
+    let mut direct = Measurements::default();
+    for iteration in 0..samples {
+        let first = if iteration % 2 == 0 {
+            initial_arm
+        } else {
+            initial_arm.other()
+        };
+        for arm in [first, first.other()] {
+            let sample = take_sample(context, scenario, arm).await.with_context(|| {
+                format!(
+                    "{} measured sample {} {:?} failed",
+                    scenario.name(),
+                    iteration + 1,
+                    arm
+                )
+            })?;
+            match arm {
+                Arm::MonitorHttp => monitor.record(sample, scenario, arm)?,
+                Arm::DirectRepository => direct.record(sample, scenario, arm)?,
+            }
+        }
+    }
+
+    let monitor_http = monitor.report(samples)?;
+    let direct_repository_cold = direct.report(samples)?;
+    let cardinality_match = monitor_http.cardinality == direct_repository_cold.cardinality;
+    let semantic_cardinality_difference = (!cardinality_match).then(|| CardinalityDifference {
+        monitor_http: monitor_http.cardinality.clone(),
+        direct_repository: direct_repository_cold.cardinality.clone(),
+    });
+    let ratio = ratio_assessment(
+        monitor_http.p95_ms,
+        direct_repository_cold.p95_ms,
+        MAX_P95_REGRESSION_RATIO,
+    )
+    .ok_or_else(|| {
+        anyhow!(
+            "{} p95 ratio rejected zero or invalid monitor baseline: {} ms",
+            scenario.name(),
+            monitor_http.p95_ms
+        )
+    })?;
+    let direct_minus_monitor_ms = direct_repository_cold.p95_ms - monitor_http.p95_ms;
+    let p95_comparison = P95Comparison {
+        direct_minus_monitor_ms,
+        absolute_delta_ms: direct_minus_monitor_ms.abs(),
+        direct_minus_monitor_percent: ratio.signed_delta_ratio * 100.0,
+        absolute_delta_percent: ratio.absolute_delta_ratio * 100.0,
+        direct_to_monitor_ratio: ratio.ratio,
+        allowed_max_regression_percent: MAX_P95_REGRESSION_RATIO * 100.0,
+        passed: ratio.passed,
+    };
+
+    Ok(ScenarioReport {
+        scenario: scenario.name(),
+        initial_order: [initial_arm, initial_arm.other()],
+        monitor_http,
+        direct_repository_cold,
+        cardinality_match,
+        semantic_cardinality_difference,
+        passed: p95_comparison.passed,
+        p95_comparison,
+    })
+}
+
+#[derive(Serialize)]
+struct WarmAnalyticsReport {
+    successful_samples: usize,
+    cardinality: Cardinality,
+    p95_ms: f64,
+}
+
+async fn run_warm_analytics_cache(
+    context: &BenchmarkContext,
+    warmups: usize,
+    samples: usize,
+) -> Result<WarmAnalyticsReport> {
+    let repository = context.fresh_repository();
+    let priming_calls = warmups.max(1);
+    for warmup in 0..priming_calls {
+        sample_direct_analytics(&repository)
+            .await
+            .with_context(|| format!("warm analytics cache priming call {} failed", warmup + 1))?;
+    }
+
+    let mut measurements = Measurements::default();
+    for sample_number in 0..samples {
+        let sample = sample_direct_analytics(&repository)
+            .await
+            .with_context(|| {
+                format!(
+                    "warm analytics cache measured sample {} failed",
+                    sample_number + 1
+                )
+            })?;
+        measurements.record(sample, Scenario::Analytics24h, Arm::DirectRepository)?;
+    }
+    let report = measurements.report(samples)?;
+
+    Ok(WarmAnalyticsReport {
+        successful_samples: report.successful_samples,
+        cardinality: report.cardinality,
+        p95_ms: report.p95_ms,
+    })
+}
+
+#[derive(Serialize)]
+struct BenchmarkReport {
+    benchmark: &'static str,
+    monitor_url: String,
+    clickhouse_url: String,
+    clickhouse_database: String,
+    warmups: usize,
+    samples_per_arm: usize,
+    max_p95_regression_percent: f64,
+    scenarios: Vec<ScenarioReport>,
+    warm_analytics_cache: WarmAnalyticsReport,
+    passed: bool,
+}
+
+#[tokio::test]
+#[ignore = "requires live monitor and ClickHouse sandbox URLs"]
+async fn live_monitor_vs_repository_latency() -> Result<()> {
+    let config = BenchmarkConfig::from_env()?;
+    let context = BenchmarkContext::new(&config)?;
+
+    let analytics = run_scenario(
+        &context,
+        Scenario::Analytics24h,
+        config.warmups,
+        config.samples,
+        Arm::MonitorHttp,
+    )
+    .await?;
+    let sessions = run_scenario(
+        &context,
+        Scenario::Sessions30d50,
+        config.warmups,
+        config.samples,
+        Arm::DirectRepository,
+    )
+    .await?;
+    let warm_analytics_cache =
+        run_warm_analytics_cache(&context, config.warmups, config.samples).await?;
+    let passed = analytics.passed && sessions.passed;
+    let report = BenchmarkReport {
+        benchmark: "monitor_http_vs_direct_clickhouse_conversation_repository",
+        monitor_url: config.monitor_url,
+        clickhouse_url: config.clickhouse_url,
+        clickhouse_database: config.clickhouse_database,
+        warmups: config.warmups,
+        samples_per_arm: config.samples,
+        max_p95_regression_percent: MAX_P95_REGRESSION_RATIO * 100.0,
+        scenarios: vec![analytics, sessions],
+        warm_analytics_cache,
+        passed,
+    };
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).context("failed to serialize benchmark report")?
+    );
+
+    if !report.passed {
+        bail!("one or more cold scenarios exceeded the 20% p95 regression ceiling");
+    }
+    Ok(())
+}
+
+fn type7_percentile(samples: &[f64], probability: f64) -> Option<f64> {
+    if samples.is_empty()
+        || !probability.is_finite()
+        || !(0.0..=1.0).contains(&probability)
+        || samples.iter().any(|sample| !sample.is_finite())
+    {
+        return None;
+    }
+
+    let mut sorted = samples.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    if sorted.len() == 1 {
+        return sorted.first().copied();
+    }
+
+    let index = (sorted.len() - 1) as f64 * probability;
+    let lower = index.floor() as usize;
+    let fraction = index - lower as f64;
+    let upper = (lower + 1).min(sorted.len() - 1);
+    Some(sorted[lower] + fraction * (sorted[upper] - sorted[lower]))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RatioAssessment {
+    ratio: f64,
+    signed_delta_ratio: f64,
+    absolute_delta_ratio: f64,
+    passed: bool,
+}
+
+fn ratio_assessment(
+    baseline: f64,
+    candidate: f64,
+    max_regression_ratio: f64,
+) -> Option<RatioAssessment> {
+    if !baseline.is_finite()
+        || baseline <= 0.0
+        || !candidate.is_finite()
+        || candidate < 0.0
+        || !max_regression_ratio.is_finite()
+        || max_regression_ratio < 0.0
+    {
+        return None;
+    }
+
+    let ratio = candidate / baseline;
+    let signed_delta_ratio = ratio - 1.0;
+    let upper_bound = baseline * (1.0 + max_regression_ratio);
+    Some(RatioAssessment {
+        ratio,
+        signed_delta_ratio,
+        absolute_delta_ratio: signed_delta_ratio.abs(),
+        passed: candidate <= upper_bound,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ratio_assessment, type7_percentile};
+
+    fn assert_close(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < 1e-12,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn type7_percentile_rejects_empty_samples() {
+        assert_eq!(type7_percentile(&[], 0.95), None);
+    }
+
+    #[test]
+    fn type7_percentile_returns_singleton() {
+        assert_eq!(type7_percentile(&[7.25], 0.50), Some(7.25));
+        assert_eq!(type7_percentile(&[7.25], 0.95), Some(7.25));
+    }
+
+    #[test]
+    fn type7_percentile_interpolates_between_adjacent_samples() {
+        let samples = [4.0, 1.0, 3.0, 2.0];
+        assert_close(type7_percentile(&samples, 0.25).unwrap(), 1.75);
+        assert_close(type7_percentile(&samples, 0.50).unwrap(), 2.50);
+        assert_close(type7_percentile(&samples, 0.95).unwrap(), 3.85);
+    }
+
+    #[test]
+    fn ratio_gate_rejects_zero_baseline() {
+        assert!(ratio_assessment(0.0, 0.0, 0.20).is_none());
+        assert!(ratio_assessment(0.0, 1.0, 0.20).is_none());
+    }
+
+    #[test]
+    fn ratio_gate_accepts_speedups_and_the_twenty_percent_regression_threshold() {
+        let faster = ratio_assessment(10.0, 5.0, 0.20).unwrap();
+        let threshold = ratio_assessment(10.0, 12.0, 0.20).unwrap();
+        assert!(faster.passed);
+        assert!(threshold.passed);
+        assert_close(faster.ratio, 0.5);
+        assert_close(threshold.ratio, 1.2);
+    }
+
+    #[test]
+    fn ratio_gate_rejects_only_regressions_over_twenty_percent() {
+        assert!(ratio_assessment(10.0, 7.999, 0.20).unwrap().passed);
+        assert!(!ratio_assessment(10.0, 12.001, 0.20).unwrap().passed);
+    }
+}

--- a/crates/moraine-conversations/tests/analytics_benchmark.rs
+++ b/crates/moraine-conversations/tests/analytics_benchmark.rs
@@ -7,9 +7,9 @@ use moraine_conversations::{
 };
 use reqwest::{Client, Url};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Map, Value};
 use std::env;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const DEFAULT_SAMPLES: usize = 60;
 const DEFAULT_WARMUPS: usize = 5;
@@ -143,6 +143,15 @@ fn monitor_endpoint(base: &str, path_and_query: &str) -> Result<Url> {
     Url::parse(&endpoint).with_context(|| format!("invalid monitor endpoint URL: {endpoint}"))
 }
 
+fn report_origin(raw: &str, label: &str) -> Result<String> {
+    let url = Url::parse(raw).with_context(|| format!("{label} is not a valid URL"))?;
+    let origin = url.origin().ascii_serialization();
+    if origin == "null" {
+        bail!("{label} must have an HTTP(S) origin");
+    }
+    Ok(format!("{origin}/"))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 enum Arm {
@@ -187,6 +196,83 @@ enum Cardinality {
     },
 }
 
+fn normalized_digest(value: &Value) -> Result<String> {
+    let bytes = serde_json::to_vec(&canonicalize_json(value))
+        .context("failed to serialize normalized benchmark payload")?;
+    let hash = bytes
+        .into_iter()
+        .fold(0xcbf29ce484222325_u64, |hash, byte| {
+            hash.wrapping_mul(0x100000001b3) ^ u64::from(byte)
+        });
+    Ok(format!("fnv1a64:{hash:016x}"))
+}
+
+fn canonicalize_json(value: &Value) -> Value {
+    match value {
+        Value::Array(values) => {
+            let mut values = values.iter().map(canonicalize_json).collect::<Vec<_>>();
+            values.sort_by_cached_key(|value| serde_json::to_string(value).unwrap_or_default());
+            Value::Array(values)
+        }
+        Value::Object(object) => {
+            let mut entries = object.iter().collect::<Vec<_>>();
+            entries.sort_unstable_by_key(|(key, _)| *key);
+            let mut normalized = Map::new();
+            for (key, value) in entries {
+                normalized.insert(key.clone(), canonicalize_json(value));
+            }
+            Value::Object(normalized)
+        }
+        scalar => scalar.clone(),
+    }
+}
+
+fn monitor_session_projection(session: &Value) -> Result<Value> {
+    let session_id = session
+        .get("id")
+        .and_then(Value::as_str)
+        .context("monitor session missing string id")?;
+    let harness = session
+        .pointer("/harness/id")
+        .and_then(Value::as_str)
+        .context("monitor session missing harness.id")?;
+    let started_at = session
+        .get("startedAt")
+        .and_then(Value::as_i64)
+        .context("monitor session missing startedAt")?;
+    let ended_at = session
+        .get("endedAt")
+        .and_then(Value::as_i64)
+        .context("monitor session missing endedAt")?;
+    let models = session
+        .get("models")
+        .and_then(Value::as_array)
+        .context("monitor session missing models")?;
+    let trace_id = session
+        .get("traceId")
+        .and_then(Value::as_str)
+        .context("monitor session missing traceId")?;
+    let turns = session
+        .get("turns")
+        .and_then(Value::as_array)
+        .context("monitor session missing turns")?;
+    let tool_calls = session
+        .get("totalToolCalls")
+        .and_then(Value::as_u64)
+        .context("monitor session missing totalToolCalls")?;
+
+    Ok(json!({
+        "session_id": session_id,
+        "harness": harness,
+        "started_at_unix_ms": started_at,
+        "ended_at_unix_ms": ended_at,
+        "models": models,
+        "trace_id": trace_id,
+        "turns": turns.len(),
+        "tool_calls": tool_calls,
+    }))
+}
+
 #[derive(Deserialize)]
 struct MonitorAnalyticsResponse {
     ok: bool,
@@ -213,11 +299,11 @@ struct MonitorSessionsResponse {
 }
 
 trait MonitorResponse: DeserializeOwned {
-    fn into_cardinality(self) -> Result<Cardinality>;
+    fn into_semantics(self) -> Result<(Cardinality, String)>;
 }
 
 impl MonitorResponse for MonitorAnalyticsResponse {
-    fn into_cardinality(self) -> Result<Cardinality> {
+    fn into_semantics(self) -> Result<(Cardinality, String)> {
         if !self.ok {
             bail!(
                 "monitor analytics response had ok=false: {}",
@@ -227,16 +313,22 @@ impl MonitorResponse for MonitorAnalyticsResponse {
         let series = self
             .series
             .context("monitor analytics response had ok=true but no series")?;
-        Ok(Cardinality::AnalyticsSeries {
+        let cardinality = Cardinality::AnalyticsSeries {
             tokens: series.tokens.len(),
             turns: series.turns.len(),
             concurrent_sessions: series.concurrent_sessions.len(),
-        })
+        };
+        let payload = json!({
+            "tokens": series.tokens,
+            "turns": series.turns,
+            "concurrent_sessions": series.concurrent_sessions,
+        });
+        Ok((cardinality, normalized_digest(&payload)?))
     }
 }
 
 impl MonitorResponse for MonitorSessionsResponse {
-    fn into_cardinality(self) -> Result<Cardinality> {
+    fn into_semantics(self) -> Result<(Cardinality, String)> {
         if !self.ok {
             bail!(
                 "monitor sessions response had ok=false: {}",
@@ -246,15 +338,23 @@ impl MonitorResponse for MonitorSessionsResponse {
         let sessions = self
             .sessions
             .context("monitor sessions response had ok=true but no sessions")?;
-        Ok(Cardinality::Sessions {
+        let cardinality = Cardinality::Sessions {
             sessions: sessions.len(),
-        })
+        };
+        let payload = Value::Array(
+            sessions
+                .iter()
+                .map(monitor_session_projection)
+                .collect::<Result<Vec<_>>>()?,
+        );
+        Ok((cardinality, normalized_digest(&payload)?))
     }
 }
 
 struct TimedSample {
     elapsed: Duration,
     cardinality: Cardinality,
+    normalized_digest: String,
 }
 
 async fn sample_monitor<T>(client: &Client, url: &Url, label: &str) -> Result<TimedSample>
@@ -284,11 +384,12 @@ where
             String::from_utf8_lossy(&body)
         );
     }
-    let cardinality = payload.into_cardinality()?;
+    let (cardinality, normalized_digest) = payload.into_semantics()?;
 
     Ok(TimedSample {
         elapsed: started.elapsed(),
         cardinality,
+        normalized_digest,
     })
 }
 
@@ -301,13 +402,22 @@ async fn sample_direct_analytics(
         .await
         .context("direct analytics repository request failed")?;
 
+    let payload = json!({
+        "tokens": snapshot.tokens,
+        "turns": snapshot.turns,
+        "concurrent_sessions": snapshot.concurrent_sessions,
+    });
+    let cardinality = Cardinality::AnalyticsSeries {
+        tokens: payload["tokens"].as_array().map_or(0, Vec::len),
+        turns: payload["turns"].as_array().map_or(0, Vec::len),
+        concurrent_sessions: payload["concurrent_sessions"]
+            .as_array()
+            .map_or(0, Vec::len),
+    };
     Ok(TimedSample {
         elapsed: started.elapsed(),
-        cardinality: Cardinality::AnalyticsSeries {
-            tokens: snapshot.tokens.len(),
-            turns: snapshot.turns.len(),
-            concurrent_sessions: snapshot.concurrent_sessions.len(),
-        },
+        cardinality,
+        normalized_digest: normalized_digest(&payload)?,
     })
 }
 
@@ -323,11 +433,30 @@ async fn sample_direct_sessions(
         .await
         .context("direct sessions repository request failed")?;
 
+    let cardinality = Cardinality::Sessions {
+        sessions: sessions.len(),
+    };
+    let payload = Value::Array(
+        sessions
+            .iter()
+            .map(|session| {
+                json!({
+                    "session_id": session.summary.session_id,
+                    "harness": session.harness,
+                    "started_at_unix_ms": session.summary.first_event_unix_ms,
+                    "ended_at_unix_ms": session.summary.last_event_unix_ms,
+                    "models": session.models,
+                    "trace_id": session.trace_id,
+                    "turns": session.turns.len(),
+                    "tool_calls": session.summary.tool_calls,
+                })
+            })
+            .collect(),
+    );
     Ok(TimedSample {
         elapsed: started.elapsed(),
-        cardinality: Cardinality::Sessions {
-            sessions: sessions.len(),
-        },
+        cardinality,
+        normalized_digest: normalized_digest(&payload)?,
     })
 }
 
@@ -368,25 +497,45 @@ async fn take_sample(
 struct Measurements {
     elapsed: Vec<Duration>,
     cardinality: Option<Cardinality>,
+    normalized_digest: Option<String>,
 }
 
 impl Measurements {
     fn record(&mut self, sample: TimedSample, scenario: Scenario, arm: Arm) -> Result<()> {
+        let TimedSample {
+            elapsed,
+            cardinality,
+            normalized_digest,
+        } = sample;
         if let Some(expected) = &self.cardinality {
-            if expected != &sample.cardinality {
+            if expected != &cardinality {
                 bail!(
                     "{} {:?} cardinality changed after {} successful samples: expected {:?}, got {:?}",
                     scenario.name(),
                     arm,
                     self.elapsed.len(),
                     expected,
-                    sample.cardinality
+                    cardinality
                 );
             }
         } else {
-            self.cardinality = Some(sample.cardinality.clone());
+            self.cardinality = Some(cardinality);
         }
-        self.elapsed.push(sample.elapsed);
+        if let Some(expected) = &self.normalized_digest {
+            if expected != &normalized_digest {
+                bail!(
+                    "{} {:?} normalized digest changed after {} successful samples: expected {}, got {}",
+                    scenario.name(),
+                    arm,
+                    self.elapsed.len(),
+                    expected,
+                    normalized_digest
+                );
+            }
+        } else {
+            self.normalized_digest = Some(normalized_digest);
+        }
+        self.elapsed.push(elapsed);
         Ok(())
     }
 
@@ -410,10 +559,15 @@ impl Measurements {
             .cardinality
             .clone()
             .context("successful samples had no cardinality")?;
+        let normalized_digest = self
+            .normalized_digest
+            .clone()
+            .context("successful samples had no normalized digest")?;
 
         Ok(ArmReport {
             successful_samples: self.elapsed.len(),
             cardinality,
+            normalized_digest,
             p50_ms,
             p95_ms,
         })
@@ -424,6 +578,7 @@ impl Measurements {
 struct ArmReport {
     successful_samples: usize,
     cardinality: Cardinality,
+    normalized_digest: String,
     p50_ms: f64,
     p95_ms: f64,
 }
@@ -432,6 +587,12 @@ struct ArmReport {
 struct CardinalityDifference {
     monitor_http: Cardinality,
     direct_repository: Cardinality,
+}
+
+#[derive(Serialize)]
+struct DigestDifference {
+    monitor_http: String,
+    direct_repository: String,
 }
 
 #[derive(Serialize)]
@@ -452,7 +613,9 @@ struct ScenarioReport {
     monitor_http: ArmReport,
     direct_repository_cold: ArmReport,
     cardinality_match: bool,
+    normalized_digest_match: bool,
     semantic_cardinality_difference: Option<CardinalityDifference>,
+    normalized_digest_difference: Option<DigestDifference>,
     p95_comparison: P95Comparison,
     passed: bool,
 }
@@ -523,6 +686,12 @@ async fn run_scenario(
         monitor_http: monitor_http.cardinality.clone(),
         direct_repository: direct_repository_cold.cardinality.clone(),
     });
+    let normalized_digest_match =
+        monitor_http.normalized_digest == direct_repository_cold.normalized_digest;
+    let normalized_digest_difference = (!normalized_digest_match).then(|| DigestDifference {
+        monitor_http: monitor_http.normalized_digest.clone(),
+        direct_repository: direct_repository_cold.normalized_digest.clone(),
+    });
     let ratio = ratio_assessment(
         monitor_http.p95_ms,
         direct_repository_cold.p95_ms,
@@ -553,7 +722,9 @@ async fn run_scenario(
         direct_repository_cold,
         cardinality_match,
         semantic_cardinality_difference,
-        passed: p95_comparison.passed,
+        normalized_digest_match,
+        normalized_digest_difference,
+        passed: cardinality_match && normalized_digest_match && p95_comparison.passed,
         p95_comparison,
     })
 }
@@ -562,6 +733,7 @@ async fn run_scenario(
 struct WarmAnalyticsReport {
     successful_samples: usize,
     cardinality: Cardinality,
+    normalized_digest: String,
     p95_ms: f64,
 }
 
@@ -595,6 +767,7 @@ async fn run_warm_analytics_cache(
     Ok(WarmAnalyticsReport {
         successful_samples: report.successful_samples,
         cardinality: report.cardinality,
+        normalized_digest: report.normalized_digest,
         p95_ms: report.p95_ms,
     })
 }
@@ -640,8 +813,8 @@ async fn live_monitor_vs_repository_latency() -> Result<()> {
     let passed = analytics.passed && sessions.passed;
     let report = BenchmarkReport {
         benchmark: "monitor_http_vs_direct_clickhouse_conversation_repository",
-        monitor_url: config.monitor_url,
-        clickhouse_url: config.clickhouse_url,
+        monitor_url: report_origin(&config.monitor_url, "MORAINE_BENCH_MONITOR_URL")?,
+        clickhouse_url: report_origin(&config.clickhouse_url, "MORAINE_BENCH_CLICKHOUSE_URL")?,
         clickhouse_database: config.clickhouse_database,
         warmups: config.warmups,
         samples_per_arm: config.samples,
@@ -657,9 +830,204 @@ async fn live_monitor_vs_repository_latency() -> Result<()> {
     );
 
     if !report.passed {
-        bail!("one or more cold scenarios exceeded the 20% p95 regression ceiling");
+        bail!("one or more scenarios failed semantic parity or the 20% p95 regression ceiling");
     }
     Ok(())
+}
+
+#[tokio::test]
+#[ignore = "creates and tears down a temporary database on a live ClickHouse sandbox"]
+async fn live_schema_semantics_and_teardown() -> Result<()> {
+    let config = BenchmarkConfig::from_env()?;
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock predates Unix epoch")?
+        .as_millis();
+    let database = format!("moraine_issue454_schema_{}_{}", std::process::id(), suffix);
+    let mut clickhouse_config = config.clickhouse_config();
+    clickhouse_config.database = database.clone();
+    let clickhouse = ClickHouseClient::new(clickhouse_config)
+        .context("failed to construct live-schema ClickHouse client")?;
+
+    let outcome = async {
+        clickhouse
+            .run_migrations()
+            .await
+            .context("failed to migrate temporary live-schema database")?;
+        let repository = ClickHouseConversationRepository::new(
+            clickhouse.clone(),
+            RepoConfig::default(),
+        );
+
+        let empty = repository
+            .analytics_series(AnalyticsRange::FifteenMinutes)
+            .await
+            .context("empty-window analytics read failed")?;
+        assert!(empty.tokens.is_empty());
+        assert!(empty.turns.is_empty());
+        assert!(empty.concurrent_sessions.is_empty());
+        let empty_heartbeat = repository
+            .latest_ingest_heartbeat()
+            .await
+            .context("empty heartbeat read failed")?;
+        assert!(empty_heartbeat.table_present);
+        assert!(empty_heartbeat.latest.is_none());
+
+        clickhouse
+            .request_text(
+                &format!(
+                    "ALTER TABLE `{database}`.`ingest_heartbeats` DROP COLUMN IF EXISTS backend_sinks"
+                ),
+                None,
+                Some(&database),
+                false,
+                None,
+            )
+            .await
+            .context("failed to remove optional heartbeat column")?;
+        let legacy_repository = ClickHouseConversationRepository::new(
+            clickhouse.clone(),
+            RepoConfig::default(),
+        );
+        let legacy_heartbeat = legacy_repository
+            .latest_ingest_heartbeat()
+            .await
+            .context("legacy heartbeat read failed")?;
+        assert!(legacy_heartbeat.table_present);
+        assert!(legacy_heartbeat.latest.is_none());
+
+        let insert = format!(
+            r#"INSERT INTO `{database}`.`events`
+(
+  ingested_at, event_uid, session_id, session_date, source_name, harness, source_file,
+  source_ref, event_ts, event_kind, actor_kind, payload_type, op_kind, request_id,
+  trace_id, turn_index, model, input_tokens, output_tokens, text_content, payload_json,
+  event_version
+)
+VALUES
+(
+  addMonths(now64(3), -1), 'issue454-dedup', 'issue454-dedup-session', today(),
+  'fixture', 'codex', 'fixture-dedup', 'fixture-old', now64(3), 'message',
+  'assistant', 'text', '', 'issue454-request', 'issue454-trace', 1, 'old-model',
+  11, 0, 'old', '{{}}', 1
+),
+(
+  now64(3), 'issue454-dedup', 'issue454-dedup-session', today(), 'fixture', 'codex',
+  'fixture-dedup', 'fixture-new', now64(3), 'message', 'assistant', 'text', '',
+  'issue454-request', 'issue454-trace', 1, 'new-model', 13, 0, 'new', '{{}}', 2
+),
+(
+  now64(3), 'issue454-web-a', 'issue454-web-session', today(), 'fixture', 'codex',
+  'fixture-web', 'issue454-web-a', now64(3), 'tool_call', 'assistant',
+  'web_search_call', 'search', '', 'issue454-trace', 1, '', 0, 0, '',
+  '{{"action":{{"query":"a"}}}}', 1
+),
+(
+  now64(3), 'issue454-web-z', 'issue454-web-session', today(), 'fixture', 'codex',
+  'fixture-web', 'issue454-web-z', now64(3), 'tool_call', 'assistant',
+  'web_search_call', 'search', '', 'issue454-trace', 1, '', 0, 0, '',
+  '{{"action":{{"query":"z"}}}}', 1
+)"#
+        );
+        clickhouse
+            .request_text(&insert, None, Some(&database), false, None)
+            .await
+            .context("failed to insert live-schema fixtures")?;
+
+        #[derive(Deserialize)]
+        struct ModelRow {
+            model: String,
+        }
+        let canonical: Vec<ModelRow> = clickhouse
+            .query_rows(
+                &format!(
+                    "SELECT model FROM (SELECT * FROM `{database}`.`events` FINAL \
+                     SETTINGS do_not_merge_across_partitions_select_final = 0) \
+                     WHERE event_uid = 'issue454-dedup' FORMAT JSONEachRow"
+                ),
+                Some(&database),
+            )
+            .await
+            .context("canonical cross-partition fixture query failed")?;
+        assert_eq!(canonical.len(), 1);
+        assert_eq!(canonical[0].model, "new-model");
+        let stale_predicate: Vec<ModelRow> = clickhouse
+            .query_rows(
+                &format!(
+                    "SELECT model FROM (SELECT * FROM `{database}`.`events` FINAL \
+                     SETTINGS do_not_merge_across_partitions_select_final = 0) \
+                     WHERE event_uid = 'issue454-dedup' AND model = 'old-model' \
+                     FORMAT JSONEachRow"
+                ),
+                Some(&database),
+            )
+            .await
+            .context("canonical outer-predicate query failed")?;
+        assert!(stale_predicate.is_empty());
+
+        let populated_repository = ClickHouseConversationRepository::new(
+            clickhouse.clone(),
+            RepoConfig::default(),
+        );
+        let analytics = populated_repository
+            .analytics_series(AnalyticsRange::FifteenMinutes)
+            .await
+            .context("populated analytics read failed")?;
+        assert!(analytics.tokens.iter().any(|point| point.model == "new-model"));
+        assert!(!analytics.tokens.iter().any(|point| point.model == "old-model"));
+        let sessions = populated_repository
+            .list_session_analytics(SessionAnalyticsQuery {
+                lookback: SessionLookback::All,
+                limit: 50,
+            })
+            .await
+            .context("populated session analytics read failed")?;
+        let deduped = sessions
+            .iter()
+            .find(|session| session.summary.session_id == "issue454-dedup-session")
+            .context("deduped fixture session missing")?;
+        assert_eq!(deduped.summary.total_events, 1);
+        assert_eq!(deduped.models, vec!["new-model"]);
+        let turn = populated_repository
+            .get_turn("issue454-dedup-session", 1)
+            .await
+            .context("view-only turn read failed")?
+            .context("view-only fixture turn missing")?;
+        assert_eq!(turn.summary.total_events, 1);
+        assert_eq!(turn.events.len(), 1);
+        assert_eq!(turn.events[0].text_content, "new");
+        let web = populated_repository
+            .list_web_searches(1000)
+            .await
+            .context("same-millisecond web feed read failed")?;
+        let fixture_refs = web
+            .iter()
+            .filter(|event| event.session_id == "issue454-web-session")
+            .map(|event| event.source_ref.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(fixture_refs, vec!["issue454-web-z", "issue454-web-a"]);
+
+        Ok::<_, anyhow::Error>(())
+    }
+    .await;
+
+    let cleanup = clickhouse
+        .request_text(
+            &format!("DROP DATABASE IF EXISTS `{database}` SYNC"),
+            None,
+            Some("system"),
+            false,
+            None,
+        )
+        .await;
+    match (outcome, cleanup) {
+        (Ok(()), Ok(_)) => Ok(()),
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(()), Err(cleanup_error)) => Err(cleanup_error.context("live-schema teardown failed")),
+        (Err(error), Err(cleanup_error)) => Err(anyhow!(
+            "{error:#}; live-schema teardown also failed: {cleanup_error:#}"
+        )),
+    }
 }
 
 fn type7_percentile(samples: &[f64], probability: f64) -> Option<f64> {
@@ -720,7 +1088,8 @@ fn ratio_assessment(
 
 #[cfg(test)]
 mod tests {
-    use super::{ratio_assessment, type7_percentile};
+    use super::{normalized_digest, ratio_assessment, report_origin, type7_percentile};
+    use serde_json::json;
 
     fn assert_close(actual: f64, expected: f64) {
         assert!(
@@ -768,5 +1137,50 @@ mod tests {
     fn ratio_gate_rejects_only_regressions_over_twenty_percent() {
         assert!(ratio_assessment(10.0, 7.999, 0.20).unwrap().passed);
         assert!(!ratio_assessment(10.0, 12.001, 0.20).unwrap().passed);
+    }
+    #[test]
+    fn normalized_digest_ignores_object_and_collection_order_but_detects_content_changes() {
+        let left = json!({
+            "series": [
+                {"bucket": 2, "tokens": 7},
+                {"bucket": 1, "tokens": 3}
+            ],
+            "range": "24h"
+        });
+        let reordered = json!({
+            "range": "24h",
+            "series": [
+                {"tokens": 3, "bucket": 1},
+                {"tokens": 7, "bucket": 2}
+            ]
+        });
+        let changed = json!({
+            "range": "24h",
+            "series": [
+                {"bucket": 1, "tokens": 3},
+                {"bucket": 2, "tokens": 8}
+            ]
+        });
+
+        assert_eq!(
+            normalized_digest(&left).unwrap(),
+            normalized_digest(&reordered).unwrap()
+        );
+        assert_ne!(
+            normalized_digest(&left).unwrap(),
+            normalized_digest(&changed).unwrap()
+        );
+    }
+
+    #[test]
+    fn report_origin_strips_credentials_paths_and_queries() {
+        assert_eq!(
+            report_origin(
+                "https://user:secret@example.test:9443/signed/path?token=secret",
+                "test URL"
+            )
+            .unwrap(),
+            "https://example.test:9443/"
+        );
     }
 }

--- a/crates/moraine-conversations/tests/repository_integration.rs
+++ b/crates/moraine-conversations/tests/repository_integration.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::collapsible_if, clippy::too_many_arguments)]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use axum::{
@@ -13,23 +13,68 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use moraine_clickhouse::ClickHouseClient;
 use moraine_config::ClickHouseConfig;
 use moraine_conversations::{
-    ClickHouseConversationRepository, ConversationListFilter, ConversationListSort,
+    AnalyticsRange, ClickHouseConversationRepository, ConversationListFilter, ConversationListSort,
     ConversationMode, ConversationRepository, ConversationSearchQuery, FileAttentionQuery,
     McpEventType, McpSessionListFilter, PageRequest, RepoConfig, RepoError, SearchEventKind,
-    SearchEventsQuery, SearchMcpEventsQuery, SessionEventsDirection, SessionEventsQuery,
-    SessionMetadataSearchQuery, SessionOriginScope,
+    SearchEventsQuery, SearchMcpEventsQuery, SessionAnalyticsQuery, SessionEventsDirection,
+    SessionEventsQuery, SessionLookback, SessionMetadataSearchQuery, SessionOriginScope,
+    SessionStep, StoreProbe, TablePreviewQuery,
 };
 use serde_json::json;
+
+#[derive(Clone)]
+struct ScriptedResponse {
+    required: Vec<&'static str>,
+    forbidden: Vec<&'static str>,
+    status: StatusCode,
+    body: String,
+}
+
+impl ScriptedResponse {
+    fn rows(required: &[&'static str], rows: serde_json::Value) -> Self {
+        Self {
+            required: required.to_vec(),
+            forbidden: Vec::new(),
+            status: StatusCode::OK,
+            body: json_each_row(rows),
+        }
+    }
+
+    fn raw(required: &[&'static str], body: impl Into<String>) -> Self {
+        Self {
+            required: required.to_vec(),
+            forbidden: Vec::new(),
+            status: StatusCode::OK,
+            body: body.into(),
+        }
+    }
+
+    fn failure(required: &[&'static str], message: &'static str) -> Self {
+        Self {
+            required: required.to_vec(),
+            forbidden: Vec::new(),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            body: message.to_string(),
+        }
+    }
+
+    fn forbidding(mut self, forbidden: &[&'static str]) -> Self {
+        self.forbidden = forbidden.to_vec();
+        self
+    }
+}
 
 #[derive(Clone, Default)]
 struct MockOptions {
     omit_second_snippet_row: bool,
+    scripted_responses: Vec<ScriptedResponse>,
 }
 
 #[derive(Default)]
 struct MockState {
     queries: Mutex<Vec<String>>,
     options: MockOptions,
+    scripted_responses: Mutex<Option<VecDeque<ScriptedResponse>>>,
 }
 
 fn test_clickhouse_config(url: String) -> ClickHouseConfig {
@@ -57,6 +102,339 @@ fn json_each_row(rows: serde_json::Value) -> String {
         }
         value => format!("{value}\n"),
     }
+}
+
+fn json_envelope(rows: serde_json::Value) -> String {
+    json!({ "data": rows }).to_string()
+}
+
+fn session_analytics_summary_row() -> serde_json::Value {
+    json!({
+        "session_id": "analytics-session",
+        "first_event_time": "2026-06-01 10:00:00.000",
+        "first_event_unix_ms": 1780308000000_i64,
+        "last_event_time": "2026-06-01 10:05:00.000",
+        "last_event_unix_ms": 1780308300000_i64,
+        "total_turns": 2_u32,
+        "total_events": 6_u64,
+        "user_messages": 1_u64,
+        "assistant_messages": 2_u64,
+        "tool_calls": 1_u64,
+        "tool_results": 1_u64,
+        "mode": "tool_calling",
+        "session_slug": "analytics-slug",
+        "session_summary": "Analytics fixture session"
+    })
+}
+
+fn session_analytics_turn_rows() -> serde_json::Value {
+    json!([
+        {
+            "session_id": "analytics-session",
+            "turn_seq": 1_u32,
+            "turn_id": "turn-one",
+            "started_at": "2026-06-01 10:00:00.000",
+            "started_at_unix_ms": 1780308000000_i64,
+            "ended_at": "2026-06-01 10:04:00.000",
+            "ended_at_unix_ms": 1780308240000_i64,
+            "total_events": 5_u64,
+            "user_messages": 1_u64,
+            "assistant_messages": 1_u64,
+            "tool_calls": 1_u64,
+            "tool_results": 1_u64,
+            "reasoning_items": 1_u64
+        },
+        {
+            "session_id": "analytics-session",
+            "turn_seq": 2_u32,
+            "turn_id": "turn-two",
+            "started_at": "2026-06-01 10:05:00.000",
+            "started_at_unix_ms": 1780308300000_i64,
+            "ended_at": "2026-06-01 10:05:00.000",
+            "ended_at_unix_ms": 1780308300000_i64,
+            "total_events": 1_u64,
+            "user_messages": 0_u64,
+            "assistant_messages": 1_u64,
+            "tool_calls": 0_u64,
+            "tool_results": 0_u64,
+            "reasoning_items": 0_u64
+        }
+    ])
+}
+
+fn session_analytics_event_rows() -> serde_json::Value {
+    json!([
+        {
+            "session_id": "analytics-session",
+            "event_order": 1_u64,
+            "turn_seq": 1_u32,
+            "event_unix_ms": 1780308000000_i64,
+            "event_class": "message",
+            "actor_role": "user",
+            "payload_type": "text",
+            "call_id": "",
+            "tool_name": "",
+            "tool_error": 0_u8,
+            "latency_ms": 0_u32,
+            "model": " GPT-X ",
+            "endpoint_kind": "",
+            "input_tokens": 5_u32,
+            "output_tokens": 2_u32,
+            "cache_read_tokens": 0_u32,
+            "cache_write_tokens": 0_u32,
+            "token_usage_buckets": {},
+            "token_usage_native_units": {},
+            "text_preview": "first user fallback",
+            "text_content": " ",
+            "tool_args_json": "",
+            "harness": "codex",
+            "source_name": "codex-jsonl",
+            "trace_id": "trace-454"
+        },
+        {
+            "session_id": "analytics-session",
+            "event_order": 2_u64,
+            "turn_seq": 1_u32,
+            "event_unix_ms": 1780308000100_i64,
+            "event_class": "message",
+            "actor_role": "assistant",
+            "payload_type": "text",
+            "call_id": "",
+            "tool_name": "",
+            "tool_error": 0_u8,
+            "latency_ms": 42_u32,
+            "model": "GPT-X",
+            "endpoint_kind": "generation",
+            "input_tokens": 99_u32,
+            "output_tokens": 99_u32,
+            "cache_read_tokens": 99_u32,
+            "cache_write_tokens": 99_u32,
+            "token_usage_buckets": { "reasoning": 7_u64 },
+            "token_usage_native_units": { "usd": 0.5, "zero": 0.0 },
+            "text_preview": "clipped answer",
+            "text_content": "full answer",
+            "tool_args_json": "",
+            "harness": "",
+            "source_name": "",
+            "trace_id": ""
+        },
+        {
+            "session_id": "analytics-session",
+            "event_order": 3_u64,
+            "turn_seq": 1_u32,
+            "event_unix_ms": 1780308000200_i64,
+            "event_class": "tool_call",
+            "actor_role": "assistant",
+            "payload_type": "tool_use",
+            "call_id": "call-read",
+            "tool_name": "Read",
+            "tool_error": 0_u8,
+            "latency_ms": 0_u32,
+            "model": "GPT-X",
+            "endpoint_kind": "",
+            "input_tokens": 0_u32,
+            "output_tokens": 0_u32,
+            "cache_read_tokens": 0_u32,
+            "cache_write_tokens": 0_u32,
+            "token_usage_buckets": {},
+            "token_usage_native_units": {},
+            "text_preview": "",
+            "text_content": "",
+            "tool_args_json": "{\"path\":\"src/lib.rs\"}",
+            "harness": "",
+            "source_name": "",
+            "trace_id": ""
+        },
+        {
+            "session_id": "analytics-session",
+            "event_order": 4_u64,
+            "turn_seq": 1_u32,
+            "event_unix_ms": 1780308000800_i64,
+            "event_class": "tool_result",
+            "actor_role": "tool",
+            "payload_type": "tool_result",
+            "call_id": "call-read",
+            "tool_name": "Read",
+            "tool_error": 1_u8,
+            "latency_ms": 999_u32,
+            "model": "",
+            "endpoint_kind": "",
+            "input_tokens": 0_u32,
+            "output_tokens": 0_u32,
+            "cache_read_tokens": 0_u32,
+            "cache_write_tokens": 0_u32,
+            "token_usage_buckets": {},
+            "token_usage_native_units": {},
+            "text_preview": "",
+            "text_content": "read failed",
+            "tool_args_json": "",
+            "harness": "",
+            "source_name": "",
+            "trace_id": ""
+        },
+        {
+            "session_id": "analytics-session",
+            "event_order": 5_u64,
+            "turn_seq": 1_u32,
+            "event_unix_ms": 1780308000900_i64,
+            "event_class": "reasoning",
+            "actor_role": "assistant",
+            "payload_type": "thinking",
+            "call_id": "",
+            "tool_name": "",
+            "tool_error": 0_u8,
+            "latency_ms": 0_u32,
+            "model": "GPT-X",
+            "endpoint_kind": "",
+            "input_tokens": 0_u32,
+            "output_tokens": 0_u32,
+            "cache_read_tokens": 0_u32,
+            "cache_write_tokens": 0_u32,
+            "token_usage_buckets": {},
+            "token_usage_native_units": {},
+            "text_preview": "",
+            "text_content": "consider the result",
+            "tool_args_json": "",
+            "harness": "",
+            "source_name": "",
+            "trace_id": ""
+        },
+        {
+            "session_id": "analytics-session",
+            "event_order": 6_u64,
+            "turn_seq": 2_u32,
+            "event_unix_ms": 1780308300000_i64,
+            "event_class": "message",
+            "actor_role": "assistant",
+            "payload_type": "text",
+            "call_id": "",
+            "tool_name": "",
+            "tool_error": 0_u8,
+            "latency_ms": 0_u32,
+            "model": "Other",
+            "endpoint_kind": "generation",
+            "input_tokens": 0_u32,
+            "output_tokens": 3_u32,
+            "cache_read_tokens": 0_u32,
+            "cache_write_tokens": 0_u32,
+            "token_usage_buckets": {},
+            "token_usage_native_units": {},
+            "text_preview": "",
+            "text_content": "second turn",
+            "tool_args_json": "",
+            "harness": "",
+            "source_name": "",
+            "trace_id": ""
+        }
+    ])
+}
+
+fn analytics_responses(
+    window_literal: &'static str,
+    interval_literal: &'static str,
+    tokens: serde_json::Value,
+    turns: serde_json::Value,
+    concurrency: serde_json::Value,
+) -> Vec<ScriptedResponse> {
+    vec![
+        ScriptedResponse::rows(
+            &[
+                "toInt64(toUnixTimestamp(now())) AS database_now_unix",
+                window_literal,
+                "FROM (SELECT * FROM `moraine`.`events` FINAL) AS e",
+                "AND notEmpty(trimBoth(e.model))",
+                "FORMAT JSONEachRow",
+            ],
+            json!([{
+                "scan_from_unix": 100_000_u64,
+                "scan_to_unix": 200_000_u64,
+                "display_to_unix": 200_000_u64
+            }]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                interval_literal,
+                "FROM (SELECT * FROM `moraine`.`events` FINAL) AS e",
+                "intDiv(toUnixTimestamp64Milli(e.event_ts), 1000) >= 100000",
+                "intDiv(toUnixTimestamp64Milli(e.event_ts), 1000) <= 200000",
+                "ARRAY JOIN mapKeys(e.token_usage_buckets)",
+                "ORDER BY bucket_unix ASC, model ASC, endpoint_kind ASC, bucket ASC",
+                "FORMAT JSONEachRow",
+            ],
+            tokens,
+        ),
+        ScriptedResponse::rows(
+            &[
+                interval_literal,
+                "toUInt64(uniqExact(tuple(e.session_id, e.request_id))) AS turns",
+                "FROM (SELECT * FROM `moraine`.`events` FINAL) AS e",
+                "intDiv(toUnixTimestamp64Milli(e.event_ts), 1000) >= 100000",
+                "ORDER BY bucket_unix ASC, model ASC",
+                "FORMAT JSONEachRow",
+            ],
+            turns,
+        ),
+        ScriptedResponse::rows(
+            &[
+                interval_literal,
+                "toUInt64(uniqExact(session_stream_key)) AS concurrent_sessions",
+                "FROM (SELECT * FROM `moraine`.`events` FINAL) AS e",
+                "intDiv(toUnixTimestamp64Milli(e.event_ts), 1000) >= 100000",
+                "ORDER BY bucket_unix ASC",
+                "FORMAT JSONEachRow",
+            ],
+            concurrency,
+        ),
+    ]
+}
+
+fn heartbeat_columns(optional: &[&str]) -> serde_json::Value {
+    let mut names = vec![
+        "ts",
+        "host",
+        "service_version",
+        "queue_depth",
+        "files_active",
+        "files_watched",
+        "rows_raw_written",
+        "rows_events_written",
+        "rows_errors_written",
+        "flush_latency_ms",
+        "append_to_visible_p50_ms",
+        "append_to_visible_p95_ms",
+        "last_error",
+    ];
+    names.extend_from_slice(optional);
+    serde_json::Value::Array(
+        names
+            .into_iter()
+            .map(|name| json!({ "name": name }))
+            .collect(),
+    )
+}
+
+fn heartbeat_row() -> serde_json::Value {
+    json!({
+        "ts": "2026-06-01 10:00:00.000",
+        "ts_unix_ms": 1780308000000_i64,
+        "host": "ingest-host",
+        "service_version": "0.17.1",
+        "queue_depth": 4_u64,
+        "files_active": 2_u32,
+        "files_watched": 9_u32,
+        "rows_raw_written": 100_u64,
+        "rows_events_written": 90_u64,
+        "rows_errors_written": 1_u64,
+        "flush_latency_ms": 12_u32,
+        "append_to_visible_p50_ms": 20_u32,
+        "append_to_visible_p95_ms": 40_u32,
+        "last_error": "",
+        "watcher_backend": null,
+        "watcher_error_count": null,
+        "watcher_reset_count": null,
+        "watcher_last_reset_unix_ms": null,
+        "backend_sinks": null
+    })
 }
 
 fn turn_summary_row(
@@ -141,6 +519,43 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
             .lock()
             .expect("query lock")
             .push(query.clone());
+
+        let scripted_response = {
+            let mut scripted = state
+                .scripted_responses
+                .lock()
+                .expect("scripted response lock");
+            scripted.as_mut().map(|responses| responses.pop_front())
+        };
+        if let Some(scripted_response) = scripted_response {
+            let Some(response) = scripted_response else {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("unexpected extra query: {query}"),
+                );
+            };
+            let missing = response
+                .required
+                .iter()
+                .filter(|required| !query.contains(**required))
+                .copied()
+                .collect::<Vec<_>>();
+            let forbidden = response
+                .forbidden
+                .iter()
+                .filter(|forbidden| query.contains(**forbidden))
+                .copied()
+                .collect::<Vec<_>>();
+            if !missing.is_empty() || !forbidden.is_empty() {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "script mismatch; missing={missing:?}; forbidden={forbidden:?}; query={query}"
+                    ),
+                );
+            }
+            return (response.status, response.body);
+        }
 
         // --project-only origin-scope gate: the point lookup issued by
         // `session_in_scope`. Sessions whose ID contains "out-of-scope" are
@@ -510,7 +925,7 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
             );
         }
 
-        if query.contains("FROM `moraine`.`events`")
+        if query.contains("FROM (SELECT * FROM `moraine`.`events` FINAL)")
             && query.contains("WHERE session_id = 'sess-open'")
             && query.contains("AS title")
             && query.contains("AS session_summary")
@@ -604,10 +1019,10 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
             );
         }
 
-        if query.contains("FROM `moraine`.`events`")
+        if query.contains("FROM `moraine`.`v_session_summary`")
             && query.contains("WHERE session_id IN")
-            && query.contains("toString(min(event_ts)) AS first_event_time")
-            && query.contains("toString(max(event_ts)) AS last_event_time")
+            && query.contains("toString(first_event_time) AS first_event_time")
+            && query.contains("toString(last_event_time) AS last_event_time")
         {
             return (
                 StatusCode::OK,
@@ -964,7 +1379,7 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
         }
 
         if query.contains("WITH\n  ['rare','summary'] AS q_terms")
-            && query.contains("FROM `moraine`.`events` AS e")
+            && query.contains("FROM (SELECT * FROM `moraine`.`events` FINAL) AS e")
             && query.contains("WHERE e.event_kind = 'session_meta'")
             && query.contains("AS meta_event_uid")
             && query.contains("AS matched_terms")
@@ -1097,10 +1512,8 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
             );
         }
 
-        if ((query.contains("FROM `moraine`.`v_conversation_trace`")
-            && query.contains("ORDER BY event_order ASC"))
-            || (query.contains("FROM `moraine`.`events`")
-                && query.contains("ORDER BY resolved_event_time")))
+        if query.contains("FROM `moraine`.`v_conversation_trace`")
+            && query.contains("ORDER BY event_order ASC, event_uid ASC")
             && query.contains("WHERE session_id = 'sess-open'")
             && !query.contains("turn_seq =")
         {
@@ -1216,6 +1629,19 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
         }
 
         if query.contains("FROM `moraine`.`v_turn_summary`")
+            && query.contains("WHERE session_id = 'sess-incomplete'")
+            && query.contains("ORDER BY turn_seq ASC")
+        {
+            return (
+                StatusCode::OK,
+                json_each_row(json!([
+                    turn_summary_row("sess-incomplete", 1, 2, 1, 1, 0, 0, 0),
+                    turn_summary_row("sess-incomplete", 2, 3, 1, 0, 1, 1, 0)
+                ])),
+            );
+        }
+
+        if query.contains("FROM `moraine`.`v_turn_summary`")
             && query.contains("WHERE session_id = 'sess-incomplete' AND turn_seq = 2")
             && query.contains("LIMIT 1")
         {
@@ -1234,9 +1660,10 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
             );
         }
 
-        if query.contains("FROM `moraine`.`events`")
+        if query.contains("FROM `moraine`.`v_conversation_trace`")
             && query.contains("WHERE session_id = 'sess-incomplete'")
-            && query.contains("ORDER BY resolved_event_time")
+            && query.contains("ORDER BY event_order ASC, event_uid ASC")
+            && !query.contains("turn_seq =")
         {
             return (
                 StatusCode::OK,
@@ -1371,6 +1798,19 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
             return (StatusCode::OK, json_each_row(json!([])));
         }
 
+        if query.contains("FROM `moraine`.`v_turn_summary`")
+            && query.contains("WHERE session_id = 'sess-event'")
+            && query.contains("ORDER BY turn_seq ASC")
+        {
+            return (
+                StatusCode::OK,
+                json_each_row(json!([
+                    turn_summary_row("sess-event", 1, 3, 1, 1, 0, 0, 0),
+                    turn_summary_row("sess-event", 2, 1, 0, 1, 0, 0, 0)
+                ])),
+            );
+        }
+
         if query.contains("FROM `moraine`.`v_conversation_trace`")
             && query.contains("WHERE event_uid = 'evt-open-full'")
             && query.contains("ORDER BY event_order DESC")
@@ -1474,9 +1914,9 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
             );
         }
 
-        if query.contains("FROM `moraine`.`events`")
+        if query.contains("FROM `moraine`.`v_conversation_trace`")
             && query.contains("WHERE session_id = 'sess-event'")
-            && query.contains("ORDER BY resolved_event_time")
+            && query.contains("ORDER BY event_order ASC, event_uid ASC")
         {
             return (
                 StatusCode::OK,
@@ -1694,9 +2134,12 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
         (StatusCode::OK, json_each_row(json!([])))
     }
 
+    let scripted_responses = (!options.scripted_responses.is_empty())
+        .then(|| options.scripted_responses.iter().cloned().collect());
     let state = Arc::new(MockState {
         queries: Mutex::default(),
         options,
+        scripted_responses: Mutex::new(scripted_responses),
     });
     let app = Router::new()
         .route("/", get(handler).post(handler))
@@ -1737,6 +2180,39 @@ async fn build_repo_with_options(
     );
 
     (repo, state)
+}
+
+async fn build_scripted_repo(
+    scripted_responses: Vec<ScriptedResponse>,
+) -> (ClickHouseConversationRepository, Arc<MockState>) {
+    build_repo_with_options(
+        100,
+        MockOptions {
+            scripted_responses,
+            ..MockOptions::default()
+        },
+    )
+    .await
+}
+
+fn assert_script_consumed(state: &MockState, expected_requests: usize) {
+    let queries = state.queries.lock().expect("queries lock");
+    assert_eq!(
+        queries.len(),
+        expected_requests,
+        "captured queries: {queries:#?}"
+    );
+    drop(queries);
+    let scripted = state
+        .scripted_responses
+        .lock()
+        .expect("scripted response lock");
+    assert!(
+        scripted
+            .as_ref()
+            .is_some_and(std::collections::VecDeque::is_empty),
+        "unconsumed scripted responses remain"
+    );
 }
 
 async fn build_repo() -> (ClickHouseConversationRepository, Arc<MockState>) {
@@ -2431,9 +2907,9 @@ async fn get_mcp_session_includes_turn_summaries_and_latest_completion() {
 
     let queries = state.queries.lock().expect("queries lock").clone();
     assert!(queries.iter().any(|query| {
-        query.contains("FROM `moraine`.`events`")
+        query.contains("FROM `moraine`.`v_conversation_trace`")
             && query.contains("WHERE session_id = 'sess-open'")
-            && query.contains("ORDER BY resolved_event_time")
+            && query.contains("ORDER BY event_order ASC, event_uid ASC")
     }));
 }
 
@@ -2612,7 +3088,7 @@ async fn search_session_metadata_applies_time_mode_filters_and_caps_limit() {
     let metadata_search_query = queries
         .iter()
         .find(|q| {
-            q.contains("FROM `moraine`.`events` AS e")
+            q.contains("FROM (SELECT * FROM `moraine`.`events` FINAL) AS e")
                 && q.contains("WHERE e.event_kind = 'session_meta'")
                 && q.contains("AS meta_event_uid")
         })
@@ -2741,6 +3217,7 @@ async fn search_conversations_falls_back_to_row_snippet_for_text_preview() {
         100,
         MockOptions {
             omit_second_snippet_row: true,
+            ..MockOptions::default()
         },
     )
     .await;
@@ -3363,4 +3840,1119 @@ async fn list_session_events_rejects_cursor_with_mismatched_direction() {
         "invalid cursor: cursor direction does not match requested direction"
     );
     assert!(state.queries.lock().expect("queries lock").is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_analytics_assembles_canonical_views_and_public_steps() {
+    let responses = vec![
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`v_session_summary` AS s",
+                "FROM (SELECT * FROM `moraine`.`events` FINAL) AS meta_events",
+                "WHERE meta_events.event_kind = 'session_meta'",
+                "WHERE notEmpty(trimBoth(s.session_id))",
+                "ORDER BY s.last_event_time DESC, s.session_id DESC",
+                "LIMIT 1",
+                "FORMAT JSONEachRow",
+            ],
+            json!([session_analytics_summary_row()]),
+        )
+        .forbidding(&["now() - INTERVAL"]),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`v_turn_summary`",
+                "WHERE session_id IN ['analytics-session']",
+                "ORDER BY session_id ASC, turn_seq ASC",
+                "FORMAT JSONEachRow",
+            ],
+            session_analytics_turn_rows(),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`v_conversation_trace` AS t",
+                "LEFT JOIN (SELECT * FROM `moraine`.`events` FINAL) AS e ON e.event_uid = t.event_uid",
+                "WHERE t.session_id IN ['analytics-session']",
+                "ORDER BY t.session_id ASC, t.event_order ASC",
+                "FORMAT JSONEachRow",
+            ],
+            session_analytics_event_rows(),
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+    let repo: Arc<dyn ConversationRepository> = Arc::new(repo);
+
+    let sessions = repo
+        .list_session_analytics(SessionAnalyticsQuery {
+            lookback: SessionLookback::All,
+            limit: 0,
+        })
+        .await
+        .expect("session analytics succeeds");
+
+    assert_eq!(sessions.len(), 1);
+    let session = &sessions[0];
+    assert_eq!(session.summary.session_id, "analytics-session");
+    assert_eq!(session.summary.total_turns, 2);
+    assert_eq!(session.summary.mode, ConversationMode::ToolCalling);
+    assert_eq!(
+        session.summary.session_slug.as_deref(),
+        Some("analytics-slug")
+    );
+    assert_eq!(
+        session.summary.session_summary.as_deref(),
+        Some("Analytics fixture session")
+    );
+    assert_eq!(session.harness, "codex");
+    assert_eq!(session.source_name, "codex-jsonl");
+    assert_eq!(session.trace_id, "trace-454");
+    assert_eq!(session.first_user_text, "first user fallback");
+    assert_eq!(session.models, vec!["gpt-x", "other"]);
+    assert_eq!(
+        session
+            .turns
+            .iter()
+            .map(|turn| turn.summary.turn_seq)
+            .collect::<Vec<_>>(),
+        vec![1, 2],
+        "canonical view turn numbers remain one-based"
+    );
+
+    let first_turn = &session.turns[0];
+    assert_eq!(first_turn.model, "GPT-X");
+    assert_eq!(first_turn.token_usage_buckets.get("input_text"), Some(&5));
+    assert_eq!(first_turn.token_usage_buckets.get("output_text"), Some(&2));
+    assert_eq!(first_turn.token_usage_buckets.get("reasoning"), Some(&7));
+    assert_eq!(first_turn.steps.len(), 4);
+    assert!(matches!(
+        &first_turn.steps[0],
+        SessionStep::User { text, .. } if text == "first user fallback"
+    ));
+    match &first_turn.steps[1] {
+        SessionStep::Assistant {
+            text,
+            endpoint_kind,
+            latency_ms,
+            token_usage_buckets,
+            token_usage_native_units,
+            ..
+        } => {
+            assert_eq!(text, "full answer");
+            assert_eq!(endpoint_kind, "generation");
+            assert_eq!(*latency_ms, Some(42));
+            assert_eq!(token_usage_buckets.get("reasoning"), Some(&7));
+            assert!(!token_usage_buckets.contains_key("input_text"));
+            assert_eq!(token_usage_native_units.get("usd"), Some(&0.5));
+            assert!(!token_usage_native_units.contains_key("zero"));
+        }
+        other => panic!("expected assistant step, got {other:?}"),
+    }
+    match &first_turn.steps[2] {
+        SessionStep::ToolCall {
+            tool_name,
+            call_id,
+            arguments,
+            result,
+            ..
+        } => {
+            assert_eq!(tool_name, "Read");
+            assert_eq!(call_id, "call-read");
+            assert_eq!(arguments, &json!({ "path": "src/lib.rs" }));
+            let result = result.as_ref().expect("paired tool result");
+            assert_eq!(result.text, "read failed");
+            assert_eq!(result.latency_ms, 600);
+            assert!(result.is_error);
+        }
+        other => panic!("expected tool call step, got {other:?}"),
+    }
+    assert!(matches!(
+        &first_turn.steps[3],
+        SessionStep::Thinking { text, .. } if text == "consider the result"
+    ));
+    assert_eq!(
+        session.turns[1].token_usage_buckets.get("output_text"),
+        Some(&3)
+    );
+    assert_script_consumed(&state, 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_analytics_empty_and_timed_limit_sql_are_deterministic() {
+    let (repo, state) = build_scripted_repo(vec![ScriptedResponse::rows(
+        &[
+            "FROM `moraine`.`v_session_summary` AS s",
+            "AND s.last_event_time >= now() - INTERVAL 86400 SECOND",
+            "ORDER BY s.last_event_time DESC, s.session_id DESC",
+            "LIMIT 200",
+            "FORMAT JSONEachRow",
+        ],
+        json!([]),
+    )])
+    .await;
+
+    let sessions = repo
+        .list_session_analytics(SessionAnalyticsQuery {
+            lookback: SessionLookback::TwentyFourHours,
+            limit: u16::MAX,
+        })
+        .await
+        .expect("empty analytics succeeds");
+    assert!(sessions.is_empty());
+    assert_script_consumed(&state, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_analytics_propagates_each_wire_stage_error() {
+    let scenarios = vec![
+        vec![ScriptedResponse::failure(
+            &["FROM `moraine`.`v_session_summary` AS s"],
+            "session stage summary failed",
+        )],
+        vec![
+            ScriptedResponse::rows(
+                &["FROM `moraine`.`v_session_summary` AS s"],
+                json!([session_analytics_summary_row()]),
+            ),
+            ScriptedResponse::failure(
+                &["FROM `moraine`.`v_turn_summary`"],
+                "session stage turns failed",
+            ),
+        ],
+        vec![
+            ScriptedResponse::rows(
+                &["FROM `moraine`.`v_session_summary` AS s"],
+                json!([session_analytics_summary_row()]),
+            ),
+            ScriptedResponse::rows(
+                &["FROM `moraine`.`v_turn_summary`"],
+                session_analytics_turn_rows(),
+            ),
+            ScriptedResponse::failure(
+                &["FROM `moraine`.`v_conversation_trace` AS t"],
+                "session stage events failed",
+            ),
+        ],
+    ];
+
+    for (stage, responses) in scenarios.into_iter().enumerate() {
+        let (repo, state) = build_scripted_repo(responses).await;
+        let error = repo
+            .list_session_analytics(SessionAnalyticsQuery {
+                lookback: SessionLookback::All,
+                limit: 1,
+            })
+            .await
+            .expect_err("wire stage error propagates");
+        assert!(
+            error.to_string().contains("session stage"),
+            "stage {stage} error: {error}"
+        );
+        assert_script_consumed(&state, stage + 1);
+    }
+}
+
+#[test]
+fn analytics_range_wire_mapping_is_complete_and_stable() {
+    let expected = [
+        (AnalyticsRange::FifteenMinutes, "15m", 900, 60),
+        (AnalyticsRange::OneHour, "1h", 3_600, 300),
+        (AnalyticsRange::SixHours, "6h", 21_600, 900),
+        (AnalyticsRange::TwentyFourHours, "24h", 86_400, 3_600),
+        (AnalyticsRange::SevenDays, "7d", 604_800, 21_600),
+        (AnalyticsRange::ThirtyDays, "30d", 2_592_000, 86_400),
+    ];
+    assert_eq!(AnalyticsRange::ALL.len(), expected.len());
+    for ((actual, (range, label, window, bucket)), index) in
+        AnalyticsRange::ALL.into_iter().zip(expected).zip(0usize..)
+    {
+        assert_eq!(actual, range, "range index {index}");
+        assert_eq!(range.as_str(), label, "range index {index}");
+        assert_eq!(range.window_seconds(), window, "range index {index}");
+        assert_eq!(range.bucket_seconds(), bucket, "range index {index}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn analytics_24h_uses_exact_four_request_canonical_wire_contract() {
+    let responses = analytics_responses(
+        "toInt64(86400)",
+        "INTERVAL 3600 SECOND",
+        json!([
+            {
+                "bucket_unix": 150_000_u64,
+                "model": "gpt-5.3-codex-xhigh",
+                "endpoint_kind": "responses",
+                "bucket": "input_text",
+                "tokens": 12_u64
+            },
+            {
+                "bucket_unix": 153_600_u64,
+                "model": "other",
+                "endpoint_kind": "messages",
+                "bucket": "output_text",
+                "tokens": 8_u64
+            }
+        ]),
+        json!([{
+            "bucket_unix": 150_000_u64,
+            "model": "gpt-5.3-codex-xhigh",
+            "turns": 3_u64
+        }]),
+        json!([{
+            "bucket_unix": 150_000_u64,
+            "concurrent_sessions": 2_u64
+        }]),
+    );
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let snapshot = repo
+        .analytics_series(AnalyticsRange::TwentyFourHours)
+        .await
+        .expect("24h analytics succeeds");
+
+    assert_eq!(snapshot.window.range, AnalyticsRange::TwentyFourHours);
+    assert_eq!(snapshot.window.window_seconds, 86_400);
+    assert_eq!(snapshot.window.bucket_seconds, 3_600);
+    assert_eq!(snapshot.window.from_unix, 113_600);
+    assert_eq!(snapshot.window.to_unix, 200_000);
+    assert_eq!(snapshot.tokens.len(), 2);
+    assert_eq!(snapshot.tokens[0].model, "gpt-5.3-codex-xhigh");
+    assert_eq!(snapshot.tokens[0].tokens, 12);
+    assert_eq!(snapshot.tokens[1].bucket, "output_text");
+    assert_eq!(snapshot.turns[0].turns, 3);
+    assert_eq!(snapshot.concurrent_sessions[0].concurrent_sessions, 2);
+    assert_script_consumed(&state, 4);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn analytics_cache_hit_and_distinct_key_are_request_count_proven() {
+    let mut responses = analytics_responses(
+        "toInt64(86400)",
+        "INTERVAL 3600 SECOND",
+        json!([]),
+        json!([]),
+        json!([]),
+    );
+    responses.extend(analytics_responses(
+        "toInt64(3600)",
+        "INTERVAL 300 SECOND",
+        json!([]),
+        json!([]),
+        json!([]),
+    ));
+    let (repo, state) = build_scripted_repo(responses).await;
+    let repo: Arc<dyn ConversationRepository> = Arc::new(repo);
+
+    let first = repo
+        .analytics_series(AnalyticsRange::TwentyFourHours)
+        .await
+        .expect("cache miss succeeds");
+    let hit = repo
+        .analytics_series(AnalyticsRange::TwentyFourHours)
+        .await
+        .expect("same-key cache hit succeeds");
+    assert_eq!(first, hit);
+    assert_eq!(state.queries.lock().expect("queries lock").len(), 4);
+
+    let distinct = repo
+        .analytics_series(AnalyticsRange::OneHour)
+        .await
+        .expect("distinct-key cache miss succeeds");
+    assert_eq!(distinct.window.range, AnalyticsRange::OneHour);
+    assert_eq!(distinct.window.window_seconds, 3_600);
+    assert_eq!(distinct.window.bucket_seconds, 300);
+    assert_script_consumed(&state, 8);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn analytics_stage_error_is_not_cached_and_empty_retry_succeeds() {
+    let success = analytics_responses(
+        "toInt64(86400)",
+        "INTERVAL 3600 SECOND",
+        json!([]),
+        json!([]),
+        json!([]),
+    );
+    let mut responses = vec![
+        success[0].clone(),
+        ScriptedResponse::failure(
+            &[
+                "ARRAY JOIN mapKeys(e.token_usage_buckets)",
+                "FORMAT JSONEachRow",
+            ],
+            "analytics token stage failed",
+        ),
+    ];
+    responses.extend(success);
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let error = repo
+        .analytics_series(AnalyticsRange::TwentyFourHours)
+        .await
+        .expect_err("token stage failure propagates");
+    assert!(error.to_string().contains("analytics token stage failed"));
+
+    let retry = repo
+        .analytics_series(AnalyticsRange::TwentyFourHours)
+        .await
+        .expect("failed load is not cached");
+    assert!(retry.tokens.is_empty());
+    assert!(retry.turns.is_empty());
+    assert!(retry.concurrent_sessions.is_empty());
+    assert_script_consumed(&state, 6);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn analytics_same_key_concurrency_coalesces_to_one_wire_load() {
+    let (repo, state) = build_scripted_repo(analytics_responses(
+        "toInt64(86400)",
+        "INTERVAL 3600 SECOND",
+        json!([]),
+        json!([]),
+        json!([]),
+    ))
+    .await;
+    let repo = Arc::new(repo);
+
+    let (left, right) = tokio::join!(
+        repo.analytics_series(AnalyticsRange::TwentyFourHours),
+        repo.analytics_series(AnalyticsRange::TwentyFourHours)
+    );
+    assert_eq!(
+        left.expect("first concurrent load"),
+        right.expect("coalesced load")
+    );
+    assert_script_consumed(&state, 4);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn web_feed_covers_variants_precedence_limit_order_and_canonical_source() {
+    let response = ScriptedResponse::rows(
+        &[
+            "FROM (SELECT * FROM `moraine`.`events` FINAL) AS e",
+            "e.payload_type = 'web_search_call'",
+            "e.payload_type = 'tool_use' AND e.tool_name IN ('WebSearch', 'WebFetch')",
+            "e.payload_type = 'search_results_received'",
+            "JSONExtractString(e.payload_json, 'action', 'query')",
+            "JSONExtractString(e.payload_json, 'input', 'query')",
+            "JSONExtractString(e.payload_json, 'data', 'query')",
+            "JSONExtractString(e.payload_json, 'action', 'url')",
+            "JSONExtractString(e.payload_json, 'input', 'url')",
+            "ORDER BY e.event_ts DESC",
+            "LIMIT 1000",
+            "FORMAT JSONEachRow",
+        ],
+        json!([
+            {
+                "event_time": "2026-06-01 12:03:00",
+                "harness": "codex",
+                "source_name": "codex-jsonl",
+                "session_id": "web-3",
+                "model": "gpt-5",
+                "action": "search_results_received",
+                "search_query": "data query",
+                "result_url": "",
+                "source_ref": "/tmp/web:3"
+            },
+            {
+                "event_time": "2026-06-01 12:02:00",
+                "harness": "claude-code",
+                "source_name": "claude-jsonl",
+                "session_id": "web-2",
+                "model": "claude",
+                "action": "open_page",
+                "search_query": "",
+                "result_url": "https://example.test/page",
+                "source_ref": "/tmp/web:2"
+            },
+            {
+                "event_time": "2026-06-01 12:01:00",
+                "harness": "codex",
+                "source_name": "codex-jsonl",
+                "session_id": "web-1",
+                "model": "gpt-5",
+                "action": "search",
+                "search_query": "action path wins",
+                "result_url": "https://example.test/result",
+                "source_ref": "/tmp/web:1"
+            }
+        ]),
+    );
+    let (repo, state) = build_scripted_repo(vec![response]).await;
+
+    let events = repo
+        .list_web_searches(u16::MAX)
+        .await
+        .expect("web feed succeeds");
+
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].session_id, "web-3");
+    assert_eq!(events[0].search_query, "data query");
+    assert_eq!(events[1].action, "open_page");
+    assert_eq!(events[1].result_url, "https://example.test/page");
+    assert_eq!(events[2].search_query, "action path wins");
+    assert_eq!(events[2].source_ref, "/tmp/web:1");
+    assert_script_consumed(&state, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn web_feed_propagates_backend_and_json_each_row_decode_errors() {
+    let scenarios = [
+        ScriptedResponse::failure(
+            &["FROM (SELECT * FROM `moraine`.`events` FINAL) AS e"],
+            "web feed backend failed",
+        ),
+        ScriptedResponse::raw(
+            &[
+                "FROM (SELECT * FROM `moraine`.`events` FINAL) AS e",
+                "FORMAT JSONEachRow",
+            ],
+            "not-json\n",
+        ),
+    ];
+
+    for (index, response) in scenarios.into_iter().enumerate() {
+        let (repo, state) = build_scripted_repo(vec![response]).await;
+        let error = repo
+            .list_web_searches(0)
+            .await
+            .expect_err("web feed failure propagates");
+        if index == 0 {
+            assert!(error.to_string().contains("web feed backend failed"));
+        } else {
+            assert!(error.to_string().contains("failed to parse JSONEachRow"));
+        }
+        assert_script_consumed(&state, 1);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn heartbeat_reports_missing_table_without_read_query() {
+    let (repo, state) = build_scripted_repo(vec![ScriptedResponse::rows(
+        &[
+            "SELECT name",
+            "FROM system.columns",
+            "WHERE database = 'moraine' AND table = 'ingest_heartbeats'",
+            "ORDER BY position ASC",
+            "FORMAT JSONEachRow",
+        ],
+        json!([]),
+    )])
+    .await;
+
+    let heartbeat = repo
+        .latest_ingest_heartbeat()
+        .await
+        .expect("missing heartbeat table is optional");
+    assert!(!heartbeat.table_present);
+    assert!(heartbeat.latest.is_none());
+    assert_script_consumed(&state, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn heartbeat_reports_present_but_empty_table() {
+    let responses = vec![
+        ScriptedResponse::rows(
+            &["FROM system.columns", "FORMAT JSONEachRow"],
+            heartbeat_columns(&[]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`ingest_heartbeats`",
+                "ORDER BY `ts` DESC, `host` DESC",
+                "LIMIT 1",
+                "FORMAT JSONEachRow",
+            ],
+            json!([]),
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let heartbeat = repo
+        .latest_ingest_heartbeat()
+        .await
+        .expect("empty heartbeat table succeeds");
+    assert!(heartbeat.table_present);
+    assert!(heartbeat.latest.is_none());
+    assert_script_consumed(&state, 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn heartbeat_pre_017_row_uses_null_projections_for_absent_columns() {
+    let mut row = heartbeat_row();
+    row["service_version"] = json!("0.16.9");
+    let responses = vec![
+        ScriptedResponse::rows(
+            &["FROM system.columns", "FORMAT JSONEachRow"],
+            heartbeat_columns(&[]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`ingest_heartbeats`",
+                "CAST(NULL, 'Nullable(String)') AS `watcher_backend`",
+                "CAST(NULL, 'Nullable(UInt64)') AS `watcher_error_count`",
+                "CAST(NULL, 'Nullable(UInt64)') AS `watcher_reset_count`",
+                "CAST(NULL, 'Nullable(UInt64)') AS `watcher_last_reset_unix_ms`",
+                "CAST(NULL, 'Nullable(String)') AS `backend_sinks`",
+                "FORMAT JSONEachRow",
+            ],
+            json!([row]),
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let heartbeat = repo
+        .latest_ingest_heartbeat()
+        .await
+        .expect("pre-0.17 heartbeat succeeds");
+    let latest = heartbeat.latest.expect("heartbeat row");
+    assert_eq!(latest.service_version, "0.16.9");
+    assert_eq!(latest.queue_depth, 4);
+    assert!(latest.watcher_backend.is_none());
+    assert!(latest.watcher_error_count.is_none());
+    assert!(latest.watcher_reset_count.is_none());
+    assert!(latest.watcher_last_reset_unix_ms.is_none());
+    assert!(latest.backend_sinks.is_none());
+
+    let queries = state.queries.lock().expect("queries lock");
+    let read_query = &queries[1];
+    for absent in [
+        "`watcher_backend`,",
+        "`watcher_error_count`,",
+        "`watcher_reset_count`,",
+        "`watcher_last_reset_unix_ms`,",
+        "`backend_sinks`",
+    ] {
+        assert!(
+            !read_query.lines().any(|line| line.trim() == absent),
+            "absent column projected directly: {absent}\n{read_query}"
+        );
+    }
+    drop(queries);
+    assert_script_consumed(&state, 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn heartbeat_partial_watcher_schema_reads_only_present_optional_columns() {
+    let mut row = heartbeat_row();
+    row["watcher_backend"] = json!("fsevents");
+    row["watcher_error_count"] = json!(3_u64);
+    let responses = vec![
+        ScriptedResponse::rows(
+            &["FROM system.columns", "FORMAT JSONEachRow"],
+            heartbeat_columns(&["watcher_backend", "watcher_error_count"]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "`watcher_backend`,",
+                "`watcher_error_count`,",
+                "CAST(NULL, 'Nullable(UInt64)') AS `watcher_reset_count`",
+                "CAST(NULL, 'Nullable(UInt64)') AS `watcher_last_reset_unix_ms`",
+                "CAST(NULL, 'Nullable(String)') AS `backend_sinks`",
+                "FROM `moraine`.`ingest_heartbeats`",
+                "FORMAT JSONEachRow",
+            ],
+            json!([row]),
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let latest = repo
+        .latest_ingest_heartbeat()
+        .await
+        .expect("partial watcher heartbeat succeeds")
+        .latest
+        .expect("heartbeat row");
+    assert_eq!(latest.watcher_backend.as_deref(), Some("fsevents"));
+    assert_eq!(latest.watcher_error_count, Some(3));
+    assert!(latest.watcher_reset_count.is_none());
+    assert!(latest.backend_sinks.is_none());
+    assert_script_consumed(&state, 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn heartbeat_post_017_backend_sinks_handles_blank_valid_and_malformed_values() {
+    let cases = [
+        ("", json!({})),
+        (
+            "{\"clickhouse\":{\"healthy\":true},\"sqlite\":{\"healthy\":false}}",
+            json!({
+                "clickhouse": { "healthy": true },
+                "sqlite": { "healthy": false }
+            }),
+        ),
+        ("malformed-backend-sinks", json!("malformed-backend-sinks")),
+    ];
+    let optional = [
+        "watcher_backend",
+        "watcher_error_count",
+        "watcher_reset_count",
+        "watcher_last_reset_unix_ms",
+        "backend_sinks",
+    ];
+
+    for (raw, expected) in cases {
+        let mut row = heartbeat_row();
+        row["watcher_backend"] = json!("fsevents");
+        row["watcher_error_count"] = json!(1_u64);
+        row["watcher_reset_count"] = json!(2_u64);
+        row["watcher_last_reset_unix_ms"] = json!(1780307999000_u64);
+        row["backend_sinks"] = json!(raw);
+        let responses = vec![
+            ScriptedResponse::rows(
+                &["FROM system.columns", "FORMAT JSONEachRow"],
+                heartbeat_columns(&optional),
+            ),
+            ScriptedResponse::rows(
+                &[
+                    "`watcher_backend`,",
+                    "`watcher_error_count`,",
+                    "`watcher_reset_count`,",
+                    "`watcher_last_reset_unix_ms`,",
+                    "`backend_sinks`",
+                    "FROM `moraine`.`ingest_heartbeats`",
+                    "FORMAT JSONEachRow",
+                ],
+                json!([row]),
+            ),
+        ];
+        let (repo, state) = build_scripted_repo(responses).await;
+
+        let latest = repo
+            .latest_ingest_heartbeat()
+            .await
+            .expect("post-0.17 heartbeat succeeds")
+            .latest
+            .expect("heartbeat row");
+        assert_eq!(latest.watcher_backend.as_deref(), Some("fsevents"));
+        assert_eq!(latest.watcher_reset_count, Some(2));
+        assert_eq!(latest.backend_sinks, Some(expected));
+        assert_script_consumed(&state, 2);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn heartbeat_propagates_column_probe_and_latest_read_errors() {
+    let (probe_repo, probe_state) = build_scripted_repo(vec![ScriptedResponse::failure(
+        &["FROM system.columns", "FORMAT JSONEachRow"],
+        "heartbeat column probe failed",
+    )])
+    .await;
+    let probe_error = probe_repo
+        .latest_ingest_heartbeat()
+        .await
+        .expect_err("column probe failure propagates");
+    assert!(probe_error
+        .to_string()
+        .contains("heartbeat column probe failed"));
+    assert_script_consumed(&probe_state, 1);
+
+    let (read_repo, read_state) = build_scripted_repo(vec![
+        ScriptedResponse::rows(
+            &["FROM system.columns", "FORMAT JSONEachRow"],
+            heartbeat_columns(&[]),
+        ),
+        ScriptedResponse::failure(
+            &["FROM `moraine`.`ingest_heartbeats`", "FORMAT JSONEachRow"],
+            "heartbeat latest read failed",
+        ),
+    ])
+    .await;
+    let read_error = read_repo
+        .latest_ingest_heartbeat()
+        .await
+        .expect_err("heartbeat read failure propagates");
+    assert!(read_error
+        .to_string()
+        .contains("heartbeat latest read failed"));
+    assert_script_consumed(&read_state, 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn table_summaries_map_metadata_and_active_part_counts() {
+    let responses = vec![
+        ScriptedResponse::rows(
+            &[
+                "SELECT name, engine, toUInt8(is_temporary) AS is_temporary",
+                "FROM system.tables",
+                "WHERE database = 'moraine'",
+                "ORDER BY name ASC",
+                "FORMAT JSONEachRow",
+            ],
+            json!([
+                {
+                    "name": "events",
+                    "engine": "ReplacingMergeTree",
+                    "is_temporary": 0_u8
+                },
+                {
+                    "name": "scratch",
+                    "engine": "Memory",
+                    "is_temporary": 1_u8
+                },
+                {
+                    "name": "v_session_summary",
+                    "engine": "View",
+                    "is_temporary": 0_u8
+                }
+            ]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "SELECT table, toUInt64(sum(rows)) AS rows",
+                "FROM system.parts",
+                "WHERE database = 'moraine' AND active",
+                "GROUP BY table",
+                "ORDER BY table ASC",
+                "FORMAT JSONEachRow",
+            ],
+            json!([
+                { "table": "events", "rows": 42_u64 },
+                { "table": "scratch", "rows": 7_u64 }
+            ]),
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let summaries = repo
+        .list_table_summaries()
+        .await
+        .expect("table summaries succeed");
+
+    assert!(summaries.row_counts_error.is_none());
+    assert_eq!(summaries.tables.len(), 3);
+    assert_eq!(summaries.tables[0].name, "events");
+    assert_eq!(summaries.tables[0].engine, "ReplacingMergeTree");
+    assert!(!summaries.tables[0].is_temporary);
+    assert_eq!(summaries.tables[0].rows, 42);
+    assert!(summaries.tables[1].is_temporary);
+    assert_eq!(summaries.tables[1].rows, 7);
+    assert_eq!(summaries.tables[2].rows, 0);
+    assert_script_consumed(&state, 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn table_summaries_return_metadata_when_parts_probe_fails() {
+    let responses = vec![
+        ScriptedResponse::rows(
+            &["FROM system.tables", "FORMAT JSONEachRow"],
+            json!([{
+                "name": "events",
+                "engine": "ReplacingMergeTree",
+                "is_temporary": 0_u8
+            }]),
+        ),
+        ScriptedResponse::failure(
+            &["FROM system.parts", "FORMAT JSONEachRow"],
+            "active parts probe failed",
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let summaries = repo
+        .list_table_summaries()
+        .await
+        .expect("parts failure is partial");
+    assert_eq!(summaries.tables.len(), 1);
+    assert_eq!(summaries.tables[0].rows, 0);
+    assert!(summaries
+        .row_counts_error
+        .as_deref()
+        .is_some_and(|message| message.contains("active parts probe failed")));
+    assert_script_consumed(&state, 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn preview_rejects_invalid_identifier_before_any_http_call() {
+    let (repo, state) = build_repo().await;
+
+    let error = repo
+        .preview_table(TablePreviewQuery {
+            table: "events; DROP TABLE events".to_string(),
+            limit: 25,
+        })
+        .await
+        .expect_err("invalid table identifier is rejected");
+
+    assert!(error
+        .to_string()
+        .contains("table must match [A-Za-z_][A-Za-z0-9_]*"));
+    assert!(state.queries.lock().expect("queries lock").is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn preview_clamps_limit_and_maps_ordered_schema_and_json_values() {
+    let responses = vec![
+        ScriptedResponse::rows(
+            &[
+                "SELECT name, type AS type_name, default_expression",
+                "FROM system.columns",
+                "WHERE database = 'moraine' AND table = 'events'",
+                "ORDER BY position ASC",
+                "FORMAT JSONEachRow",
+            ],
+            json!([
+                {
+                    "name": "id",
+                    "type_name": "UInt64",
+                    "default_expression": ""
+                },
+                {
+                    "name": "name",
+                    "type_name": "String",
+                    "default_expression": "'anonymous'"
+                }
+            ]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "SELECT * FROM `moraine`.`events`",
+                "ORDER BY `id`, `name`",
+                "LIMIT 500",
+                "FORMAT JSONEachRow",
+            ],
+            json!([
+                { "id": 1_u64, "name": "alpha", "nested": { "ok": true } },
+                { "id": 2_u64, "name": "beta", "nullable": null }
+            ]),
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let preview = repo
+        .preview_table(TablePreviewQuery {
+            table: "events".to_string(),
+            limit: u16::MAX,
+        })
+        .await
+        .expect("table preview succeeds");
+
+    assert_eq!(preview.table, "events");
+    assert_eq!(preview.limit, 500);
+    assert_eq!(preview.schema.len(), 2);
+    assert_eq!(preview.schema[0].name, "id");
+    assert_eq!(preview.schema[0].type_name, "UInt64");
+    assert_eq!(preview.schema[1].default_expression, "'anonymous'");
+    assert_eq!(preview.rows[0]["nested"]["ok"], json!(true));
+    assert_eq!(preview.rows[1]["nullable"], serde_json::Value::Null);
+    assert_script_consumed(&state, 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn preview_propagates_schema_and_row_stage_errors() {
+    let (schema_repo, schema_state) = build_scripted_repo(vec![ScriptedResponse::failure(
+        &["FROM system.columns", "FORMAT JSONEachRow"],
+        "preview schema failed",
+    )])
+    .await;
+    let schema_error = schema_repo
+        .preview_table(TablePreviewQuery {
+            table: "events".to_string(),
+            limit: 10,
+        })
+        .await
+        .expect_err("schema failure propagates");
+    assert!(schema_error.to_string().contains("preview schema failed"));
+    assert_script_consumed(&schema_state, 1);
+
+    let (row_repo, row_state) = build_scripted_repo(vec![
+        ScriptedResponse::rows(
+            &["FROM system.columns", "FORMAT JSONEachRow"],
+            json!([{
+                "name": "id",
+                "type_name": "UInt64",
+                "default_expression": ""
+            }]),
+        ),
+        ScriptedResponse::failure(
+            &["SELECT * FROM `moraine`.`events` ORDER BY `id` LIMIT 10 FORMAT JSONEachRow"],
+            "preview row read failed",
+        ),
+    ])
+    .await;
+    let row_error = row_repo
+        .preview_table(TablePreviewQuery {
+            table: "events".to_string(),
+            limit: 10,
+        })
+        .await
+        .expect_err("row failure propagates");
+    assert!(row_error.to_string().contains("preview row read failed"));
+    assert_script_consumed(&row_state, 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn store_health_maps_all_successful_probe_facts() {
+    let responses = vec![
+        ScriptedResponse::raw(&["SELECT 1"], "1\n"),
+        ScriptedResponse::raw(
+            &["SELECT version() AS version"],
+            json_envelope(json!([{ "version": "25.8.1.1" }])),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM system.databases",
+                "WHERE name = 'moraine'",
+                "FORMAT JSONEachRow",
+            ],
+            json!([{ "exists": 1_u8 }]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM system.metrics",
+                "WHERE metric IN ('TCPConnection', 'HTTPConnection', 'MySQLConnection', 'PostgreSQLConnection', 'InterserverConnection')",
+                "ORDER BY metric ASC",
+                "FORMAT JSONEachRow",
+            ],
+            json!([
+                { "metric": "HTTPConnection", "value": 2_u64 },
+                { "metric": "InterserverConnection", "value": 5_u64 },
+                { "metric": "MySQLConnection", "value": 3_u64 },
+                { "metric": "PostgreSQLConnection", "value": 4_u64 },
+                { "metric": "TCPConnection", "value": 7_u64 },
+                { "metric": "TCPConnection", "value": 1_u64 }
+            ]),
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let health = repo
+        .read_store_health()
+        .await
+        .expect("health probes succeed");
+
+    assert!(matches!(health.ping, StoreProbe::Available(ms) if ms >= 0.0));
+    assert_eq!(
+        health.version,
+        StoreProbe::Available("25.8.1.1".to_string())
+    );
+    assert_eq!(health.database_exists, StoreProbe::Available(true));
+    match health.connections {
+        StoreProbe::Available(metrics) => {
+            assert_eq!(metrics.tcp, 8);
+            assert_eq!(metrics.http, 2);
+            assert_eq!(metrics.mysql, 3);
+            assert_eq!(metrics.postgres, 4);
+            assert_eq!(metrics.interserver, 5);
+            assert_eq!(metrics.total, 22);
+        }
+        other => panic!("expected connection metrics, got {other:?}"),
+    }
+    assert_script_consumed(&state, 4);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn store_health_keeps_each_probe_failure_independent() {
+    let responses = vec![
+        ScriptedResponse::failure(&["SELECT 1"], "health ping failed"),
+        ScriptedResponse::failure(&["SELECT version() AS version"], "health version failed"),
+        ScriptedResponse::failure(&["FROM system.databases"], "health database failed"),
+        ScriptedResponse::failure(&["FROM system.metrics"], "health connections failed"),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let health = repo
+        .read_store_health()
+        .await
+        .expect("probe failures are facts, not method errors");
+
+    assert!(matches!(
+        health.ping,
+        StoreProbe::Failed { ref message } if message.contains("health ping failed")
+    ));
+    assert!(matches!(
+        health.version,
+        StoreProbe::Failed { ref message } if message.contains("health version failed")
+    ));
+    assert!(matches!(
+        health.database_exists,
+        StoreProbe::Failed { ref message } if message.contains("health database failed")
+    ));
+    assert!(matches!(
+        health.connections,
+        StoreProbe::Failed { ref message } if message.contains("health connections failed")
+    ));
+    assert_script_consumed(&state, 4);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn diagnostics_maps_doctor_partial_report_and_ping_short_circuit() {
+    let required_tables = json!([
+        { "name": "raw_events" },
+        { "name": "events" },
+        { "name": "event_links" },
+        { "name": "tool_io" },
+        { "name": "ingest_checkpoints" },
+        { "name": "ingest_heartbeats" },
+        { "name": "search_documents" },
+        { "name": "search_postings" },
+        { "name": "search_conversation_terms" },
+        { "name": "search_term_stats" },
+        { "name": "search_corpus_stats" },
+        { "name": "search_query_log" },
+        { "name": "search_hit_log" },
+        { "name": "search_interaction_log" },
+        { "name": "schema_migrations" }
+    ]);
+    let responses = vec![
+        ScriptedResponse::raw(&["SELECT 1"], "1\n"),
+        ScriptedResponse::failure(
+            &["SELECT version() AS version"],
+            "doctor version probe failed",
+        ),
+        ScriptedResponse::raw(
+            &[
+                "SELECT toUInt8(count() > 0) AS exists FROM system.databases WHERE name = 'moraine'",
+            ],
+            json_envelope(json!([{ "exists": 1_u8 }])),
+        ),
+        ScriptedResponse::failure(
+            &["SELECT version FROM `moraine`.schema_migrations GROUP BY version"],
+            "doctor ledger read failed",
+        ),
+        ScriptedResponse::raw(
+            &["SELECT name FROM system.tables WHERE database = 'moraine'"],
+            json_envelope(required_tables),
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let diagnostics = repo
+        .read_store_diagnostics()
+        .await
+        .expect("doctor partial report maps");
+
+    assert!(diagnostics.healthy);
+    assert!(diagnostics.version.is_none());
+    assert_eq!(diagnostics.database, "moraine");
+    assert!(diagnostics.database_exists);
+    assert!(diagnostics.applied_schema_versions.is_empty());
+    assert!(!diagnostics.pending_schema_versions.is_empty());
+    assert_eq!(diagnostics.missing_tables, vec!["ingest_errors"]);
+    assert_eq!(diagnostics.errors.len(), 2);
+    assert!(diagnostics.errors[0].contains("version query failed"));
+    assert!(diagnostics.errors[0].contains("doctor version probe failed"));
+    assert!(diagnostics.errors[1].contains("failed to read migration ledger"));
+    assert!(diagnostics.errors[1].contains("doctor ledger read failed"));
+    assert_script_consumed(&state, 5);
+
+    let (down_repo, down_state) = build_scripted_repo(vec![ScriptedResponse::failure(
+        &["SELECT 1"],
+        "doctor ping unavailable",
+    )])
+    .await;
+    let down = down_repo
+        .read_store_diagnostics()
+        .await
+        .expect("doctor ping failure returns partial report");
+    assert!(!down.healthy);
+    assert!(down.version.is_none());
+    assert!(!down.database_exists);
+    assert_eq!(down.database, "moraine");
+    assert!(down.applied_schema_versions.is_empty());
+    assert!(down.pending_schema_versions.is_empty());
+    assert!(down.missing_tables.is_empty());
+    assert_eq!(down.errors.len(), 1);
+    assert!(down.errors[0].contains("ping failed"));
+    assert!(down.errors[0].contains("doctor ping unavailable"));
+    assert_script_consumed(&down_state, 1);
 }

--- a/crates/moraine-conversations/tests/repository_integration.rs
+++ b/crates/moraine-conversations/tests/repository_integration.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use axum::{
     extract::{Query, State},
@@ -21,6 +22,13 @@ use moraine_conversations::{
     SessionStep, StoreProbe, TablePreviewQuery,
 };
 use serde_json::json;
+use tokio::sync::Notify;
+
+#[derive(Clone)]
+struct ScriptedBarrier {
+    reached: Arc<Notify>,
+    release: Arc<Notify>,
+}
 
 #[derive(Clone)]
 struct ScriptedResponse {
@@ -28,6 +36,7 @@ struct ScriptedResponse {
     forbidden: Vec<&'static str>,
     status: StatusCode,
     body: String,
+    barrier: Option<ScriptedBarrier>,
 }
 
 impl ScriptedResponse {
@@ -36,6 +45,7 @@ impl ScriptedResponse {
             required: required.to_vec(),
             forbidden: Vec::new(),
             status: StatusCode::OK,
+            barrier: None,
             body: json_each_row(rows),
         }
     }
@@ -45,6 +55,7 @@ impl ScriptedResponse {
             required: required.to_vec(),
             forbidden: Vec::new(),
             status: StatusCode::OK,
+            barrier: None,
             body: body.into(),
         }
     }
@@ -54,12 +65,18 @@ impl ScriptedResponse {
             required: required.to_vec(),
             forbidden: Vec::new(),
             status: StatusCode::INTERNAL_SERVER_ERROR,
+            barrier: None,
             body: message.to_string(),
         }
     }
 
     fn forbidding(mut self, forbidden: &[&'static str]) -> Self {
         self.forbidden = forbidden.to_vec();
+        self
+    }
+
+    fn blocked(mut self, reached: Arc<Notify>, release: Arc<Notify>) -> Self {
+        self.barrier = Some(ScriptedBarrier { reached, release });
         self
     }
 }
@@ -228,8 +245,8 @@ fn session_analytics_event_rows() -> serde_json::Value {
             "payload_type": "tool_use",
             "call_id": "call-read",
             "tool_name": "Read",
-            "tool_error": 0_u8,
-            "latency_ms": 0_u32,
+            "tool_error": 1_u8,
+            "latency_ms": 17_u32,
             "model": "GPT-X",
             "endpoint_kind": "",
             "input_tokens": 0_u32,
@@ -553,6 +570,10 @@ async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
                         "script mismatch; missing={missing:?}; forbidden={forbidden:?}; query={query}"
                     ),
                 );
+            }
+            if let Some(barrier) = response.barrier {
+                barrier.reached.notify_one();
+                barrier.release.notified().await;
             }
             return (response.status, response.body);
         }
@@ -3951,12 +3972,16 @@ async fn session_analytics_assembles_canonical_views_and_public_steps() {
             tool_name,
             call_id,
             arguments,
+            latency_ms,
+            is_error,
             result,
             ..
         } => {
             assert_eq!(tool_name, "Read");
             assert_eq!(call_id, "call-read");
             assert_eq!(arguments, &json!({ "path": "src/lib.rs" }));
+            assert_eq!(*latency_ms, Some(17));
+            assert!(*is_error);
             let result = result.as_ref().expect("paired tool result");
             assert_eq!(result.text, "read failed");
             assert_eq!(result.latency_ms, 600);
@@ -4050,27 +4075,6 @@ async fn session_analytics_propagates_each_wire_stage_error() {
     }
 }
 
-#[test]
-fn analytics_range_wire_mapping_is_complete_and_stable() {
-    let expected = [
-        (AnalyticsRange::FifteenMinutes, "15m", 900, 60),
-        (AnalyticsRange::OneHour, "1h", 3_600, 300),
-        (AnalyticsRange::SixHours, "6h", 21_600, 900),
-        (AnalyticsRange::TwentyFourHours, "24h", 86_400, 3_600),
-        (AnalyticsRange::SevenDays, "7d", 604_800, 21_600),
-        (AnalyticsRange::ThirtyDays, "30d", 2_592_000, 86_400),
-    ];
-    assert_eq!(AnalyticsRange::ALL.len(), expected.len());
-    for ((actual, (range, label, window, bucket)), index) in
-        AnalyticsRange::ALL.into_iter().zip(expected).zip(0usize..)
-    {
-        assert_eq!(actual, range, "range index {index}");
-        assert_eq!(range.as_str(), label, "range index {index}");
-        assert_eq!(range.window_seconds(), window, "range index {index}");
-        assert_eq!(range.bucket_seconds(), bucket, "range index {index}");
-    }
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn analytics_24h_uses_exact_four_request_canonical_wire_contract() {
     let responses = analytics_responses(
@@ -4124,6 +4128,62 @@ async fn analytics_24h_uses_exact_four_request_canonical_wire_contract() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn analytics_all_six_ranges_use_distinct_wire_keys() {
+    let cases = [
+        (
+            AnalyticsRange::FifteenMinutes,
+            "toInt64(900)",
+            "INTERVAL 60 SECOND",
+        ),
+        (
+            AnalyticsRange::OneHour,
+            "toInt64(3600)",
+            "INTERVAL 300 SECOND",
+        ),
+        (
+            AnalyticsRange::SixHours,
+            "toInt64(21600)",
+            "INTERVAL 900 SECOND",
+        ),
+        (
+            AnalyticsRange::TwentyFourHours,
+            "toInt64(86400)",
+            "INTERVAL 3600 SECOND",
+        ),
+        (
+            AnalyticsRange::SevenDays,
+            "toInt64(604800)",
+            "INTERVAL 21600 SECOND",
+        ),
+        (
+            AnalyticsRange::ThirtyDays,
+            "toInt64(2592000)",
+            "INTERVAL 86400 SECOND",
+        ),
+    ];
+    let mut responses = Vec::new();
+    for (_, window, interval) in cases {
+        responses.extend(analytics_responses(
+            window,
+            interval,
+            json!([]),
+            json!([]),
+            json!([]),
+        ));
+    }
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    for (range, _, _) in cases {
+        let snapshot = repo
+            .analytics_series(range)
+            .await
+            .expect("distinct analytics range succeeds");
+        assert_eq!(snapshot.window.range, range);
+    }
+    assert_script_consumed(&state, 24);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn analytics_cache_hit_and_distinct_key_are_request_count_proven() {
     let mut responses = analytics_responses(
         "toInt64(86400)",
@@ -4140,13 +4200,13 @@ async fn analytics_cache_hit_and_distinct_key_are_request_count_proven() {
         json!([]),
     ));
     let (repo, state) = build_scripted_repo(responses).await;
-    let repo: Arc<dyn ConversationRepository> = Arc::new(repo);
+    let clone = repo.clone();
 
     let first = repo
         .analytics_series(AnalyticsRange::TwentyFourHours)
         .await
         .expect("cache miss succeeds");
-    let hit = repo
+    let hit = clone
         .analytics_series(AnalyticsRange::TwentyFourHours)
         .await
         .expect("same-key cache hit succeeds");
@@ -4160,6 +4220,52 @@ async fn analytics_cache_hit_and_distinct_key_are_request_count_proven() {
     assert_eq!(distinct.window.range, AnalyticsRange::OneHour);
     assert_eq!(distinct.window.window_seconds, 3_600);
     assert_eq!(distinct.window.bucket_seconds, 300);
+    assert_script_consumed(&state, 8);
+}
+
+#[tokio::test]
+async fn analytics_expired_entry_refills_from_the_repository() {
+    let mut responses = analytics_responses(
+        "toInt64(86400)",
+        "INTERVAL 3600 SECOND",
+        json!([{
+            "bucket_unix": 100_000_u64,
+            "model": "model",
+            "endpoint_kind": "generation",
+            "bucket": "input_text",
+            "tokens": 1_u64
+        }]),
+        json!([]),
+        json!([]),
+    );
+    responses.extend(analytics_responses(
+        "toInt64(86400)",
+        "INTERVAL 3600 SECOND",
+        json!([{
+            "bucket_unix": 100_000_u64,
+            "model": "model",
+            "endpoint_kind": "generation",
+            "bucket": "input_text",
+            "tokens": 2_u64
+        }]),
+        json!([]),
+        json!([]),
+    ));
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let first = repo
+        .analytics_series(AnalyticsRange::TwentyFourHours)
+        .await
+        .expect("initial cache fill succeeds");
+    assert_eq!(first.tokens[0].tokens, 1);
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(31)).await;
+    tokio::time::resume();
+    let refilled = repo
+        .analytics_series(AnalyticsRange::TwentyFourHours)
+        .await
+        .expect("stale cache entry refills");
+    assert_eq!(refilled.tokens[0].tokens, 2);
     assert_script_consumed(&state, 8);
 }
 
@@ -4202,6 +4308,79 @@ async fn analytics_stage_error_is_not_cached_and_empty_retry_succeeds() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn analytics_anchor_decode_and_late_stage_errors_are_not_cached() {
+    let success = analytics_responses(
+        "toInt64(86400)",
+        "INTERVAL 3600 SECOND",
+        json!([]),
+        json!([]),
+        json!([]),
+    );
+    let scenarios = [
+        (
+            "anchor",
+            vec![ScriptedResponse::failure(
+                &["database_now_unix", "FORMAT JSONEachRow"],
+                "analytics anchor stage failed",
+            )],
+            5,
+        ),
+        (
+            "decode",
+            vec![ScriptedResponse::raw(
+                &["database_now_unix", "FORMAT JSONEachRow"],
+                "not-json\n",
+            )],
+            5,
+        ),
+        (
+            "turn",
+            vec![
+                success[0].clone(),
+                success[1].clone(),
+                ScriptedResponse::failure(
+                    &[
+                        "uniqExact(tuple(e.session_id, e.request_id))",
+                        "FORMAT JSONEachRow",
+                    ],
+                    "analytics turn stage failed",
+                ),
+            ],
+            7,
+        ),
+        (
+            "concurrency",
+            vec![
+                success[0].clone(),
+                success[1].clone(),
+                success[2].clone(),
+                ScriptedResponse::failure(
+                    &["uniqExact(session_stream_key)", "FORMAT JSONEachRow"],
+                    "analytics concurrency stage failed",
+                ),
+            ],
+            8,
+        ),
+    ];
+
+    for (stage, mut responses, expected_requests) in scenarios {
+        responses.extend(success.clone());
+        let (repo, state) = build_scripted_repo(responses).await;
+        repo.analytics_series(AnalyticsRange::TwentyFourHours)
+            .await
+            .expect_err(stage);
+        let retry = repo
+            .analytics_series(AnalyticsRange::TwentyFourHours)
+            .await
+            .unwrap_or_else(|error| panic!("{stage} retry failed: {error}"));
+        assert!(retry.tokens.is_empty());
+        assert!(retry.turns.is_empty());
+        assert!(retry.concurrent_sessions.is_empty());
+        assert_script_consumed(&state, expected_requests);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn analytics_same_key_concurrency_coalesces_to_one_wire_load() {
     let (repo, state) = build_scripted_repo(analytics_responses(
         "toInt64(86400)",
@@ -4225,6 +4404,164 @@ async fn analytics_same_key_concurrency_coalesces_to_one_wire_load() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn analytics_different_ranges_fill_concurrently() {
+    let first_anchor_reached = Arc::new(Notify::new());
+    let first_anchor_release = Arc::new(Notify::new());
+    let second_anchor_reached = Arc::new(Notify::new());
+    let second_anchor_release = Arc::new(Notify::new());
+    let first_fill_reached_last_stage = Arc::new(Notify::new());
+    let first_fill_release_last_stage = Arc::new(Notify::new());
+    let anchor_row = json!([{
+        "scan_from_unix": 100_000_u64,
+        "scan_to_unix": 200_000_u64,
+        "display_to_unix": 200_000_u64
+    }]);
+    let generic_anchor = |reached: Arc<Notify>, release: Arc<Notify>| {
+        ScriptedResponse::rows(
+            &[
+                "toInt64(toUnixTimestamp(now())) AS database_now_unix",
+                "FROM (SELECT * FROM `moraine`.`events` FINAL) AS e",
+            ],
+            anchor_row.clone(),
+        )
+        .blocked(reached, release)
+    };
+    let token = || {
+        ScriptedResponse::rows(
+            &[
+                "ARRAY JOIN mapKeys(e.token_usage_buckets)",
+                "FORMAT JSONEachRow",
+            ],
+            json!([]),
+        )
+    };
+    let turns = || {
+        ScriptedResponse::rows(
+            &[
+                "uniqExact(tuple(e.session_id, e.request_id))",
+                "FORMAT JSONEachRow",
+            ],
+            json!([]),
+        )
+    };
+    let concurrency = || {
+        ScriptedResponse::rows(
+            &["uniqExact(session_stream_key)", "FORMAT JSONEachRow"],
+            json!([]),
+        )
+    };
+    let responses = vec![
+        generic_anchor(first_anchor_reached.clone(), first_anchor_release.clone()),
+        generic_anchor(second_anchor_reached.clone(), second_anchor_release.clone()),
+        token(),
+        turns(),
+        concurrency().blocked(
+            first_fill_reached_last_stage.clone(),
+            first_fill_release_last_stage.clone(),
+        ),
+        token(),
+        turns(),
+        concurrency(),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+    let repo = Arc::new(repo);
+
+    let one_hour_repo = repo.clone();
+    let one_hour = tokio::spawn(async move {
+        one_hour_repo
+            .analytics_series(AnalyticsRange::OneHour)
+            .await
+    });
+    let day_repo = repo.clone();
+    let day = tokio::spawn(async move {
+        day_repo
+            .analytics_series(AnalyticsRange::TwentyFourHours)
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(2), first_anchor_reached.notified())
+        .await
+        .expect("first range reached its anchor");
+    tokio::time::timeout(Duration::from_secs(2), second_anchor_reached.notified())
+        .await
+        .expect("second range reached its anchor before the first was released");
+
+    first_anchor_release.notify_one();
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        first_fill_reached_last_stage.notified(),
+    )
+    .await
+    .expect("first range reached its final stage");
+    first_fill_release_last_stage.notify_one();
+    second_anchor_release.notify_one();
+
+    let (one_hour, day) = tokio::join!(one_hour, day);
+    assert_eq!(
+        one_hour
+            .expect("one-hour task joined")
+            .expect("one-hour fill succeeds")
+            .window
+            .range,
+        AnalyticsRange::OneHour
+    );
+    assert_eq!(
+        day.expect("day task joined")
+            .expect("day fill succeeds")
+            .window
+            .range,
+        AnalyticsRange::TwentyFourHours
+    );
+    assert_script_consumed(&state, 8);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn analytics_cancelled_fill_releases_slot_and_recovery_is_cached() {
+    let success = analytics_responses(
+        "toInt64(86400)",
+        "INTERVAL 3600 SECOND",
+        json!([]),
+        json!([]),
+        json!([]),
+    );
+    let reached = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let mut responses = vec![success[0].clone().blocked(reached.clone(), release.clone())];
+    responses.extend(success);
+    let (repo, state) = build_scripted_repo(responses).await;
+    let repo = Arc::new(repo);
+
+    let first_repo = repo.clone();
+    let first = tokio::spawn(async move {
+        first_repo
+            .analytics_series(AnalyticsRange::TwentyFourHours)
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(2), reached.notified())
+        .await
+        .expect("scripted analytics load reached the wire barrier");
+    first.abort();
+    release.notify_one();
+    assert!(first
+        .await
+        .expect_err("fill task was aborted")
+        .is_cancelled());
+
+    let recovered = tokio::time::timeout(
+        Duration::from_secs(2),
+        repo.analytics_series(AnalyticsRange::TwentyFourHours),
+    )
+    .await
+    .expect("cancelled fill released the range slot")
+    .expect("recovery fill succeeds");
+    let hit = repo
+        .analytics_series(AnalyticsRange::TwentyFourHours)
+        .await
+        .expect("recovery result was cached");
+    assert_eq!(recovered, hit);
+    assert_script_consumed(&state, 5);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn web_feed_covers_variants_precedence_limit_order_and_canonical_source() {
     let response = ScriptedResponse::rows(
         &[
@@ -4237,7 +4574,7 @@ async fn web_feed_covers_variants_precedence_limit_order_and_canonical_source() 
             "JSONExtractString(e.payload_json, 'data', 'query')",
             "JSONExtractString(e.payload_json, 'action', 'url')",
             "JSONExtractString(e.payload_json, 'input', 'url')",
-            "ORDER BY e.event_ts DESC",
+            "ORDER BY e.event_ts DESC, e.event_uid DESC",
             "LIMIT 1000",
             "FORMAT JSONEachRow",
         ],


### PR DESCRIPTION
## Description

**What.** Adds the shared `moraine-conversations` analytics and operational read surface required by the monitor and CLI migrations.

**Why.** Monitor and CLI consumers currently own divergent raw ClickHouse SQL, event-dedup rules, session aggregation, and heavy polling scans.

The branch adds these `ConversationRepository` methods and implements them for ClickHouse and the programmable in-memory repository:

- `list_session_analytics(SessionAnalyticsQuery)`
- `analytics_series(AnalyticsRange)`
- `list_web_searches(limit)`
- `latest_ingest_heartbeat()`
- `list_table_summaries()`
- `preview_table(TablePreviewQuery)`
- `read_store_health()`
- `read_store_diagnostics()`

Session reads delegate to `v_session_summary`, `v_turn_summary`, and `v_conversation_trace`. Event-backed reads use the single `canonical_events_source` helper, while every repository read attaches `do_not_merge_across_partitions_select_final=0` request-locally so view-only reads preserve the same cross-partition ReplacingMergeTree winner rule. The analytics cache has six range-specific 30-second TTL slots, coalesces same-key fills, permits different-key concurrency, and does not retain failed or cancelled fills.

`SessionStep::ToolCall` now retains call-side `latency_ms` and `is_error` even when no tool result arrives; paired calls continue to expose result-side latency/error independently.

Resolves #454

## Usage

Downstream monitor and CLI code can depend on `Arc<dyn ConversationRepository>` and call the methods above instead of constructing raw SQL. Consumer migrations remain in #455 and #456.

## Semantic consolidation evidence

- A repeatable ignored live-schema target creates and migrates a unique temporary database, verifies empty analytics, current and pre-017 optional-heartbeat schemas, cross-partition FINAL winner selection, outer-predicate safety, populated session/analytics views, view-only `get_turn`, and same-millisecond web ordering, then drops the database.
- The live target caught a real profile-sensitive gap: `FINAL` inside `v_turn_summary` / `v_conversation_trace` is request-local. All repository row reads now set `do_not_merge_across_partitions_select_final=0`, including view-only and cancellation-parameter paths.
- The exact-final performance run required matching normalized content digests as well as matching cardinalities before a scenario could pass.

Semantic parity in that run:

| Scenario | Cardinality | Monitor digest | Repository digest |
| --- | --- | --- | --- |
| Analytics 24h | tokens 42, turns 12, concurrent buckets 7 | `fnv1a64:19d8d6c734019d8f` | `fnv1a64:19d8d6c734019d8f` |
| Sessions 30d / limit 50 | sessions 50 | `fnv1a64:58314cf9b834fa37` | `fnv1a64:58314cf9b834fa37` |

Workspace-wide removal of legacy monitor/CLI SQL is intentionally not claimed here; that cutover belongs to #455/#456.

## Performance

Setup: Darwin arm64 host; sandbox `sb-72757e`; ClickHouse `v25.12.5.44-stable`; database `moraine`; 289,895 canonical event rows at fixture teardown; existing monitor HTTP endpoints versus a fresh direct repository per cold sample; 5 warmups and 60 successful samples per arm; alternating A/B then B/A order; Type-7 percentiles; 20% p95 regression ceiling. The warm-cache arm reused one repository after priming.

Command:

```bash
MORAINE_BENCH_MONITOR_URL=http://127.0.0.1:55023 \
MORAINE_BENCH_CLICKHOUSE_URL=http://127.0.0.1:29547 \
MORAINE_BENCH_CLICKHOUSE_DATABASE=moraine \
MORAINE_BENCH_WARMUPS=5 \
MORAINE_BENCH_SAMPLES=60 \
cargo test -p moraine-conversations --test analytics_benchmark \
  live_monitor_vs_repository_latency --locked -- --ignored --exact --nocapture
```

| Scenario / arm | p50 | p95 | p95 delta vs monitor | Gate |
| --- | ---: | ---: | ---: | --- |
| Analytics 24h — monitor HTTP | 373.4590 ms | 480.8481 ms | baseline | pass |
| Analytics 24h — repository cold | 80.5180 ms | 101.8396 ms | -78.8208% | pass |
| Sessions 30d / 50 — monitor HTTP | 1915.0852 ms | 2201.5025 ms | baseline | pass |
| Sessions 30d / 50 — repository cold | 1685.5010 ms | 2011.9565 ms | -8.6098% | pass (≤20%) |
| Analytics 24h — repository warm cache | — | 0.0647024 ms | cache-only arm | pass |

## Review

A full seven-persona final review completed with no unresolved actionable findings:

- **Correctness:** fixed call-side tool facts, benchmark semantic gating, deterministic web ties, and request-local cross-partition settings for view-only reads; final disposition correct/high confidence.
- **Completeness:** added the deterministic cache matrix, configured-success cumulative fake coverage, repeatable live-schema/teardown target, MCP rerun, and exact-final benchmark evidence; clean disposition.
- **Security:** benchmark output reports URL origins only, stripping userinfo/path/query/fragment; the isolated live target uses a generated fixed-format database name and unconditional teardown; clean disposition.
- **Idiomatic Rust/SQL:** uses UTF-8-aware ClickHouse truncation and deterministic event ordering; clean disposition.
- **Elegance:** reuses shared summary/turn rows and mappers, derives MCP turn neighbors from one batch, and removes redundant post-FINAL aggregation; clean disposition.
- **YAGNI:** narrowed repository-only helpers, removed an unused lookback formatter, duplicate mapping test, and unused reqwest feature; clean disposition.
- **Scope:** removed the construction-only #455/#457 factory from this branch and retained only the shared #454 surface/tests/benchmark; clean disposition.

## Changelog

- Adds shared conversation session analytics, time-series analytics, web-search, heartbeat, table, health, and diagnostics reads.
- Adds 30-second range-keyed analytics caching with deterministic concurrency, expiry, failure, and cancellation behavior.
- Consolidates repository event reads around one canonical dedup source and one request-local cross-partition winner setting.
- Preserves unmatched tool-call latency/error facts in session traces.

## Validation

`cargo test -p moraine-conversations --locked` passed 112 tests across four suites; the two live targets are ignored in the default run. `cargo test -p moraine-mcp-core --locked` passed 64 tests. `live_schema_semantics_and_teardown` passed against the sandbox in 0.89 seconds and removed its temporary database. The exact benchmark command above passed all 60 samples per arm with matching cardinalities and normalized digests; session p95 was 8.6098% faster than the current monitor and therefore within the ±20% requirement.

The commit hook also completed repository formatting and strict clippy successfully.

## Residual risks

- Exhaustive malformed/partial heartbeat and trace variants are deterministic wire tests rather than duplicated live fixtures; the live target is intentionally limited to schema/engine behavior mocks cannot prove.
- The ignored live target performs destructive teardown and must remain restricted to an isolated sandbox, never a shared or production database.
- The normalized benchmark digest is order-insensitive and non-cryptographic (64-bit FNV-1a); it detects practical content drift but is not a cryptographic proof.
- Whole-trace reads can be large, and dropping a cancelled client future may leave already-started ClickHouse work running until the server/client timeout.
- End-to-end workspace dedup consolidation depends on the #455/#456 consumer cutovers.