### PR TITLE
refactor(cli): route status reads through repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,6 +1146,7 @@ dependencies = [
  "jsonc-parser",
  "moraine-clickhouse",
  "moraine-config",
+ "moraine-conversations",
  "ratatui",
  "reqwest",
  "serde",

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -20,3 +20,4 @@ toml_edit = "0.22"
 uuid = { version = "1.11", features = ["v4"] }
 moraine-config = { path = "../../crates/moraine-config" }
 moraine-clickhouse = { path = "../../crates/moraine-clickhouse" }
+moraine-conversations = { path = "../../crates/moraine-conversations" }

--- a/apps/moraine/src/commands.rs
+++ b/apps/moraine/src/commands.rs
@@ -9,6 +9,7 @@ mod up;
 use anyhow::{bail, Context, Result};
 use moraine_clickhouse::{ClickHouseClient, DoctorReport};
 use moraine_config::AppConfig;
+use moraine_conversations::{ClickHouseConversationRepository, RepoConfig};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -41,7 +42,8 @@ pub(crate) async fn dispatch(cli: Cli, output: CliOutput) -> Result<ExitCode> {
         CliCommand::Status => {
             let (_, cfg) = load_cfg(cli.config.clone())?;
             let paths = runtime_paths(&cfg);
-            let snapshot = status::cmd_status(&paths, &cfg).await?;
+            let repository = conversation_repository(&cfg)?;
+            let snapshot = status::cmd_status(&paths, &cfg, &repository).await?;
             crate::render::render_status(&output, &snapshot)?;
             Ok(ExitCode::SUCCESS)
         }
@@ -188,6 +190,18 @@ async fn run_service(global_config: Option<PathBuf>, run: RunArgs) -> Result<Exi
 
     Ok(ExitCode::from(status.code().unwrap_or(1) as u8))
 }
+
+fn conversation_repository(cfg: &AppConfig) -> Result<ClickHouseConversationRepository> {
+    let ch = ClickHouseClient::new(cfg.clickhouse.clone())?;
+    Ok(ClickHouseConversationRepository::new(
+        ch,
+        RepoConfig::default(),
+    ))
+}
+
+// Deliberate shared-read-layer exception: `db *`/`doctor` are storage administration,
+// while `export` owns a versioned row contract and schema-skew gate. Those paths keep
+// direct ClickHouse access; operational status reads go through ConversationRepository.
 
 async fn cmd_db_migrate(cfg: &AppConfig) -> Result<MigrationOutcome> {
     let ch = ClickHouseClient::new(cfg.clickhouse.clone())?;

--- a/apps/moraine/src/commands/status.rs
+++ b/apps/moraine/src/commands/status.rs
@@ -1,9 +1,3 @@
-use anyhow::Result;
-use moraine_clickhouse::{ClickHouseClient, DoctorReport};
-use moraine_config::AppConfig;
-use serde::Deserialize;
-
-use super::cmd_db_doctor;
 use crate::managed_clickhouse::{
     active_clickhouse_source, managed_clickhouse_bin, managed_clickhouse_checksum_state,
     managed_clickhouse_version,
@@ -12,67 +6,10 @@ use crate::paths::RuntimePaths;
 use crate::process::service_running;
 use crate::render::{HeartbeatSnapshot, ServiceRuntimeStatus, StatusSnapshot};
 use crate::service::Service;
-
-#[derive(Debug, Deserialize)]
-struct HeartbeatRow {
-    latest: String,
-    queue_depth: u64,
-    files_active: u64,
-    #[serde(default)]
-    watcher_backend: String,
-    #[serde(default)]
-    watcher_error_count: u64,
-    #[serde(default)]
-    watcher_reset_count: u64,
-    #[serde(default)]
-    watcher_last_reset_unix_ms: u64,
-}
-
-#[derive(Debug, Deserialize)]
-struct LegacyHeartbeatRow {
-    latest: String,
-    queue_depth: u64,
-    files_active: u64,
-}
-
-async fn query_heartbeat(cfg: &AppConfig) -> Result<Option<HeartbeatRow>> {
-    let ch = ClickHouseClient::new(cfg.clickhouse.clone())?;
-    let db = quote_identifier(&cfg.clickhouse.database);
-    let query = format!(
-        "SELECT \
-            toString(max(ts)) AS latest, \
-            toUInt64(argMax(queue_depth, ts)) AS queue_depth, \
-            toUInt64(argMax(files_active, ts)) AS files_active, \
-            toString(argMax(watcher_backend, ts)) AS watcher_backend, \
-            toUInt64(argMax(watcher_error_count, ts)) AS watcher_error_count, \
-            toUInt64(argMax(watcher_reset_count, ts)) AS watcher_reset_count, \
-            toUInt64(argMax(watcher_last_reset_unix_ms, ts)) AS watcher_last_reset_unix_ms \
-         FROM {db}.ingest_heartbeats"
-    );
-
-    match ch.query_json_data::<HeartbeatRow>(&query, None).await {
-        Ok(rows) => Ok(rows.into_iter().next()),
-        Err(_) => {
-            let legacy_query = format!(
-                "SELECT toString(max(ts)) AS latest, toUInt64(argMax(queue_depth, ts)) AS queue_depth, toUInt64(argMax(files_active, ts)) AS files_active FROM {db}.ingest_heartbeats"
-            );
-            let rows: Vec<LegacyHeartbeatRow> = ch.query_json_data(&legacy_query, None).await?;
-            Ok(rows.into_iter().next().map(|row| HeartbeatRow {
-                latest: row.latest,
-                queue_depth: row.queue_depth,
-                files_active: row.files_active,
-                watcher_backend: "unknown".to_string(),
-                watcher_error_count: 0,
-                watcher_reset_count: 0,
-                watcher_last_reset_unix_ms: 0,
-            }))
-        }
-    }
-}
-
-fn quote_identifier(value: &str) -> String {
-    format!("`{}`", value.replace('`', "``"))
-}
+use anyhow::Result;
+use moraine_clickhouse::DoctorReport;
+use moraine_config::AppConfig;
+use moraine_conversations::{ConversationRepository, IngestHeartbeatRead, StoreDiagnostics};
 
 fn service_runtime_running(services: &[ServiceRuntimeStatus], service: Service) -> bool {
     services
@@ -125,7 +62,54 @@ fn build_status_notes(
     notes
 }
 
-pub(super) async fn cmd_status(paths: &RuntimePaths, cfg: &AppConfig) -> Result<StatusSnapshot> {
+fn doctor_report(diagnostics: StoreDiagnostics) -> DoctorReport {
+    DoctorReport {
+        clickhouse_healthy: diagnostics.healthy,
+        clickhouse_version: diagnostics.version,
+        database: diagnostics.database,
+        database_exists: diagnostics.database_exists,
+        applied_migrations: diagnostics.applied_schema_versions,
+        pending_migrations: diagnostics.pending_schema_versions,
+        missing_tables: diagnostics.missing_tables,
+        errors: diagnostics.errors,
+    }
+}
+
+fn heartbeat_snapshot(read: IngestHeartbeatRead) -> HeartbeatSnapshot {
+    match read.latest {
+        Some(heartbeat) => HeartbeatSnapshot::Available {
+            latest: heartbeat.ts,
+            queue_depth: heartbeat.queue_depth,
+            files_active: u64::from(heartbeat.files_active),
+            watcher_backend: heartbeat
+                .watcher_backend
+                .unwrap_or_else(|| "unknown".to_string()),
+            watcher_error_count: heartbeat.watcher_error_count.unwrap_or(0),
+            watcher_reset_count: heartbeat.watcher_reset_count.unwrap_or(0),
+            watcher_last_reset_unix_ms: heartbeat.watcher_last_reset_unix_ms.unwrap_or(0),
+        },
+        None => HeartbeatSnapshot::Unavailable,
+    }
+}
+
+async fn read_repository_status(
+    repository: &dyn ConversationRepository,
+) -> Result<(DoctorReport, HeartbeatSnapshot)> {
+    let report = doctor_report(repository.read_store_diagnostics().await?);
+    let heartbeat = match repository.latest_ingest_heartbeat().await {
+        Ok(read) => heartbeat_snapshot(read),
+        Err(err) => HeartbeatSnapshot::Error {
+            message: err.to_string(),
+        },
+    };
+    Ok((report, heartbeat))
+}
+
+pub(super) async fn cmd_status(
+    paths: &RuntimePaths,
+    cfg: &AppConfig,
+    repository: &dyn ConversationRepository,
+) -> Result<StatusSnapshot> {
     let services = [
         Service::ClickHouse,
         Service::Ingest,
@@ -141,25 +125,10 @@ pub(super) async fn cmd_status(paths: &RuntimePaths, cfg: &AppConfig) -> Result<
     .collect::<Vec<_>>();
     let managed_server = managed_clickhouse_bin(paths, "clickhouse-server");
     let (source, source_path) = active_clickhouse_source(paths);
-    let report = cmd_db_doctor(cfg).await?;
+    let (report, heartbeat) = read_repository_status(repository).await?;
     let clickhouse_health_url = cfg.clickhouse.url.clone();
     let status_notes = build_status_notes(&services, &report, &clickhouse_health_url);
     let monitor_url = monitor_runtime_running(&services).then(|| monitor_runtime_url(cfg));
-    let heartbeat = match query_heartbeat(cfg).await {
-        Ok(Some(row)) => HeartbeatSnapshot::Available {
-            latest: row.latest,
-            queue_depth: row.queue_depth,
-            files_active: row.files_active,
-            watcher_backend: row.watcher_backend,
-            watcher_error_count: row.watcher_error_count,
-            watcher_reset_count: row.watcher_reset_count,
-            watcher_last_reset_unix_ms: row.watcher_last_reset_unix_ms,
-        },
-        Ok(None) => HeartbeatSnapshot::Unavailable,
-        Err(err) => HeartbeatSnapshot::Error {
-            message: err.to_string(),
-        },
-    };
 
     Ok(StatusSnapshot {
         services,
@@ -180,6 +149,123 @@ pub(super) async fn cmd_status(paths: &RuntimePaths, cfg: &AppConfig) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use moraine_conversations::{
+        InMemoryConversationRepository, InMemoryConversationResponses, IngestHeartbeat, RepoConfig,
+        RepoResult,
+    };
+    use serde_json::{json, Value};
+
+    async fn status_json(heartbeat: RepoResult<IngestHeartbeatRead>) -> Value {
+        let mut cfg = AppConfig::default();
+        let test_root = std::env::temp_dir().join(format!(
+            "moraine-status-unit-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("unnamed")
+        ));
+        cfg.runtime.root_dir = test_root.display().to_string();
+        cfg.runtime.logs_dir = test_root.join("logs").display().to_string();
+        cfg.runtime.pids_dir = test_root.join("run").display().to_string();
+        cfg.runtime.service_bin_dir = test_root.join("services").display().to_string();
+        cfg.runtime.managed_clickhouse_dir = test_root.join("managed").display().to_string();
+        let paths = crate::paths::runtime_paths(&cfg);
+        let repository = InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            InMemoryConversationResponses {
+                latest_ingest_heartbeat: Some(heartbeat),
+                read_store_diagnostics: Some(Ok(StoreDiagnostics {
+                    healthy: true,
+                    version: Some("25.8.1.1".to_string()),
+                    database: "moraine".to_string(),
+                    database_exists: true,
+                    applied_schema_versions: vec!["001".to_string()],
+                    pending_schema_versions: Vec::new(),
+                    missing_tables: Vec::new(),
+                    errors: Vec::new(),
+                })),
+                ..InMemoryConversationResponses::default()
+            },
+        );
+        let snapshot = cmd_status(&paths, &cfg, &repository)
+            .await
+            .expect("collect status");
+        serde_json::to_value(snapshot).expect("serialize status")
+    }
+
+    fn stale_heartbeat() -> IngestHeartbeat {
+        IngestHeartbeat {
+            ts: "2000-01-01 00:00:00.000".to_string(),
+            ts_unix_ms: 946_684_800_000,
+            host: "old-host".to_string(),
+            service_version: "0.1.0".to_string(),
+            queue_depth: 7,
+            files_active: 3,
+            files_watched: 9,
+            rows_raw_written: 11,
+            rows_events_written: 10,
+            rows_errors_written: 1,
+            flush_latency_ms: 12,
+            append_to_visible_p50_ms: 13,
+            append_to_visible_p95_ms: 14,
+            last_error: String::new(),
+            watcher_backend: None,
+            watcher_error_count: None,
+            watcher_reset_count: None,
+            watcher_last_reset_unix_ms: None,
+            backend_sinks: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn healthy_status_preserves_stale_heartbeat_json_output() {
+        let status = status_json(Ok(IngestHeartbeatRead {
+            table_present: true,
+            latest: Some(stale_heartbeat()),
+        }))
+        .await;
+
+        assert_eq!(
+            status["doctor"],
+            json!({
+                "clickhouse_healthy": true,
+                "clickhouse_version": "25.8.1.1",
+                "database": "moraine",
+                "database_exists": true,
+                "applied_migrations": ["001"],
+                "pending_migrations": [],
+                "missing_tables": [],
+                "errors": []
+            })
+        );
+        assert_eq!(
+            status["heartbeat"],
+            json!({
+                "state": "available",
+                "latest": "2000-01-01 00:00:00.000",
+                "queue_depth": 7,
+                "files_active": 3,
+                "watcher_backend": "unknown",
+                "watcher_error_count": 0,
+                "watcher_reset_count": 0,
+                "watcher_last_reset_unix_ms": 0
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_heartbeat_preserves_unavailable_json_output() {
+        for table_present in [false, true] {
+            let status = status_json(Ok(IngestHeartbeatRead {
+                table_present,
+                latest: None,
+            }))
+            .await;
+            assert_eq!(
+                status["heartbeat"],
+                json!({"state": "unavailable"}),
+                "table_present={table_present}"
+            );
+        }
+    }
 
     fn test_doctor_report(clickhouse_healthy: bool) -> DoctorReport {
         DoctorReport {

--- a/apps/moraine/src/commands/up.rs
+++ b/apps/moraine/src/commands/up.rs
@@ -9,7 +9,7 @@ use crate::process::{preflight_required_service_binaries, start_background_servi
 use crate::render::{render_up, CliOutput, UpSnapshot};
 use crate::service::Service;
 
-use super::{cmd_db_migrate, status::cmd_status};
+use super::{cmd_db_migrate, conversation_repository, status::cmd_status};
 
 pub(super) async fn handle_args(
     output: &CliOutput,
@@ -47,7 +47,8 @@ async fn start_selected_services(
         )?);
     }
 
-    let status = cmd_status(paths, cfg).await?;
+    let repository = conversation_repository(cfg)?;
+    let status = cmd_status(paths, cfg, &repository).await?;
     let snapshot = UpSnapshot {
         clickhouse,
         migrations,

--- a/apps/moraine/tests/status_cli.rs
+++ b/apps/moraine/tests/status_cli.rs
@@ -1,0 +1,84 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+
+fn temp_dir() -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "moraine-status-cli-read-error-{}-{stamp}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&path).expect("create temp dir");
+    path
+}
+
+fn write_config(root: &Path) -> PathBuf {
+    let runtime = root.join("runtime");
+    let config = root.join("config.toml");
+    fs::write(
+        &config,
+        format!(
+            r#"[clickhouse]
+url = "http://127.0.0.1:9"
+database = "moraine"
+timeout_seconds = 1.0
+
+[runtime]
+root_dir = "{}"
+logs_dir = "{}"
+pids_dir = "{}"
+service_bin_dir = "{}"
+managed_clickhouse_dir = "{}"
+"#,
+            runtime.display(),
+            runtime.join("logs").display(),
+            runtime.join("run").display(),
+            root.join("services").display(),
+            root.join("managed").display(),
+        ),
+    )
+    .expect("write status config");
+    config
+}
+
+fn run_status(config: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_moraine"))
+        .args(["--output", "json", "--config"])
+        .arg(config)
+        .arg("status")
+        .output()
+        .expect("run moraine status")
+}
+
+#[test]
+fn heartbeat_read_error_remains_visible_without_failing_status() {
+    let root = temp_dir();
+    let config = write_config(&root);
+
+    let output = run_status(&config);
+    assert!(
+        output.status.success(),
+        "status failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let status: Value = serde_json::from_slice(&output.stdout).expect("status JSON output");
+
+    assert_eq!(status["doctor"]["clickhouse_healthy"], false);
+    assert_eq!(status["heartbeat"]["state"], "error");
+    assert!(
+        status["heartbeat"]["message"]
+            .as_str()
+            .expect("heartbeat error message")
+            .contains("backend error"),
+        "{}",
+        status["heartbeat"]
+    );
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Description

**What.** Routes `moraine status` health and heartbeat reads through the shared conversation repository.

**Why.** Status should consume the shared analytics read surface rather than owning raw ClickHouse queries, while preserving its existing user-visible contract.

- Injects the repository into both direct `status` dispatch and the `up` readiness path.
- Maps shared store diagnostics and heartbeat summaries into the existing status snapshot, keeping text and JSON output unchanged.
- Keeps `db *`, `doctor`, and `export` on direct database access as the explicit storage-admin exception; export continues to own its versioned data contract and skew gate.

## Usage

Run `moraine status` as before. The command, configuration, exit behavior, text rendering, and JSON fields are unchanged; only the backing read path moves to the shared repository.

## Changelog

- Routes status health and heartbeat reads through the shared repository.
- Preserves status output and the direct-database exception for admin and export workflows.

## Validation

Validated the final rebased commit with `cargo check -p moraine --bin moraine --locked`, `cargo test -p moraine --bin moraine commands::status::tests --locked` (7 passed), `cargo test -p moraine --test status_cli --locked` (1 passed), and `cargo test -p moraine --bin moraine commands::up::tests --locked` (2 passed). A focused search of `apps/moraine/src/commands/status.rs` for `SELECT`, `query_json_data`, and `ClickHouseClient` returned no matches. A dead-port manual smoke test via `cargo run -q -p moraine -- --config <dead-port-config> status` exited successfully and rendered stopped services, an unhealthy database, and the visible heartbeat backend error.

The full seven-persona review wave—elegance, idiomatic Rust, correctness, completeness, security, YAGNI, and scope—completed cleanly, including final-base follow-ups.

Resolves #456