### PR TITLE
refactor(monitor): use shared conversation read layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,10 +1279,10 @@ version = "0.6.4"
 dependencies = [
  "anyhow",
  "axum",
- "chrono",
  "mime_guess",
  "moraine-clickhouse",
  "moraine-config",
+ "moraine-conversations",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,7 +1280,6 @@ dependencies = [
  "anyhow",
  "axum",
  "mime_guess",
- "moraine-clickhouse",
  "moraine-config",
  "moraine-conversations",
  "serde",

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -17,9 +17,9 @@ tokio = { version = "1.40", features = ["macros", "rt", "sync"] }
 tracing = "0.1"
 uuid = { version = "1.11", features = ["v4"] }
 moraine-clickhouse = { path = "../moraine-clickhouse" }
+moraine-config = { path = "../moraine-config" }
 
 [dev-dependencies]
 axum = "0.7"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 tokio = { version = "1.40", features = ["macros", "rt-multi-thread", "net", "time", "test-util"] }
-moraine-config = { path = "../moraine-config" }

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -31,3 +31,34 @@ pub use in_memory_repo::{
     InMemoryConversationCalls, InMemoryConversationRepository, InMemoryConversationResponses,
 };
 pub use repo::ConversationRepository;
+
+/// Build the production ClickHouse repository behind its backend-neutral read
+/// trait. Consumers provide configuration, but never construct or retain the
+/// storage client themselves.
+pub fn build_clickhouse_repository(
+    clickhouse: moraine_config::ClickHouseConfig,
+    config: RepoConfig,
+) -> anyhow::Result<std::sync::Arc<dyn ConversationRepository>> {
+    let client = moraine_clickhouse::ClickHouseClient::new(clickhouse)?;
+    Ok(std::sync::Arc::new(ClickHouseConversationRepository::new(
+        client, config,
+    )))
+}
+
+#[cfg(test)]
+mod construction_tests {
+    use super::{build_clickhouse_repository, RepoConfig};
+
+    #[test]
+    fn clickhouse_factory_returns_configured_trait_object() {
+        let config = RepoConfig {
+            max_results: 73,
+            ..RepoConfig::default()
+        };
+        let repository =
+            build_clickhouse_repository(moraine_config::ClickHouseConfig::default(), config)
+                .expect("valid ClickHouse configuration");
+
+        assert_eq!(repository.config().max_results, 73);
+    }
+}

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -7,10 +7,10 @@ description = "Analytics and query logic for Moraine monitor service"
 [dependencies]
 anyhow = "1.0"
 axum = "0.7"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
 mime_guess = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "fs"] }
 moraine-config = { path = "../moraine-config" }
 moraine-clickhouse = { path = "../moraine-clickhouse" }
+moraine-conversations = { path = "../moraine-conversations" }

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -12,5 +12,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "fs"] }
 moraine-config = { path = "../moraine-config" }
-moraine-clickhouse = { path = "../moraine-clickhouse" }
 moraine-conversations = { path = "../moraine-conversations" }

--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -621,6 +621,8 @@ fn monitor_step_json(step: SessionStep) -> Value {
             tool_name,
             call_id,
             arguments,
+            latency_ms: call_latency_ms,
+            is_error: call_is_error,
             result,
         } => {
             let (latency_ms, result_text, result_at, status) = match result {
@@ -628,9 +630,18 @@ fn monitor_step_json(step: SessionStep) -> Value {
                     result.latency_ms,
                     result.text,
                     result.event_unix_ms,
-                    if result.is_error { "error" } else { "ok" },
+                    if call_is_error || result.is_error {
+                        "error"
+                    } else {
+                        "ok"
+                    },
                 ),
-                None => (0, String::new(), event_unix_ms, "ok"),
+                None => (
+                    call_latency_ms.unwrap_or_default(),
+                    String::new(),
+                    event_unix_ms,
+                    if call_is_error { "error" } else { "ok" },
+                ),
             };
             json!({
                 "kind": "tool_call",
@@ -1066,6 +1077,8 @@ mod tests {
                         tool_name: "Read".to_string(),
                         call_id: "call-1".to_string(),
                         arguments: json!({"path": "Cargo.toml"}),
+                        latency_ms: Some(250),
+                        is_error: false,
                         result: Some(ToolResult {
                             event_unix_ms: 1_771_243_203_000,
                             text: "workspace".to_string(),
@@ -1332,6 +1345,24 @@ mod tests {
             SessionLookback::ThirtyDays
         );
         assert_eq!(resolve_session_lookback(Some("all")), SessionLookback::All);
+    }
+
+    #[test]
+    fn unmatched_tool_call_preserves_call_latency_and_error() {
+        let step = monitor_step_json(SessionStep::ToolCall {
+            event_unix_ms: 1_000,
+            tool_name: "Read".to_string(),
+            call_id: "call-unmatched".to_string(),
+            arguments: json!({"path": "Cargo.toml"}),
+            latency_ms: Some(321),
+            is_error: true,
+            result: None,
+        });
+
+        assert_eq!(step["latencyMs"], json!(321));
+        assert_eq!(step["status"], json!("error"));
+        assert_eq!(step["result"], json!(""));
+        assert_eq!(step["resultAt"], json!(1_000));
     }
 
     #[tokio::test]

--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -7,23 +7,29 @@ use axum::{
     routing::get,
     Json, Router,
 };
+use moraine_clickhouse::ClickHouseClient;
+use moraine_config::AppConfig;
+use moraine_conversations::{
+    AnalyticsRange, ClickHouseConversationRepository, ConversationRepository, IngestHeartbeatRead,
+    RepoConfig, RepoError, SessionAnalytics, SessionAnalyticsQuery, SessionLookback, SessionStep,
+    SessionTurn, StoreConnectionMetrics, StoreHealth, StoreProbe, TablePreviewQuery,
+    TableSummaries,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::path::{Path as FsPath, PathBuf};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::fs;
-use tokio::time::Instant;
-
-use moraine_clickhouse::ClickHouseClient;
-use moraine_config::AppConfig;
 
 #[derive(Clone)]
 struct AppState {
-    clickhouse: ClickHouseClient,
+    repository: Arc<dyn ConversationRepository>,
     static_dir: PathBuf,
+    clickhouse_url: String,
+    clickhouse_database: String,
 }
 
 #[derive(Deserialize)]
@@ -36,8 +42,14 @@ struct AnalyticsQuery {
     range: Option<String>,
 }
 
+#[derive(Deserialize)]
+struct SessionsQuery {
+    limit: Option<u32>,
+    since: Option<String>,
+}
+
 #[derive(Serialize)]
-struct TableSummary {
+struct MonitorTableSummary {
     name: String,
     engine: String,
     is_temporary: u8,
@@ -52,29 +64,25 @@ pub async fn run_server(
 ) -> Result<()> {
     validate_static_dir(&static_dir)?;
 
-    let clickhouse = ClickHouseClient::new(cfg.clickhouse)?;
-
+    let clickhouse_url = cfg.clickhouse.url.clone();
+    let clickhouse_database = cfg.clickhouse.database.clone();
+    let client = ClickHouseClient::new(cfg.clickhouse.clone())?;
+    let repository: Arc<dyn ConversationRepository> = Arc::new(
+        ClickHouseConversationRepository::new(client, repository_config(&cfg)),
+    );
     let state = AppState {
-        clickhouse,
+        repository,
         static_dir,
+        clickhouse_url,
+        clickhouse_database,
     };
+    let app = monitor_router(state.clone());
 
-    let app = Router::new()
-        .route("/api/health", get(api_health))
-        .route("/api/status", get(api_status))
-        .route("/api/analytics", get(api_analytics))
-        .route("/api/tables", get(api_tables))
-        .route("/api/web-searches", get(api_web_searches))
-        .route("/api/tables/:table", get(api_table_rows))
-        .route("/api/sessions", get(api_sessions))
-        .fallback(get(static_fallback))
-        .with_state(state.clone());
-
-    let bind = format!("{}:{}", host, port)
+    let bind = format!("{host}:{port}")
         .parse::<SocketAddr>()
         .map_err(|err| anyhow!("invalid bind address: {err}"))?;
 
-    println!("moraine-monitor running at http://{}", bind);
+    println!("moraine-monitor running at http://{bind}");
     println!("serving UI from {}", state.static_dir.display());
 
     let listener = tokio::net::TcpListener::bind(bind).await.map_err(|error| {
@@ -88,6 +96,37 @@ pub async fn run_server(
     })?;
     axum::serve(listener, app).await?;
     Ok(())
+}
+
+fn repository_config(cfg: &AppConfig) -> RepoConfig {
+    RepoConfig {
+        max_results: cfg.mcp.max_results,
+        preview_chars: cfg.mcp.preview_chars,
+        default_context_before: cfg.mcp.default_context_before,
+        default_context_after: cfg.mcp.default_context_after,
+        default_include_tool_events: cfg.mcp.default_include_tool_events,
+        default_exclude_codex_mcp: cfg.mcp.default_exclude_codex_mcp,
+        async_log_writes: cfg.mcp.async_log_writes,
+        bm25_k1: cfg.bm25.k1,
+        bm25_b: cfg.bm25.b,
+        bm25_default_min_score: cfg.bm25.default_min_score,
+        bm25_default_min_should_match: cfg.bm25.default_min_should_match,
+        bm25_max_query_terms: cfg.bm25.max_query_terms,
+        session_scope: None,
+    }
+}
+
+fn monitor_router(state: AppState) -> Router {
+    Router::new()
+        .route("/api/health", get(api_health))
+        .route("/api/status", get(api_status))
+        .route("/api/analytics", get(api_analytics))
+        .route("/api/tables", get(api_tables))
+        .route("/api/web-searches", get(api_web_searches))
+        .route("/api/tables/:table", get(api_table_rows))
+        .route("/api/sessions", get(api_sessions))
+        .fallback(get(static_fallback))
+        .with_state(state)
 }
 
 fn validate_static_dir(static_dir: &FsPath) -> Result<()> {
@@ -122,153 +161,116 @@ fn json_response<T: Serialize>(payload: T, status: StatusCode) -> Response {
     response
 }
 
-fn clickhouse_ping_payload(version: String, ping_result: Result<()>, ping_ms: f64) -> Value {
-    match ping_result {
-        Ok(()) => json!({
-            "healthy": true,
-            "version": version,
-            "ping_ms": ping_ms,
-            "error": Value::Null,
-        }),
-        Err(error) => json!({
-            "healthy": false,
-            "version": version,
-            "ping_ms": ping_ms,
-            "error": error.to_string(),
-        }),
-    }
-}
-
 async fn api_health(State(state): State<AppState>) -> Response {
-    let start = Instant::now();
-    let connection_stats = query_clickhouse_connections(&state)
-        .await
-        .unwrap_or_else(|error| json!({"total": Value::Null, "error": error.to_string()}));
-
-    match state.clickhouse.ping().await {
-        Ok(()) => match state.clickhouse.version().await {
-            Ok(version) => {
-                let ingestor = query_health_heartbeat_or_absent(&state).await;
-                let body = json!({
-                    "ok": true,
-                    "url": state.clickhouse.config().url,
-                    "database": state.clickhouse.config().database,
-                    "version": version,
-                    "ping_ms": (Instant::elapsed(&start).as_secs_f64() * 1000.0),
-                    "connections": connection_stats,
-                    "ingestor": ingestor,
-                });
-                json_response(body, StatusCode::OK)
-            }
-            Err(error) => json_response(
+    let (health, heartbeat) = tokio::join!(
+        state.repository.read_store_health(),
+        state.repository.latest_ingest_heartbeat()
+    );
+    let health = match health {
+        Ok(health) => health,
+        Err(error) => {
+            let message = error.to_string();
+            return json_response(
                 json!({
                     "ok": false,
-                    "url": state.clickhouse.config().url,
-                    "database": state.clickhouse.config().database,
-                    "error": error.to_string(),
-                    "connections": connection_stats,
+                    "url": state.clickhouse_url,
+                    "database": state.clickhouse_database,
+                    "error": message,
+                    "connections": {"total": Value::Null, "error": message},
                 }),
                 StatusCode::SERVICE_UNAVAILABLE,
-            ),
-        },
-        Err(error) => json_response(
-            json!({
-                "ok": false,
-                "url": state.clickhouse.config().url,
-                "database": state.clickhouse.config().database,
-                "error": error.to_string(),
-                "connections": connection_stats,
-            }),
-            StatusCode::SERVICE_UNAVAILABLE,
-        ),
-    }
+            );
+        }
+    };
+    let connections = connection_payload(&health.connections);
+
+    let ping_ms = match &health.ping {
+        StoreProbe::Available(value) => *value,
+        StoreProbe::Failed { message } => {
+            return health_failure_response(&state, message, connections);
+        }
+    };
+    let version = match &health.version {
+        StoreProbe::Available(value) => value,
+        StoreProbe::Failed { message } => {
+            return health_failure_response(&state, message, connections);
+        }
+    };
+    let heartbeat = heartbeat
+        .map(heartbeat_payload)
+        .unwrap_or_else(|_| heartbeat_absent());
+
+    json_response(
+        json!({
+            "ok": true,
+            "url": state.clickhouse_url,
+            "database": state.clickhouse_database,
+            "version": version,
+            "ping_ms": ping_ms,
+            "connections": connections,
+            "ingestor": health_heartbeat(&heartbeat),
+        }),
+        StatusCode::OK,
+    )
+}
+
+fn health_failure_response(state: &AppState, message: &str, connections: Value) -> Response {
+    json_response(
+        json!({
+            "ok": false,
+            "url": state.clickhouse_url,
+            "database": state.clickhouse_database,
+            "error": message,
+            "connections": connections,
+        }),
+        StatusCode::SERVICE_UNAVAILABLE,
+    )
 }
 
 async fn api_status(State(state): State<AppState>) -> Response {
-    let db_exists = match state
-        .clickhouse
-        .query_rows::<Value>(
-            &format!(
-                "SELECT name FROM system.databases WHERE name = '{}'",
-                escape_literal(&state.clickhouse.config().database)
-            ),
-            None,
-        )
-        .await
-    {
-        Ok(rows) => !rows.is_empty(),
-        Err(_) => false,
+    let (health, diagnostics) = tokio::join!(
+        state.repository.read_store_health(),
+        state.repository.read_store_diagnostics()
+    );
+    let health = health.unwrap_or_else(|error| unavailable_store_health(error.to_string()));
+    let database_exists = match diagnostics {
+        Ok(diagnostics) => diagnostics.database_exists,
+        Err(_) => probe_bool(&health.database_exists).unwrap_or(false),
     };
 
-    let tables = if db_exists {
-        match query_table_summaries(&state).await {
-            Ok(value) => value,
+    let (tables, heartbeat) = if database_exists {
+        let (tables, heartbeat) = tokio::join!(
+            state.repository.list_table_summaries(),
+            state.repository.latest_ingest_heartbeat()
+        );
+        let tables = match tables {
+            Ok(tables) => monitor_table_summaries(tables),
             Err(error) => {
                 return json_response(
                     json!({"ok": false, "error": error.to_string()}),
                     StatusCode::SERVICE_UNAVAILABLE,
                 );
             }
-        }
+        };
+        let heartbeat = heartbeat
+            .map(heartbeat_payload)
+            .unwrap_or_else(|_| heartbeat_absent());
+        (tables, heartbeat)
     } else {
-        Vec::new()
+        (Vec::new(), heartbeat_absent())
     };
 
     let estimated_total_rows = tables.iter().map(|table| table.rows).sum::<u64>();
-    let heartbeat = if db_exists {
-        query_heartbeat_or_absent(&state).await
-    } else {
-        heartbeat_absent()
-    };
-
-    let clickhouse_ping = if db_exists {
-        match state.clickhouse.version().await {
-            Ok(version) => {
-                let start = Instant::now();
-                let ping_result = state.clickhouse.ping().await;
-                let ping_ms = Instant::elapsed(&start).as_secs_f64() * 1000.0;
-                clickhouse_ping_payload(version, ping_result, ping_ms)
-            }
-            Err(error) => {
-                json!({
-                    "healthy": false,
-                    "version": Value::Null,
-                    "ping_ms": Value::Null,
-                    "error": error.to_string(),
-                })
-            }
-        }
-    } else {
-        json!({
-            "healthy": false,
-            "version": Value::Null,
-            "ping_ms": Value::Null,
-            "error": "database not found",
-        })
-    };
+    let clickhouse = status_clickhouse_payload(&state, &health, database_exists);
 
     json_response(
         json!({
             "ok": true,
-            "clickhouse": {
-                "url": state.clickhouse.config().url,
-            "database": state.clickhouse.config().database,
-            "healthy": clickhouse_ping["healthy"],
-            "version": clickhouse_ping["version"],
-            "ping_ms": clickhouse_ping["ping_ms"],
-            "error": clickhouse_ping["error"],
-            "connections": if db_exists {
-                query_clickhouse_connections(&state)
-                    .await
-                    .unwrap_or_else(|error| json!({"total": Value::Null, "error": error.to_string()}))
-            } else {
-                json!({"total": Value::Null, "error": "database not found"})
-            },
-        },
-        "database": {
-            "exists": db_exists,
-            "table_count": tables.len(),
-            "estimated_total_rows": estimated_total_rows,
+            "clickhouse": clickhouse,
+            "database": {
+                "exists": database_exists,
+                "table_count": tables.len(),
+                "estimated_total_rows": estimated_total_rows,
                 "tables": tables,
             },
             "ingestor": heartbeat,
@@ -277,9 +279,79 @@ async fn api_status(State(state): State<AppState>) -> Response {
     )
 }
 
+fn unavailable_store_health(message: String) -> StoreHealth {
+    StoreHealth {
+        ping: StoreProbe::Failed {
+            message: message.clone(),
+        },
+        version: StoreProbe::Failed {
+            message: message.clone(),
+        },
+        database_exists: StoreProbe::Failed {
+            message: message.clone(),
+        },
+        connections: StoreProbe::Failed { message },
+    }
+}
+
+fn probe_bool(probe: &StoreProbe<bool>) -> Option<bool> {
+    match probe {
+        StoreProbe::Available(value) => Some(*value),
+        StoreProbe::Failed { .. } => None,
+    }
+}
+
+fn status_clickhouse_payload(
+    state: &AppState,
+    health: &StoreHealth,
+    database_exists: bool,
+) -> Value {
+    if !database_exists {
+        return json!({
+            "url": state.clickhouse_url,
+            "database": state.clickhouse_database,
+            "healthy": false,
+            "version": Value::Null,
+            "ping_ms": Value::Null,
+            "error": "database not found",
+            "connections": {"total": Value::Null, "error": "database not found"},
+        });
+    }
+
+    let (version, ping_ms, healthy, error) = match &health.version {
+        StoreProbe::Failed { message } => (Value::Null, Value::Null, false, json!(message)),
+        StoreProbe::Available(version) => match &health.ping {
+            StoreProbe::Available(ping_ms) => (json!(version), json!(ping_ms), true, Value::Null),
+            StoreProbe::Failed { message } => (json!(version), Value::Null, false, json!(message)),
+        },
+    };
+
+    json!({
+        "url": state.clickhouse_url,
+        "database": state.clickhouse_database,
+        "healthy": healthy,
+        "version": version,
+        "ping_ms": ping_ms,
+        "error": error,
+        "connections": connection_payload(&health.connections),
+    })
+}
+
+fn connection_payload(probe: &StoreProbe<StoreConnectionMetrics>) -> Value {
+    match probe {
+        StoreProbe::Available(metrics) => json!(metrics),
+        StoreProbe::Failed { message } => {
+            json!({"total": Value::Null, "error": message})
+        }
+    }
+}
+
 async fn api_tables(State(state): State<AppState>) -> Response {
-    match query_table_summaries(&state).await {
-        Ok(tables) => json_response(json!({"ok": true, "tables": tables}), StatusCode::OK),
+    match state.repository.list_table_summaries().await {
+        Ok(tables) => json_response(
+            json!({"ok": true, "tables": monitor_table_summaries(tables)}),
+            StatusCode::OK,
+        ),
         Err(error) => json_response(
             json!({"ok": false, "error": error.to_string()}),
             StatusCode::SERVICE_UNAVAILABLE,
@@ -287,65 +359,25 @@ async fn api_tables(State(state): State<AppState>) -> Response {
     }
 }
 
+fn monitor_table_summaries(summaries: TableSummaries) -> Vec<MonitorTableSummary> {
+    summaries
+        .tables
+        .into_iter()
+        .map(|table| MonitorTableSummary {
+            name: table.name,
+            engine: table.engine,
+            is_temporary: u8::from(table.is_temporary),
+            rows: table.rows,
+        })
+        .collect()
+}
+
 async fn api_web_searches(
     Query(params): Query<LimitQuery>,
     State(state): State<AppState>,
 ) -> Response {
-    #[derive(serde::Deserialize, serde::Serialize)]
-    struct WebSearchRow {
-        event_time: String,
-        harness: String,
-        source_name: String,
-        session_id: String,
-        model: String,
-        action: String,
-        search_query: String,
-        result_url: String,
-        source_ref: String,
-    }
-
-    let limit = params.limit.unwrap_or(100).clamp(1, 1000);
-    let database = &state.clickhouse.config().database;
-    let table = format!(
-        "{}.{}",
-        escape_identifier(database),
-        escape_identifier("events")
-    );
-
-    let query = format!(
-        "SELECT \
-            toString(event_ts) AS event_time, \
-            harness, \
-            source_name, \
-            session_id, \
-            lowerUTF8(trim(BOTH ' ' FROM model)) AS model, \
-            if(payload_type = 'web_search_call', op_kind, if(tool_name = 'WebFetch', 'open_page', if(tool_name = 'WebSearch', 'search', payload_type))) AS action, \
-            if(length(JSONExtractString(payload_json, 'action', 'query')) > 0, \
-               JSONExtractString(payload_json, 'action', 'query'), \
-               if(length(JSONExtractString(payload_json, 'input', 'query')) > 0, \
-                  JSONExtractString(payload_json, 'input', 'query'), \
-                  if(length(JSONExtractString(payload_json, 'data', 'query')) > 0, \
-                     JSONExtractString(payload_json, 'data', 'query'), \
-                     text_content))) AS search_query, \
-            if(length(JSONExtractString(payload_json, 'action', 'url')) > 0, \
-               JSONExtractString(payload_json, 'action', 'url'), \
-               JSONExtractString(payload_json, 'input', 'url')) AS result_url, \
-            source_ref \
-         FROM {table} \
-         WHERE payload_type = 'web_search_call' \
-            OR (payload_type = 'tool_use' AND tool_name IN ('WebSearch', 'WebFetch')) \
-            OR payload_type = 'search_results_received' \
-         ORDER BY event_ts DESC \
-         LIMIT {limit}",
-        table = table,
-        limit = limit,
-    );
-
-    let rows = match state
-        .clickhouse
-        .query_rows::<WebSearchRow>(&query, None)
-        .await
-    {
+    let limit = params.limit.unwrap_or(100).clamp(1, 1000) as u16;
+    let rows = match state.repository.list_web_searches(limit).await {
         Ok(rows) => rows,
         Err(error) => {
             return json_response(
@@ -377,289 +409,18 @@ async fn api_web_searches(
     )
 }
 
-#[derive(Clone, Copy)]
-struct AnalyticsRange {
-    key: &'static str,
-    label: &'static str,
-    window_seconds: u32,
-    bucket_seconds: u32,
-}
-
-fn resolve_analytics_range(value: Option<&str>) -> AnalyticsRange {
-    match value.unwrap_or("24h") {
-        "15m" => AnalyticsRange {
-            key: "15m",
-            label: "Last 15m",
-            window_seconds: 15 * 60,
-            bucket_seconds: 60,
-        },
-        "1h" => AnalyticsRange {
-            key: "1h",
-            label: "Last 1h",
-            window_seconds: 60 * 60,
-            bucket_seconds: 5 * 60,
-        },
-        "6h" => AnalyticsRange {
-            key: "6h",
-            label: "Last 6h",
-            window_seconds: 6 * 60 * 60,
-            bucket_seconds: 15 * 60,
-        },
-        "24h" => AnalyticsRange {
-            key: "24h",
-            label: "Last 24h",
-            window_seconds: 24 * 60 * 60,
-            bucket_seconds: 60 * 60,
-        },
-        "7d" => AnalyticsRange {
-            key: "7d",
-            label: "Last 7d",
-            window_seconds: 7 * 24 * 60 * 60,
-            bucket_seconds: 6 * 60 * 60,
-        },
-        "30d" => AnalyticsRange {
-            key: "30d",
-            label: "Last 30d",
-            window_seconds: 30 * 24 * 60 * 60,
-            bucket_seconds: 24 * 60 * 60,
-        },
-        _ => AnalyticsRange {
-            key: "24h",
-            label: "Last 24h",
-            window_seconds: 24 * 60 * 60,
-            bucket_seconds: 60 * 60,
-        },
-    }
-}
-
-fn analytics_window_query(table: &str, window_filter: &str, window_seconds: u32) -> String {
-    format!(
-        "SELECT \
-           toUInt64(anchor_unix) AS now_unix, \
-           toUInt64(greatest(anchor_unix - toInt64({window_seconds}), toInt64(0))) AS from_unix \
-         FROM ( \
-           SELECT \
-             if( \
-               count() = 0, \
-               toInt64(toUnixTimestamp(now())), \
-               toInt64(intDiv(toUnixTimestamp64Milli(max(event_ts)), 1000)) \
-             ) AS anchor_unix \
-           FROM {table} \
-           WHERE {window_filter} \
-         )",
-    )
-}
-
 async fn api_analytics(
     Query(params): Query<AnalyticsQuery>,
     State(state): State<AppState>,
 ) -> Response {
-    #[derive(serde::Deserialize, serde::Serialize)]
-    struct TokenRow {
-        bucket_unix: u64,
-        model: String,
-        endpoint_kind: String,
-        bucket: String,
-        tokens: u64,
-    }
-
-    #[derive(serde::Deserialize, serde::Serialize)]
-    struct TurnRow {
-        bucket_unix: u64,
-        model: String,
-        turns: u64,
-    }
-
-    #[derive(serde::Deserialize, serde::Serialize)]
-    struct ConcurrentRow {
-        bucket_unix: u64,
-        concurrent_sessions: u64,
-    }
-
     let range = resolve_analytics_range(params.range.as_deref());
-    let database = &state.clickhouse.config().database;
-    let table = format!(
-        "{}.{}",
-        escape_identifier(database),
-        escape_identifier("events")
-    );
-    let model_expr = "if(lowerUTF8(trim(BOTH ' ' FROM model)) = 'codex', 'gpt-5.3-codex-xhigh', lowerUTF8(trim(BOTH ' ' FROM model)))";
-    let model_expr_latest = "if(lowerUTF8(trim(BOTH ' ' FROM model_latest)) = 'codex', 'gpt-5.3-codex-xhigh', lowerUTF8(trim(BOTH ' ' FROM model_latest)))";
-    let window_filter = format!(
-        "event_ts >= now() - INTERVAL {} SECOND AND length(trim(BOTH ' ' FROM model)) > 0 AND lowerUTF8(trim(BOTH ' ' FROM model)) != '<synthetic>'",
-        range.window_seconds
-    );
-    let token_latest_filter = format!(
-        "event_ts_latest >= now() - INTERVAL {} SECOND AND length(trim(BOTH ' ' FROM model_latest)) > 0 AND lowerUTF8(trim(BOTH ' ' FROM model_latest)) != '<synthetic>' AND arraySum(mapValues(token_usage_buckets_latest)) > 0",
-        range.window_seconds
-    );
-    let turn_filter = format!(
-        "{} AND length(trim(BOTH ' ' FROM request_id)) > 0",
-        window_filter
-    );
-    let concurrent_filter = format!(
-        "event_ts >= now() - INTERVAL {} SECOND AND length(trim(BOTH ' ' FROM session_id)) > 0 AND arraySum(mapValues(token_usage_buckets)) > 0",
-        range.window_seconds
-    );
-
-    let token_query = format!(
-        "SELECT bucket_unix, model, endpoint_kind, bucket, toUInt64(sum(tokens)) AS tokens \
-         FROM ( \
-           SELECT bucket_unix, model, endpoint_kind, bucket, toUInt64(max(tokens_latest)) AS tokens \
-           FROM ( \
-             SELECT \
-               toUInt64(toUnixTimestamp(toStartOfInterval(event_ts_latest, INTERVAL {bucket_seconds} SECOND))) AS bucket_unix, \
-               {model_expr_latest} AS model, \
-               endpoint_kind_latest AS endpoint_kind, \
-               harness_latest, \
-               session_id_latest, \
-               request_id_latest, \
-               bucket, \
-               toUInt64(tokens_latest) AS tokens_latest \
-             FROM ( \
-               SELECT \
-                 event_uid, \
-                 argMax(event_ts, event_version) AS event_ts_latest, \
-                 argMax(model, event_version) AS model_latest, \
-                 argMax(endpoint_kind, event_version) AS endpoint_kind_latest, \
-                 argMax(harness, event_version) AS harness_latest, \
-                 argMax(session_id, event_version) AS session_id_latest, \
-                 argMax(request_id, event_version) AS request_id_latest, \
-                 argMax(token_usage_buckets, event_version) AS token_usage_buckets_latest \
-               FROM {table} \
-               GROUP BY event_uid \
-             ) ARRAY JOIN mapKeys(token_usage_buckets_latest) AS bucket, mapValues(token_usage_buckets_latest) AS tokens_latest \
-             WHERE {token_latest_filter} AND tokens_latest > 0 \
-           ) \
-           WHERE harness_latest = 'claude-code' AND length(trim(BOTH ' ' FROM request_id_latest)) > 0 \
-           GROUP BY bucket_unix, model, endpoint_kind, session_id_latest, request_id_latest, bucket \
-           UNION ALL \
-           SELECT \
-             toUInt64(toUnixTimestamp(toStartOfInterval(event_ts_latest, INTERVAL {bucket_seconds} SECOND))) AS bucket_unix, \
-             {model_expr_latest} AS model, \
-             endpoint_kind_latest AS endpoint_kind, \
-             bucket, \
-             toUInt64(tokens_latest) AS tokens \
-           FROM ( \
-             SELECT \
-               event_uid, \
-               argMax(event_ts, event_version) AS event_ts_latest, \
-               argMax(model, event_version) AS model_latest, \
-               argMax(endpoint_kind, event_version) AS endpoint_kind_latest, \
-               argMax(harness, event_version) AS harness_latest, \
-               argMax(session_id, event_version) AS session_id_latest, \
-               argMax(request_id, event_version) AS request_id_latest, \
-               argMax(token_usage_buckets, event_version) AS token_usage_buckets_latest \
-             FROM {table} \
-             GROUP BY event_uid \
-           ) ARRAY JOIN mapKeys(token_usage_buckets_latest) AS bucket, mapValues(token_usage_buckets_latest) AS tokens_latest \
-           WHERE {token_latest_filter} AND tokens_latest > 0 \
-           AND NOT (harness_latest = 'claude-code' AND length(trim(BOTH ' ' FROM request_id_latest)) > 0) \
-         ) \
-         GROUP BY bucket_unix, model, endpoint_kind, bucket \
-         ORDER BY bucket_unix ASC, model ASC, endpoint_kind ASC, bucket ASC",
-        bucket_seconds = range.bucket_seconds,
-        model_expr_latest = model_expr_latest,
-        table = table,
-        token_latest_filter = token_latest_filter,
-    );
-
-    let turns_query = format!(
-        "SELECT \
-            toUInt64(toUnixTimestamp(toStartOfInterval(event_ts, INTERVAL {bucket_seconds} SECOND))) AS bucket_unix, \
-            {model_expr} AS model, \
-            toUInt64(uniqExact(tuple(session_id, request_id))) AS turns \
-         FROM {table} \
-         WHERE {turn_filter} \
-         GROUP BY bucket_unix, model \
-         ORDER BY bucket_unix ASC, model ASC",
-        bucket_seconds = range.bucket_seconds,
-        model_expr = model_expr,
-        table = table,
-        turn_filter = turn_filter,
-    );
-
-    let concurrent_query = format!(
-        "SELECT bucket_unix, toUInt64(uniqExact(session_stream_key)) AS concurrent_sessions \
-         FROM ( \
-           SELECT \
-             toUInt64(toUnixTimestamp(toStartOfInterval(event_ts, INTERVAL {bucket_seconds} SECOND))) AS bucket_unix, \
-             if(harness = 'claude-code' AND length(trim(BOTH ' ' FROM agent_run_id)) > 0, concat(session_id, '::', agent_run_id), session_id) AS session_stream_key \
-           FROM {table} \
-           WHERE {concurrent_filter} \
-         ) \
-         GROUP BY bucket_unix \
-         ORDER BY bucket_unix ASC",
-        bucket_seconds = range.bucket_seconds,
-        table = table,
-        concurrent_filter = concurrent_filter,
-    );
-
-    let token_rows = match state
-        .clickhouse
-        .query_rows::<TokenRow>(&token_query, None)
-        .await
-    {
-        Ok(rows) => rows,
+    let snapshot = match state.repository.analytics_series(range).await {
+        Ok(snapshot) => snapshot,
         Err(error) => {
             return json_response(
-                json!({"ok": false, "error": format!("analytics token query failed: {error}")}),
+                json!({"ok": false, "error": format!("analytics query failed: {error}")}),
                 StatusCode::SERVICE_UNAVAILABLE,
             );
-        }
-    };
-
-    let turn_rows = match state
-        .clickhouse
-        .query_rows::<TurnRow>(&turns_query, None)
-        .await
-    {
-        Ok(rows) => rows,
-        Err(error) => {
-            return json_response(
-                json!({"ok": false, "error": format!("analytics turns query failed: {error}")}),
-                StatusCode::SERVICE_UNAVAILABLE,
-            );
-        }
-    };
-
-    let concurrent_rows = match state
-        .clickhouse
-        .query_rows::<ConcurrentRow>(&concurrent_query, None)
-        .await
-    {
-        Ok(rows) => rows,
-        Err(error) => {
-            return json_response(
-                json!({"ok": false, "error": format!("analytics concurrent-session query failed: {error}")}),
-                StatusCode::SERVICE_UNAVAILABLE,
-            );
-        }
-    };
-
-    #[derive(serde::Deserialize)]
-    struct WindowRow {
-        now_unix: u64,
-        from_unix: u64,
-    }
-
-    let window_query = analytics_window_query(&table, &window_filter, range.window_seconds);
-
-    let (now_unix, from_unix) = match state
-        .clickhouse
-        .query_rows::<WindowRow>(&window_query, None)
-        .await
-    {
-        Ok(rows) if !rows.is_empty() => {
-            let row = &rows[0];
-            (row.now_unix, row.from_unix)
-        }
-        _ => {
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0);
-            (now, now.saturating_sub(range.window_seconds as u64))
         }
     };
 
@@ -667,284 +428,243 @@ async fn api_analytics(
         json!({
             "ok": true,
             "range": {
-                "key": range.key,
-                "label": range.label,
-                "window_seconds": range.window_seconds,
-                "bucket_seconds": range.bucket_seconds,
-                "from_unix": from_unix,
-                "to_unix": now_unix,
+                "key": snapshot.window.range.as_str(),
+                "label": format!("Last {}", snapshot.window.range.as_str()),
+                "window_seconds": snapshot.window.window_seconds,
+                "bucket_seconds": snapshot.window.bucket_seconds,
+                "from_unix": snapshot.window.from_unix,
+                "to_unix": snapshot.window.to_unix,
             },
             "series": {
-                "tokens": token_rows,
-                "turns": turn_rows,
-                "concurrent_sessions": concurrent_rows,
+                "tokens": snapshot.tokens,
+                "turns": snapshot.turns,
+                "concurrent_sessions": snapshot.concurrent_sessions,
             }
         }),
         StatusCode::OK,
     )
 }
 
-#[derive(Deserialize)]
-struct SessionsQuery {
-    limit: Option<u32>,
-    since: Option<String>,
+fn resolve_analytics_range(value: Option<&str>) -> AnalyticsRange {
+    match value.unwrap_or("24h") {
+        "15m" => AnalyticsRange::FifteenMinutes,
+        "1h" => AnalyticsRange::OneHour,
+        "6h" => AnalyticsRange::SixHours,
+        "24h" => AnalyticsRange::TwentyFourHours,
+        "7d" => AnalyticsRange::SevenDays,
+        "30d" => AnalyticsRange::ThirtyDays,
+        _ => AnalyticsRange::TwentyFourHours,
+    }
 }
 
 async fn api_sessions(
     Query(params): Query<SessionsQuery>,
     State(state): State<AppState>,
 ) -> Response {
-    let limit = params.limit.unwrap_or(50).clamp(1, 200);
-    let since = params.since.as_deref().unwrap_or("30d");
-
-    let since_seconds: u64 = match since {
-        "1h" => 60 * 60,
-        "6h" => 6 * 60 * 60,
-        "24h" => 24 * 60 * 60,
-        "7d" => 7 * 24 * 60 * 60,
-        "30d" => 30 * 24 * 60 * 60,
-        "90d" => 90 * 24 * 60 * 60,
-        "all" => 0,
-        _ => 30 * 24 * 60 * 60,
+    let query = SessionAnalyticsQuery {
+        lookback: resolve_session_lookback(params.since.as_deref()),
+        limit: params.limit.unwrap_or(50).clamp(1, 200) as u16,
     };
-
-    match build_sessions_payload(&state, limit, since_seconds).await {
-        Ok(payload) => json_response(payload, StatusCode::OK),
-        Err(error) => json_response(
-            json!({"ok": false, "error": format!("sessions query failed: {error}")}),
-            StatusCode::SERVICE_UNAVAILABLE,
-        ),
-    }
-}
-
-#[derive(serde::Deserialize)]
-struct SessionSummaryRow {
-    session_id: String,
-    harness: String,
-    source_name: String,
-    started_at_ms: i64,
-    ended_at_ms: i64,
-    models_blob: String,
-    trace_id: String,
-    first_user_text: String,
-}
-
-#[derive(serde::Deserialize)]
-struct SessionEventRow {
-    session_id: String,
-    event_ts_ms: i64,
-    event_kind: String,
-    actor_kind: String,
-    payload_type: String,
-    tool_name: String,
-    tool_call_id: String,
-    tool_error: u8,
-    latency_ms: u32,
-    model: String,
-    endpoint_kind: String,
-    input_tokens: u32,
-    output_tokens: u32,
-    cache_read_tokens: u32,
-    cache_write_tokens: u32,
-    #[serde(default)]
-    token_usage_buckets: HashMap<String, u64>,
-    #[serde(default)]
-    token_usage_native_units: HashMap<String, f64>,
-    text_preview: String,
-    text_content: String,
-    tool_args_json: String,
-}
-
-fn events_table_ref(database: &str) -> String {
-    format!(
-        "{}.{}",
-        escape_identifier(database),
-        escape_identifier("events")
-    )
-}
-
-fn deduped_events_source(events_table: &str, filter: &str) -> String {
-    let filter = filter.trim();
-    debug_assert!(!filter.is_empty());
-
-    format!(
-        "(SELECT * FROM {events_table} WHERE {filter} \
-         ORDER BY event_uid ASC, event_version DESC, ingested_at DESC \
-         LIMIT 1 BY event_uid)"
-    )
-}
-
-fn session_summary_query(events_table: &str, limit: u32, since_seconds: u64) -> String {
-    let recency_filter = if since_seconds == 0 {
-        String::new()
-    } else {
-        format!(" AND event_ts >= now() - INTERVAL {} SECOND", since_seconds)
+    let sessions = match state.repository.list_session_analytics(query).await {
+        Ok(sessions) => sessions,
+        Err(error) => {
+            return json_response(
+                json!({"ok": false, "error": format!("sessions query failed: {error}")}),
+                StatusCode::SERVICE_UNAVAILABLE,
+            );
+        }
     };
-    let source_filter = format!("length(trim(BOTH ' ' FROM session_id)) > 0{recency_filter}");
-    let events_source = deduped_events_source(events_table, &source_filter);
-
-    format!(
-        "SELECT \
-            session_id, \
-            any(harness) AS harness, \
-            any(source_name) AS source_name, \
-            toInt64(toUnixTimestamp64Milli(min(event_ts))) AS started_at_ms, \
-            toInt64(toUnixTimestamp64Milli(max(event_ts))) AS ended_at_ms, \
-            arrayStringConcat( \
-                arrayFilter(m -> length(m) > 0, \
-                    groupUniqArray(lowerUTF8(trim(BOTH ' ' FROM model)))), \
-                '\u{1f}' \
-            ) AS models_blob, \
-            any(if(length(trim(BOTH ' ' FROM trace_id)) > 0, trace_id, '')) AS trace_id, \
-            argMin( \
-                if(length(text_content) > 0, substring(text_content, 1, 400), substring(text_preview, 1, 400)), \
-                if(event_kind = 'message' AND actor_kind = 'user', event_ts, toDateTime64('2099-01-01', 3)) \
-            ) AS first_user_text \
-         FROM {events_source} AS deduped_events \
-         GROUP BY session_id \
-         ORDER BY ended_at_ms DESC \
-         LIMIT {limit}"
-    )
-}
-
-fn session_events_query(events_table: &str, session_ids: &[String]) -> String {
-    debug_assert!(!session_ids.is_empty());
-    let id_list = session_ids
-        .iter()
-        .map(|id| format!("'{}'", escape_literal(id)))
-        .collect::<Vec<_>>()
-        .join(",");
-    let source_filter = format!("session_id IN ({id_list})");
-    let events_source = deduped_events_source(events_table, &source_filter);
-
-    format!(
-        "SELECT \
-            session_id, \
-            toInt64(toUnixTimestamp64Milli(event_ts)) AS event_ts_ms, \
-            event_kind, \
-            actor_kind, \
-            payload_type, \
-            tool_name, \
-            tool_call_id, \
-            tool_error, \
-            latency_ms, \
-            model, \
-            endpoint_kind, \
-            input_tokens, \
-            output_tokens, \
-            cache_read_tokens, \
-            cache_write_tokens, \
-            token_usage_buckets, \
-            token_usage_native_units, \
-            substring(text_preview, 1, 2000) AS text_preview, \
-            substring(text_content, 1, 2000) AS text_content, \
-            if(event_kind = 'tool_call', substring(JSONExtractRaw(payload_json, 'input'), 1, 2000), '') AS tool_args_json \
-         FROM {events_source} AS deduped_events \
-         ORDER BY session_id, event_ts, source_file, source_generation, source_offset, source_line_no, event_uid"
-    )
-}
-
-async fn build_sessions_payload(state: &AppState, limit: u32, since_seconds: u64) -> Result<Value> {
-    let database = &state.clickhouse.config().database;
-    let events_table = events_table_ref(database);
-    let summary_query = session_summary_query(&events_table, limit, since_seconds);
-
-    let summary_rows = state
-        .clickhouse
-        .query_rows::<SessionSummaryRow>(&summary_query, None)
-        .await?;
-
-    if summary_rows.is_empty() {
-        return Ok(json!({"ok": true, "sessions": []}));
-    }
-
-    let session_ids: Vec<String> = summary_rows.iter().map(|r| r.session_id.clone()).collect();
-    let events_query = session_events_query(&events_table, &session_ids);
-
-    let event_rows = state
-        .clickhouse
-        .query_rows::<SessionEventRow>(&events_query, None)
-        .await?;
-
-    let mut events_by_session: HashMap<String, Vec<SessionEventRow>> = HashMap::new();
-    for row in event_rows {
-        events_by_session
-            .entry(row.session_id.clone())
-            .or_default()
-            .push(row);
-    }
-
-    let now_ms = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
-        .unwrap_or(0);
-
-    let sessions: Vec<Value> = summary_rows
+    let now_ms = unix_now_ms();
+    let sessions = sessions
         .into_iter()
-        .map(|summary| {
-            let events = events_by_session
-                .remove(&summary.session_id)
-                .unwrap_or_default();
-            build_session_json(summary, events, now_ms)
-        })
-        .collect();
+        .map(|session| monitor_session_json(session, now_ms))
+        .collect::<Vec<_>>();
 
-    Ok(json!({"ok": true, "sessions": sessions}))
+    json_response(json!({"ok": true, "sessions": sessions}), StatusCode::OK)
 }
 
-fn build_session_json(
-    summary: SessionSummaryRow,
-    events: Vec<SessionEventRow>,
-    now_ms: i64,
-) -> Value {
-    let duration_ms = (summary.ended_at_ms - summary.started_at_ms).max(0);
+fn resolve_session_lookback(value: Option<&str>) -> SessionLookback {
+    match value.unwrap_or("30d") {
+        "1h" => SessionLookback::OneHour,
+        "6h" => SessionLookback::SixHours,
+        "24h" => SessionLookback::TwentyFourHours,
+        "7d" => SessionLookback::SevenDays,
+        "30d" => SessionLookback::ThirtyDays,
+        "90d" => SessionLookback::NinetyDays,
+        "all" => SessionLookback::All,
+        _ => SessionLookback::ThirtyDays,
+    }
+}
 
-    let status = if now_ms - summary.ended_at_ms < 60_000 {
+fn monitor_session_json(session: SessionAnalytics, now_ms: i64) -> Value {
+    let mut total_tokens = 0_u64;
+    let mut total_tool_calls = 0_u64;
+    let turns = session
+        .turns
+        .into_iter()
+        .enumerate()
+        .map(|(idx, turn)| {
+            let (value, tokens, tool_calls) = monitor_turn_json(idx, turn);
+            total_tokens = total_tokens.saturating_add(tokens);
+            total_tool_calls = total_tool_calls.saturating_add(tool_calls);
+            value
+        })
+        .collect::<Vec<_>>();
+    let duration_ms = session
+        .summary
+        .last_event_unix_ms
+        .saturating_sub(session.summary.first_event_unix_ms)
+        .max(0);
+    let status = if now_ms.saturating_sub(session.summary.last_event_unix_ms) < 60_000 {
         "active"
     } else {
         "completed"
     };
 
-    let models: Vec<String> = if summary.models_blob.is_empty() {
-        Vec::new()
-    } else {
-        summary
-            .models_blob
-            .split('\u{1f}')
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string())
-            .collect()
-    };
-
-    let title = derive_title(&summary.first_user_text);
-
-    let turns = build_turns(&events);
-    let total_tokens: u64 = turns
-        .iter()
-        .map(|t| t.get("totalTokens").and_then(|v| v.as_u64()).unwrap_or(0))
-        .sum();
-    let total_tool_calls: u64 = turns
-        .iter()
-        .map(|t| t.get("toolCalls").and_then(|v| v.as_u64()).unwrap_or(0))
-        .sum();
-
-    let harness = harness_descriptor(&summary.harness, &summary.source_name);
-
     json!({
-        "id": summary.session_id,
-        "title": title,
-        "harness": harness,
-        "startedAt": summary.started_at_ms,
-        "endedAt": summary.ended_at_ms,
+        "id": session.summary.session_id,
+        "title": derive_title(&session.first_user_text),
+        "harness": harness_descriptor(&session.harness, &session.source_name),
+        "startedAt": session.summary.first_event_unix_ms,
+        "endedAt": session.summary.last_event_unix_ms,
         "durationMs": duration_ms,
         "status": status,
-        "models": models,
+        "models": session.models,
         "turns": turns,
         "totalTokens": total_tokens,
         "totalToolCalls": total_tool_calls,
         "tags": Vec::<String>::new(),
-        "traceId": summary.trace_id,
+        "traceId": session.trace_id,
     })
+}
+
+fn monitor_turn_json(idx: usize, turn: SessionTurn) -> (Value, u64, u64) {
+    let prompt_tokens = sum_buckets(
+        &turn.token_usage_buckets,
+        &[
+            "input_text",
+            "input_cache_read",
+            "input_cache_write",
+            "input_image",
+            "input_audio",
+            "embedding_input_text",
+            "embedding_input_image",
+        ],
+    );
+    let total_tokens = turn
+        .token_usage_buckets
+        .values()
+        .copied()
+        .fold(0_u64, u64::saturating_add);
+    let completion_tokens = total_tokens.saturating_sub(prompt_tokens);
+    let tool_calls = turn.summary.tool_calls;
+    let steps = turn
+        .steps
+        .into_iter()
+        .map(monitor_step_json)
+        .collect::<Vec<_>>();
+    let duration_ms = turn
+        .summary
+        .ended_at_unix_ms
+        .saturating_sub(turn.summary.started_at_unix_ms)
+        .max(0);
+
+    (
+        json!({
+            "idx": idx,
+            "model": turn.model,
+            "startedAt": turn.summary.started_at_unix_ms,
+            "endedAt": turn.summary.ended_at_unix_ms,
+            "durationMs": duration_ms,
+            "promptTokens": prompt_tokens,
+            "completionTokens": completion_tokens,
+            "totalTokens": total_tokens,
+            "toolCalls": tool_calls,
+            "steps": steps,
+        }),
+        total_tokens,
+        tool_calls,
+    )
+}
+
+fn monitor_step_json(step: SessionStep) -> Value {
+    match step {
+        SessionStep::User {
+            event_unix_ms,
+            text,
+        } => json!({"kind": "user", "at": event_unix_ms, "text": text}),
+        SessionStep::Assistant {
+            event_unix_ms,
+            text,
+            endpoint_kind,
+            latency_ms,
+            token_usage_buckets,
+            token_usage_native_units,
+        } => {
+            let tokens = sum_buckets(
+                &token_usage_buckets,
+                &[
+                    "output_text",
+                    "output_image",
+                    "output_audio",
+                    "reasoning",
+                    "server_tool_use",
+                ],
+            );
+            let mut value = json!({
+                "kind": "assistant",
+                "at": event_unix_ms,
+                "text": text,
+                "tokens": tokens,
+                "endpointKind": endpoint_kind,
+                "nativeTokenUnits": token_usage_native_units,
+            });
+            if let Some(latency_ms) = latency_ms {
+                value["durationMs"] = json!(latency_ms);
+            }
+            value
+        }
+        SessionStep::Thinking {
+            event_unix_ms,
+            text,
+        } => json!({"kind": "thinking", "at": event_unix_ms, "text": text}),
+        SessionStep::ToolCall {
+            event_unix_ms,
+            tool_name,
+            call_id,
+            arguments,
+            result,
+        } => {
+            let (latency_ms, result_text, result_at, status) = match result {
+                Some(result) => (
+                    result.latency_ms,
+                    result.text,
+                    result.event_unix_ms,
+                    if result.is_error { "error" } else { "ok" },
+                ),
+                None => (0, String::new(), event_unix_ms, "ok"),
+            };
+            json!({
+                "kind": "tool_call",
+                "at": event_unix_ms,
+                "tool": tool_name,
+                "args": arguments,
+                "latencyMs": latency_ms,
+                "result": result_text,
+                "resultAt": result_at,
+                "status": status,
+                "callId": call_id,
+            })
+        }
+    }
+}
+
+fn sum_buckets(buckets: &std::collections::BTreeMap<String, u64>, names: &[&str]) -> u64 {
+    names
+        .iter()
+        .filter_map(|name| buckets.get(*name))
+        .copied()
+        .fold(0_u64, u64::saturating_add)
 }
 
 fn derive_title(first_user_text: &str) -> String {
@@ -953,15 +673,14 @@ fn derive_title(first_user_text: &str) -> String {
         return "(untitled session)".to_string();
     }
 
-    let first_line = trimmed.lines().next().unwrap_or(trimmed);
-    let clean = first_line.trim();
-    let max_chars = 120;
-    let char_count = clean.chars().count();
-    if char_count <= max_chars {
-        clean.to_string()
+    let first_line = trimmed.lines().next().unwrap_or(trimmed).trim();
+    if first_line.chars().count() <= 120 {
+        first_line.to_string()
     } else {
-        let truncated: String = clean.chars().take(max_chars).collect();
-        format!("{truncated}\u{2026}")
+        format!(
+            "{}\u{2026}",
+            first_line.chars().take(120).collect::<String>()
+        )
     }
 }
 
@@ -972,9 +691,8 @@ fn harness_descriptor(harness_id: &str, source_name: &str) -> Value {
         harness_id.trim()
     };
     let id = if id.is_empty() { "unknown" } else { id };
-    let label = id.to_string();
-    let short: String = id
-        .split(|c: char| !c.is_ascii_alphanumeric())
+    let short = id
+        .split(|character: char| !character.is_ascii_alphanumeric())
         .filter(|part| !part.is_empty())
         .take(2)
         .filter_map(|part| part.chars().next())
@@ -986,13 +704,11 @@ fn harness_descriptor(harness_id: &str, source_name: &str) -> Value {
         short
     };
 
-    let hue = hue_for_label(id);
-
     json!({
         "id": id,
-        "label": label,
+        "label": id,
         "short": short,
-        "hue": hue,
+        "hue": hue_for_label(id),
     })
 }
 
@@ -1006,400 +722,27 @@ fn hue_for_label(label: &str) -> u32 {
         "continue" => 100,
         "cli" => 60,
         _ => {
-            let mut hash: u32 = 0;
-            for byte in label.bytes() {
-                hash = hash.wrapping_mul(31).wrapping_add(byte as u32);
-            }
-            hash % 360
+            label.bytes().fold(0_u32, |hash, byte| {
+                hash.wrapping_mul(31).wrapping_add(u32::from(byte))
+            }) % 360
         }
     }
 }
 
-fn token_bucket(event: &SessionEventRow, bucket: &str) -> u64 {
-    event.token_usage_buckets.get(bucket).copied().unwrap_or(0)
-}
-
-fn sum_token_buckets(event: &SessionEventRow, buckets: &[&str]) -> u64 {
-    buckets
-        .iter()
-        .map(|bucket| token_bucket(event, bucket))
-        .sum()
-}
-
-fn event_token_total(event: &SessionEventRow) -> u64 {
-    let canonical_total: u64 = event.token_usage_buckets.values().copied().sum();
-    if canonical_total > 0 {
-        canonical_total
-    } else {
-        (event.input_tokens
-            + event.output_tokens
-            + event.cache_read_tokens
-            + event.cache_write_tokens) as u64
-    }
-}
-
-fn event_prompt_tokens(event: &SessionEventRow) -> u64 {
-    let canonical_prompt = sum_token_buckets(
-        event,
-        &[
-            "input_text",
-            "input_cache_read",
-            "input_cache_write",
-            "input_image",
-            "input_audio",
-            "embedding_input_text",
-            "embedding_input_image",
-        ],
-    );
-    if canonical_prompt > 0 {
-        canonical_prompt
-    } else {
-        (event.input_tokens + event.cache_read_tokens + event.cache_write_tokens) as u64
-    }
-}
-
-fn event_output_tokens(event: &SessionEventRow) -> u64 {
-    let canonical_output = sum_token_buckets(
-        event,
-        &[
-            "output_text",
-            "output_image",
-            "output_audio",
-            "reasoning",
-            "server_tool_use",
-        ],
-    );
-    if canonical_output > 0 {
-        canonical_output
-    } else {
-        event.output_tokens as u64
-    }
-}
-
-fn nonzero_native_units(event: &SessionEventRow) -> Value {
-    let units = event
-        .token_usage_native_units
-        .iter()
-        .filter(|(_, value)| **value > 0.0)
-        .map(|(key, value)| (key.clone(), json!(value)))
-        .collect::<serde_json::Map<_, _>>();
-    Value::Object(units)
-}
-
-fn build_turns(events: &[SessionEventRow]) -> Vec<Value> {
-    struct TurnBuilder {
-        idx: u32,
-        model: String,
-        started_at: i64,
-        ended_at: i64,
-        steps: Vec<Value>,
-        prompt_tokens: u64,
-        completion_tokens: u64,
-        tool_calls: u64,
-    }
-
-    if events.is_empty() {
-        return Vec::new();
-    }
-
-    let mut turns: Vec<TurnBuilder> = Vec::new();
-    let mut current: Option<TurnBuilder> = None;
-    let mut open_tool_calls: HashMap<String, usize> = HashMap::new();
-
-    for event in events {
-        let starts_new_turn = event.event_kind == "message" && event.actor_kind == "user";
-
-        if starts_new_turn {
-            if let Some(finished) = current.take() {
-                turns.push(finished);
-            }
-            current = Some(TurnBuilder {
-                idx: turns.len() as u32,
-                model: String::new(),
-                started_at: event.event_ts_ms,
-                ended_at: event.event_ts_ms,
-                steps: Vec::new(),
-                prompt_tokens: 0,
-                completion_tokens: 0,
-                tool_calls: 0,
-            });
-            open_tool_calls.clear();
-        }
-
-        let turn = match current.as_mut() {
-            Some(t) => t,
-            None => continue,
-        };
-
-        turn.ended_at = turn.ended_at.max(event.event_ts_ms);
-        let event_prompt = event_prompt_tokens(event);
-        let event_total = event_token_total(event);
-        turn.prompt_tokens += event_prompt;
-        turn.completion_tokens += event_total.saturating_sub(event_prompt);
-        if !event.model.trim().is_empty() && turn.model.is_empty() {
-            turn.model = event.model.trim().to_string();
-        }
-
-        match (
-            event.event_kind.as_str(),
-            event.actor_kind.as_str(),
-            event.payload_type.as_str(),
-        ) {
-            ("message", "user", _) => {
-                turn.steps.push(json!({
-                    "kind": "user",
-                    "at": event.event_ts_ms,
-                    "text": preferred_text(event),
-                }));
-            }
-            ("message", "assistant", _) | (_, "assistant", "text") => {
-                let mut step = json!({
-                    "kind": "assistant",
-                    "at": event.event_ts_ms,
-                    "text": preferred_text(event),
-                    "tokens": event_output_tokens(event),
-                    "endpointKind": event.endpoint_kind,
-                    "nativeTokenUnits": nonzero_native_units(event),
-                });
-                if event.latency_ms > 0 {
-                    if let Some(obj) = step.as_object_mut() {
-                        obj.insert("durationMs".into(), json!(event.latency_ms));
-                    }
-                }
-                turn.steps.push(step);
-            }
-            ("reasoning", _, _) | (_, _, "thinking") => {
-                let text = preferred_text(event);
-                if !text.is_empty() {
-                    turn.steps.push(json!({
-                        "kind": "thinking",
-                        "at": event.event_ts_ms,
-                        "text": text,
-                    }));
-                }
-            }
-            ("tool_call", _, _) | (_, _, "tool_use") => {
-                turn.tool_calls += 1;
-                let step_index = turn.steps.len();
-                if !event.tool_call_id.is_empty() {
-                    open_tool_calls.insert(event.tool_call_id.clone(), step_index);
-                }
-                let args = if event.tool_args_json.trim().is_empty() {
-                    Value::Object(Default::default())
-                } else {
-                    serde_json::from_str::<Value>(&event.tool_args_json)
-                        .unwrap_or_else(|_| Value::Object(Default::default()))
-                };
-                turn.steps.push(json!({
-                    "kind": "tool_call",
-                    "at": event.event_ts_ms,
-                    "tool": if event.tool_name.is_empty() { "tool".to_string() } else { event.tool_name.clone() },
-                    "args": args,
-                    "latencyMs": event.latency_ms,
-                    "result": "",
-                    "resultAt": event.event_ts_ms,
-                    "status": if event.tool_error != 0 { "error" } else { "ok" },
-                    "callId": event.tool_call_id,
-                }));
-            }
-            ("tool_result", _, _) | (_, "tool", "tool_result") => {
-                let result_text = preferred_text(event);
-                if let Some(&step_index) = open_tool_calls.get(&event.tool_call_id) {
-                    if let Some(step) = turn.steps.get_mut(step_index) {
-                        if let Some(obj) = step.as_object_mut() {
-                            let call_at = obj
-                                .get("at")
-                                .and_then(|v| v.as_i64())
-                                .unwrap_or(event.event_ts_ms);
-                            obj.insert("resultAt".into(), json!(event.event_ts_ms));
-                            obj.insert(
-                                "latencyMs".into(),
-                                json!((event.event_ts_ms - call_at).max(0) as u32),
-                            );
-                            obj.insert("result".into(), json!(result_text));
-                            if event.tool_error != 0 {
-                                obj.insert("status".into(), json!("error"));
-                            }
-                        }
-                    }
-                    open_tool_calls.remove(&event.tool_call_id);
-                }
-            }
-            _ => {}
-        }
-    }
-
-    if let Some(finished) = current.take() {
-        turns.push(finished);
-    }
-
-    turns
-        .into_iter()
-        .map(|builder| {
-            let duration = (builder.ended_at - builder.started_at).max(0);
-            let total = builder.prompt_tokens + builder.completion_tokens;
-            json!({
-                "idx": builder.idx,
-                "model": builder.model,
-                "startedAt": builder.started_at,
-                "endedAt": builder.ended_at,
-                "durationMs": duration,
-                "promptTokens": builder.prompt_tokens,
-                "completionTokens": builder.completion_tokens,
-                "totalTokens": total,
-                "toolCalls": builder.tool_calls,
-                "steps": builder.steps,
-            })
-        })
-        .collect()
-}
-
-fn preferred_text(event: &SessionEventRow) -> String {
-    if !event.text_content.trim().is_empty() {
-        event.text_content.trim().to_string()
-    } else {
-        event.text_preview.trim().to_string()
-    }
-}
-
-async fn query_table_summaries(state: &AppState) -> Result<Vec<TableSummary>> {
-    #[derive(serde::Deserialize)]
-    struct TableRow {
-        name: String,
-        engine: String,
-        is_temporary: u8,
-    }
-
-    #[derive(serde::Deserialize)]
-    struct PartsRow {
-        table: String,
-        rows: u64,
-    }
-
-    let database = &state.clickhouse.config().database;
-    let tables = state
-        .clickhouse
-        .query_rows::<TableRow>(&format!(
-            "SELECT name, engine, is_temporary FROM system.tables WHERE database = '{}' ORDER BY name",
-            escape_literal(database)
-        ), None)
-        .await?;
-
-    let parts = state
-        .clickhouse
-        .query_rows::<PartsRow>(&format!(
-            "SELECT table, SUM(rows) AS rows FROM system.parts WHERE database = '{}' AND active GROUP BY table",
-            escape_literal(database)
-        ), None)
-        .await
-        .unwrap_or_default();
-
-    let counts: HashMap<String, u64> = parts.into_iter().map(|row| (row.table, row.rows)).collect();
-
-    let values = tables
-        .into_iter()
-        .map(|row| TableSummary {
-            name: row.name.clone(),
-            engine: row.engine,
-            is_temporary: row.is_temporary,
-            rows: counts.get(&row.name).copied().unwrap_or(0),
-        })
-        .collect();
-
-    Ok(values)
-}
-
-async fn query_heartbeat(state: &AppState) -> Result<Value> {
-    let database = &state.clickhouse.config().database;
-    // Column-level probe: presence of any column means the table exists, and
-    // the optional backend_sinks column (migration 017) is only selected when
-    // the database actually carries it.
-    #[derive(serde::Deserialize)]
-    struct ColumnRow {
-        name: String,
-    }
-    let columns = state
-        .clickhouse
-        .query_rows::<ColumnRow>(
-            &format!(
-            "SELECT name FROM system.columns WHERE database = '{}' AND table = 'ingest_heartbeats'",
-            escape_literal(database)
-        ),
-            None,
-        )
-        .await?;
-
-    if columns.is_empty() {
-        return Ok(json!({
-            "present": false,
-            "alive": false,
-            "latest": Value::Null,
-            "age_seconds": Value::Null,
-        }));
-    }
-
-    let backend_sinks_select = if columns.iter().any(|col| col.name == "backend_sinks") {
-        ", backend_sinks"
-    } else {
-        ""
+fn heartbeat_payload(read: IngestHeartbeatRead) -> Value {
+    let Some(latest) = read.latest else {
+        return heartbeat_absent();
     };
-    let query = format!(
-        "SELECT ts, toUnixTimestamp64Milli(ts) AS ts_unix_ms, host, service_version, queue_depth, files_active, files_watched, rows_raw_written, rows_events_written, rows_errors_written, flush_latency_ms, append_to_visible_p50_ms, append_to_visible_p95_ms, last_error{} FROM {}.ingest_heartbeats ORDER BY ts DESC LIMIT 1",
-        backend_sinks_select,
-        escape_identifier(database)
-    );
+    let age_seconds = unix_now_ms()
+        .checked_sub(latest.ts_unix_ms)
+        .map(|age_ms| age_ms.max(0) as u64 / 1000);
 
-    let latest = state
-        .clickhouse
-        .query_rows::<Value>(&query, None)
-        .await?
-        .into_iter()
-        .next();
-
-    let Some(mut latest) = latest else {
-        return Ok(
-            json!({"present": false, "alive": false, "latest": Value::Null, "age_seconds": Value::Null}),
-        );
-    };
-
-    // The sink stores backend_sinks as a JSON-encoded string; decode it so
-    // /api/health consumers see a structured `{backend: status}` map.
-    if let Some(obj) = latest.as_object_mut() {
-        if let Some(Value::String(raw)) = obj.get("backend_sinks") {
-            let decoded = if raw.trim().is_empty() {
-                json!({})
-            } else {
-                serde_json::from_str::<Value>(raw).unwrap_or_else(|_| Value::String(raw.clone()))
-            };
-            obj.insert("backend_sinks".to_string(), decoded);
-        }
-    }
-
-    let age_seconds = latest
-        .get("ts_unix_ms")
-        .and_then(value_to_i64)
-        .and_then(|ts_ms| {
-            if ts_ms < 0 {
-                return None;
-            }
-
-            let now_ms = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .ok()?
-                .as_millis() as i64;
-            if now_ms < ts_ms {
-                return Some(0);
-            }
-
-            Some(((now_ms - ts_ms) / 1000) as u64)
-        });
-
-    Ok(json!({
+    json!({
         "present": true,
+        "alive": age_seconds.map(|age| age <= 30).unwrap_or(false),
         "latest": latest,
         "age_seconds": age_seconds,
-        "alive": age_seconds.map(|age| age <= 30).unwrap_or(false),
-    }))
+    })
 }
 
 fn heartbeat_absent() -> Value {
@@ -1411,19 +754,13 @@ fn heartbeat_absent() -> Value {
     })
 }
 
-async fn query_heartbeat_or_absent(state: &AppState) -> Value {
-    query_heartbeat(state)
-        .await
-        .unwrap_or_else(|_| heartbeat_absent())
-}
-
-fn health_heartbeat(heartbeat: Value) -> Value {
+fn health_heartbeat(heartbeat: &Value) -> Value {
     let latest = heartbeat
         .get("latest")
         .and_then(Value::as_object)
-        .map(|obj| {
+        .map(|latest| {
             json!({
-                "backend_sinks": obj
+                "backend_sinks": latest
                     .get("backend_sinks")
                     .cloned()
                     .unwrap_or_else(|| json!({})),
@@ -1432,69 +769,19 @@ fn health_heartbeat(heartbeat: Value) -> Value {
         .unwrap_or(Value::Null);
 
     json!({
-        "present": heartbeat
-            .get("present")
-            .cloned()
-            .unwrap_or(Value::Bool(false)),
-        "alive": heartbeat
-            .get("alive")
-            .cloned()
-            .unwrap_or(Value::Bool(false)),
+        "present": heartbeat.get("present").cloned().unwrap_or(Value::Bool(false)),
+        "alive": heartbeat.get("alive").cloned().unwrap_or(Value::Bool(false)),
         "latest": latest,
         "age_seconds": heartbeat.get("age_seconds").cloned().unwrap_or(Value::Null),
     })
 }
 
-async fn query_health_heartbeat_or_absent(state: &AppState) -> Value {
-    health_heartbeat(query_heartbeat_or_absent(state).await)
-}
-
-async fn query_clickhouse_connections(state: &AppState) -> Result<Value> {
-    #[derive(serde::Deserialize)]
-    struct MetricRow {
-        metric: String,
-        value: u64,
-    }
-
-    let metrics = state
-        .clickhouse
-        .query_rows::<MetricRow>(
-            "SELECT metric, value FROM system.metrics WHERE metric IN ('TCPConnection','HTTPConnection','MySQLConnection','PostgreSQLConnection','InterserverConnection')",
-            None,
-        )
-        .await?;
-
-    let mut tcp = 0_u64;
-    let mut http = 0_u64;
-    let mut mysql = 0_u64;
-    let mut postgres = 0_u64;
-    let mut interserver = 0_u64;
-
-    for row in metrics {
-        match row.metric.as_str() {
-            "TCPConnection" => tcp = tcp.saturating_add(row.value),
-            "HTTPConnection" => http = http.saturating_add(row.value),
-            "MySQLConnection" => mysql = mysql.saturating_add(row.value),
-            "PostgreSQLConnection" => postgres = postgres.saturating_add(row.value),
-            "InterserverConnection" => interserver = interserver.saturating_add(row.value),
-            _ => {}
-        }
-    }
-
-    let total = tcp
-        .saturating_add(http)
-        .saturating_add(mysql)
-        .saturating_add(postgres)
-        .saturating_add(interserver);
-
-    Ok(json!({
-        "total": total,
-        "tcp": tcp,
-        "http": http,
-        "mysql": mysql,
-        "postgres": postgres,
-        "interserver": interserver,
-    }))
+fn unix_now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| i64::try_from(duration.as_millis()).ok())
+        .unwrap_or(0)
 }
 
 async fn api_table_rows(
@@ -1502,86 +789,50 @@ async fn api_table_rows(
     Query(params): Query<LimitQuery>,
     State(state): State<AppState>,
 ) -> Response {
-    if !is_safe_identifier(&table) {
-        return json_response(
+    let limit = params.limit.unwrap_or(25).clamp(1, 500) as u16;
+    match state
+        .repository
+        .preview_table(TablePreviewQuery {
+            table: table.clone(),
+            limit,
+        })
+        .await
+    {
+        Ok(preview) => {
+            let schema = preview
+                .schema
+                .into_iter()
+                .map(|column| {
+                    json!({
+                        "name": column.name,
+                        "type": column.type_name,
+                        "default_expression": column.default_expression,
+                    })
+                })
+                .collect::<Vec<_>>();
+            json_response(
+                json!({
+                    "ok": true,
+                    "table": preview.table,
+                    "limit": preview.limit,
+                    "schema": schema,
+                    "rows": preview.rows,
+                }),
+                StatusCode::OK,
+            )
+        }
+        Err(RepoError::InvalidArgument(_)) => json_response(
             json!({"ok": false, "error": "invalid table name"}),
             StatusCode::BAD_REQUEST,
-        );
-    }
-
-    let limit = params.limit.unwrap_or(25).clamp(1, 500);
-    let database = &state.clickhouse.config().database;
-
-    #[derive(serde::Deserialize)]
-    struct SchemaRow {
-        name: String,
-        #[serde(rename = "type")]
-        type_name: String,
-        default_expression: Option<String>,
-    }
-
-    let schema = match state
-        .clickhouse
-        .query_rows::<SchemaRow>(&format!(
-            "SELECT name, type, default_expression FROM system.columns WHERE database = '{}' AND table = '{}' ORDER BY position",
-            escape_literal(database),
-            escape_literal(&table)
-        ), None)
-        .await
-    {
-        Ok(value) => value,
-        Err(error) => {
-            return json_response(
-                json!({
-                    "ok": false,
-                    "error": format!("unable to read schema for table {table}: {error}"),
-                }),
-                StatusCode::SERVICE_UNAVAILABLE,
-            );
-        }
-    };
-
-    let preview_columns: Vec<String> = schema.iter().map(|entry| entry.name.clone()).collect();
-    let rows_query = table_preview_rows_query(database, &table, &preview_columns, limit);
-
-    let rows = match state
-        .clickhouse
-        .query_rows::<Value>(&rows_query, None)
-        .await
-    {
-        Ok(value) => value,
-        Err(error) => {
-            return json_response(
-                json!({
-                    "ok": false,
-                    "error": format!("unable to read table {table}: {error}"),
-                }),
-                StatusCode::SERVICE_UNAVAILABLE,
-            );
-        }
-    };
-
-    let schema_payload: Vec<Value> = schema
-        .into_iter()
-        .map(|entry| {
+        ),
+        Err(error) => json_response(
             json!({
-                "name": entry.name,
-                "type": entry.type_name,
-                "default_expression": entry.default_expression.unwrap_or_default(),
-            })
-        })
-        .collect();
-
-    json_response(
-        json!({
-            "ok": true,
-            "table": table,
-            "limit": limit,
-            "schema": schema_payload,
-            "rows": rows,
-        }),
-        StatusCode::OK,
-    )
+                "ok": false,
+                "error": format!("unable to read table {table}: {error}"),
+            }),
+            StatusCode::SERVICE_UNAVAILABLE,
+        ),
+    }
 }
 
 async fn static_fallback(State(state): State<AppState>, uri: Uri) -> Response {
@@ -1612,7 +863,6 @@ async fn static_fallback(State(state): State<AppState>, uri: Uri) -> Response {
             );
         }
     };
-
     let canonical_file = match fs::canonicalize(&file_path).await {
         Ok(path) => path,
         Err(_) => {
@@ -1622,7 +872,6 @@ async fn static_fallback(State(state): State<AppState>, uri: Uri) -> Response {
             );
         }
     };
-
     if !canonical_file.starts_with(&canonical_root) {
         return json_response(
             json!({"ok": false, "error": "forbidden"}),
@@ -1639,12 +888,10 @@ async fn static_fallback(State(state): State<AppState>, uri: Uri) -> Response {
             );
         }
     };
-
     let content_type = mime_guess::from_path(&canonical_file)
         .first_or_octet_stream()
         .essence_str()
         .to_string();
-
     let mut response = Response::new(Body::from(bytes));
     *response.status_mut() = StatusCode::OK;
     response.headers_mut().insert(
@@ -1655,67 +902,18 @@ async fn static_fallback(State(state): State<AppState>, uri: Uri) -> Response {
     response
 }
 
-fn is_safe_identifier(value: &str) -> bool {
-    let mut chars = value.chars();
-    match chars.next() {
-        Some(first) if first == '_' || first.is_ascii_alphabetic() => {}
-        _ => return false,
-    }
-
-    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-}
-
-fn escape_literal(value: &str) -> String {
-    value.replace('\'', "''")
-}
-
-fn escape_identifier(value: &str) -> String {
-    format!("`{}`", value.replace('`', "``"))
-}
-
-fn table_preview_rows_query(
-    database: &str,
-    table: &str,
-    column_names: &[String],
-    limit: u32,
-) -> String {
-    let database = escape_identifier(database);
-    let table = escape_identifier(table);
-
-    if column_names.is_empty() {
-        return format!("SELECT * FROM {database}.{table} LIMIT {limit}");
-    }
-
-    let order_by = column_names
-        .iter()
-        .map(|name| escape_identifier(name))
-        .collect::<Vec<_>>()
-        .join(", ");
-
-    format!("SELECT * FROM {database}.{table} ORDER BY {order_by} LIMIT {limit}")
-}
-
-fn value_to_i64(value: &Value) -> Option<i64> {
-    if let Some(n) = value.as_i64() {
-        return Some(n);
-    }
-    if let Some(n) = value.as_u64() {
-        return i64::try_from(n).ok();
-    }
-    value.as_str().and_then(|raw| raw.parse::<i64>().ok())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::anyhow;
-    use axum::{body::to_bytes, extract::Query, http::StatusCode, routing::post};
-    use moraine_clickhouse::ClickHouseClient;
-    use moraine_config::ClickHouseConfig;
-    use std::collections::HashMap;
+    use axum::body::to_bytes;
+    use moraine_conversations::{
+        AnalyticsConcurrencyPoint, AnalyticsSnapshot, AnalyticsTokenPoint, AnalyticsTurnPoint,
+        AnalyticsWindow, ConversationMode, ConversationSummary, InMemoryConversationRepository,
+        InMemoryConversationResponses, IngestHeartbeat, SessionStep, StoreDiagnostics, TableColumn,
+        TablePreview, TableSummary, ToolResult, TurnSummary, WebSearchEvent,
+    };
+    use std::collections::BTreeMap;
     use std::fs;
-    use std::path::PathBuf;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn temp_path(suffix: &str) -> PathBuf {
         let stamp = SystemTime::now()
@@ -1728,293 +926,441 @@ mod tests {
         ))
     }
 
-    fn session_event(
-        event_kind: &str,
-        actor_kind: &str,
-        payload_type: &str,
-        at: i64,
-    ) -> SessionEventRow {
-        SessionEventRow {
-            session_id: "session-1".to_string(),
-            event_ts_ms: at,
-            event_kind: event_kind.to_string(),
-            actor_kind: actor_kind.to_string(),
-            payload_type: payload_type.to_string(),
-            tool_name: String::new(),
-            tool_call_id: String::new(),
-            tool_error: 0,
-            latency_ms: 0,
-            model: String::new(),
-            endpoint_kind: String::new(),
-            input_tokens: 0,
-            output_tokens: 0,
-            cache_read_tokens: 0,
-            cache_write_tokens: 0,
-            token_usage_buckets: HashMap::new(),
-            token_usage_native_units: HashMap::new(),
-            text_preview: String::new(),
-            text_content: String::new(),
-            tool_args_json: String::new(),
-        }
-    }
-
-    fn compact_sql(query: &str) -> String {
-        query.split_whitespace().collect::<Vec<_>>().join(" ")
-    }
-
-    async fn health_mock_handler(Query(params): Query<HashMap<String, String>>) -> String {
-        let query = params.get("query").cloned().unwrap_or_default();
-        if query.trim() == "SELECT 1" {
-            return "1".to_string();
-        }
-        if query.contains("version()") {
-            return json!({"data": [{"version": "25.1.1"}]}).to_string();
-        }
-        if query.contains("system.metrics") {
-            return json!({"data": []}).to_string();
-        }
-        if query.contains("system.columns") && query.contains("ingest_heartbeats") {
-            return json!({"data": [{"name": "backend_sinks"}]}).to_string();
-        }
-        if query.contains("ingest_heartbeats") {
-            let now_ms = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_millis() as u64;
-            return json!({
-                "data": [{
-                    "ts": "2026-07-07 20:00:00.000",
-                    "ts_unix_ms": now_ms,
-                    "host": "host-a",
-                    "service_version": "0.6.4",
-                    "queue_depth": 0,
-                    "files_active": 0,
-                    "files_watched": 1,
-                    "rows_raw_written": 2,
-                    "rows_events_written": 2,
-                    "rows_errors_written": 0,
-                    "flush_latency_ms": 1,
-                    "append_to_visible_p50_ms": 1,
-                    "append_to_visible_p95_ms": 2,
-                    "last_error": "",
-                    "backend_sinks": "{\"team-ch\":\"disabled_missing_identity_author\"}"
-                }]
-            })
-            .to_string();
-        }
-        json!({"data": []}).to_string()
-    }
-
-    async fn mock_health_state() -> AppState {
-        let app = Router::new().route("/", post(health_mock_handler));
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind mock clickhouse");
-        let addr = listener.local_addr().expect("mock addr");
-        tokio::spawn(async move {
-            let _ = axum::serve(listener, app).await;
-        });
-
-        let cfg = ClickHouseConfig {
-            url: format!("http://{}", addr),
-            timeout_seconds: 1.0,
-            ..Default::default()
-        };
-        AppState {
-            clickhouse: ClickHouseClient::new(cfg).expect("mock client"),
+    fn fake_state(
+        responses: InMemoryConversationResponses,
+    ) -> (AppState, Arc<InMemoryConversationRepository>) {
+        let repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            responses,
+        ));
+        let state = AppState {
+            repository: repository.clone(),
             static_dir: PathBuf::new(),
-        }
+            clickhouse_url: "http://127.0.0.1:8123".to_string(),
+            clickhouse_database: "moraine".to_string(),
+        };
+        (state, repository)
     }
 
-    #[test]
-    fn identifier_safety_helper() {
-        assert!(is_safe_identifier("events"));
-        assert!(is_safe_identifier("_tmp_1"));
-        assert!(!is_safe_identifier("1events"));
-        assert!(!is_safe_identifier("events;drop"));
-    }
-
-    #[test]
-    fn build_turns_emits_assistant_latency_duration() {
-        let mut user = session_event("message", "user", "text", 1_000);
-        user.text_content = "run the tool".to_string();
-        let mut assistant = session_event("message", "assistant", "text", 5_500);
-        assistant.text_content = "done".to_string();
-        assistant.output_tokens = 42;
-        assistant.latency_ms = 4_500;
-
-        let turns = build_turns(&[user, assistant]);
-        let steps = turns[0]["steps"].as_array().expect("steps");
-
-        assert_eq!(steps[1]["durationMs"], json!(4_500));
-        assert_eq!(steps[1]["tokens"], json!(42));
-    }
-
-    #[test]
-    fn build_turns_omits_zero_assistant_latency_duration() {
-        let mut user = session_event("message", "user", "text", 1_000);
-        user.text_content = "fresh prompt".to_string();
-        let mut assistant = session_event("message", "assistant", "text", 1_600);
-        assistant.text_content = "first reply".to_string();
-
-        let turns = build_turns(&[user, assistant]);
-        let steps = turns[0]["steps"].as_array().expect("steps");
-
-        assert!(steps[1].get("durationMs").is_none());
-    }
-
-    #[test]
-    fn escaping_helpers() {
-        assert_eq!(escape_literal("a'b"), "a''b");
-        assert_eq!(escape_identifier("ev`ents"), "`ev``ents`");
-    }
-
-    #[test]
-    fn events_table_ref_escapes_database_identifier() {
-        assert_eq!(events_table_ref("mor`aine"), "`mor``aine`.`events`");
-    }
-
-    #[test]
-    fn session_summary_query_dedups_by_latest_event_uid_with_recency() {
-        let query = compact_sql(&session_summary_query("`moraine`.`events`", 50, 86_400));
-
-        assert!(query.contains(
-            "FROM (SELECT * FROM `moraine`.`events` WHERE length(trim(BOTH ' ' FROM session_id)) > 0 AND event_ts >= now() - INTERVAL 86400 SECOND ORDER BY event_uid ASC, event_version DESC, ingested_at DESC LIMIT 1 BY event_uid) AS deduped_events"
-        ));
-        assert!(query.contains("GROUP BY session_id ORDER BY ended_at_ms DESC LIMIT 50"));
-    }
-
-    #[test]
-    fn session_summary_query_since_all_omits_recency_filter() {
-        let query = compact_sql(&session_summary_query("`moraine`.`events`", 25, 0));
-
-        assert!(query.contains(
-            "FROM (SELECT * FROM `moraine`.`events` WHERE length(trim(BOTH ' ' FROM session_id)) > 0 ORDER BY event_uid ASC, event_version DESC, ingested_at DESC LIMIT 1 BY event_uid) AS deduped_events"
-        ));
-        assert!(!query.contains("INTERVAL"));
-    }
-
-    #[test]
-    fn session_events_query_dedups_and_escapes_session_ids() {
-        let query = compact_sql(&session_events_query(
-            "`moraine`.`events`",
-            &["session-1".to_string(), "quote's".to_string()],
-        ));
-
-        assert!(query.contains(
-            "FROM (SELECT * FROM `moraine`.`events` WHERE session_id IN ('session-1','quote''s') ORDER BY event_uid ASC, event_version DESC, ingested_at DESC LIMIT 1 BY event_uid) AS deduped_events"
-        ));
-        assert!(query.contains(
-            "ORDER BY session_id, event_ts, source_file, source_generation, source_offset, source_line_no, event_uid"
-        ));
-    }
-
-    #[test]
-    fn table_preview_query_orders_by_schema_columns() {
-        let query = table_preview_rows_query(
-            "analytics",
-            "events",
-            &[
-                "event_ts".to_string(),
-                "session_id".to_string(),
-                "event_id".to_string(),
-            ],
-            25,
-        );
-        assert_eq!(
-            query,
-            "SELECT * FROM `analytics`.`events` ORDER BY `event_ts`, `session_id`, `event_id` LIMIT 25"
-        );
-    }
-
-    #[test]
-    fn table_preview_query_escapes_identifiers() {
-        let query = table_preview_rows_query("ana`lytics", "ev`ents", &["co`l".to_string()], 10);
-        assert_eq!(
-            query,
-            "SELECT * FROM `ana``lytics`.`ev``ents` ORDER BY `co``l` LIMIT 10"
-        );
-    }
-
-    #[test]
-    fn table_preview_query_handles_empty_schema() {
-        let columns: Vec<String> = Vec::new();
-        let query = table_preview_rows_query("analytics", "events", &columns, 5);
-        assert_eq!(query, "SELECT * FROM `analytics`.`events` LIMIT 5");
-    }
-
-    #[test]
-    fn analytics_window_query_guards_empty_recent_window() {
-        let query = analytics_window_query(
-            "`moraine`.`events`",
-            "event_ts >= now() - INTERVAL 86400 SECOND",
-            86_400,
-        );
-
-        assert!(query.contains("count() = 0"));
-        assert!(query.contains("toUnixTimestamp64Milli(max(event_ts))"));
-        assert!(query.contains("greatest(anchor_unix - toInt64(86400), toInt64(0))"));
-        assert!(!query.contains("max(event_ts) - INTERVAL"));
-    }
-
-    #[test]
-    fn clickhouse_ping_payload_marks_healthy_when_ping_succeeds() {
-        let payload = clickhouse_ping_payload("24.8".to_string(), Ok(()), 3.5);
-        assert_eq!(payload["healthy"], json!(true));
-        assert_eq!(payload["version"], json!("24.8"));
-        assert_eq!(payload["ping_ms"], json!(3.5));
-        assert_eq!(payload["error"], Value::Null);
-    }
-
-    #[test]
-    fn clickhouse_ping_payload_marks_unhealthy_when_ping_fails() {
-        let payload =
-            clickhouse_ping_payload("24.8".to_string(), Err(anyhow!("ping failed")), 8.25);
-        assert_eq!(payload["healthy"], json!(false));
-        assert_eq!(payload["version"], json!("24.8"));
-        assert_eq!(payload["ping_ms"], json!(8.25));
-        assert_eq!(payload["error"], json!("ping failed"));
-    }
-
-    #[tokio::test]
-    async fn query_heartbeat_decodes_disabled_backend_status() {
-        let state = mock_health_state().await;
-        let heartbeat = query_heartbeat(&state).await.expect("heartbeat");
-
-        assert_eq!(
-            heartbeat["latest"]["backend_sinks"]["team-ch"],
-            json!("disabled_missing_identity_author")
-        );
-        assert_eq!(heartbeat["present"], json!(true));
-        assert_eq!(heartbeat["alive"], json!(true));
-    }
-
-    #[tokio::test]
-    async fn api_health_includes_ingestor_without_affecting_health_status() {
-        let state = mock_health_state().await;
-        let response = api_health(axum::extract::State(state)).await;
-
-        assert_eq!(response.status(), StatusCode::OK);
+    async fn response_json(response: Response) -> Value {
         let body = to_bytes(response.into_body(), usize::MAX)
             .await
             .expect("body bytes");
-        let payload: Value = serde_json::from_slice(&body).expect("health json");
-        assert_eq!(payload["ok"], json!(true));
+        serde_json::from_slice(&body).expect("response json")
+    }
+
+    fn sample_health() -> StoreHealth {
+        StoreHealth {
+            ping: StoreProbe::Available(3.5),
+            version: StoreProbe::Available("25.1.1".to_string()),
+            database_exists: StoreProbe::Available(true),
+            connections: StoreProbe::Available(StoreConnectionMetrics {
+                total: 15,
+                tcp: 2,
+                http: 3,
+                mysql: 4,
+                postgres: 5,
+                interserver: 1,
+            }),
+        }
+    }
+
+    fn sample_heartbeat() -> IngestHeartbeatRead {
+        IngestHeartbeatRead {
+            table_present: true,
+            latest: Some(IngestHeartbeat {
+                ts: "2026-07-10 00:00:00.000".to_string(),
+                ts_unix_ms: unix_now_ms(),
+                host: "host-a".to_string(),
+                service_version: "0.6.4".to_string(),
+                queue_depth: 1,
+                files_active: 2,
+                files_watched: 3,
+                rows_raw_written: 4,
+                rows_events_written: 5,
+                rows_errors_written: 0,
+                flush_latency_ms: 6,
+                append_to_visible_p50_ms: 7,
+                append_to_visible_p95_ms: 8,
+                last_error: String::new(),
+                watcher_backend: Some("fsevents".to_string()),
+                watcher_error_count: Some(0),
+                watcher_reset_count: Some(0),
+                watcher_last_reset_unix_ms: None,
+                backend_sinks: Some(json!({"team-ch": "healthy"})),
+            }),
+        }
+    }
+
+    fn sample_session() -> SessionAnalytics {
+        let assistant_buckets =
+            BTreeMap::from([("output_text".to_string(), 4), ("reasoning".to_string(), 2)]);
+        SessionAnalytics {
+            summary: ConversationSummary {
+                session_id: "session-1".to_string(),
+                first_event_time: "2026-02-16T12:00:00.000Z".to_string(),
+                first_event_unix_ms: 1_771_243_200_000,
+                last_event_time: "2026-02-16T12:00:03.900Z".to_string(),
+                last_event_unix_ms: 1_771_243_203_900,
+                total_turns: 1,
+                total_events: 7,
+                user_messages: 1,
+                assistant_messages: 1,
+                tool_calls: 1,
+                tool_results: 1,
+                mode: ConversationMode::ToolCalling,
+                session_slug: None,
+                session_summary: None,
+            },
+            harness: "codex".to_string(),
+            source_name: "ci-codex".to_string(),
+            models: vec!["gpt-5.3-codex".to_string()],
+            trace_id: "trace-1".to_string(),
+            first_user_text: "Inspect the repository".to_string(),
+            turns: vec![SessionTurn {
+                summary: TurnSummary {
+                    session_id: "session-1".to_string(),
+                    turn_seq: 1,
+                    turn_id: "turn-1".to_string(),
+                    started_at: "2026-02-16T12:00:00.000Z".to_string(),
+                    started_at_unix_ms: 1_771_243_200_000,
+                    ended_at: "2026-02-16T12:00:03.900Z".to_string(),
+                    ended_at_unix_ms: 1_771_243_203_900,
+                    total_events: 7,
+                    user_messages: 1,
+                    assistant_messages: 1,
+                    tool_calls: 1,
+                    tool_results: 1,
+                    reasoning_items: 1,
+                },
+                model: "gpt-5.3-codex".to_string(),
+                token_usage_buckets: BTreeMap::from([
+                    ("input_text".to_string(), 10),
+                    ("output_text".to_string(), 4),
+                    ("reasoning".to_string(), 2),
+                ]),
+                steps: vec![
+                    SessionStep::User {
+                        event_unix_ms: 1_771_243_200_000,
+                        text: "Inspect the repository".to_string(),
+                    },
+                    SessionStep::Assistant {
+                        event_unix_ms: 1_771_243_201_000,
+                        text: "I will inspect it".to_string(),
+                        endpoint_kind: "responses".to_string(),
+                        latency_ms: Some(900),
+                        token_usage_buckets: assistant_buckets,
+                        token_usage_native_units: BTreeMap::new(),
+                    },
+                    SessionStep::ToolCall {
+                        event_unix_ms: 1_771_243_202_000,
+                        tool_name: "Read".to_string(),
+                        call_id: "call-1".to_string(),
+                        arguments: json!({"path": "Cargo.toml"}),
+                        result: Some(ToolResult {
+                            event_unix_ms: 1_771_243_203_000,
+                            text: "workspace".to_string(),
+                            latency_ms: 1_000,
+                            is_error: false,
+                        }),
+                    },
+                ],
+            }],
+        }
+    }
+
+    fn successful_responses() -> InMemoryConversationResponses {
+        InMemoryConversationResponses {
+            list_session_analytics: Some(Ok(vec![sample_session()])),
+            analytics_series: Some(Ok(AnalyticsSnapshot {
+                window: AnalyticsWindow {
+                    range: AnalyticsRange::SevenDays,
+                    window_seconds: 604_800,
+                    bucket_seconds: 21_600,
+                    from_unix: 100,
+                    to_unix: 200,
+                },
+                tokens: vec![AnalyticsTokenPoint {
+                    bucket_unix: 100,
+                    model: "gpt-5.3-codex".to_string(),
+                    endpoint_kind: "responses".to_string(),
+                    bucket: "output_text".to_string(),
+                    tokens: 4,
+                }],
+                turns: vec![AnalyticsTurnPoint {
+                    bucket_unix: 100,
+                    model: "gpt-5.3-codex".to_string(),
+                    turns: 1,
+                }],
+                concurrent_sessions: vec![AnalyticsConcurrencyPoint {
+                    bucket_unix: 100,
+                    concurrent_sessions: 1,
+                }],
+            })),
+            list_web_searches: Some(Ok(vec![WebSearchEvent {
+                event_time: "2026-02-16T12:00:00.000Z".to_string(),
+                harness: "codex".to_string(),
+                source_name: "ci-codex".to_string(),
+                session_id: "session-1".to_string(),
+                model: "gpt-5.3-codex".to_string(),
+                action: "search".to_string(),
+                search_query: "moraine".to_string(),
+                result_url: String::new(),
+                source_ref: "fixture".to_string(),
+            }])),
+            latest_ingest_heartbeat: Some(Ok(sample_heartbeat())),
+            list_table_summaries: Some(Ok(TableSummaries {
+                tables: vec![TableSummary {
+                    name: "events".to_string(),
+                    engine: "ReplacingMergeTree".to_string(),
+                    is_temporary: false,
+                    rows: 7,
+                }],
+                row_counts_error: None,
+            })),
+            preview_table: Some(Ok(TablePreview {
+                table: "events".to_string(),
+                limit: 500,
+                schema: vec![TableColumn {
+                    name: "session_id".to_string(),
+                    type_name: "String".to_string(),
+                    default_expression: String::new(),
+                }],
+                rows: vec![json!({"session_id": "session-1"})],
+            })),
+            read_store_health: Some(Ok(sample_health())),
+            read_store_diagnostics: Some(Ok(StoreDiagnostics {
+                healthy: true,
+                version: Some("25.1.1".to_string()),
+                database: "moraine".to_string(),
+                database_exists: true,
+                applied_schema_versions: Vec::new(),
+                pending_schema_versions: Vec::new(),
+                missing_tables: Vec::new(),
+                errors: Vec::new(),
+            })),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn handlers_delegate_to_shared_repository_and_preserve_json_contracts() {
+        let (state, repository) = fake_state(successful_responses());
+
+        let response = api_health(State(state.clone())).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let health = response_json(response).await;
+        assert_eq!(health["ok"], json!(true));
+        assert_eq!(health["version"], json!("25.1.1"));
+        assert_eq!(health["connections"]["total"], json!(15));
         assert_eq!(
-            payload["ingestor"]["latest"]["backend_sinks"]["team-ch"],
-            json!("disabled_missing_identity_author")
+            health["ingestor"]["latest"],
+            json!({"backend_sinks": {"team-ch": "healthy"}})
         );
-        let latest = payload["ingestor"]["latest"]
-            .as_object()
-            .expect("latest object");
+
+        let response = api_status(State(state.clone())).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let status = response_json(response).await;
+        assert_eq!(status["database"]["exists"], json!(true));
+        assert_eq!(status["database"]["table_count"], json!(1));
+        assert_eq!(status["database"]["estimated_total_rows"], json!(7));
+        assert_eq!(status["ingestor"]["latest"]["host"], json!("host-a"));
+
+        let response = api_tables(State(state.clone())).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let tables = response_json(response).await;
+        assert_eq!(tables["tables"][0]["is_temporary"], json!(0));
+
+        let response = api_web_searches(
+            Query(LimitQuery { limit: Some(2_500) }),
+            State(state.clone()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let web_searches = response_json(response).await;
+        assert_eq!(web_searches["limit"], json!(1_000));
+        assert_eq!(web_searches["schema"].as_array().unwrap().len(), 9);
+        assert_eq!(web_searches["rows"][0]["search_query"], json!("moraine"));
+
+        let response = api_analytics(
+            Query(AnalyticsQuery {
+                range: Some("7d".to_string()),
+            }),
+            State(state.clone()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let analytics = response_json(response).await;
+        assert_eq!(analytics["range"]["key"], json!("7d"));
+        assert_eq!(analytics["range"]["label"], json!("Last 7d"));
+        assert_eq!(analytics["series"]["tokens"][0]["tokens"], json!(4));
+
+        let response = api_sessions(
+            Query(SessionsQuery {
+                limit: Some(0),
+                since: Some("not-a-window".to_string()),
+            }),
+            State(state.clone()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let sessions = response_json(response).await;
+        let session = &sessions["sessions"][0];
+        assert_eq!(session["id"], json!("session-1"));
+        assert_eq!(session["endedAt"], json!(1_771_243_203_900_i64));
+        assert_eq!(session["turns"][0]["idx"], json!(0));
+        assert_eq!(session["turns"][0]["promptTokens"], json!(10));
+        assert_eq!(session["turns"][0]["completionTokens"], json!(6));
+        assert_eq!(session["turns"][0]["steps"][1]["durationMs"], json!(900));
+        assert_eq!(session["turns"][0]["steps"][2]["latencyMs"], json!(1_000));
         assert!(
-            !latest.contains_key("last_error"),
-            "/api/health should expose mirror status without full heartbeat internals"
+            session.get("eventCount").is_none(),
+            "session response shape must remain unchanged"
         );
-        assert!(
-            !latest.contains_key("host"),
-            "/api/health should expose mirror status without full heartbeat internals"
+
+        let response = api_table_rows(
+            Path("events".to_string()),
+            Query(LimitQuery { limit: Some(999) }),
+            State(state),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let preview = response_json(response).await;
+        assert_eq!(preview["limit"], json!(500));
+        assert_eq!(preview["schema"][0]["type"], json!("String"));
+
+        let calls = repository.calls();
+        assert_eq!(calls.read_store_health, 2);
+        assert_eq!(calls.read_store_diagnostics, 1);
+        assert_eq!(calls.latest_ingest_heartbeat, 2);
+        assert_eq!(calls.list_table_summaries, 2);
+        assert_eq!(calls.list_web_searches, vec![1_000]);
+        assert_eq!(calls.analytics_series, vec![AnalyticsRange::SevenDays]);
+        assert_eq!(
+            calls.list_session_analytics,
+            vec![SessionAnalyticsQuery {
+                lookback: SessionLookback::ThirtyDays,
+                limit: 1,
+            }]
         );
+        assert_eq!(
+            calls.preview_table,
+            vec![TablePreviewQuery {
+                table: "events".to_string(),
+                limit: 500,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn repository_failures_keep_existing_http_status_envelopes() {
+        let (state, _) = fake_state(InMemoryConversationResponses {
+            list_session_analytics: Some(Err(RepoError::backend("sessions unavailable"))),
+            analytics_series: Some(Err(RepoError::backend("analytics unavailable"))),
+            list_web_searches: Some(Err(RepoError::backend("web unavailable"))),
+            list_table_summaries: Some(Err(RepoError::backend("tables unavailable"))),
+            preview_table: Some(Err(RepoError::invalid_argument("unsafe table"))),
+            read_store_health: Some(Ok(StoreHealth {
+                ping: StoreProbe::Failed {
+                    message: "ping unavailable".to_string(),
+                },
+                ..sample_health()
+            })),
+            read_store_diagnostics: Some(Ok(StoreDiagnostics {
+                database_exists: false,
+                ..Default::default()
+            })),
+            ..Default::default()
+        });
+
+        let health = api_health(State(state.clone())).await;
+        assert_eq!(health.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response_json(health).await["error"],
+            json!("ping unavailable")
+        );
+
+        let analytics =
+            api_analytics(Query(AnalyticsQuery { range: None }), State(state.clone())).await;
+        assert_eq!(analytics.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response_json(analytics).await["ok"], json!(false));
+
+        let sessions = api_sessions(
+            Query(SessionsQuery {
+                limit: None,
+                since: None,
+            }),
+            State(state.clone()),
+        )
+        .await;
+        assert_eq!(sessions.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let web = api_web_searches(Query(LimitQuery { limit: None }), State(state.clone())).await;
+        assert_eq!(web.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let tables = api_tables(State(state.clone())).await;
+        assert_eq!(tables.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let preview = api_table_rows(
+            Path("events;drop".to_string()),
+            Query(LimitQuery { limit: None }),
+            State(state),
+        )
+        .await;
+        assert_eq!(preview.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response_json(preview).await["error"],
+            json!("invalid table name")
+        );
+    }
+
+    #[test]
+    fn monitor_projection_matches_repository_and_mcp_parity_values() {
+        let session = sample_session();
+        let repository_event_count = session.summary.total_events;
+        let repository_last_activity = session.summary.last_event_unix_ms;
+        let monitor = monitor_session_json(session, i64::MAX);
+
+        assert_eq!(
+            repository_event_count, 7,
+            "MCP event_count uses this repository value"
+        );
+        assert_eq!(repository_last_activity, 1_771_243_203_900);
+        assert_eq!(monitor["endedAt"], json!(repository_last_activity));
+    }
+
+    #[test]
+    fn default_and_invalid_ranges_keep_legacy_fallbacks() {
+        assert_eq!(
+            resolve_analytics_range(None),
+            AnalyticsRange::TwentyFourHours
+        );
+        assert_eq!(
+            resolve_analytics_range(Some("invalid")),
+            AnalyticsRange::TwentyFourHours
+        );
+        assert_eq!(resolve_session_lookback(None), SessionLookback::ThirtyDays);
+        assert_eq!(
+            resolve_session_lookback(Some("invalid")),
+            SessionLookback::ThirtyDays
+        );
+        assert_eq!(resolve_session_lookback(Some("all")), SessionLookback::All);
+    }
+
+    #[tokio::test]
+    async fn api_health_redacts_full_heartbeat_internals() {
+        let (state, _) = fake_state(InMemoryConversationResponses {
+            read_store_health: Some(Ok(sample_health())),
+            latest_ingest_heartbeat: Some(Ok(sample_heartbeat())),
+            ..Default::default()
+        });
+        let payload = response_json(api_health(State(state)).await).await;
+        let latest = payload["ingestor"]["latest"].as_object().expect("latest");
+
+        assert_eq!(latest.len(), 1);
+        assert_eq!(latest["backend_sinks"]["team-ch"], json!("healthy"));
+        assert!(!latest.contains_key("host"));
+        assert!(!latest.contains_key("last_error"));
     }
 
     #[test]
@@ -2031,8 +1377,8 @@ mod tests {
     #[test]
     fn validate_static_dir_rejects_missing_directory() {
         let missing = temp_path("static-missing");
-        let err = validate_static_dir(&missing).expect_err("missing static dir should fail");
-        assert!(err.to_string().contains("is unavailable"));
+        let error = validate_static_dir(&missing).expect_err("missing static dir should fail");
+        assert!(error.to_string().contains("is unavailable"));
     }
 
     #[test]
@@ -2042,8 +1388,8 @@ mod tests {
         let path = root.join("dist");
         fs::write(&path, "not a dir").expect("write file");
 
-        let err = validate_static_dir(&path).expect_err("file should fail");
-        assert!(err.to_string().contains("is not a directory"));
+        let error = validate_static_dir(&path).expect_err("file should fail");
+        assert!(error.to_string().contains("is not a directory"));
 
         let _ = fs::remove_dir_all(root);
     }
@@ -2053,8 +1399,8 @@ mod tests {
         let root = temp_path("static-no-index");
         fs::create_dir_all(&root).expect("create root");
 
-        let err = validate_static_dir(&root).expect_err("missing index should fail");
-        assert!(err.to_string().contains("does not contain `index.html`"));
+        let error = validate_static_dir(&root).expect_err("missing index should fail");
+        assert!(error.to_string().contains("does not contain `index.html`"));
 
         let _ = fs::remove_dir_all(root);
     }

--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -10,10 +10,10 @@ use axum::{
 use moraine_clickhouse::ClickHouseClient;
 use moraine_config::AppConfig;
 use moraine_conversations::{
-    AnalyticsRange, ClickHouseConversationRepository, ConversationRepository, IngestHeartbeatRead,
-    RepoConfig, RepoError, SessionAnalytics, SessionAnalyticsQuery, SessionLookback, SessionStep,
-    SessionTurn, StoreConnectionMetrics, StoreHealth, StoreProbe, TablePreviewQuery,
-    TableSummaries,
+    AnalyticsRange, ClickHouseConversationRepository, ConversationRepository, IngestHeartbeat,
+    IngestHeartbeatRead, RepoConfig, RepoError, SessionAnalytics, SessionAnalyticsQuery,
+    SessionLookback, SessionStep, SessionTurn, StoreConnectionMetrics, StoreHealth, StoreProbe,
+    TablePreviewQuery, TableSummaries,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -24,7 +24,6 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::fs;
 
-#[derive(Clone)]
 struct AppState {
     repository: Arc<dyn ConversationRepository>,
     static_dir: PathBuf,
@@ -70,13 +69,13 @@ pub async fn run_server(
     let repository: Arc<dyn ConversationRepository> = Arc::new(
         ClickHouseConversationRepository::new(client, repository_config(&cfg)),
     );
-    let state = AppState {
+    let state = Arc::new(AppState {
         repository,
         static_dir,
         clickhouse_url,
         clickhouse_database,
-    };
-    let app = monitor_router(state.clone());
+    });
+    let app = monitor_router(Arc::clone(&state));
 
     let bind = format!("{host}:{port}")
         .parse::<SocketAddr>()
@@ -116,7 +115,7 @@ fn repository_config(cfg: &AppConfig) -> RepoConfig {
     }
 }
 
-fn monitor_router(state: AppState) -> Router {
+fn monitor_router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/api/health", get(api_health))
         .route("/api/status", get(api_status))
@@ -161,7 +160,7 @@ fn json_response<T: Serialize>(payload: T, status: StatusCode) -> Response {
     response
 }
 
-async fn api_health(State(state): State<AppState>) -> Response {
+async fn api_health(State(state): State<Arc<AppState>>) -> Response {
     let (health, heartbeat) = tokio::join!(
         state.repository.read_store_health(),
         state.repository.latest_ingest_heartbeat()
@@ -196,9 +195,7 @@ async fn api_health(State(state): State<AppState>) -> Response {
             return health_failure_response(&state, message, connections);
         }
     };
-    let heartbeat = heartbeat
-        .map(heartbeat_payload)
-        .unwrap_or_else(|_| heartbeat_absent());
+    let heartbeat = heartbeat.map(monitor_heartbeat_status).unwrap_or_default();
 
     json_response(
         json!({
@@ -208,7 +205,7 @@ async fn api_health(State(state): State<AppState>) -> Response {
             "version": version,
             "ping_ms": ping_ms,
             "connections": connections,
-            "ingestor": health_heartbeat(&heartbeat),
+            "ingestor": health_heartbeat_payload(&heartbeat),
         }),
         StatusCode::OK,
     )
@@ -227,16 +224,13 @@ fn health_failure_response(state: &AppState, message: &str, connections: Value) 
     )
 }
 
-async fn api_status(State(state): State<AppState>) -> Response {
-    let (health, diagnostics) = tokio::join!(
-        state.repository.read_store_health(),
-        state.repository.read_store_diagnostics()
-    );
-    let health = health.unwrap_or_else(|error| unavailable_store_health(error.to_string()));
-    let database_exists = match diagnostics {
-        Ok(diagnostics) => diagnostics.database_exists,
-        Err(_) => probe_bool(&health.database_exists).unwrap_or(false),
-    };
+async fn api_status(State(state): State<Arc<AppState>>) -> Response {
+    let health = state
+        .repository
+        .read_store_health()
+        .await
+        .unwrap_or_else(|error| unavailable_store_health(error.to_string()));
+    let database_exists = probe_bool(&health.database_exists).unwrap_or(false);
 
     let (tables, heartbeat) = if database_exists {
         let (tables, heartbeat) = tokio::join!(
@@ -252,12 +246,10 @@ async fn api_status(State(state): State<AppState>) -> Response {
                 );
             }
         };
-        let heartbeat = heartbeat
-            .map(heartbeat_payload)
-            .unwrap_or_else(|_| heartbeat_absent());
+        let heartbeat = heartbeat.map(monitor_heartbeat_status).unwrap_or_default();
         (tables, heartbeat)
     } else {
-        (Vec::new(), heartbeat_absent())
+        (Vec::new(), MonitorHeartbeatStatus::default())
     };
 
     let estimated_total_rows = tables.iter().map(|table| table.rows).sum::<u64>();
@@ -273,7 +265,7 @@ async fn api_status(State(state): State<AppState>) -> Response {
                 "estimated_total_rows": estimated_total_rows,
                 "tables": tables,
             },
-            "ingestor": heartbeat,
+            "ingestor": heartbeat_payload(&heartbeat),
         }),
         StatusCode::OK,
     )
@@ -346,7 +338,7 @@ fn connection_payload(probe: &StoreProbe<StoreConnectionMetrics>) -> Value {
     }
 }
 
-async fn api_tables(State(state): State<AppState>) -> Response {
+async fn api_tables(State(state): State<Arc<AppState>>) -> Response {
     match state.repository.list_table_summaries().await {
         Ok(tables) => json_response(
             json!({"ok": true, "tables": monitor_table_summaries(tables)}),
@@ -374,7 +366,7 @@ fn monitor_table_summaries(summaries: TableSummaries) -> Vec<MonitorTableSummary
 
 async fn api_web_searches(
     Query(params): Query<LimitQuery>,
-    State(state): State<AppState>,
+    State(state): State<Arc<AppState>>,
 ) -> Response {
     let limit = params.limit.unwrap_or(100).clamp(1, 1000) as u16;
     let rows = match state.repository.list_web_searches(limit).await {
@@ -411,7 +403,7 @@ async fn api_web_searches(
 
 async fn api_analytics(
     Query(params): Query<AnalyticsQuery>,
-    State(state): State<AppState>,
+    State(state): State<Arc<AppState>>,
 ) -> Response {
     let range = resolve_analytics_range(params.range.as_deref());
     let snapshot = match state.repository.analytics_series(range).await {
@@ -459,7 +451,7 @@ fn resolve_analytics_range(value: Option<&str>) -> AnalyticsRange {
 
 async fn api_sessions(
     Query(params): Query<SessionsQuery>,
-    State(state): State<AppState>,
+    State(state): State<Arc<AppState>>,
 ) -> Response {
     let query = SessionAnalyticsQuery {
         lookback: resolve_session_lookback(params.since.as_deref()),
@@ -729,50 +721,71 @@ fn hue_for_label(label: &str) -> u32 {
     }
 }
 
-fn heartbeat_payload(read: IngestHeartbeatRead) -> Value {
-    let Some(latest) = read.latest else {
-        return heartbeat_absent();
-    };
-    let age_seconds = unix_now_ms()
-        .checked_sub(latest.ts_unix_ms)
-        .map(|age_ms| age_ms.max(0) as u64 / 1000);
-
-    json!({
-        "present": true,
-        "alive": age_seconds.map(|age| age <= 30).unwrap_or(false),
-        "latest": latest,
-        "age_seconds": age_seconds,
-    })
+#[derive(Default)]
+struct MonitorHeartbeatStatus {
+    latest: Option<IngestHeartbeat>,
+    age_seconds: Option<u64>,
 }
 
-fn heartbeat_absent() -> Value {
-    json!({
-        "present": false,
-        "alive": false,
-        "latest": Value::Null,
-        "age_seconds": Value::Null,
-    })
+fn monitor_heartbeat_status(read: IngestHeartbeatRead) -> MonitorHeartbeatStatus {
+    let age_seconds = read.latest.as_ref().and_then(|latest| {
+        (latest.ts_unix_ms >= 0)
+            .then(|| unix_now_ms().saturating_sub(latest.ts_unix_ms).max(0) as u64 / 1_000)
+    });
+    MonitorHeartbeatStatus {
+        latest: read.latest,
+        age_seconds,
+    }
 }
 
-fn health_heartbeat(heartbeat: &Value) -> Value {
-    let latest = heartbeat
-        .get("latest")
-        .and_then(Value::as_object)
+fn heartbeat_payload(status: &MonitorHeartbeatStatus) -> Value {
+    let latest = status
+        .latest
+        .as_ref()
         .map(|latest| {
-            json!({
-                "backend_sinks": latest
-                    .get("backend_sinks")
-                    .cloned()
-                    .unwrap_or_else(|| json!({})),
-            })
+            let mut payload = json!({
+                "ts": latest.ts,
+                "ts_unix_ms": latest.ts_unix_ms,
+                "host": latest.host,
+                "service_version": latest.service_version,
+                "queue_depth": latest.queue_depth,
+                "files_active": latest.files_active,
+                "files_watched": latest.files_watched,
+                "rows_raw_written": latest.rows_raw_written,
+                "rows_events_written": latest.rows_events_written,
+                "rows_errors_written": latest.rows_errors_written,
+                "flush_latency_ms": latest.flush_latency_ms,
+                "append_to_visible_p50_ms": latest.append_to_visible_p50_ms,
+                "append_to_visible_p95_ms": latest.append_to_visible_p95_ms,
+                "last_error": latest.last_error,
+            });
+            if let Some(backend_sinks) = &latest.backend_sinks {
+                payload["backend_sinks"] = backend_sinks.clone();
+            }
+            payload
         })
         .unwrap_or(Value::Null);
 
     json!({
-        "present": heartbeat.get("present").cloned().unwrap_or(Value::Bool(false)),
-        "alive": heartbeat.get("alive").cloned().unwrap_or(Value::Bool(false)),
+        "present": status.latest.is_some(),
+        "alive": status.age_seconds.map(|age| age <= 30).unwrap_or(false),
         "latest": latest,
-        "age_seconds": heartbeat.get("age_seconds").cloned().unwrap_or(Value::Null),
+        "age_seconds": status.age_seconds,
+    })
+}
+
+fn health_heartbeat_payload(status: &MonitorHeartbeatStatus) -> Value {
+    let latest = status.latest.as_ref().map_or(Value::Null, |latest| {
+        json!({
+            "backend_sinks": latest.backend_sinks.clone().unwrap_or_else(|| json!({})),
+        })
+    });
+
+    json!({
+        "present": status.latest.is_some(),
+        "alive": status.age_seconds.map(|age| age <= 30).unwrap_or(false),
+        "latest": latest,
+        "age_seconds": status.age_seconds,
     })
 }
 
@@ -787,7 +800,7 @@ fn unix_now_ms() -> i64 {
 async fn api_table_rows(
     Path(table): Path<String>,
     Query(params): Query<LimitQuery>,
-    State(state): State<AppState>,
+    State(state): State<Arc<AppState>>,
 ) -> Response {
     let limit = params.limit.unwrap_or(25).clamp(1, 500) as u16;
     match state
@@ -835,7 +848,7 @@ async fn api_table_rows(
     }
 }
 
-async fn static_fallback(State(state): State<AppState>, uri: Uri) -> Response {
+async fn static_fallback(State(state): State<Arc<AppState>>, uri: Uri) -> Response {
     let requested = uri.path();
     if requested.contains("..") {
         return json_response(
@@ -909,8 +922,8 @@ mod tests {
     use moraine_conversations::{
         AnalyticsConcurrencyPoint, AnalyticsSnapshot, AnalyticsTokenPoint, AnalyticsTurnPoint,
         AnalyticsWindow, ConversationMode, ConversationSummary, InMemoryConversationRepository,
-        InMemoryConversationResponses, IngestHeartbeat, SessionStep, StoreDiagnostics, TableColumn,
-        TablePreview, TableSummary, ToolResult, TurnSummary, WebSearchEvent,
+        InMemoryConversationResponses, IngestHeartbeat, SessionStep, TableColumn, TablePreview,
+        TableSummary, ToolResult, TurnSummary, WebSearchEvent,
     };
     use std::collections::BTreeMap;
     use std::fs;
@@ -928,17 +941,17 @@ mod tests {
 
     fn fake_state(
         responses: InMemoryConversationResponses,
-    ) -> (AppState, Arc<InMemoryConversationRepository>) {
+    ) -> (Arc<AppState>, Arc<InMemoryConversationRepository>) {
         let repository = Arc::new(InMemoryConversationRepository::with_responses(
             RepoConfig::default(),
             responses,
         ));
-        let state = AppState {
+        let state = Arc::new(AppState {
             repository: repository.clone(),
             static_dir: PathBuf::new(),
             clickhouse_url: "http://127.0.0.1:8123".to_string(),
             clickhouse_database: "moraine".to_string(),
-        };
+        });
         (state, repository)
     }
 
@@ -1129,16 +1142,6 @@ mod tests {
                 rows: vec![json!({"session_id": "session-1"})],
             })),
             read_store_health: Some(Ok(sample_health())),
-            read_store_diagnostics: Some(Ok(StoreDiagnostics {
-                healthy: true,
-                version: Some("25.1.1".to_string()),
-                database: "moraine".to_string(),
-                database_exists: true,
-                applied_schema_versions: Vec::new(),
-                pending_schema_versions: Vec::new(),
-                missing_tables: Vec::new(),
-                errors: Vec::new(),
-            })),
             ..Default::default()
         }
     }
@@ -1165,6 +1168,13 @@ mod tests {
         assert_eq!(status["database"]["table_count"], json!(1));
         assert_eq!(status["database"]["estimated_total_rows"], json!(7));
         assert_eq!(status["ingestor"]["latest"]["host"], json!("host-a"));
+        let status_latest = status["ingestor"]["latest"]
+            .as_object()
+            .expect("status latest");
+        assert!(!status_latest.contains_key("watcher_backend"));
+        assert!(!status_latest.contains_key("watcher_error_count"));
+        assert!(!status_latest.contains_key("watcher_reset_count"));
+        assert!(!status_latest.contains_key("watcher_last_reset_unix_ms"));
 
         let response = api_tables(State(state.clone())).await;
         assert_eq!(response.status(), StatusCode::OK);
@@ -1231,7 +1241,7 @@ mod tests {
 
         let calls = repository.calls();
         assert_eq!(calls.read_store_health, 2);
-        assert_eq!(calls.read_store_diagnostics, 1);
+        assert_eq!(calls.read_store_diagnostics, 0);
         assert_eq!(calls.latest_ingest_heartbeat, 2);
         assert_eq!(calls.list_table_summaries, 2);
         assert_eq!(calls.list_web_searches, vec![1_000]);
@@ -1265,10 +1275,6 @@ mod tests {
                     message: "ping unavailable".to_string(),
                 },
                 ..sample_health()
-            })),
-            read_store_diagnostics: Some(Ok(StoreDiagnostics {
-                database_exists: false,
-                ..Default::default()
             })),
             ..Default::default()
         });
@@ -1315,21 +1321,6 @@ mod tests {
     }
 
     #[test]
-    fn monitor_projection_matches_repository_and_mcp_parity_values() {
-        let session = sample_session();
-        let repository_event_count = session.summary.total_events;
-        let repository_last_activity = session.summary.last_event_unix_ms;
-        let monitor = monitor_session_json(session, i64::MAX);
-
-        assert_eq!(
-            repository_event_count, 7,
-            "MCP event_count uses this repository value"
-        );
-        assert_eq!(repository_last_activity, 1_771_243_203_900);
-        assert_eq!(monitor["endedAt"], json!(repository_last_activity));
-    }
-
-    #[test]
     fn default_and_invalid_ranges_keep_legacy_fallbacks() {
         assert_eq!(
             resolve_analytics_range(None),
@@ -1361,6 +1352,26 @@ mod tests {
         assert_eq!(latest["backend_sinks"]["team-ch"], json!("healthy"));
         assert!(!latest.contains_key("host"));
         assert!(!latest.contains_key("last_error"));
+    }
+
+    #[tokio::test]
+    async fn pre017_heartbeat_keeps_legacy_health_and_status_shapes() {
+        let mut heartbeat = sample_heartbeat();
+        let latest = heartbeat.latest.as_mut().expect("latest heartbeat");
+        latest.backend_sinks = None;
+        let (state, _) = fake_state(InMemoryConversationResponses {
+            read_store_health: Some(Ok(sample_health())),
+            latest_ingest_heartbeat: Some(Ok(heartbeat)),
+            ..Default::default()
+        });
+
+        let health = response_json(api_health(State(state.clone())).await).await;
+        assert_eq!(health["ingestor"]["latest"]["backend_sinks"], json!({}));
+
+        let status = response_json(api_status(State(state)).await).await;
+        let latest = status["ingestor"]["latest"].as_object().expect("latest");
+        assert!(!latest.contains_key("backend_sinks"));
+        assert!(!latest.contains_key("watcher_backend"));
     }
 
     #[test]

--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -7,10 +7,9 @@ use axum::{
     routing::get,
     Json, Router,
 };
-use moraine_clickhouse::ClickHouseClient;
 use moraine_config::AppConfig;
 use moraine_conversations::{
-    AnalyticsRange, ClickHouseConversationRepository, ConversationRepository, IngestHeartbeat,
+    build_clickhouse_repository, AnalyticsRange, ConversationRepository, IngestHeartbeat,
     IngestHeartbeatRead, RepoConfig, RepoError, SessionAnalytics, SessionAnalyticsQuery,
     SessionLookback, SessionStep, SessionTurn, StoreConnectionMetrics, StoreHealth, StoreProbe,
     TablePreviewQuery, TableSummaries,
@@ -65,10 +64,7 @@ pub async fn run_server(
 
     let clickhouse_url = cfg.clickhouse.url.clone();
     let clickhouse_database = cfg.clickhouse.database.clone();
-    let client = ClickHouseClient::new(cfg.clickhouse.clone())?;
-    let repository: Arc<dyn ConversationRepository> = Arc::new(
-        ClickHouseConversationRepository::new(client, repository_config(&cfg)),
-    );
+    let repository = build_clickhouse_repository(cfg.clickhouse.clone(), repository_config(&cfg))?;
     let state = Arc::new(AppState {
         repository,
         static_dir,

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -902,6 +902,10 @@ PY
   # Re-enable merges now that the pre-merge assertions have passed.
   clickhouse_scalar "$clickhouse_url" "SYSTEM START MERGES ${clickhouse_database}.events" >/dev/null
 
+  echo "[e2e] checking monitor/repository session last-activity parity"
+  sessions_body="$(curl -fsS "http://127.0.0.1:${monitor_port}/api/sessions?since=all&limit=200")"
+  printf '%s' "$sessions_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; expected=int(sys.argv[2]); session=next((s for s in data.get("sessions", []) if s.get("id")==sid), None); ok=session is not None and session.get("endedAt")==expected; sys.exit(0 if ok else 1)' "$codex_session_id" "1771243203900"
+
   echo "[e2e] checking MCP initialize/tools/search_sessions/open/list_sessions (codex)"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
     --moraine "$moraine_bin" \
@@ -909,6 +913,8 @@ PY
     --query "$codex_keyword" \
     --expect-session-id "$codex_session_id" \
     --expect-open-text "$codex_trace_marker" \
+    --expect-event-count "7" \
+    --expect-updated-at "2026-02-16T12:00:03.900Z" \
     --file-attention-path "Cargo.toml"
 
   echo "[e2e] checking MCP initialize/tools/search_sessions/open/list_sessions (claude)"

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -902,9 +902,15 @@ PY
   # Re-enable merges now that the pre-merge assertions have passed.
   clickhouse_scalar "$clickhouse_url" "SYSTEM START MERGES ${clickhouse_database}.events" >/dev/null
 
-  echo "[e2e] checking monitor/repository session last-activity parity"
+  # `/api/sessions` intentionally keeps its legacy shape without eventCount.
+  # Derive the monitor-side canonical count through the existing trace preview
+  # route, then compare both that count and sessions.endedAt with MCP below.
+  echo "[e2e] checking monitor/repository session count + last-activity parity"
   sessions_body="$(curl -fsS "http://127.0.0.1:${monitor_port}/api/sessions?since=all&limit=200")"
   printf '%s' "$sessions_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; expected=int(sys.argv[2]); session=next((s for s in data.get("sessions", []) if s.get("id")==sid), None); ok=session is not None and session.get("endedAt")==expected; sys.exit(0 if ok else 1)' "$codex_session_id" "1771243203900"
+  local trace_body
+  trace_body="$(curl -fsS "http://127.0.0.1:${monitor_port}/api/tables/v_conversation_trace?limit=500")"
+  printf '%s' "$trace_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; expected=int(sys.argv[2]); count=sum(1 for row in data.get("rows", []) if row.get("session_id")==sid); sys.exit(0 if count==expected else 1)' "$codex_session_id" "7"
 
   echo "[e2e] checking MCP initialize/tools/search_sessions/open/list_sessions (codex)"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \

--- a/scripts/ci/mcp_smoke.py
+++ b/scripts/ci/mcp_smoke.py
@@ -418,6 +418,8 @@ def run_smoke(
     project_dir: Optional[str] = None,
     absent_session_ids: Optional[list[str]] = None,
     expect_no_results: bool = False,
+    expect_event_count: Optional[int] = None,
+    expect_updated_at: Optional[str] = None,
 ) -> None:
     absent_session_ids = absent_session_ids or []
     argv = [moraine, "run", "mcp", "--config", config]
@@ -553,6 +555,29 @@ def run_smoke(
                     "list_sessions returned no sessions for the in-scope fixture window"
                 )
             selected_session = select_list_sessions_result(sessions, expect_session_id)
+            session_metadata = selected_session.get("session")
+            if not isinstance(session_metadata, dict):
+                raise AssertionError(
+                    f"list_sessions result missing session metadata: {selected_session}"
+                )
+            if (
+                expect_event_count is not None
+                and session_metadata.get("event_count") != expect_event_count
+            ):
+                raise AssertionError(
+                    "list_sessions event_count parity failed: "
+                    f"got {session_metadata.get('event_count')}, "
+                    f"wanted {expect_event_count}"
+                )
+            if (
+                expect_updated_at is not None
+                and session_metadata.get("updated_at") != expect_updated_at
+            ):
+                raise AssertionError(
+                    "list_sessions updated_at parity failed: "
+                    f"got {session_metadata.get('updated_at')!r}, "
+                    f"wanted {expect_updated_at!r}"
+                )
             next_id = assert_open_search_ids(
                 proc,
                 next_id,
@@ -638,6 +663,15 @@ def main() -> int:
         action="store_true",
         help="assert search_sessions returns zero results for the query",
     )
+    parser.add_argument(
+        "--expect-event-count",
+        type=int,
+        help="expected canonical event_count for the selected list_sessions fixture",
+    )
+    parser.add_argument(
+        "--expect-updated-at",
+        help="expected RFC3339 updated_at for the selected list_sessions fixture",
+    )
     args = parser.parse_args()
 
     run_smoke(
@@ -650,6 +684,8 @@ def main() -> int:
         project_dir=args.project_dir,
         absent_session_ids=args.expect_absent_session_id,
         expect_no_results=args.expect_no_results,
+        expect_event_count=args.expect_event_count,
+        expect_updated_at=args.expect_updated_at,
     )
     print("mcp smoke passed")
     return 0

--- a/web/monitor/e2e/monitor.smoke.spec.ts
+++ b/web/monitor/e2e/monitor.smoke.spec.ts
@@ -84,7 +84,50 @@ async function setupMockMonitorApi(page: Page): Promise<void> {
   });
 
   await page.route('**/api/sessions', async (route) => {
-    await route.fulfill({ status: 404, body: 'not found' });
+    await route.fulfill({
+      json: {
+        ok: true,
+        sessions: [
+          {
+            id: 'session-monitor-fixture',
+            title: 'Inspect the repository',
+            harness: { id: 'codex', label: 'codex', short: 'C', hue: 150 },
+            startedAt: 1_700_000_000_000,
+            endedAt: 1_700_000_003_900,
+            durationMs: 3_900,
+            status: 'completed',
+            models: ['gpt-5.3-codex'],
+            turns: [
+              {
+                idx: 0,
+                model: 'gpt-5.3-codex',
+                startedAt: 1_700_000_000_000,
+                endedAt: 1_700_000_003_900,
+                durationMs: 3_900,
+                promptTokens: 10,
+                completionTokens: 6,
+                totalTokens: 16,
+                toolCalls: 0,
+                steps: [
+                  { kind: 'user', at: 1_700_000_000_000, text: 'Inspect the repository' },
+                  {
+                    kind: 'assistant',
+                    at: 1_700_000_003_900,
+                    text: 'Repository inspection complete',
+                    tokens: 6,
+                    durationMs: 3_900,
+                  },
+                ],
+              },
+            ],
+            totalTokens: 16,
+            totalToolCalls: 0,
+            tags: [],
+            traceId: 'trace-monitor-fixture',
+          },
+        ],
+      },
+    });
   });
 
   await page.route('**/api/analytics?range=*', async (route) => {
@@ -131,8 +174,9 @@ test('loads dashboard and handles core interactions', async ({ page }) => {
   await page.locator('#analyticsRanges').getByRole('button', { name: '7d' }).click();
   await expect(page.locator('#analyticsMeta')).toContainText('Last 7d');
 
-  // Sessions panel (mock fallback) renders cards
+  // Sessions panel consumes the monitor API response rather than mock fallback data.
   await expect(page.locator('#sessionsPanel')).toBeVisible();
+  await expect(page.locator('.mv-card-title').first()).toHaveText('Inspect the repository');
   await expect(page.locator('.mv-card').first()).toBeVisible();
 
   // Clicking a card opens the side panel with detail (transcript is default)


### PR DESCRIPTION
## Description

Port every `moraine-monitor-core` read handler from monitor-owned ClickHouse queries to the shared `Arc<dyn ConversationRepository>` read layer introduced by #454.

The monitor keeps its existing routes and response envelopes while adapting the typed repository results at the HTTP boundary. Concrete ClickHouse construction now lives behind `moraine_conversations::build_clickhouse_repository`, so `moraine-monitor-core` no longer depends on `moraine-clickhouse` or sees client/SQL types.

| Monitor route | Shared repository read |
| --- | --- |
| `GET /api/health` | `read_store_health`, `latest_ingest_heartbeat` |
| `GET /api/status` | `read_store_health`, `list_table_summaries`, `latest_ingest_heartbeat` |
| `GET /api/tables` | `list_table_summaries` |
| `GET /api/web-searches` | `list_web_searches` |
| `GET /api/analytics` | `analytics_series` |
| `GET /api/sessions` | `list_session_analytics` |
| `GET /api/tables/:table` | `preview_table` |

This deletes monitor-core's SQL formatters, literal/identifier escaping, local dedup and `argMax` queries, ClickHouse row types, analytics query assembly, and Rust turn assembly. The compatibility adapters preserve the legacy camelCase monitor JSON, including pre-0.17 heartbeat projection and unmatched tool-call latency/error values.

### Canonical fixture characterization

The targeted duplicate-event fixture contains eight physical event rows (seven distinct logical events plus one duplicate `event_uuid`). The canonical read layer intentionally exposes seven events. The monitor trace preview reports count `7` and `endedAt = 2026-02-16T12:00:03.900Z`; MCP `list_sessions` reports `event_count = 7` and the same `updated_at`. Treating the duplicate as a physical eighth event, or letting its ingest timestamp become session last activity, would be a correctness bug; the shared canonical definition fixes that drift.

On the frozen 50-session benchmark corpus, final old/new response aggregates were otherwise unchanged: analytics token total `36,447,962`, turn total `29`, concurrency sum `10`, with series cardinalities `42/12/7`; session totals were `707,009,933` tokens, `4,362` tool calls, and `376` turns, with zero per-session count/time deltas. This confirms the cutover does not invent unrelated number changes.

Resolves #455

## Usage

No route or client change is required. Start the monitor as before and use the existing `/api/health`, `/api/status`, `/api/tables`, `/api/web-searches`, `/api/analytics`, `/api/sessions`, and table-preview endpoints. Invalid ranges still fall back to the legacy defaults, route limits remain clamped, and existing error/status envelopes are preserved.

## Changelog

- Changed: monitor reads now share the canonical conversation analytics/operations repository used by MCP and CLI.
- Fixed: duplicate physical rows no longer risk changing logical event counts or session last activity in monitor projections.
- Fixed: legacy monitor heartbeat and unmatched tool-call projections remain stable across the typed repository cutover.
- Removed: monitor-owned SQL, escaping, dedup, analytics, and turn-assembly implementations.

## Performance

Workload: the same frozen ClickHouse corpus used for the #454 repository benchmark, comparing the pre-migration monitor with this repository-backed monitor. Measurements used 5 warmups and 60 alternating AB/BA Type-7 samples per endpoint.

| Dashboard read | Baseline p95 | This PR p95 | Delta | Gate |
| --- | ---: | ---: | ---: | --- |
| `/api/analytics?range=24h` | 467.418 ms | 2.518 ms | -99.46% | Pass; below the +20% regression ceiling |
| `/api/sessions?since=30d&limit=50` | 2,193.477 ms | 2,292.755 ms | +4.526% | Pass; within ±20% |

Both sides returned identical cardinality and aggregate payloads. The large analytics improvement reflects removal of monitor-local analytics SQL in favor of the warmed shared repository read/cache; it is not required for acceptance, but it is safely below the regression ceiling.

## Validation

- `cargo test -p moraine-monitor-core --lib --locked` — 10 passed.
- `cargo test -p moraine-conversations --lib --locked` — 39 passed, including the production repository factory seam.
- `cargo clippy -p moraine-conversations -p moraine-monitor-core --all-targets --locked -- -D warnings` — passed.
- `bun run typecheck` in `web/monitor` — 0 errors and 0 warnings.
- `bun run test:e2e -- e2e/monitor.smoke.spec.ts` — 2 passed, covering dashboard routes and interactions against the monitor API shape.
- `bash -n scripts/ci/e2e-stack.sh` and `python3 -m py_compile scripts/ci/mcp_smoke.py` — passed.
- `scripts/ci/e2e-stack.sh` inside a rebuilt Moraine dev sandbox — passed end to end after the final rebase, including normalized ingest, all monitor routes, stable duplicate-event turn sequencing, monitor/MCP event-count and last-activity parity, eight harness MCP smoke fixtures, project scoping, and final service health.
- Public Moraine MCP smoke — `search_sessions`, `list_sessions`, `file_attention`, and `open` for both event and session IDs passed.
- Source/dependency audit — no SQL/client/escaping/dedup/turn-builder strings in non-test `moraine-monitor-core`; Cargo metadata lists only `moraine-config` and `moraine-conversations` as internal monitor-core dependencies.

## Review

Seven focused review personas covered elegance, idiomatic Rust, correctness, completeness, security, YAGNI, and scope. Accepted follow-ups removed a redundant diagnostics read, kept heartbeat projection typed, shared `Arc<AppState>` without per-request state clones, restored pre-0.17 heartbeat compatibility, preserved unmatched tool-call latency/error values, replaced a tautological parity test with a real HTTP/MCP fixture assertion, and moved concrete repository construction behind the conversations boundary. Follow-up review after rebasing onto the merged #454 and #456 base found no remaining implementation findings. Broader authentication/error-redaction and cross-crate config-mapping consolidation were left unchanged as pre-existing, out-of-scope concerns.