### PR TITLE
ci: enforce Phase 1 dependency rule

### DIFF
--- a/.github/workflows/ci-pr-fast.yml
+++ b/.github/workflows/ci-pr-fast.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
 
+      - name: Phase 1 dependency policy
+        run: make dependency-policy USE_RUSTUP=0
+
       - name: Format check
         run: cargo fmt --all -- --check
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,7 +1254,6 @@ version = "0.6.4"
 dependencies = [
  "anyhow",
  "chrono",
- "moraine-clickhouse",
  "moraine-config",
  "moraine-conversations",
  "serde",

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
 UV ?= uv
+PYTHON ?= python3
 CODEX ?= codex
 AGENT_PLUGINS_SOURCE ?= main
 AGENT_PLUGINS_REMOTE ?= origin
@@ -21,15 +22,17 @@ endif
 CARGO_TARGET_DIR ?= $(DEFAULT_CARGO_TARGET_DIR)
 RUST_LABEL = $(if $(filter 1,$(USE_RUSTUP)),$(RUST_TOOLCHAIN) via $(RUSTUP_BIN_DIR),host PATH)
 
-.PHONY: help fmt clippy build test ci-check install docs-build docs-serve docs-clean sandbox-up sandbox-down sandbox-list hooks-install agent-plugins-install
+.PHONY: help dependency-policy fmt clippy build test ci-check install docs-build docs-serve docs-clean sandbox-up sandbox-down sandbox-list hooks-install agent-plugins-install
 
 help:
 	@echo "Available targets:"
+	@echo "  make dependency-policy"
+	@echo "                       Enforce the epic #451 Phase 1 dependency rules"
 	@echo "  make fmt            Check Rust formatting"
 	@echo "  make clippy         Run strict clippy baseline"
 	@echo "  make build          Build all workspace crates"
 	@echo "  make test           Run workspace tests"
-	@echo "  make ci-check       Run local CI checks: fmt, clippy, build, test"
+	@echo "  make ci-check       Run local CI checks: dependency policy, fmt, clippy, build, test"
 	@echo "  make install        Build the current checkout and install it to the host"
 	@echo "  make docs-build     Build static docs site into ./site"
 	@echo "  make docs-serve     Run live docs server at $(DOCS_ADDR)"
@@ -45,6 +48,11 @@ help:
 	@echo "Cargo command: $(CARGO_CMD)"
 	@echo "Cargo target dir: $(CARGO_TARGET_DIR)"
 	@echo "Override with: make ci-check USE_RUSTUP=0 CARGO_TARGET_DIR=target/nix"
+
+dependency-policy:
+	@echo "[dependency-policy] $(RUST_LABEL)"
+	@$(PYTHON) -m unittest -v scripts/ci/test_dependency_policy.py
+	@$(CARGO_ENV) MORAINE_CARGO='$(CARGO_CMD)' $(PYTHON) scripts/ci/dependency_policy.py
 
 fmt:
 	@echo "[fmt] $(RUST_LABEL)"
@@ -62,7 +70,7 @@ test:
 	@echo "[test] $(RUST_LABEL); target $(CARGO_TARGET_DIR)"
 	@$(CARGO_ENV) CARGO_TARGET_DIR='$(CARGO_TARGET_DIR)' $(CARGO_CMD) test --workspace --locked
 
-ci-check: fmt clippy build test
+ci-check: dependency-policy fmt clippy build test
 
 # Build the current checkout for the host target and install it over the
 # active `moraine` on your PATH. Pass flags via INSTALL_ARGS, e.g.

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -1,3 +1,5 @@
+use anyhow::Context as _;
+
 mod clickhouse_repo;
 mod cursor;
 mod domain;
@@ -43,6 +45,20 @@ pub fn build_clickhouse_repository(
     Ok(std::sync::Arc::new(ClickHouseConversationRepository::new(
         client, config,
     )))
+}
+/// Validate that a non-default ClickHouse backend's migration ledger is
+/// compatible with this Moraine build. Storage construction and schema reads
+/// stay behind the conversations boundary.
+pub async fn validate_remote_clickhouse_schema(
+    backend_name: &str,
+    clickhouse: moraine_config::ClickHouseConfig,
+) -> anyhow::Result<()> {
+    let allow_newer_server = clickhouse.allow_newer_server;
+    let client = moraine_clickhouse::ClickHouseClient::new(clickhouse)?;
+    let skew = client.schema_skew().await.with_context(|| {
+        format!("backend '{backend_name}': schema handshake failed (is the server reachable?)")
+    })?;
+    moraine_clickhouse::enforce_remote_schema_policy(backend_name, &skew, allow_newer_server)
 }
 
 #[cfg(test)]

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -20,7 +20,6 @@ tokio = { version = "1.40", features = [
 ] }
 tracing = "0.1"
 moraine-config = { path = "../moraine-config" }
-moraine-clickhouse = { path = "../moraine-clickhouse" }
 moraine-conversations = { path = "../moraine-conversations" }
 
 [dev-dependencies]

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -7,11 +7,11 @@ mod open_v1;
 mod search_sessions_v1;
 
 use anyhow::{anyhow, Context, Result};
-use moraine_clickhouse::{enforce_remote_schema_policy, ClickHouseClient};
 use moraine_config::{AppConfig, DEFAULT_BACKEND_NAME};
 pub use moraine_conversations::SessionOriginScope;
 use moraine_conversations::{
-    ClickHouseConversationRepository, ConversationRepository, RepoConfig, RepoError,
+    build_clickhouse_repository, validate_remote_clickhouse_schema, ConversationRepository,
+    RepoConfig, RepoError,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -452,8 +452,6 @@ impl AppState {
         cfg: AppConfig,
         session_scope: Option<SessionOriginScope>,
     ) -> Result<Arc<AppState>> {
-        let ch = ClickHouseClient::new(cfg.clickhouse.clone())?;
-
         let repo_cfg = RepoConfig {
             max_results: cfg.mcp.max_results,
             preview_chars: cfg.mcp.preview_chars,
@@ -470,8 +468,7 @@ impl AppState {
             session_scope,
         };
 
-        let repo: Arc<dyn ConversationRepository> =
-            Arc::new(ClickHouseConversationRepository::new(ch, repo_cfg));
+        let repo = build_clickhouse_repository(cfg.clickhouse.clone(), repo_cfg)?;
         Ok(Arc::new(AppState {
             cfg,
             repo,
@@ -803,11 +800,7 @@ async fn run_stdio_for_backend(
         .cloned()
         .ok_or_else(|| anyhow!("backend '{backend}' is not configured"))?;
 
-    let client = ClickHouseClient::new(backend_cfg.clone())?;
-    let skew = client.schema_skew().await.with_context(|| {
-        format!("backend '{backend}': schema handshake failed (is the server reachable?)")
-    })?;
-    enforce_remote_schema_policy(backend, &skew, backend_cfg.allow_newer_server)?;
+    validate_remote_clickhouse_schema(backend, backend_cfg.clone()).await?;
 
     cfg.clickhouse = backend_cfg;
     run_stdio(cfg, session_scope).await

--- a/scripts/ci/dependency_policy.py
+++ b/scripts/ci/dependency_policy.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+"""Enforce the epic #451 Phase 1 storage dependency boundaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+CLICKHOUSE_PACKAGE = "moraine-clickhouse"
+ALLOWED_DIRECT_DEPENDENTS = frozenset(
+    {
+        "moraine",
+        "moraine-conversations",
+        "moraine-ingest-core",
+    }
+)
+EPIC_RULE = "epic #451 Phase 1 dependency rule"
+SQL_STATEMENT = re.compile(
+    r"(?i)(?P<select>\bSELECT\b)|(?P<insert>\bINSERT\s+INTO\b)"
+)
+ATTRIBUTE_START = re.compile(r"#\s*\[")
+INCLUDE_STR_CALL = re.compile(r"\binclude_str\s*!\s*\(")
+IGNORED_SOURCE_DIRS = frozenset({"fixture", "fixtures", "test", "tests"})
+IGNORED_SOURCE_STEMS = frozenset({"test", "tests"})
+
+
+class PolicyViolation(RuntimeError):
+    """A checked workspace violates the Phase 1 dependency policy."""
+
+
+@dataclass(frozen=True)
+class SqlFinding:
+    path: Path
+    line: int
+    statement: str
+
+
+@dataclass(frozen=True)
+class _RustString:
+    start: int
+    line: int
+    value: str
+    raw: bool
+
+
+def direct_clickhouse_dependents(metadata: dict[str, Any]) -> tuple[str, ...]:
+    """Return workspace packages with a direct dependency on moraine-clickhouse."""
+    workspace_members = set(metadata.get("workspace_members", ()))
+    dependents: set[str] = set()
+
+    for package in metadata.get("packages", ()):
+        if workspace_members and package.get("id") not in workspace_members:
+            continue
+        if any(
+            dependency.get("name") == CLICKHOUSE_PACKAGE
+            for dependency in package.get("dependencies", ())
+        ):
+            dependents.add(package["name"])
+
+    return tuple(sorted(dependents))
+
+
+def assert_clickhouse_dependency_policy(metadata: dict[str, Any]) -> tuple[str, ...]:
+    dependents = direct_clickhouse_dependents(metadata)
+    offenders = tuple(
+        package for package in dependents if package not in ALLOWED_DIRECT_DEPENDENTS
+    )
+    if offenders:
+        offender_lines = "\n".join(f"  - {package}" for package in offenders)
+        allowed = ", ".join(sorted(ALLOWED_DIRECT_DEPENDENTS))
+        raise PolicyViolation(
+            f"{EPIC_RULE} violated: direct workspace dependents of "
+            f"{CLICKHOUSE_PACKAGE} outside the allowlist:\n"
+            f"{offender_lines}\n"
+            f"Allowed direct dependents: {allowed}"
+        )
+    return dependents
+
+
+def _blank(mask: list[str], start: int, end: int) -> None:
+    for index in range(start, end):
+        if mask[index] != "\n":
+            mask[index] = " "
+
+
+def _raw_string_at(source: str, start: int) -> tuple[int, str] | None:
+    prefix_length = 0
+    if source.startswith("br", start):
+        prefix_length = 2
+    elif source.startswith("r", start):
+        prefix_length = 1
+    else:
+        return None
+
+    cursor = start + prefix_length
+    while cursor < len(source) and source[cursor] == "#":
+        cursor += 1
+    if cursor >= len(source) or source[cursor] != '"':
+        return None
+
+    hashes = source[start + prefix_length : cursor]
+    terminator = '"' + hashes
+    body_start = cursor + 1
+    body_end = source.find(terminator, body_start)
+    if body_end < 0:
+        body_end = len(source)
+        token_end = len(source)
+    else:
+        token_end = body_end + len(terminator)
+    return token_end, source[body_start:body_end]
+
+
+def _regular_string_at(source: str, quote: int) -> tuple[int, str]:
+    cursor = quote + 1
+    while cursor < len(source):
+        if source[cursor] == "\\":
+            cursor += 2
+            continue
+        if source[cursor] == '"':
+            return cursor + 1, source[quote + 1 : cursor]
+        cursor += 1
+    return len(source), source[quote + 1 :]
+
+
+def _char_literal_end(source: str, quote: int) -> int | None:
+    if quote + 1 >= len(source):
+        return None
+    cursor = quote + 1
+    if source[cursor] == "\\":
+        cursor += 2
+        if cursor < len(source) and source[cursor - 1] == "u" and source[cursor] == "{":
+            closing = source.find("}", cursor + 1)
+            if closing < 0:
+                return None
+            cursor = closing + 1
+    else:
+        cursor += 1
+    if cursor < len(source) and source[cursor] == "'":
+        return cursor + 1
+    return None
+
+
+def _lex_rust(source: str) -> tuple[str, tuple[_RustString, ...]]:
+    """Mask comments/literals while retaining strings for SQL inspection."""
+    mask = list(source)
+    strings: list[_RustString] = []
+    index = 0
+    line = 1
+
+    while index < len(source):
+        if source.startswith("//", index):
+            end = source.find("\n", index + 2)
+            if end < 0:
+                end = len(source)
+            _blank(mask, index, end)
+            index = end
+            continue
+
+        if source.startswith("/*", index):
+            cursor = index + 2
+            depth = 1
+            while cursor < len(source) and depth:
+                if source.startswith("/*", cursor):
+                    depth += 1
+                    cursor += 2
+                elif source.startswith("*/", cursor):
+                    depth -= 1
+                    cursor += 2
+                else:
+                    cursor += 1
+            line += source.count("\n", index, cursor)
+            _blank(mask, index, cursor)
+            index = cursor
+            continue
+
+        raw = _raw_string_at(source, index)
+        if raw is not None and (index == 0 or not source[index - 1].isalnum()):
+            end, value = raw
+            strings.append(_RustString(index, line, value, raw=True))
+            line += source.count("\n", index, end)
+            _blank(mask, index, end)
+            index = end
+            continue
+
+        if source[index] == '"':
+            end, value = _regular_string_at(source, index)
+            strings.append(_RustString(index, line, value, raw=False))
+            line += source.count("\n", index, end)
+            _blank(mask, index, end)
+            index = end
+            continue
+
+        if source[index] == "'":
+            end = _char_literal_end(source, index)
+            if end is not None:
+                _blank(mask, index, end)
+                index = end
+                continue
+
+        if source[index] == "\n":
+            line += 1
+        index += 1
+
+    return "".join(mask), tuple(strings)
+
+
+def _matching_brace(masked_source: str, opening: int) -> int:
+    depth = 0
+    for index in range(opening, len(masked_source)):
+        if masked_source[index] == "{":
+            depth += 1
+        elif masked_source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    return len(masked_source)
+
+
+def _call_parts(expression: str) -> tuple[str, str | None] | None:
+    expression = expression.strip()
+    name = re.match(r"[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*", expression)
+    if name is None:
+        return None
+    cursor = name.end()
+    while cursor < len(expression) and expression[cursor].isspace():
+        cursor += 1
+    if cursor == len(expression):
+        return name.group(), None
+    if expression[cursor] != "(":
+        return None
+
+    depth = 0
+    closing = -1
+    for index in range(cursor, len(expression)):
+        if expression[index] == "(":
+            depth += 1
+        elif expression[index] == ")":
+            depth -= 1
+            if depth == 0:
+                closing = index
+                break
+    if closing < 0 or expression[closing + 1 :].strip():
+        return None
+    return name.group(), expression[cursor + 1 : closing]
+
+
+def _split_cfg_arguments(arguments: str) -> tuple[str, ...]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    for index, character in enumerate(arguments):
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+        elif character == "," and depth == 0:
+            parts.append(arguments[start:index].strip())
+            start = index + 1
+    tail = arguments[start:].strip()
+    if tail:
+        parts.append(tail)
+    return tuple(parts)
+
+
+def _cfg_possibilities_without_test(expression: str) -> tuple[bool, bool]:
+    """Return whether a cfg can be true/false when the `test` cfg is false."""
+    call = _call_parts(expression)
+    if call is None:
+        return True, True
+    name, arguments = call
+    if arguments is None:
+        return (False, True) if name == "test" else (True, True)
+
+    children = [
+        _cfg_possibilities_without_test(argument)
+        for argument in _split_cfg_arguments(arguments)
+    ]
+    if name == "all":
+        return all(child[0] for child in children), any(child[1] for child in children)
+    if name == "any":
+        return any(child[0] for child in children), all(child[1] for child in children)
+    if name == "not" and len(children) == 1:
+        can_be_true, can_be_false = children[0]
+        return can_be_false, can_be_true
+    return True, True
+
+
+def _is_test_only_attribute(content: str) -> bool:
+    call = _call_parts(content)
+    if call is None:
+        return False
+    name, arguments = call
+    if name == "test" or name.endswith("::test"):
+        return True
+    if name != "cfg" or arguments is None:
+        return False
+    can_be_true_without_test, _ = _cfg_possibilities_without_test(arguments)
+    return not can_be_true_without_test
+
+
+def _test_only_attributes(masked_source: str) -> tuple[tuple[int, int], ...]:
+    attributes: list[tuple[int, int]] = []
+    cursor = 0
+    while found := ATTRIBUTE_START.search(masked_source, cursor):
+        opening = masked_source.find("[", found.start(), found.end())
+        depth = 1
+        end = opening + 1
+        while end < len(masked_source) and depth:
+            if masked_source[end] == "[":
+                depth += 1
+            elif masked_source[end] == "]":
+                depth -= 1
+            end += 1
+        if depth:
+            break
+        if _is_test_only_attribute(masked_source[opening + 1 : end - 1]):
+            attributes.append((found.start(), end))
+        cursor = end
+    return tuple(attributes)
+
+
+def _test_only_ranges(masked_source: str) -> tuple[tuple[int, int], ...]:
+    ranges: list[tuple[int, int]] = []
+    for attribute_start, attribute_end in _test_only_attributes(masked_source):
+        opening = masked_source.find("{", attribute_end)
+        semicolon = masked_source.find(";", attribute_end)
+        if opening >= 0 and (semicolon < 0 or opening < semicolon):
+            ranges.append((attribute_start, _matching_brace(masked_source, opening)))
+        elif semicolon >= 0:
+            ranges.append((attribute_start, semicolon + 1))
+        else:
+            ranges.append((attribute_start, len(masked_source)))
+    return tuple(ranges)
+
+
+def _inside_ranges(offset: int, ranges: Iterable[tuple[int, int]]) -> bool:
+    return any(start <= offset < end for start, end in ranges)
+
+
+def _normalized_string(literal: _RustString) -> str:
+    if literal.raw:
+        return literal.value
+
+    value = literal.value
+    normalized: list[str] = []
+    index = 0
+    escapes = {"n": "\n", "r": "\r", "t": "\t", "0": "\0", "\\": "\\", '"': '"'}
+    while index < len(value):
+        if value[index] != "\\":
+            normalized.append(value[index])
+            index += 1
+            continue
+
+        if index + 1 >= len(value):
+            normalized.append("\\")
+            break
+        escaped = value[index + 1]
+        if escaped == "\n":
+            index += 2
+            while index < len(value) and value[index] in " \t":
+                index += 1
+            continue
+        if escaped == "\r" and value.startswith("\r\n", index + 1):
+            index += 3
+            while index < len(value) and value[index] in " \t":
+                index += 1
+            continue
+        if escaped == "x" and re.fullmatch(r"[0-9A-Fa-f]{2}", value[index + 2 : index + 4]):
+            normalized.append(chr(int(value[index + 2 : index + 4], 16)))
+            index += 4
+            continue
+        if escaped == "u" and index + 2 < len(value) and value[index + 2] == "{":
+            closing = value.find("}", index + 3)
+            digits = value[index + 3 : closing].replace("_", "") if closing >= 0 else ""
+            if digits and re.fullmatch(r"[0-9A-Fa-f]+", digits):
+                normalized.append(chr(int(digits, 16)))
+                index = closing + 1
+                continue
+        normalized.append(escapes.get(escaped, escaped))
+        index += 2
+    return "".join(normalized)
+
+
+def _included_string_path(
+    source_path: Path, masked_source: str, literal: _RustString
+) -> tuple[int, Path] | None:
+    prefix = masked_source[: literal.start]
+    calls = tuple(INCLUDE_STR_CALL.finditer(prefix))
+    if not calls or prefix[calls[-1].end() :].strip():
+        return None
+    return calls[-1].start(), (
+        source_path.parent / _normalized_string(literal)
+    ).resolve()
+
+
+def _without_sql_comments(value: str) -> str:
+    masked = list(value)
+    index = 0
+    quote: str | None = None
+    while index < len(value):
+        if quote is not None:
+            if value[index] == "\\":
+                index += 2
+                continue
+            if value[index] == quote:
+                if index + 1 < len(value) and value[index + 1] == quote:
+                    index += 2
+                    continue
+                quote = None
+            index += 1
+            continue
+        if value[index] in {"'", '"'}:
+            quote = value[index]
+            index += 1
+            continue
+
+        hash_comment = value[index] == "#" and (
+            index + 1 == len(value)
+            or value[index + 1] == "!"
+            or value[index + 1].isspace()
+        )
+        if value.startswith(("--", "//"), index) or hash_comment:
+            end = value.find("\n", index + 1)
+            if end < 0:
+                end = len(value)
+            _blank(masked, index, end)
+            index = end
+            continue
+        if value.startswith("/*", index):
+            cursor = index + 2
+            depth = 1
+            while cursor < len(value) and depth:
+                if value.startswith("/*", cursor):
+                    depth += 1
+                    cursor += 2
+                elif value.startswith("*/", cursor):
+                    depth -= 1
+                    cursor += 2
+                else:
+                    cursor += 1
+            _blank(masked, index, cursor)
+            index = cursor
+            continue
+        index += 1
+    return "".join(masked)
+
+
+def _append_sql_findings(
+    findings: list[SqlFinding], path: Path, start_line: int, value: str
+) -> None:
+    for match in SQL_STATEMENT.finditer(value):
+        statement = "SELECT" if match.group("select") else "INSERT INTO"
+        line = start_line + value.count("\n", 0, match.start())
+        findings.append(SqlFinding(path, line, statement))
+
+
+def sql_findings(source_root: Path) -> tuple[SqlFinding, ...]:
+    if not source_root.is_dir():
+        raise RuntimeError(f"monitor source root does not exist: {source_root}")
+    findings: list[SqlFinding] = []
+    source_root_resolved = source_root.resolve()
+    for path in sorted(source_root.rglob("*.rs")):
+        relative = path.relative_to(source_root)
+        if relative.stem.lower() in IGNORED_SOURCE_STEMS or any(
+            part.lower() in IGNORED_SOURCE_DIRS for part in relative.parts[:-1]
+        ):
+            continue
+
+        source = path.read_text(encoding="utf-8")
+        masked, strings = _lex_rust(source)
+        test_ranges = _test_only_ranges(masked)
+        resolved_include_calls: set[int] = set()
+        for literal in strings:
+            if _inside_ranges(literal.start, test_ranges):
+                continue
+            included = _included_string_path(path, masked, literal)
+            if included is not None:
+                include_call, included_path = included
+                resolved_include_calls.add(include_call)
+                try:
+                    included_display = included_path.relative_to(source_root_resolved)
+                except ValueError:
+                    included_display = included_path
+                included_source = included_path.read_text(encoding="utf-8")
+                _append_sql_findings(
+                    findings,
+                    included_display,
+                    1,
+                    _without_sql_comments(included_source),
+                )
+                continue
+
+            _append_sql_findings(
+                findings,
+                relative,
+                literal.line,
+                _without_sql_comments(_normalized_string(literal)),
+            )
+        for include_call in INCLUDE_STR_CALL.finditer(masked):
+            if (
+                _inside_ranges(include_call.start(), test_ranges)
+                or include_call.start() in resolved_include_calls
+            ):
+                continue
+            line = source.count("\n", 0, include_call.start()) + 1
+            raise PolicyViolation(
+                f"{EPIC_RULE} violated: cannot verify production include_str! "
+                f"at {relative}:{line}; use a direct string-literal path so the "
+                "included source can be checked for SQL"
+            )
+    return tuple(findings)
+
+
+def assert_monitor_sql_policy(source_root: Path) -> tuple[SqlFinding, ...]:
+    findings = sql_findings(source_root)
+    if findings:
+        finding_lines = "\n".join(
+            f"  - {finding.path}:{finding.line}: {finding.statement} statement literal"
+            for finding in findings
+        )
+        raise PolicyViolation(
+            f"{EPIC_RULE} violated: moraine-monitor-core contains SQL statement "
+            f"literals in non-test source:\n{finding_lines}"
+        )
+    return findings
+
+
+def load_cargo_metadata(workspace_root: Path, cargo_command: str) -> dict[str, Any]:
+    command = shlex.split(cargo_command) + [
+        "metadata",
+        "--format-version",
+        "1",
+        "--no-deps",
+        "--locked",
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=workspace_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise RuntimeError(f"cargo metadata failed ({completed.returncode}): {detail}")
+    return json.loads(completed.stdout)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    default_root = Path(__file__).resolve().parents[2]
+    parser.add_argument("--workspace-root", type=Path, default=default_root)
+    parser.add_argument(
+        "--metadata-json",
+        type=Path,
+        help="read Cargo metadata JSON from a fixture instead of invoking cargo",
+    )
+    parser.add_argument(
+        "--monitor-source",
+        type=Path,
+        help="scan this source root instead of crates/moraine-monitor-core/src",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    workspace_root = args.workspace_root.resolve()
+    monitor_source = (
+        args.monitor_source.resolve()
+        if args.monitor_source
+        else workspace_root / "crates" / "moraine-monitor-core" / "src"
+    )
+
+    try:
+        if args.metadata_json:
+            metadata = json.loads(args.metadata_json.read_text(encoding="utf-8"))
+        else:
+            cargo_command = os.environ.get("MORAINE_CARGO", "cargo")
+            metadata = load_cargo_metadata(workspace_root, cargo_command)
+        dependents = assert_clickhouse_dependency_policy(metadata)
+        assert_monitor_sql_policy(monitor_source)
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
+        print(f"[dependency-policy] FAIL: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "[dependency-policy] direct moraine-clickhouse dependents: "
+        + ", ".join(dependents)
+    )
+    print(
+        "[dependency-policy] moraine-monitor-core non-test Rust sources contain "
+        "no SELECT or INSERT INTO statement literals"
+    )
+    print(f"[dependency-policy] PASS: {EPIC_RULE}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_dependency_policy.py
+++ b/scripts/ci/test_dependency_policy.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import tempfile
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dependency_policy as policy
+
+
+def metadata_fixture(*dependents: str) -> dict[str, object]:
+    package_ids = {name: f"path+file:///{name}#0.0.0" for name in dependents}
+    packages = [
+        {
+            "id": package_id,
+            "name": name,
+            "dependencies": [{"name": policy.CLICKHOUSE_PACKAGE}],
+        }
+        for name, package_id in package_ids.items()
+    ]
+    packages.append(
+        {
+            "id": "path+file:///moraine-clickhouse#0.0.0",
+            "name": policy.CLICKHOUSE_PACKAGE,
+            "dependencies": [],
+        }
+    )
+    return {
+        "workspace_members": [
+            *package_ids.values(),
+            "path+file:///moraine-clickhouse#0.0.0",
+        ],
+        "packages": packages,
+    }
+
+
+class ClickHouseDependencyPolicyTests(unittest.TestCase):
+    def test_exact_allowlist_is_accepted(self) -> None:
+        dependents = policy.assert_clickhouse_dependency_policy(
+            metadata_fixture(*sorted(policy.ALLOWED_DIRECT_DEPENDENTS))
+        )
+        self.assertEqual(dependents, tuple(sorted(policy.ALLOWED_DIRECT_DEPENDENTS)))
+
+    def test_forbidden_direct_edge_is_rejected_with_epic_rule_and_offender(self) -> None:
+        fixture = metadata_fixture(
+            *sorted(policy.ALLOWED_DIRECT_DEPENDENTS), "moraine-mcp-core"
+        )
+        with self.assertRaises(policy.PolicyViolation) as raised:
+            policy.assert_clickhouse_dependency_policy(fixture)
+
+        message = str(raised.exception)
+        self.assertIn("epic #451 Phase 1 dependency rule", message)
+        self.assertIn("moraine-mcp-core", message)
+        self.assertIn("outside the allowlist", message)
+
+
+class MonitorSqlPolicyTests(unittest.TestCase):
+    def test_comments_and_standard_test_sources_are_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source_root = Path(temporary)
+            (source_root / "lib.rs").write_text(
+                """
+// \"SELECT * FROM comments\"
+/* \"INSERT INTO comments VALUES (1)\" */
+const DESCRIPTION: &str = "selectivity is not a SQL statement";
+const NOTES: &str = include_str!("notes.sql");
+#[cfg(test)]
+mod tests {
+    const QUERY: &str = "SELECT * FROM test_rows";
+    const WRITE: &str = r#"INSERT INTO test_rows VALUES (1)"#;
+    const INCLUDED: &str = include_str!("test_query.sql");
+}
+#[test]
+fn top_level_test() {
+    let _ = "SELECT * FROM top_level_test_rows";
+}
+#[tokio::test(flavor = "current_thread")]
+async fn tokio_test() {
+    let _ = "INSERT INTO tokio_test_rows VALUES (1)";
+}
+#[cfg(all(unix, test))]
+mod unix_tests {
+    const QUERY: &str = "SELECT * FROM unix_test_rows";
+}
+""",
+                encoding="utf-8",
+            )
+            fixture_dir = source_root / "fixtures"
+            fixture_dir.mkdir()
+            (fixture_dir / "sql.rs").write_text(
+                'const QUERY: &str = "SELECT * FROM fixture_rows";\n',
+                encoding="utf-8",
+            )
+            (source_root / "tests.rs").write_text(
+                'const QUERY: &str = "SELECT * FROM external_test_rows";\n',
+                encoding="utf-8",
+            )
+            (source_root / "notes.sql").write_text(
+                "-- SELECT * FROM comments\n/* INSERT INTO comments VALUES (1) */\n",
+                encoding="utf-8",
+            )
+            (source_root / "test_query.sql").write_text(
+                "SELECT * FROM external_test_rows\n",
+                encoding="utf-8",
+            )
+
+
+            self.assertEqual(policy.assert_monitor_sql_policy(source_root), ())
+
+    def test_production_select_literal_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source_root = Path(temporary)
+            (source_root / "lib.rs").write_text(
+                'const QUERY: &str = "SELECT * FROM sessions";\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(policy.PolicyViolation) as raised:
+                policy.assert_monitor_sql_policy(source_root)
+            message = str(raised.exception)
+            self.assertIn("lib.rs:1: SELECT statement literal", message)
+            self.assertIn("epic #451 Phase 1 dependency rule", message)
+
+    def test_production_select_token_forms_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source_root = Path(temporary)
+            (source_root / "lib.rs").write_text(
+                'const STAR: &str = "SELECT* FROM sessions";\n'
+                'const PAREN: &str = "SELECT(1)";\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(policy.PolicyViolation):
+                policy.assert_monitor_sql_policy(source_root)
+
+    def test_escaped_production_select_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source_root = Path(temporary)
+            (source_root / "lib.rs").write_text(
+                r'const QUERY: &str = "\x53ELECT * FROM sessions";' + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(policy.PolicyViolation):
+                policy.assert_monitor_sql_policy(source_root)
+
+    def test_cfg_any_test_or_feature_remains_production(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source_root = Path(temporary)
+            (source_root / "lib.rs").write_text(
+                """
+#[cfg(any(test, feature = "debug-sql"))]
+fn query() {
+    let _ = "SELECT * FROM sessions";
+}
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(policy.PolicyViolation):
+                policy.assert_monitor_sql_policy(source_root)
+
+    def test_nested_cfg_that_can_run_without_test_is_scanned(self) -> None:
+        expressions = (
+            "all(unix, not(test))",
+            'all(unix, any(test, feature = "debug-sql"))',
+        )
+        for expression in expressions:
+            with self.subTest(expression=expression):
+                with tempfile.TemporaryDirectory() as temporary:
+                    source_root = Path(temporary)
+                    (source_root / "lib.rs").write_text(
+                        f"""
+#[cfg({expression})]
+fn query() {{
+    let _ = "SELECT * FROM sessions";
+}}
+""",
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaises(policy.PolicyViolation):
+                        policy.assert_monitor_sql_policy(source_root)
+
+    def test_production_include_str_sql_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source_root = Path(temporary)
+            (source_root / "lib.rs").write_text(
+                'const QUERY: &str = include_str!("query.sql");\n',
+                encoding="utf-8",
+            )
+            (source_root / "query.sql").write_text(
+                "-- ignored comment\nSELECT * FROM sessions\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(policy.PolicyViolation) as raised:
+                policy.assert_monitor_sql_policy(source_root)
+            self.assertIn("query.sql:2: SELECT statement literal", str(raised.exception))
+
+    def test_unresolved_production_include_str_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source_root = Path(temporary)
+            (source_root / "lib.rs").write_text(
+                'const QUERY: &str = include_str!(concat!('
+                'env!("CARGO_MANIFEST_DIR"), "/query.sql"));\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(policy.PolicyViolation) as raised:
+                policy.assert_monitor_sql_policy(source_root)
+            self.assertIn("cannot verify production include_str!", str(raised.exception))
+
+    def test_comment_separated_insert_into_is_rejected(self) -> None:
+        queries = (
+            "INSERT/**/INTO sessions VALUES (1)",
+            "INSERT// note\nINTO sessions VALUES (1)",
+            "INSERT#! note\nINTO sessions VALUES (1)",
+            "INSERT# note\nINTO sessions VALUES (1)",
+            "INSERT/* outer /* nested */ outer */INTO sessions VALUES (1)",
+        )
+        for query in queries:
+            with self.subTest(query=query):
+                with tempfile.TemporaryDirectory() as temporary:
+                    source_root = Path(temporary)
+                    (source_root / "lib.rs").write_text(
+                        f'const QUERY: &str = r#"{query}"#;\n',
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaises(policy.PolicyViolation):
+                        policy.assert_monitor_sql_policy(source_root)
+
+    def test_production_insert_into_literal_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            source_root = Path(temporary)
+            (source_root / "writer.rs").write_text(
+                'const QUERY: &str = r#"INSERT INTO sessions VALUES (1)"#;\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(policy.PolicyViolation) as raised:
+                policy.assert_monitor_sql_policy(source_root)
+            self.assertIn(
+                "writer.rs:1: INSERT INTO statement literal", str(raised.exception)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

**What.** Adds a CI-enforced Phase 1 policy for direct `moraine-clickhouse` dependencies and SQL ownership in `moraine-monitor-core`.

**Why.** The read-layer consolidation in epic #451 needs a permanent guard so consumers cannot silently reconstruct ClickHouse clients or move SQL back into monitor-core.

- Uses `cargo metadata --no-deps --locked` to enumerate every direct workspace dependent of `moraine-clickhouse` and reject packages outside `moraine`, `moraine-conversations`, and `moraine-ingest-core`.
- Scans non-test Rust string literals and directly included sources in `moraine-monitor-core` for SELECT and INSERT INTO statements while excluding comments, fixtures, and test-only code.
- Runs deterministic positive and negative fixtures plus the real workspace check from `make dependency-policy`, `make ci-check`, and PR CI.
- Removes `moraine-mcp-core`'s direct ClickHouse dependency by routing repository construction and remote schema validation through `moraine-conversations`, preserving the existing schema-skew failure behavior.

## Usage

Run the focused policy locally:

```bash
make dependency-policy
```

A failure cites the epic #451 dependency rule and lists the offending package or monitor source location.

## Changelog

- Adds a developer and CI guard for the epic #451 Phase 1 storage dependency boundary.
- No end-user MCP or monitor behavior change.

## Validation

`make dependency-policy USE_RUSTUP=0` passed all 12 deterministic fixtures and the real Cargo metadata/source tree check. The real tree reported exactly `moraine`, `moraine-conversations`, and `moraine-ingest-core` as direct dependents. Deliberate fixtures proved that a `moraine-mcp-core` direct edge and production SELECT/INSERT INTO literals fail with an epic #451 message.

`cargo test -p moraine-mcp-core --locked` passed 64 tests, and `cargo test -p moraine-conversations construction_tests --locked` passed the focused construction test. `cargo fmt -p moraine-conversations -p moraine-mcp-core -- --check` and Python byte-compilation passed. `bash scripts/ci/e2e-stack.sh` passed monitor checks and MCP smoke across Codex, Claude, Kimi, Cursor, Cursor SQLite, Pi, Hermes, and project-only routing.

The seven-persona review completed clean after fixes for test-only cfg classification, external test modules, escaped/comment-separated SQL, and included-source coverage.

Resolves #457
Part of #451