### PR TITLE
fix(ingest): restore OMP session visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Moraine ships session trace ingestion adapters for these agent harnesses:
 | [OpenCode](https://opencode.ai/) | `opencode` | SQLite session history from `~/.local/share/opencode/opencode*.db` (default on; `opencode_sqlite` format) |
 | [Cursor](https://cursor.com/docs) | `cursor` | Agent transcript JSONL under `~/.cursor/projects` (default on); Cursor IDE chat history from `state.vscdb` SQLite databases (default on; `cursor_sqlite` format) |
 | [Hermes](https://hermes-agent.nousresearch.com/docs/) | `hermes` | Live session JSON and trajectory JSONL traces |
-| [Pi Coding Agent](https://pi.dev/docs/latest) | `pi-coding-agent` | JSONL session trees under `~/.pi/agent/sessions` |
+| [Pi Coding Agent](https://pi.dev/docs/latest) / OMP | `pi-coding-agent` | JSONL session trees under `~/.pi/agent/sessions` and `~/.omp/agent/sessions` |
 
 ## Quickstart
 

--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -2776,6 +2776,58 @@ mod tests {
     }
 
     #[test]
+    fn ingest_selection_adds_omp_source_to_existing_pi_config() {
+        let mut document = r#"
+[ingest]
+
+[[ingest.sources]]
+name = "pi"
+harness = "pi-coding-agent"
+enabled = true
+glob = "~/.pi/agent/sessions/**/*.jsonl"
+watch_root = "~/.pi/agent/sessions"
+format = "jsonl"
+"#
+        .parse::<DocumentMut>()
+        .expect("existing pi config parses");
+
+        let update = apply_ingest_selections_to_document(
+            &mut document,
+            &[SetupTargetSelection {
+                target: SetupMcpTarget::PiCodingAgent,
+                mode: SetupSelectionMode::IngestOnly,
+            }],
+        )
+        .expect("apply pi ingest selection");
+
+        assert_eq!(
+            update,
+            IngestSelectionUpdate {
+                enabled_sources: 0,
+                disabled_sources: 0,
+                added_sources: 1,
+                updated_sources: 0,
+            }
+        );
+        assert!(source_enabled(&document, "pi"));
+        assert!(source_enabled(&document, "omp"));
+        assert_eq!(
+            source_value(&document, "omp", "glob"),
+            Some("~/.omp/agent/sessions/**/*.jsonl")
+        );
+        assert_eq!(
+            source_value(&document, "omp", "watch_root"),
+            Some("~/.omp/agent/sessions")
+        );
+        assert_eq!(source_value(&document, "omp", "format"), Some("jsonl"));
+
+        let path = temp_path("ingest-adds-omp-to-pi-config");
+        fs::write(&path, document.to_string()).expect("write updated config");
+        moraine_config::load_config(&path).expect("updated config loads");
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
     fn ingest_selection_reconciles_missing_setup_owned_sources() {
         let mut document = r#"
 [ingest]

--- a/apps/moraine/src/commands/setup/harnesses.rs
+++ b/apps/moraine/src/commands/setup/harnesses.rs
@@ -215,13 +215,22 @@ const CURSOR_INGEST: [DefaultIngestSource; 2] = [
     },
 ];
 
-const PI_INGEST: [DefaultIngestSource; 1] = [DefaultIngestSource {
-    name: "pi",
-    harness: "pi-coding-agent",
-    glob: "~/.pi/agent/sessions/**/*.jsonl",
-    watch_root: "~/.pi/agent/sessions",
-    format: Some("jsonl"),
-}];
+const PI_INGEST: [DefaultIngestSource; 2] = [
+    DefaultIngestSource {
+        name: "pi",
+        harness: "pi-coding-agent",
+        glob: "~/.pi/agent/sessions/**/*.jsonl",
+        watch_root: "~/.pi/agent/sessions",
+        format: Some("jsonl"),
+    },
+    DefaultIngestSource {
+        name: "omp",
+        harness: "pi-coding-agent",
+        glob: "~/.omp/agent/sessions/**/*.jsonl",
+        watch_root: "~/.omp/agent/sessions",
+        format: Some("jsonl"),
+    },
+];
 
 const SPECS: [HarnessSpec; 7] = [
     HarnessSpec {

--- a/config/moraine.toml
+++ b/config/moraine.toml
@@ -115,6 +115,16 @@ glob = "~/.pi/agent/sessions/**/*.jsonl"
 watch_root = "~/.pi/agent/sessions"
 format = "jsonl"
 
+# OMP (oh-my-pi) uses the same session schema as Pi but writes to ~/.omp.
+# Keep this source separate so historical ~/.pi sessions remain available.
+[[ingest.sources]]
+name = "omp"
+harness = "pi-coding-agent"
+enabled = true
+glob = "~/.omp/agent/sessions/**/*.jsonl"
+watch_root = "~/.omp/agent/sessions"
+format = "jsonl"
+
 # Hermes Agent LIVE sessions: one JSON file per conversation under
 # ~/.hermes/sessions/ that the agent rewrites in place every turn.
 # `format = "session_json"` opts into the rewrite-aware processor that emits

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -517,6 +517,14 @@ fn default_sources() -> Vec<IngestSource> {
             watch_root: "~/.pi/agent/sessions".to_string(),
             format: String::new(),
         },
+        IngestSource {
+            name: "omp".to_string(),
+            harness: "pi-coding-agent".to_string(),
+            enabled: true,
+            glob: "~/.omp/agent/sessions/**/*.jsonl".to_string(),
+            watch_root: "~/.omp/agent/sessions".to_string(),
+            format: String::new(),
+        },
     ]
 }
 
@@ -1063,7 +1071,47 @@ fn normalize_backends_and_routes(cfg: &mut AppConfig) -> Result<()> {
     Ok(())
 }
 
+fn migrate_legacy_pi_source(sources: &mut Vec<IngestSource>) {
+    if sources.iter().any(|source| source.name.trim() == "omp") {
+        return;
+    }
+
+    let Some(enabled) = sources
+        .iter()
+        .find(|source| {
+            source.name.trim() == "pi"
+                && source.harness.trim() == "pi-coding-agent"
+                && source.glob.trim() == "~/.pi/agent/sessions/**/*.jsonl"
+                && source.watch_root.trim() == "~/.pi/agent/sessions"
+                && (source.format.trim().is_empty()
+                    || source
+                        .format
+                        .trim()
+                        .eq_ignore_ascii_case(SOURCE_FORMAT_JSONL))
+        })
+        .map(|source| source.enabled)
+    else {
+        return;
+    };
+
+    // Configs created before OMP moved its session tree explicitly list only
+    // the setup-owned Pi source, so Serde defaults cannot add the new source.
+    // Migrate that exact legacy source in memory without rewriting user config
+    // or changing customized Pi sources. A distinct source name gives OMP a
+    // fresh checkpoint namespace, causing the first post-upgrade startup to
+    // backfill the full ~/.omp tree.
+    sources.push(IngestSource {
+        name: "omp".to_string(),
+        harness: "pi-coding-agent".to_string(),
+        enabled,
+        glob: "~/.omp/agent/sessions/**/*.jsonl".to_string(),
+        watch_root: "~/.omp/agent/sessions".to_string(),
+        format: String::new(),
+    });
+}
+
 fn normalize_config(mut cfg: AppConfig) -> Result<AppConfig> {
+    migrate_legacy_pi_source(&mut cfg.ingest.sources);
     for (source_idx, source) in cfg.ingest.sources.iter_mut().enumerate() {
         source.harness = normalize_harness(&source.harness, source_idx, &source.name)?;
         source.glob = expand_path(&source.glob);
@@ -1855,6 +1903,39 @@ watch_root = "~/.cursor/projects"
     }
 
     #[test]
+    fn shipped_template_enables_pi_and_omp_sources_by_default() {
+        let path = write_temp_config(
+            include_str!("../../../config/moraine.toml"),
+            "shipped-template-pi-omp",
+        );
+        let cfg = load_config(&path).expect("shipped template must parse");
+        std::fs::remove_file(&path).ok();
+
+        let pi = cfg
+            .ingest
+            .sources
+            .iter()
+            .find(|source| source.name == "pi")
+            .expect("template retains the historical pi source");
+        let omp = cfg
+            .ingest
+            .sources
+            .iter()
+            .find(|source| source.name == "omp")
+            .expect("template ships an omp source");
+
+        for source in [pi, omp] {
+            assert!(source.enabled);
+            assert_eq!(source.harness, "pi-coding-agent");
+            assert_eq!(source.format, SOURCE_FORMAT_JSONL);
+        }
+        assert!(pi.glob.ends_with("/.pi/agent/sessions/**/*.jsonl"));
+        assert!(pi.watch_root.ends_with("/.pi/agent/sessions"));
+        assert!(omp.glob.ends_with("/.omp/agent/sessions/**/*.jsonl"));
+        assert!(omp.watch_root.ends_with("/.omp/agent/sessions"));
+    }
+
+    #[test]
     fn default_sources_enable_cursor_sqlite() {
         let sources = default_sources();
         let source = sources
@@ -1864,6 +1945,80 @@ watch_root = "~/.cursor/projects"
         assert!(source.enabled, "cursor_sqlite is default on");
         assert_eq!(source.format, SOURCE_FORMAT_CURSOR_SQLITE);
         assert!(source.glob.ends_with("/**/state.vscdb"));
+    }
+
+    #[test]
+    fn default_sources_cover_pi_and_omp_session_trees() {
+        let sources = default_sources();
+        let pi = sources
+            .iter()
+            .find(|source| source.name == "pi")
+            .expect("defaults retain the historical pi source");
+        let omp = sources
+            .iter()
+            .find(|source| source.name == "omp")
+            .expect("defaults include an omp source");
+
+        for source in [pi, omp] {
+            assert!(source.enabled);
+            assert_eq!(source.harness, "pi-coding-agent");
+            assert!(source.format.is_empty());
+        }
+        assert_eq!(pi.glob, "~/.pi/agent/sessions/**/*.jsonl");
+        assert_eq!(pi.watch_root, "~/.pi/agent/sessions");
+        assert_eq!(omp.glob, "~/.omp/agent/sessions/**/*.jsonl");
+        assert_eq!(omp.watch_root, "~/.omp/agent/sessions");
+    }
+
+    #[test]
+    fn load_config_migrates_only_the_legacy_default_pi_source() {
+        let legacy_path = write_temp_config(
+            r#"
+[[ingest.sources]]
+name = "pi"
+harness = "pi-coding-agent"
+enabled = true
+glob = "~/.pi/agent/sessions/**/*.jsonl"
+watch_root = "~/.pi/agent/sessions"
+format = "jsonl"
+"#,
+            "legacy-pi-source",
+        );
+        let legacy = load_config(&legacy_path).expect("legacy Pi config should load");
+        std::fs::remove_file(&legacy_path).ok();
+        let omp = legacy
+            .ingest
+            .sources
+            .iter()
+            .find(|source| source.name == "omp")
+            .expect("legacy default Pi config should gain OMP");
+        assert!(omp.enabled);
+        assert_eq!(omp.harness, "pi-coding-agent");
+        assert_eq!(omp.format, SOURCE_FORMAT_JSONL);
+        assert!(omp.glob.ends_with("/.omp/agent/sessions/**/*.jsonl"));
+
+        let custom_path = write_temp_config(
+            r#"
+[[ingest.sources]]
+name = "pi"
+harness = "pi-coding-agent"
+enabled = true
+glob = "~/custom/pi/**/*.jsonl"
+watch_root = "~/custom/pi"
+format = "jsonl"
+"#,
+            "custom-pi-source",
+        );
+        let custom = load_config(&custom_path).expect("custom Pi config should load");
+        std::fs::remove_file(&custom_path).ok();
+        assert!(
+            custom
+                .ingest
+                .sources
+                .iter()
+                .all(|source| source.name != "omp"),
+            "custom Pi sources must not opt into OMP implicitly"
+        );
     }
 
     #[test]

--- a/crates/moraine-ingest-core/src/dispatch.rs
+++ b/crates/moraine-ingest-core/src/dispatch.rs
@@ -376,23 +376,35 @@ fn infer_initial_record_ts_hint(source_file: &str, offset: u64) -> Option<String
         })
 }
 
-/// Best-effort session-level cwd recovered from the head of a file that is
-/// being resumed mid-stream. Harnesses like codex and pi only carry the
-/// working directory on the session header (line 1); after a restart the
-/// resumed tail would otherwise stamp empty `cwd` values and leave backend
-/// route resolution blind to the session's directory. Bounded so the peek
-/// stays cheap on every resumed-file processing pass.
-fn infer_initial_cwd_hint(source_file: &str, harness: &str) -> Option<String> {
+#[derive(Default)]
+struct InitialSourceHints {
+    session_id: String,
+    cwd: String,
+}
+
+/// Best-effort session-level identity recovered from the bounded file head.
+/// Resumed files restart after their session header, while OMP subagent files
+/// use descriptive filenames and begin with a title record before the session
+/// header. Priming both hints prevents resumed rows from losing cwd and leading
+/// OMP rows from creating an empty-ID pseudo-session.
+fn infer_initial_source_hints(source_file: &str, harness: &str) -> InitialSourceHints {
     const MAX_HEAD_LINES: usize = 25;
     const MAX_HEAD_BYTES: u64 = 512 * 1024;
 
-    let source = crate::sources::registry().get(harness)?;
-    let file = std::fs::File::open(source_file).ok()?;
+    let Some(source) = crate::sources::registry().get(harness) else {
+        return InitialSourceHints::default();
+    };
+    let Ok(file) = std::fs::File::open(source_file) else {
+        return InitialSourceHints::default();
+    };
     let mut reader = BufReader::new(file.take(MAX_HEAD_BYTES));
+    let mut hints = InitialSourceHints::default();
 
     for _ in 0..MAX_HEAD_LINES {
         let mut buf = Vec::<u8>::new();
-        let bytes_read = reader.read_until(b'\n', &mut buf).ok()?;
+        let Ok(bytes_read) = reader.read_until(b'\n', &mut buf) else {
+            break;
+        };
         if bytes_read == 0 {
             break;
         }
@@ -401,14 +413,33 @@ fn infer_initial_cwd_hint(source_file: &str, harness: &str) -> Option<String> {
         let Ok(record) = serde_json::from_str::<Value>(text.trim()) else {
             continue;
         };
-        let cwd = source.cwd(&record);
-        let trimmed = cwd.trim();
-        if !trimmed.is_empty() {
-            return Some(trimmed.to_string());
+        if hints.session_id.is_empty() {
+            let top_type = source.top_type(&record);
+            let session_id = source.session_id(
+                &record,
+                &crate::sources::SourceRecordContext {
+                    source_file,
+                    session_hint: "",
+                    top_type: &top_type,
+                    base_uid: "",
+                },
+            );
+            if !session_id.trim().is_empty() {
+                hints.session_id = session_id;
+            }
+        }
+        if hints.cwd.is_empty() {
+            let cwd = source.cwd(&record);
+            if !cwd.trim().is_empty() {
+                hints.cwd = cwd;
+            }
+        }
+        if !hints.session_id.is_empty() && !hints.cwd.is_empty() {
+            break;
         }
     }
 
-    None
+    hints
 }
 
 /// Post-process event rows from a single Claude Code record:
@@ -709,15 +740,14 @@ pub(crate) async fn process_file(
     let mut reader = BufReader::new(file);
     let mut offset = checkpoint.last_offset;
     let mut line_no = checkpoint.last_line_no;
-    let mut session_hint = String::new();
-    let mut model_hint = String::new();
-    // Resuming mid-file restarts the hint chain after the session header,
-    // so recover the session-level cwd from the file head when needed.
-    let mut cwd_hint = if checkpoint.last_offset > 0 {
-        infer_initial_cwd_hint(source_file, &work.harness).unwrap_or_default()
+    let initial_hints = if checkpoint.last_offset > 0 || work.harness == "pi-coding-agent" {
+        infer_initial_source_hints(source_file, &work.harness)
     } else {
-        String::new()
+        InitialSourceHints::default()
     };
+    let mut session_hint = initial_hints.session_id;
+    let mut model_hint = String::new();
+    let mut cwd_hint = initial_hints.cwd;
     let mut record_ts_hint =
         infer_initial_record_ts_hint(source_file, checkpoint.last_offset).unwrap_or_default();
     let mut session_cursors: HashMap<String, SessionCursor> = HashMap::new();
@@ -1916,6 +1946,85 @@ mod tests {
             Some("/repo"),
             "resumed records inherit the session cwd from the file head"
         );
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn process_file_primes_omp_subagent_session_id_before_leading_title() {
+        let path = unique_test_file("omp-named-subagent");
+        let session_id = "019f4be3-7d9d-7005-85e0-d9527b0aad24";
+        fs::write(
+            &path,
+            [
+                json!({
+                    "type": "title",
+                    "v": 1,
+                    "title": "ReviewCorrectness",
+                    "updatedAt": "2026-07-10T11:57:07.869Z"
+                })
+                .to_string(),
+                json!({
+                    "type": "session",
+                    "version": 3,
+                    "id": session_id,
+                    "timestamp": "2026-07-10T11:57:07.869Z",
+                    "cwd": "/work/omp-project"
+                })
+                .to_string(),
+                json!({
+                    "type": "mode_change",
+                    "id": "mode-1",
+                    "parentId": null,
+                    "timestamp": "2026-07-10T11:57:07.870Z",
+                    "mode": "goal"
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        )
+        .expect("write OMP subagent fixture");
+
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "omp".to_string(),
+            harness: "pi-coding-agent".to_string(),
+            format: "jsonl".to_string(),
+            path: source_file,
+        };
+        let config = moraine_config::AppConfig::default();
+        let checkpoints = Arc::new(RwLock::new(HashMap::<String, Checkpoint>::new()));
+        let metrics = Arc::new(Metrics::default());
+        let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(16);
+
+        process_file(
+            &config,
+            &work,
+            checkpoints,
+            &VolatilePollMap::new(),
+            sink_tx,
+            &metrics,
+        )
+        .await
+        .expect("OMP subagent file should process");
+
+        let batches = drain_batches(&mut sink_rx).await;
+        assert_eq!(batches.len(), 1);
+        let batch = &batches[0];
+        assert_eq!(batch.raw_rows.len(), 3);
+        assert_eq!(batch.event_rows.len(), 3);
+        assert!(batch
+            .raw_rows
+            .iter()
+            .all(|row| { row.get("session_id").and_then(Value::as_str) == Some(session_id) }));
+        assert!(batch
+            .event_rows
+            .iter()
+            .all(|row| { row.get("session_id").and_then(Value::as_str) == Some(session_id) }));
+        assert!(batch
+            .raw_rows
+            .iter()
+            .all(|row| { row.get("cwd").and_then(Value::as_str) == Some("/work/omp-project") }));
 
         let _ = fs::remove_file(&path);
     }

--- a/crates/moraine-ingest-core/tests/normalize_unit.rs
+++ b/crates/moraine-ingest-core/tests/normalize_unit.rs
@@ -1424,6 +1424,98 @@ fn pi_session_header_cwd_is_extracted() {
 }
 
 #[test]
+fn current_omp_event_types_normalize_with_pi_adapter() {
+    let cases = [
+        (
+            json!({
+                "type": "custom",
+                "customType": "tool_execution_start",
+                "data": {"toolCallId": "call-1", "toolName": "read"},
+                "id": "custom-1",
+                "parentId": "parent-1",
+                "timestamp": "2026-07-10T02:45:40.169Z"
+            }),
+            "system",
+        ),
+        (
+            json!({
+                "type": "mode_change",
+                "id": "mode-1",
+                "parentId": "custom-1",
+                "timestamp": "2026-07-10T02:45:40.170Z",
+                "mode": "goal",
+                "data": {"goal": {"status": "active"}}
+            }),
+            "unknown",
+        ),
+        (
+            json!({
+                "type": "custom_message",
+                "customType": "irc:incoming",
+                "content": "peer update",
+                "display": true,
+                "id": "custom-message-1",
+                "parentId": "mode-1",
+                "timestamp": "2026-07-10T02:45:40.171Z"
+            }),
+            "message",
+        ),
+        (
+            json!({
+                "type": "mcp_tool_selection",
+                "id": "selection-1",
+                "parentId": "custom-message-1",
+                "timestamp": "2026-07-10T02:45:40.172Z",
+                "selectedToolNames": ["mcp__example"]
+            }),
+            "unknown",
+        ),
+        (
+            json!({
+                "type": "compaction",
+                "id": "compaction-1",
+                "parentId": "selection-1",
+                "timestamp": "2026-07-10T02:45:40.173Z",
+                "summary": "Earlier context",
+                "firstKeptEntryId": "kept-1"
+            }),
+            "summary",
+        ),
+    ];
+
+    for (record, expected_event_kind) in cases {
+        let out = normalize_record(
+            &record,
+            "omp",
+            "pi-coding-agent",
+            "/Users/demo/.omp/agent/sessions/project/2026-07-10T02-43-10-562Z_11111111-2222-4333-8444-555555555555.jsonl",
+            1,
+            1,
+            2,
+            0,
+            "11111111-2222-4333-8444-555555555555",
+            "",
+            "/work/omp-demo",
+        )
+        .expect("OMP record should normalize with the Pi adapter");
+
+        assert_eq!(
+            out.raw_row.get("source_name").and_then(Value::as_str),
+            Some("omp")
+        );
+        assert_eq!(
+            out.raw_row.get("harness").and_then(Value::as_str),
+            Some("pi-coding-agent")
+        );
+        assert_eq!(out.event_rows.len(), 1);
+        assert_eq!(
+            out.event_rows[0].get("event_kind").and_then(Value::as_str),
+            Some(expected_event_kind)
+        );
+    }
+}
+
+#[test]
 fn harnesses_without_cwd_emit_empty_cwd() {
     let kimi = json!({
         "timestamp": 1775953946.2_f64,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -353,7 +353,8 @@ The default template in `config/moraine.toml` includes these source families:
 | OpenCode | `opencode` | `~/.local/share/opencode/opencode*.db` | `~/.local/share/opencode` | `opencode_sqlite` (default on) |
 | Cursor Agent | `cursor` | `~/.cursor/projects/*/agent-transcripts/**/*.jsonl` | `~/.cursor/projects` | inferred `jsonl` |
 | Cursor SQLite history | `cursor` | `~/Library/Application Support/Cursor/User/**/state.vscdb` (macOS) | `~/Library/Application Support/Cursor/User` | `cursor_sqlite` (default on) |
-| Pi Coding Agent | `pi-coding-agent` | `~/.pi/agent/sessions/**/*.jsonl` | `~/.pi/agent/sessions` | `jsonl` |
+| Pi Coding Agent (historical) | `pi-coding-agent` | `~/.pi/agent/sessions/**/*.jsonl` | `~/.pi/agent/sessions` | `jsonl` |
+| OMP (oh-my-pi) | `pi-coding-agent` | `~/.omp/agent/sessions/**/*.jsonl` | `~/.omp/agent/sessions` | `jsonl` |
 | Hermes live sessions | `hermes` | `~/.hermes/sessions/session_*.json` | `~/.hermes/sessions` | `session_json` |
 | Hermes trajectories | `hermes` | user-provided trajectory JSONL | trajectory output directory | `jsonl` |
 
@@ -473,7 +474,7 @@ drift is Moraine's job. When the schema drifts, Moraine reports rate-limited
 until the normalizer is updated to follow the new format. Set `enabled = false`
 if you don't want IDE chat history ingested.
 
-Pi Coding Agent:
+Pi Coding Agent and OMP:
 
 ```toml
 [[ingest.sources]]
@@ -483,7 +484,19 @@ enabled = true
 glob = "~/.pi/agent/sessions/**/*.jsonl"
 watch_root = "~/.pi/agent/sessions"
 format = "jsonl"
+
+[[ingest.sources]]
+name = "omp"
+harness = "pi-coding-agent"
+enabled = true
+glob = "~/.omp/agent/sessions/**/*.jsonl"
+watch_root = "~/.omp/agent/sessions"
+format = "jsonl"
 ```
+
+OMP uses the Pi session schema, so both sources share the `pi-coding-agent`
+adapter. Separate source names preserve historical `~/.pi` checkpoints while
+allowing startup backfill and live watching of current `~/.omp` sessions.
 
 Hermes live sessions:
 

--- a/docs/development/ingest-sources.md
+++ b/docs/development/ingest-sources.md
@@ -21,7 +21,7 @@ all rows that leave the adapter.
 | `opencode` | `sources/opencode.rs` | record-derived | `opencode_sqlite` | OpenCode `opencode*.db`; append-only conversation events synthesized into session, message, part, and session-message records. Credential/account tables are deliberately out of scope. |
 | `cursor` | `sources/cursor.rs` | `cursor` | `jsonl` or `cursor_sqlite` | Cursor Agent transcripts under `agent-transcripts/`; text blocks, tool-use blocks, and local file references. Also normalizes the synthetic `cursor_composer`/`cursor_bubble` records produced by polling `state.vscdb` (see SQLite-Polled Sources below); composer names become `session_meta` events that carry the session title. |
 | `hermes` | `sources/hermes.rs` | record-derived | `jsonl` or `session_json` | ShareGPT trajectories and live Hermes session JSON with vendor/model splitting. |
-| `pi-coding-agent` | `sources/pi.rs` | record-derived | `jsonl` | Pi session JSONL trees, model/thinking metadata, assistant tool calls, tool results, and parent links. |
+| `pi-coding-agent` | `sources/pi.rs` | record-derived | `jsonl` | Pi and OMP session JSONL trees, model/thinking metadata, assistant tool calls, tool results, and parent links. |
 
 ### Kimi parent and sub-agent streams
 

--- a/docs/full-config.toml
+++ b/docs/full-config.toml
@@ -187,6 +187,16 @@ watch_root = "~/.pi/agent/sessions"
 format = "jsonl"
 
 [[ingest.sources]]
+# OMP (oh-my-pi) JSONL session files. OMP uses the Pi session schema but
+# stores current sessions separately; keep the historical Pi source above.
+name = "omp"
+harness = "pi-coding-agent"
+enabled = true
+glob = "~/.omp/agent/sessions/**/*.jsonl"
+watch_root = "~/.omp/agent/sessions"
+format = "jsonl"
+
+[[ingest.sources]]
 # Hermes live session JSON files rewritten in place.
 name = "hermes"
 harness = "hermes"

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -39,7 +39,7 @@ Moraine ships session trace ingestion adapters for these agent harnesses:
 | [Kimi CLI](https://moonshotai.github.io/kimi-cli/en/) | `kimi-cli` | `wire.jsonl` session traces under `~/.kimi/sessions` |
 | [Cursor](https://cursor.com/docs) | `cursor` | Agent transcript JSONL under `~/.cursor/projects` (default on); Cursor IDE chat history from `state.vscdb` SQLite databases (default on; `cursor_sqlite` format) |
 | [Hermes](https://hermes-agent.nousresearch.com/docs/) | `hermes` | Live session JSON and trajectory JSONL traces |
-| [Pi Coding Agent](https://pi.dev/docs/latest) | `pi-coding-agent` | JSONL session trees under `~/.pi/agent/sessions` |
+| [Pi Coding Agent](https://pi.dev/docs/latest) / OMP | `pi-coding-agent` | JSONL session trees under `~/.pi/agent/sessions` and `~/.omp/agent/sessions` |
 
 ## Where To Start
 


### PR DESCRIPTION
## Description

**What.** Adds first-class ingestion coverage for OMP session trees under `~/.omp/agent/sessions` while retaining historical Pi sessions under `~/.pi/agent/sessions`.

**Why.** OMP moved its session data directory, so recent OMP work was absent from session listing, search, file attention, and realtime views.

The change adds a distinct `omp` source that reuses the existing `pi-coding-agent` JSONL adapter. Fresh configs and `moraine setup` receive both sources. Existing configs containing the exact legacy setup-owned Pi source are reconciled in memory on load, preserving their enabled state and giving OMP a fresh checkpoint namespace for first-start backfill; customized Pi paths are left untouched.

OMP named subagent traces can begin with a title record before their session header and do not contain a UUID in the filename. The JSONL dispatcher now primes bounded session and cwd hints from the file head for Pi-family files, preventing those leading records from creating an empty-ID pseudo-session. Current OMP event kinds (`custom`, `mode_change`, `custom_message`, `mcp_tool_selection`, and `compaction`) are covered by focused normalization tests.

## Usage

No manual config change is required for installations that still have Moraine's legacy default Pi source. After upgrading, restart normally:

```bash
moraine up
```

The first startup discovers the migrated `omp` source and backfills existing OMP JSONL files. Customized source configurations can add the documented `[[ingest.sources]]` entry explicitly or rerun `moraine setup`.

## Bug Evidence

Before this change, the shipped/default source list contained only:

```toml
glob = "~/.pi/agent/sessions/**/*.jsonl"
```

A sandbox run using that legacy explicit config now loaded two sources, watched both `~/.pi` and `~/.omp`, and queued the existing OMP fixture on first startup:

```text
loaded 0 checkpoints across 2 sources
startup backfill queueing 0 files for source=pi
startup backfill queueing 1 files for source=omp
```

The named-subagent fixture produced 7 deduplicated OMP events, 0 ingest errors, and 0 events with an empty session ID. `/api/sessions` returned the expected session under harness `pi-coding-agent`.

## Operational Impact

- Adds an enabled watcher and startup backfill source for `~/.omp/agent/sessions`.
- Keeps `~/.pi/agent/sessions` and its checkpoint history unchanged.
- Does not rewrite existing user config files; the exact legacy source is reconciled in memory.
- Reuses the existing Pi adapter and ClickHouse schema; no schema migration or dependency change.

## Changelog

- Restores OMP session visibility in session listing, search, file attention, and realtime views.
- Backfills existing OMP sessions after the first post-upgrade startup.
- Prevents named OMP subagent traces from emitting empty-session records.

## Validation

In the required Linux dev sandbox, `cargo test -p moraine-config -p moraine-ingest-core --locked` passed all affected library suites: 62 config tests and 189 ingest-core unit/integration tests. The Moraine CLI package passed all 131 test executions with `cargo test -p moraine --locked -- --test-threads=1`. The default parallel CLI run exposed the existing `central_socket_live_detects_listener_vs_dead_socket` test race (121 passed, 1 failed); that test passed in isolation in the sandbox and the complete serialized package run passed.

Focused host regressions for legacy config migration, setup reconciliation, current OMP event normalization, named-subagent session priming, and resumed cwd recovery all passed. `cargo fmt --all -- --check` passed. `make docs-build` completed with no issues. The repository pre-commit hook also passed.

Closes #469
