### PR TITLE
feat(monitor): version dashboard HTTP API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ scripts/dev/sandbox/moraine-sandbox shell "$id"
 
 # 3. Validate behavior against the printed monitor URL.
 port=$(scripts/dev/sandbox/moraine-sandbox status "$id" | awk -F: '/^\[sandbox\] monitor/{print $NF}')
-curl -fsS "http://127.0.0.1:${port}/api/health"
+curl -fsS "http://127.0.0.1:${port}/api/v1/health"
 
 # 4. Tear down before reporting task complete. Leftover sandboxes leak
 #    ClickHouse data and consume host ports.

--- a/crates/moraine-conversations/tests/analytics_benchmark.rs
+++ b/crates/moraine-conversations/tests/analytics_benchmark.rs
@@ -113,9 +113,9 @@ impl BenchmarkContext {
             .build()
             .context("failed to construct monitor HTTP client")?;
         let monitor_analytics_url =
-            monitor_endpoint(&config.monitor_url, "/api/analytics?range=24h")?;
+            monitor_endpoint(&config.monitor_url, "/api/v1/analytics?range=24h")?;
         let monitor_sessions_url =
-            monitor_endpoint(&config.monitor_url, "/api/sessions?since=30d&limit=50")?;
+            monitor_endpoint(&config.monitor_url, "/api/v1/sessions?since=30d&limit=50")?;
         let clickhouse = ClickHouseClient::new(config.clickhouse_config())
             .context("failed to construct ClickHouse client")?;
 

--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -112,16 +112,26 @@ fn router_with_repository(
 }
 
 fn monitor_router(state: Arc<AppState>) -> Router {
+    let versioned_routes = dashboard_routes().route("/capabilities", get(api_capabilities));
+
     Router::new()
-        .route("/api/health", get(api_health))
-        .route("/api/status", get(api_status))
-        .route("/api/analytics", get(api_analytics))
-        .route("/api/tables", get(api_tables))
-        .route("/api/web-searches", get(api_web_searches))
-        .route("/api/tables/:table", get(api_table_rows))
-        .route("/api/sessions", get(api_sessions))
+        .nest("/api/v1", versioned_routes)
+        // One-release compatibility surface. These are direct aliases so
+        // status codes, query handling, and response payloads remain identical.
+        .nest("/api", dashboard_routes())
         .fallback(get(static_fallback))
         .with_state(state)
+}
+
+fn dashboard_routes() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/health", get(api_health))
+        .route("/status", get(api_status))
+        .route("/analytics", get(api_analytics))
+        .route("/tables", get(api_tables))
+        .route("/web-searches", get(api_web_searches))
+        .route("/tables/:table", get(api_table_rows))
+        .route("/sessions", get(api_sessions))
 }
 
 const MONITOR_DIST_ENV_KEYS: &[&str] = &["MORAINE_MONITOR_DIST", "MORAINE_MONITOR_STATIC_DIR"];
@@ -212,6 +222,29 @@ fn json_response<T: Serialize>(payload: T, status: StatusCode) -> Response {
     let mut response = Json(payload).into_response();
     *response.status_mut() = status;
     response
+}
+async fn api_capabilities(State(state): State<Arc<AppState>>) -> Response {
+    let schema_migration_level = state
+        .repository
+        .read_store_diagnostics()
+        .await
+        .ok()
+        .and_then(|diagnostics| diagnostics.applied_schema_versions.into_iter().max());
+
+    json_response(
+        json!({
+            "ok": true,
+            "server_version": env!("CARGO_PKG_VERSION"),
+            "schema_migration_level": schema_migration_level,
+            "features": {
+                "analytics": true,
+                "sessions": true,
+                "table_inspection": true,
+                "web_searches": true,
+            },
+        }),
+        StatusCode::OK,
+    )
 }
 
 async fn api_health(State(state): State<Arc<AppState>>) -> Response {
@@ -987,7 +1020,8 @@ mod tests {
     use moraine_conversations::{
         AnalyticsConcurrencyPoint, AnalyticsSnapshot, AnalyticsTokenPoint, AnalyticsTurnPoint,
         AnalyticsWindow, ConversationMode, ConversationSummary, InMemoryConversationRepository,
-        InMemoryConversationResponses, IngestHeartbeat, RepoConfig, SessionStep, TableColumn,
+        InMemoryConversationResponses, IngestHeartbeat, RepoConfig, SessionStep, StoreDiagnostics,
+        TableColumn,
         TablePreview, TableSummary, ToolResult, TurnSummary, WebSearchEvent,
     };
     use std::collections::BTreeMap;
@@ -1026,6 +1060,21 @@ mod tests {
             .await
             .expect("body bytes");
         serde_json::from_slice(&body).expect("response json")
+    }
+
+    async fn router_json(app: &Router, uri: &str) -> (StatusCode, Value) {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .body(Body::empty())
+                    .expect("API request"),
+            )
+            .await
+            .expect("API response");
+        let status = response.status();
+        (status, response_json(response).await)
     }
 
     fn sample_health() -> StoreHealth {
@@ -1212,6 +1261,89 @@ mod tests {
             read_store_health: Some(Ok(sample_health())),
             ..Default::default()
         }
+    }
+
+    #[tokio::test]
+    async fn capabilities_report_runtime_schema_and_feature_facts() {
+        let (state, repository) = fake_state(InMemoryConversationResponses {
+            read_store_diagnostics: Some(Ok(StoreDiagnostics {
+                applied_schema_versions: vec![
+                    "003".to_string(),
+                    "025".to_string(),
+                    "017".to_string(),
+                ],
+                ..Default::default()
+            })),
+            ..Default::default()
+        });
+
+        let response = api_capabilities(State(state)).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response_json(response).await,
+            json!({
+                "ok": true,
+                "server_version": env!("CARGO_PKG_VERSION"),
+                "schema_migration_level": "025",
+                "features": {
+                    "analytics": true,
+                    "sessions": true,
+                    "table_inspection": true,
+                    "web_searches": true,
+                },
+            })
+        );
+        assert_eq!(repository.calls().read_store_diagnostics, 1);
+    }
+
+    #[tokio::test]
+    async fn capabilities_keep_schema_level_null_when_diagnostics_are_unavailable() {
+        for response in [
+            Ok(StoreDiagnostics::default()),
+            Err(RepoError::backend("migration ledger unavailable")),
+        ] {
+            let (state, repository) = fake_state(InMemoryConversationResponses {
+                read_store_diagnostics: Some(response),
+                ..Default::default()
+            });
+
+            let response = api_capabilities(State(state)).await;
+            assert_eq!(response.status(), StatusCode::OK);
+            let payload = response_json(response).await;
+            assert_eq!(payload["ok"], json!(true));
+            assert_eq!(payload["schema_migration_level"], Value::Null);
+            assert_eq!(repository.calls().read_store_diagnostics, 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn versioned_route_errors_keep_existing_status_and_envelope() {
+        let (state, _) = fake_state(InMemoryConversationResponses {
+            analytics_series: Some(Err(RepoError::backend("analytics unavailable"))),
+            ..Default::default()
+        });
+        let app = monitor_router(state);
+
+        let canonical = router_json(&app, "/api/v1/analytics?range=24h").await;
+        let legacy = router_json(&app, "/api/analytics?range=24h").await;
+        assert_eq!(canonical, legacy);
+        assert_eq!(canonical.0, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(canonical.1["ok"], json!(false));
+        assert_eq!(
+            canonical.1["error"],
+            json!("analytics query failed: backend error: analytics unavailable")
+        );
+
+        let malformed = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/sessions?limit=not-a-number")
+                    .body(Body::empty())
+                    .expect("malformed query request"),
+            )
+            .await
+            .expect("malformed query response");
+        assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]
@@ -1461,19 +1593,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn injected_router_preserves_routes_repository_and_static_bytes() {
+    async fn versioned_routes_alias_legacy_payloads_and_preserve_static_assets() {
         const INDEX_BYTES: &[u8] = b"<!doctype html><title>shared-backend</title>\n";
-        let root = temp_path("injected-router");
+        let root = temp_path("versioned-router");
         fs::create_dir_all(&root).expect("create static root");
         fs::write(root.join("index.html"), INDEX_BYTES).expect("write index");
 
+        let mut responses = successful_responses();
+        responses.latest_ingest_heartbeat = Some(Ok(IngestHeartbeatRead {
+            table_present: true,
+            latest: None,
+        }));
+        responses.read_store_diagnostics = Some(Ok(StoreDiagnostics {
+            applied_schema_versions: vec!["001".to_string(), "025".to_string()],
+            ..Default::default()
+        }));
         let repository = Arc::new(InMemoryConversationRepository::with_responses(
             RepoConfig::default(),
-            InMemoryConversationResponses {
-                read_store_health: Some(Ok(sample_health())),
-                latest_ingest_heartbeat: Some(Ok(sample_heartbeat())),
-                ..Default::default()
-            },
+            responses,
         ));
         let injected: Arc<dyn ConversationRepository> = repository.clone();
         let app = router_with_repository(&AppConfig::default(), injected, root.clone())
@@ -1499,21 +1636,88 @@ mod tests {
             .expect("static body");
         assert_eq!(&static_body[..], INDEX_BYTES);
 
-        let health_response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/api/health")
-                    .body(Body::empty())
-                    .expect("health request"),
-            )
-            .await
-            .expect("health response");
-        assert_eq!(health_response.status(), StatusCode::OK);
-        let health = response_json(health_response).await;
-        assert_eq!(health["ok"], json!(true));
+        let route_matrix = [
+            ("/api/v1/health", "/api/health"),
+            ("/api/v1/status", "/api/status"),
+            ("/api/v1/analytics?range=7d", "/api/analytics?range=7d"),
+            ("/api/v1/tables", "/api/tables"),
+            (
+                "/api/v1/web-searches?limit=1000",
+                "/api/web-searches?limit=1000",
+            ),
+            (
+                "/api/v1/tables/events?limit=500",
+                "/api/tables/events?limit=500",
+            ),
+            (
+                "/api/v1/sessions?since=30d&limit=1",
+                "/api/sessions?since=30d&limit=1",
+            ),
+        ];
+        for (canonical_path, legacy_path) in route_matrix {
+            let canonical = router_json(&app, canonical_path).await;
+            let legacy = router_json(&app, legacy_path).await;
+            assert_eq!(
+                canonical, legacy,
+                "{legacy_path} must directly alias {canonical_path}"
+            );
+            assert_eq!(canonical.0, StatusCode::OK);
+        }
+
+        let (status, capabilities) = router_json(&app, "/api/v1/capabilities").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(capabilities["server_version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(capabilities["schema_migration_level"], json!("025"));
+        assert_eq!(
+            capabilities["features"],
+            json!({
+                "analytics": true,
+                "sessions": true,
+                "table_inspection": true,
+                "web_searches": true,
+            })
+        );
+
+        let (status, missing) = router_json(&app, "/api/v1/not-a-route").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(missing, json!({"ok": false, "error": "not found"}));
+
         let calls = repository.calls();
-        assert_eq!(calls.read_store_health, 1);
-        assert_eq!(calls.latest_ingest_heartbeat, 1);
+        assert_eq!(calls.read_store_health, 4);
+        assert_eq!(calls.read_store_diagnostics, 1);
+        assert_eq!(calls.latest_ingest_heartbeat, 4);
+        assert_eq!(calls.list_table_summaries, 4);
+        assert_eq!(calls.list_web_searches, vec![1_000, 1_000]);
+        assert_eq!(
+            calls.analytics_series,
+            vec![AnalyticsRange::SevenDays, AnalyticsRange::SevenDays]
+        );
+        assert_eq!(
+            calls.list_session_analytics,
+            vec![
+                SessionAnalyticsQuery {
+                    lookback: SessionLookback::ThirtyDays,
+                    limit: 1,
+                },
+                SessionAnalyticsQuery {
+                    lookback: SessionLookback::ThirtyDays,
+                    limit: 1,
+                },
+            ]
+        );
+        assert_eq!(
+            calls.preview_table,
+            vec![
+                TablePreviewQuery {
+                    table: "events".to_string(),
+                    limit: 500,
+                },
+                TablePreviewQuery {
+                    table: "events".to_string(),
+                    limit: 500,
+                },
+            ]
+        );
 
         let _ = fs::remove_dir_all(root);
     }

--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -1021,8 +1021,7 @@ mod tests {
         AnalyticsConcurrencyPoint, AnalyticsSnapshot, AnalyticsTokenPoint, AnalyticsTurnPoint,
         AnalyticsWindow, ConversationMode, ConversationSummary, InMemoryConversationRepository,
         InMemoryConversationResponses, IngestHeartbeat, RepoConfig, SessionStep, StoreDiagnostics,
-        TableColumn,
-        TablePreview, TableSummary, ToolResult, TurnSummary, WebSearchEvent,
+        TableColumn, TablePreview, TableSummary, ToolResult, TurnSummary, WebSearchEvent,
     };
     use std::collections::BTreeMap;
     use std::fs;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,7 +224,7 @@ only affects traces that carry no working directory at all.
 Per-backend mirror status — `connecting`, `ok`, `lagging`, `unreachable`,
 `disabled_skew`, or `disabled_missing_identity_author` — is written to ingest
 heartbeats as a `backend_sinks` map and surfaced through the monitor's
-`/api/health`. This uses a column added by migration 017; until
+`/api/v1/health`. This uses a column added by migration 017; until
 `moraine db migrate` runs (and ingest restarts), ingest warns and omits the
 field rather than failing heartbeats. `disabled_missing_identity_author` means
 `[identity].author` is empty; set it and restart ingest before mirroring to
@@ -244,7 +244,7 @@ build — a strictly read-only probe — and enforces:
 | Server ahead (server-applied migrations unknown to this build) | Mirror disabled unless that backend sets `allow_newer_server = true`. Upgrade Moraine, or opt in. |
 
 For ingest mirroring, a skew failure disables that one mirror until the
-ingest service restarts and shows as `disabled_skew` in `/api/health`; the
+ingest service restarts and shows as `disabled_skew` in `/api/v1/health`; the
 default backend is unaffected. A backend that simply does not answer retries
 the handshake periodically and shows as `unreachable`. The same handshake
 also runs when `moraine run mcp` starts in a routed directory, where it

--- a/docs/monitor-http-api.md
+++ b/docs/monitor-http-api.md
@@ -1,0 +1,213 @@
+# Monitor HTTP API v1
+
+Moraine exposes a read-only HTTP API for the monitor dashboard and other local
+monitor clients. The canonical base path is `/api/v1`. API versioning applies to
+the HTTP surface only; it does not change the MCP transport or MCP tool schemas.
+
+The examples below use relative paths because the bundled dashboard calls the
+API on the same origin that served the dashboard.
+
+## Route Matrix
+
+All canonical routes are `GET` routes and successful responses use JSON.
+
+| Route | Query | Purpose |
+| --- | --- | --- |
+| `/api/v1/capabilities` | none | Describe this server build, its observed schema migration level, and available HTTP feature groups. |
+| `/api/v1/health` | none | Probe ClickHouse health and report a compact ingest heartbeat summary. |
+| `/api/v1/status` | none | Return the diagnostic ClickHouse, database, table, connection, and ingestor snapshot used by the status dashboard. |
+| `/api/v1/analytics` | `range` | Return token, turn, and concurrent-session time series for a supported window. |
+| `/api/v1/tables` | none | List tables with engine, temporary-table marker, and estimated row count. |
+| `/api/v1/tables/:table` | `limit` | Return the named table's schema and a bounded row preview. `:table` is a path parameter. |
+| `/api/v1/web-searches` | `limit` | Return a bounded list of normalized web-search activity. |
+| `/api/v1/sessions` | `since`, `limit` | Return bounded session analytics, including the turns and steps used by the dashboard. |
+
+There is no session-detail backend route. In particular,
+`/api/v1/sessions/:id` is not part of the API. A client that needs a session
+must use the records returned by `/api/v1/sessions`; it must not infer a detail
+route from the collection URL.
+
+## Capabilities Contract
+
+`GET /api/v1/capabilities` returns HTTP `200` with this contract:
+
+```json
+{
+  "ok": true,
+  "server_version": "0.0.0",
+  "schema_migration_level": "017",
+  "features": {
+    "analytics": true,
+    "sessions": true,
+    "table_inspection": true,
+    "web_searches": true
+  }
+}
+```
+
+The example version values are illustrative. Field semantics are:
+
+- `ok` is always `true` for a successfully generated capabilities document.
+- `server_version` is the version of the running Moraine server build. It is
+  not the ClickHouse version.
+- `schema_migration_level` is the latest applied Moraine migration identifier
+  the server can observe. Migration identifiers are opaque strings; clients
+  must not parse them as integers. It is `null` when no applied migration level
+  is available, including when the database or migration ledger is absent or
+  cannot be read. That `null` is capability metadata, not by itself an HTTP
+  error.
+- `features.analytics` means the analytics collection route is implemented.
+- `features.sessions` means session collection is implemented. It does not
+  advertise a session-detail route.
+- `features.table_inspection` means table listing and bounded table preview are
+  implemented.
+- `features.web_searches` means the normalized web-search collection is
+  implemented.
+
+Feature values advertise route support, not backend health or the presence of
+rows. A feature can be `true` while a particular read returns an empty result
+or a backend error.
+
+The `features` object is additive. Clients must test the keys they understand
+and ignore unrecognized feature keys. Adding another feature key does not, on
+its own, require a new API version. The top-level fields and the four feature
+keys shown above are the required v1 contract.
+
+## Query Parameters and Bounds
+
+Limits are parsed as unsigned decimal integers and then clamped. A value below
+the lower bound, including `0`, becomes the lower bound; a value above the
+upper bound becomes the upper bound. A value that cannot be parsed as an
+unsigned integer is a malformed query and returns HTTP `400`.
+
+| Route | Parameter | Default | Accepted or effective values |
+| --- | --- | --- | --- |
+| `/api/v1/analytics` | `range` | `24h` | `15m`, `1h`, `6h`, `24h`, `7d`, or `30d` |
+| `/api/v1/sessions` | `since` | `30d` | `1h`, `6h`, `24h`, `7d`, `30d`, `90d`, or `all` |
+| `/api/v1/sessions` | `limit` | `50` | clamped to `1..=200` |
+| `/api/v1/web-searches` | `limit` | `100` | clamped to `1..=1000` |
+| `/api/v1/tables/:table` | `limit` | `25` | clamped to `1..=500` |
+
+An unknown `range` does not produce an error; it resolves to `24h`. An unknown
+`since` similarly resolves to `30d`. Responses report or embody the resolved
+window, so clients should treat the supported values above as the request
+contract rather than relying on fallback behavior.
+
+The table path parameter must match the strict ASCII identifier pattern
+`[A-Za-z_][A-Za-z0-9_]*`. A rejected identifier returns HTTP `400`. A
+syntactically valid name that cannot be read from the configured database is a
+backend read failure, not a `404` resource response.
+
+## Successful Empty and Nullable Values
+
+Collection routes use empty arrays when a successful query has no matching
+rows. They do not use `null` to mean an empty collection.
+
+`null` marks unavailable or unobserved optional diagnostics:
+
+- `capabilities.schema_migration_level` is `null` under the conditions described
+  in the capabilities contract.
+- `/api/v1/status` can return HTTP `200` and `ok: true` while
+  `clickhouse.healthy` is `false`. In that diagnostic response, unavailable
+  `clickhouse.version` or `clickhouse.ping_ms` values are `null` and
+  `clickhouse.error` explains the probe result. If the database does not exist,
+  its table list is empty.
+- Health and status connection diagnostics use `connections.total: null` with
+  a sibling `connections.error` when connection metrics are unavailable. A
+  connection-metrics error alone does not make an otherwise successful health
+  probe fail.
+- When no ingest heartbeat is available, `ingestor.present` and
+  `ingestor.alive` are `false`, while `ingestor.latest` and
+  `ingestor.age_seconds` are `null`.
+
+Clients must distinguish a diagnostic value inside an HTTP `200` response from
+an endpoint failure represented by a non-2xx status.
+
+## Errors and Status Codes
+
+API handlers use JSON errors with at least this envelope:
+
+```json
+{
+  "ok": false,
+  "error": "human-readable message"
+}
+```
+
+An endpoint can add diagnostic fields to that minimum envelope. For example, a
+health failure also reports its configured database information and connection
+diagnostics. Error message text is for operators and can include backend
+details; clients should branch on the HTTP status and `ok`, not match arbitrary
+message text.
+
+| Status | Meaning |
+| --- | --- |
+| `200 OK` | The request completed. Inspect diagnostic fields such as `clickhouse.healthy`; `200` does not mean every component is healthy. |
+| `400 Bad Request` | The query could not be deserialized, or a table identifier was rejected. A rejected table identifier uses `{"ok":false,"error":"invalid table name"}`. Framework-generated malformed-query responses are not guaranteed to use the application JSON envelope. |
+| `403 Forbidden` | Static-file path traversal or a path that resolves outside the configured static root. The JSON error is `{"ok":false,"error":"forbidden"}`. |
+| `404 Not Found` | No requested static file exists. The JSON error is `{"ok":false,"error":"not found"}`. |
+| `405 Method Not Allowed` | The path exists but does not support the requested HTTP method. A JSON error envelope is not guaranteed. |
+| `500 Internal Server Error` | The static root cannot be resolved or a selected static file cannot be read. |
+| `503 Service Unavailable` | A required repository or ClickHouse read failed. Handler-generated responses use the JSON error envelope. |
+
+`/api/v1/health` returns `503` when the required store-health read, ping, or
+version probe fails. Most collection read failures also return `503`.
+`/api/v1/status` is deliberately diagnostic: it can describe a missing or
+unhealthy database with `200`; it returns `503` when a required table-summary
+read fails after the database was observed to exist.
+
+## One-Release Legacy Aliases
+
+The previous `/api/*` dashboard routes remain as direct aliases for one release:
+
+| Canonical route | Temporary legacy alias |
+| --- | --- |
+| `/api/v1/health` | `/api/health` |
+| `/api/v1/status` | `/api/status` |
+| `/api/v1/analytics` | `/api/analytics` |
+| `/api/v1/tables` | `/api/tables` |
+| `/api/v1/tables/:table` | `/api/tables/:table` |
+| `/api/v1/web-searches` | `/api/web-searches` |
+| `/api/v1/sessions` | `/api/sessions` |
+
+A direct alias invokes the same handler, with the same query handling, response
+payload, and status code. It is not an HTTP redirect and does not return a
+`Location` header. New clients must use `/api/v1`; the aliases are temporary
+migration support and are removed after their one-release compatibility window.
+
+`/api/v1/capabilities` is new and has no `/api/capabilities` alias.
+
+## Static Assets
+
+API routes take precedence over static-file handling. Every other `GET` request
+is resolved under the configured monitor static directory:
+
+- `/` serves `index.html`.
+- A path naming a directory serves that directory's `index.html`.
+- A path naming a file serves that file with a MIME type inferred from its
+  extension.
+- Missing paths return the JSON `404` described above. There is no implicit
+  single-page-app rewrite of an unknown path back to the root `index.html`.
+- Paths containing `..`, and paths whose canonical location escapes the static
+  root, return the JSON `403` described above.
+
+The server validates at startup that the selected static path is a directory
+and contains `index.html`. `--static-dir` selects custom built assets; without
+an explicit override, packaged assets or the source-tree `web/monitor/dist`
+build are used according to the server's static-directory resolution rules.
+
+Because unmatched paths enter static-file handling, an unknown path under
+`/api/v1` is not evidence that an API resource exists. In particular, clients
+must not probe an inferred `/api/v1/sessions/:id` path.
+
+## MCP Protocol Is Unchanged
+
+The versioned HTTP API does not replace or tunnel MCP. Agent harnesses still
+launch `moraine run mcp` over stdio, and its existing local central-server proxy
+continues to use the configured Unix socket and existing socket protocol. MCP
+tool names, request/response schemas, and fallback behavior are unchanged by
+this HTTP API version.
+
+There are no MCP tool endpoints under `/api/v1`, and HTTP clients cannot select
+a named backend through this API. This API version also does not introduce HTTP
+authentication or a remote-deployment contract.

--- a/moraine-monitor/README.md
+++ b/moraine-monitor/README.md
@@ -48,11 +48,21 @@ Serve custom assets by passing `--static-dir` if needed.
 
 ## API endpoints
 
-- `GET /api/health` – ClickHouse ping/version
-- `GET /api/status` – database and ingestor status summary
-- `GET /api/analytics?range=24h` – model analytics (token usage and turns by time bucket)
-- `GET /api/tables` – table list and estimated row counts
-- `GET /api/tables/:name?limit=25` – schema and sample rows
+The canonical dashboard API is versioned under `/api/v1`:
+
+- `GET /api/v1/capabilities` – server version, applied schema migration level, and feature flags
+- `GET /api/v1/health` – ClickHouse ping/version
+- `GET /api/v1/status` – database and ingestor status summary
+- `GET /api/v1/analytics?range=24h` – model analytics (token usage and turns by time bucket)
+- `GET /api/v1/tables` – table list and estimated row counts
+- `GET /api/v1/tables/:name?limit=25` – schema and sample rows
+- `GET /api/v1/web-searches?limit=100` – normalized web-search activity
+- `GET /api/v1/sessions?since=30d&limit=50` – session analytics
+
+The former `/api/*` dashboard paths remain direct aliases for one release.
+New clients must use `/api/v1`. See
+[`docs/monitor-http-api.md`](../docs/monitor-http-api.md) for the complete
+contract, query bounds, compatibility matrix, and error behavior.
 
 Supported analytics ranges:
 

--- a/plugins/moraine-dev/skills/moraine-sandbox-qa/SKILL.md
+++ b/plugins/moraine-dev/skills/moraine-sandbox-qa/SKILL.md
@@ -56,7 +56,7 @@ Check the monitor health endpoint using the sandbox-reported port:
 
 ```bash
 port=$(scripts/dev/sandbox/moraine-sandbox status "$id" | awk -F: '/^\[sandbox\] monitor/{print $NF}')
-curl -fsS "http://127.0.0.1:${port}/api/health"
+curl -fsS "http://127.0.0.1:${port}/api/v1/health"
 ```
 
 For MCP tool surface changes or release-level confidence, consider `scripts/dev/sandbox/agent-smoke-e2e --help`. It requires `ANTHROPIC_API_KEY`.

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -98,6 +98,57 @@ json_ok_true() {
   "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sys.exit(0 if data.get("ok") is True else 1)'
 }
 
+assert_monitor_api_alias() {
+  local python_bin="$1"
+  local base_url="$2"
+  local tmp_root="$3"
+  local canonical_path="$4"
+  local legacy_path="$5"
+  local canonical_body_file
+  local legacy_body_file
+  canonical_body_file="$(mktemp "$tmp_root/canonical-api.XXXXXX")"
+  legacy_body_file="$(mktemp "$tmp_root/legacy-api.XXXXXX")"
+
+  local canonical_status
+  local legacy_status
+  # Deliberately omit --location: compatibility aliases must respond directly,
+  # not pass by redirecting curl to the canonical route.
+  if ! canonical_status="$(curl -sS --max-time 30 -o "$canonical_body_file" -w '%{http_code}' -- "${base_url}${canonical_path}")"; then
+    echo "[e2e] canonical monitor request failed: ${canonical_path}" >&2
+    rm -f "$canonical_body_file" "$legacy_body_file"
+    return 1
+  fi
+  if ! legacy_status="$(curl -sS --max-time 30 -o "$legacy_body_file" -w '%{http_code}' -- "${base_url}${legacy_path}")"; then
+    echo "[e2e] legacy monitor request failed: ${legacy_path}" >&2
+    rm -f "$canonical_body_file" "$legacy_body_file"
+    return 1
+  fi
+
+  if [[ "$canonical_status" != "$legacy_status" ]]; then
+    echo "[e2e] monitor alias status mismatch: ${legacy_path} (${legacy_status}) != ${canonical_path} (${canonical_status})" >&2
+    rm -f "$canonical_body_file" "$legacy_body_file"
+    return 1
+  fi
+
+  if [[ "$canonical_status" != "200" ]]; then
+    echo "[e2e] monitor alias returned unexpected status: ${canonical_path} (${canonical_status})" >&2
+    rm -f "$canonical_body_file" "$legacy_body_file"
+    return 1
+  fi
+  if ! json_ok_true "$python_bin" <"$canonical_body_file"; then
+    echo "[e2e] canonical monitor response is not successful JSON: ${canonical_path}" >&2
+    rm -f "$canonical_body_file" "$legacy_body_file"
+    return 1
+  fi
+  if ! json_ok_true "$python_bin" <"$legacy_body_file"; then
+    echo "[e2e] legacy monitor response is not successful JSON: ${legacy_path}" >&2
+    rm -f "$canonical_body_file" "$legacy_body_file"
+    return 1
+  fi
+
+  rm -f "$canonical_body_file" "$legacy_body_file"
+}
+
 wait_for_endpoint_ok() {
   local python_bin="$1"
   local url="$2"
@@ -986,7 +1037,7 @@ EOF
   local expected_ingest_ua="moraine-ingest/${moraine_version} (pid=${ingest_pid})"
 
   echo "[e2e] waiting for monitor health"
-  wait_for_endpoint_ok "$python_bin" "http://127.0.0.1:${monitor_port}/api/health" 120
+  wait_for_endpoint_ok "$python_bin" "http://127.0.0.1:${monitor_port}/api/v1/health" 120
 
   echo "[e2e] checking unified backend HTML + referenced static asset"
   assert_frontend_asset_served "$python_bin" "http://127.0.0.1:${monitor_port}" "$tmp_root"
@@ -1145,14 +1196,86 @@ PY
     return 1
   fi
 
-  echo "[e2e] checking monitor API routes"
-  for path in /api/health /api/status /api/analytics /api/web-searches /api/sessions; do
+  echo "[e2e] checking canonical monitor API routes"
+  local path
+  for path in \
+    "/api/v1/health" \
+    "/api/v1/status" \
+    "/api/v1/analytics?range=24h" \
+    "/api/v1/tables" \
+    "/api/v1/web-searches?limit=25" \
+    "/api/v1/tables/v_conversation_trace?limit=500" \
+    "/api/v1/sessions?since=all&limit=200"; do
     local body
     body="$(curl -fsS "http://127.0.0.1:${monitor_port}${path}")"
     printf '%s' "$body" | json_ok_true "$python_bin"
   done
+
+  echo "[e2e] checking monitor API capabilities"
+  local applied_schema_level
+  applied_schema_level="$(clickhouse_scalar "$clickhouse_url" "SELECT max(version) FROM ${clickhouse_database}.schema_migrations")"
+  local expected_server_version
+  expected_server_version="$("$moraine_bin" --version)"
+  expected_server_version="${expected_server_version##* }"
+  local capabilities_body
+  capabilities_body="$(curl -fsS "http://127.0.0.1:${monitor_port}/api/v1/capabilities")"
+  printf '%s' "$capabilities_body" | "$python_bin" -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+expected_server_version, expected_schema_level = sys.argv[1:]
+expected_features = {
+    "analytics": True,
+    "sessions": True,
+    "table_inspection": True,
+    "web_searches": True,
+}
+valid = (
+    isinstance(data, dict)
+    and set(data) == {
+        "ok",
+        "server_version",
+        "schema_migration_level",
+        "features",
+    }
+    and data.get("ok") is True
+    and data.get("server_version") == expected_server_version
+    and data.get("schema_migration_level") == expected_schema_level
+    and data.get("features") == expected_features
+)
+if not valid:
+    print(
+        "unexpected monitor capabilities payload: "
+        f"expected server_version={expected_server_version!r}, "
+        f"schema_migration_level={expected_schema_level!r}, "
+        f"features={expected_features!r}; got {data!r}",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+' "$expected_server_version" "$applied_schema_level"
+
+  local monitor_api_url="http://127.0.0.1:${monitor_port}"
+  echo "[e2e] checking one-release monitor API aliases"
+  assert_monitor_api_alias "$python_bin" "$monitor_api_url" "$tmp_root" \
+    "/api/v1/health" "/api/health"
+  assert_monitor_api_alias "$python_bin" "$monitor_api_url" "$tmp_root" \
+    "/api/v1/status" "/api/status"
+  assert_monitor_api_alias "$python_bin" "$monitor_api_url" "$tmp_root" \
+    "/api/v1/analytics?range=24h" "/api/analytics?range=24h"
+  assert_monitor_api_alias "$python_bin" "$monitor_api_url" "$tmp_root" \
+    "/api/v1/tables" "/api/tables"
+  assert_monitor_api_alias "$python_bin" "$monitor_api_url" "$tmp_root" \
+    "/api/v1/web-searches?limit=25" "/api/web-searches?limit=25"
+  assert_monitor_api_alias "$python_bin" "$monitor_api_url" "$tmp_root" \
+    "/api/v1/tables/v_conversation_trace?limit=500" \
+    "/api/tables/v_conversation_trace?limit=500"
+  assert_monitor_api_alias "$python_bin" "$monitor_api_url" "$tmp_root" \
+    "/api/v1/sessions?since=all&limit=200" \
+    "/api/sessions?since=all&limit=200"
+
   local sessions_body
-  sessions_body="$(curl -fsS "http://127.0.0.1:${monitor_port}/api/sessions?since=all&limit=200")"
+  sessions_body="$(curl -fsS "http://127.0.0.1:${monitor_port}/api/v1/sessions?since=all&limit=200")"
   printf '%s' "$sessions_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; ok=any(s.get("id")==sid and s.get("harness",{}).get("id")=="cursor" for s in data.get("sessions", [])); sys.exit(0 if ok else 1)' "$cursor_session_id"
   printf '%s' "$sessions_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; ok=any(s.get("id")==sid and s.get("harness",{}).get("id")=="pi-coding-agent" for s in data.get("sessions", [])); sys.exit(0 if ok else 1)' "$pi_session_id"
 
@@ -1196,14 +1319,15 @@ PY
   # Re-enable merges now that the pre-merge assertions have passed.
   clickhouse_scalar "$clickhouse_url" "SYSTEM START MERGES ${clickhouse_database}.events" >/dev/null
 
-  # `/api/sessions` intentionally keeps its legacy shape without eventCount.
-  # Derive the monitor-side canonical count through the existing trace preview
-  # route, then compare both that count and sessions.endedAt with MCP below.
+  # `/api/v1/sessions` intentionally keeps its dashboard shape without
+  # eventCount. Derive the monitor-side canonical count through the existing
+  # trace preview route, then compare both that count and sessions.endedAt with
+  # MCP below.
   echo "[e2e] checking monitor/repository session count + last-activity parity"
-  sessions_body="$(curl -fsS "http://127.0.0.1:${monitor_port}/api/sessions?since=all&limit=200")"
+  sessions_body="$(curl -fsS "http://127.0.0.1:${monitor_port}/api/v1/sessions?since=all&limit=200")"
   printf '%s' "$sessions_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; expected=int(sys.argv[2]); session=next((s for s in data.get("sessions", []) if s.get("id")==sid), None); ok=session is not None and session.get("endedAt")==expected; sys.exit(0 if ok else 1)' "$codex_session_id" "1771243203900"
   local trace_body
-  trace_body="$(curl -fsS "http://127.0.0.1:${monitor_port}/api/tables/v_conversation_trace?limit=500")"
+  trace_body="$(curl -fsS "http://127.0.0.1:${monitor_port}/api/v1/tables/v_conversation_trace?limit=500")"
   printf '%s' "$trace_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; expected=int(sys.argv[2]); count=sum(1 for row in data.get("rows", []) if row.get("session_id")==sid); sys.exit(0 if count==expected else 1)' "$codex_session_id" "7"
 
   # Capture a server-clock-bounded query_log window after `moraine up` and its

--- a/scripts/dev/sandbox/compose.yaml
+++ b/scripts/dev/sandbox/compose.yaml
@@ -105,7 +105,7 @@ services:
       - "cargo-target:/home/moraine/target"
       - "state:/home/moraine/.moraine"
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8080/api/health || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8080/api/v1/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 60

--- a/scripts/dev/sandbox/moraine-sandbox
+++ b/scripts/dev/sandbox/moraine-sandbox
@@ -698,7 +698,7 @@ cmd_up() {
     dc "$project" "$mount_sessions" up -d
 
     # Wait for health. The first boot of a sandbox runs `cargo build
-    # --workspace --locked` inside the container before moraine's /api/health
+    # --workspace --locked` inside the container before moraine's /api/v1/health
     # comes online. With a cold sccache a from-scratch workspace build can
     # take ~10 minutes; with the host's sccache warm it's seconds. Budget
     # 900s and surface progress via the log hint so operators don't worry.

--- a/sql/017_heartbeat_backend_sinks.sql
+++ b/sql/017_heartbeat_backend_sinks.sql
@@ -1,6 +1,6 @@
 -- Per-backend mirror sink status on ingest heartbeats: a JSON-encoded
 -- `{backend_name: status}` map (statuses: connecting / ok / lagging /
--- unreachable / disabled_skew) written by the default sink so /api/health
+-- unreachable / disabled_skew) written by the default sink so /api/v1/health
 -- can surface the health of every named-backend tee. Empty for installs
 -- without named backends.
 --

--- a/web/monitor/README.md
+++ b/web/monitor/README.md
@@ -41,7 +41,7 @@ bun run build
 bun run preview -- --host 127.0.0.1 --port 4173
 ```
 
-Note: the app calls `/api/*` on the same origin. When running `bun run dev`, API calls fail unless you provide a same-origin proxy/backend.
+Note: the app calls `/api/v1/*` on the same origin. When running `bun run dev`, API calls fail unless you provide a same-origin proxy/backend.
 
 ## Test Workflow
 

--- a/web/monitor/e2e/monitor.live.spec.ts
+++ b/web/monitor/e2e/monitor.live.spec.ts
@@ -46,6 +46,71 @@ interface AnalyticsResponse extends ApiBaseResponse {
 
 const ANALYTICS_RANGE_CANDIDATES: AnalyticsRangeKey[] = ['24h', '7d', '30d', '6h', '1h', '15m'];
 
+const CANONICAL_API_PATHNAMES = [
+  '/api/v1/health',
+  '/api/v1/status',
+  '/api/v1/analytics',
+  '/api/v1/sessions',
+] as const;
+const STATIC_PATHNAMES = ['/', '/app.js', '/styles.css'] as const;
+
+interface RuntimeTraffic {
+  apiPathnames: string[];
+  responses: Array<{ origin: string; pathname: string; status: number }>;
+}
+
+function trackRuntimeTraffic(page: Page): RuntimeTraffic {
+  const traffic: RuntimeTraffic = {
+    apiPathnames: [],
+    responses: [],
+  };
+
+  page.on('request', (request) => {
+    const { pathname } = new URL(request.url());
+    if (pathname.startsWith('/api/')) {
+      traffic.apiPathnames.push(pathname);
+    }
+  });
+
+  page.on('response', (response) => {
+    const { origin, pathname } = new URL(response.url());
+    traffic.responses.push({ origin, pathname, status: response.status() });
+  });
+
+  return traffic;
+}
+
+async function expectVersionedRuntimeTraffic(
+  traffic: RuntimeTraffic,
+  pageOrigin: string,
+): Promise<void> {
+  await expect
+    .poll(() => [...traffic.apiPathnames], {
+      message: 'expected the dashboard to request every canonical monitor endpoint',
+    })
+    .toEqual(expect.arrayContaining([...CANONICAL_API_PATHNAMES]));
+
+  const legacyApiPathnames = traffic.apiPathnames.filter(
+    (pathname) => pathname.startsWith('/api/') && !pathname.startsWith('/api/v1/'),
+  );
+  expect(legacyApiPathnames).toEqual([]);
+
+  for (const pathname of STATIC_PATHNAMES) {
+    await expect
+      .poll(
+        () =>
+          traffic.responses.some(
+            (response) =>
+              response.origin === pageOrigin &&
+              response.pathname === pathname &&
+              response.status === 200,
+          ),
+        { message: `expected same-origin ${pathname} to return 200` },
+      )
+      .toBe(true);
+  }
+}
+
 async function getJson<T extends ApiBaseResponse>(page: Page, path: string): Promise<T> {
   const response = await page.request.get(path);
   expect(response.ok(), `request failed for ${path}`).toBeTruthy();
@@ -70,7 +135,7 @@ async function findPopulatedAnalytics(
   page: Page,
 ): Promise<{ analytics: AnalyticsResponse; modelCount: number } | null> {
   for (const range of ANALYTICS_RANGE_CANDIDATES) {
-    const analytics = await getJson<AnalyticsResponse>(page, `/api/analytics?range=${range}`);
+    const analytics = await getJson<AnalyticsResponse>(page, `/api/v1/analytics?range=${range}`);
     expect(analytics.ok).toBe(true);
 
     const modelCount = modelCountFromAnalytics(analytics);
@@ -83,8 +148,8 @@ async function findPopulatedAnalytics(
 }
 
 test('live monitor UI reflects ingested fixture data', async ({ page }) => {
-  const health = await getJson<HealthResponse>(page, '/api/health');
-  const status = await getJson<StatusResponse>(page, '/api/status');
+  const health = await getJson<HealthResponse>(page, '/api/v1/health');
+  const status = await getJson<StatusResponse>(page, '/api/v1/status');
   const populatedAnalytics = await findPopulatedAnalytics(page);
 
   expect(health.ok).toBe(true);
@@ -97,7 +162,10 @@ test('live monitor UI reflects ingested fixture data', async ({ page }) => {
   const { analytics, modelCount: expectedModelCount } = populatedAnalytics!;
   const expectedModelText = `${expectedModelCount} model${expectedModelCount === 1 ? '' : 's'}`;
 
-  await page.goto('/');
+  const runtimeTraffic = trackRuntimeTraffic(page);
+  const navigationResponse = await page.goto('/');
+  expect(navigationResponse).not.toBeNull();
+  const pageOrigin = new URL(navigationResponse!.url()).origin;
 
   await expect(page.getByRole('heading', { name: 'Moraine Monitor' })).toBeVisible();
 
@@ -127,4 +195,6 @@ test('live monitor UI reflects ingested fixture data', async ({ page }) => {
   await expect(page.locator('#concurrentSessionsChart')).toBeVisible();
 
   await expect(page.locator('#sessionsPanel')).toBeVisible();
+
+  await expectVersionedRuntimeTraffic(runtimeTraffic, pageOrigin);
 });

--- a/web/monitor/e2e/monitor.smoke.spec.ts
+++ b/web/monitor/e2e/monitor.smoke.spec.ts
@@ -51,8 +51,73 @@ function analyticsFixture(range: string) {
   };
 }
 
+const CANONICAL_API_PATHNAMES = [
+  '/api/v1/health',
+  '/api/v1/status',
+  '/api/v1/analytics',
+  '/api/v1/sessions',
+] as const;
+const STATIC_PATHNAMES = ['/', '/app.js', '/styles.css'] as const;
+
+interface RuntimeTraffic {
+  apiPathnames: string[];
+  responses: Array<{ origin: string; pathname: string; status: number }>;
+}
+
+function trackRuntimeTraffic(page: Page): RuntimeTraffic {
+  const traffic: RuntimeTraffic = {
+    apiPathnames: [],
+    responses: [],
+  };
+
+  page.on('request', (request) => {
+    const { pathname } = new URL(request.url());
+    if (pathname.startsWith('/api/')) {
+      traffic.apiPathnames.push(pathname);
+    }
+  });
+
+  page.on('response', (response) => {
+    const { origin, pathname } = new URL(response.url());
+    traffic.responses.push({ origin, pathname, status: response.status() });
+  });
+
+  return traffic;
+}
+
+async function expectVersionedRuntimeTraffic(
+  traffic: RuntimeTraffic,
+  pageOrigin: string,
+): Promise<void> {
+  await expect
+    .poll(() => [...traffic.apiPathnames], {
+      message: 'expected the dashboard to request every canonical monitor endpoint',
+    })
+    .toEqual(expect.arrayContaining([...CANONICAL_API_PATHNAMES]));
+
+  const legacyApiPathnames = traffic.apiPathnames.filter(
+    (pathname) => pathname.startsWith('/api/') && !pathname.startsWith('/api/v1/'),
+  );
+  expect(legacyApiPathnames).toEqual([]);
+
+  for (const pathname of STATIC_PATHNAMES) {
+    await expect
+      .poll(
+        () =>
+          traffic.responses.some(
+            (response) =>
+              response.origin === pageOrigin &&
+              response.pathname === pathname &&
+              response.status === 200,
+          ),
+        { message: `expected same-origin ${pathname} to return 200` },
+      )
+      .toBe(true);
+  }
+}
+
 async function setupMockMonitorApi(page: Page): Promise<void> {
-  await page.route('**/api/health', async (route) => {
+  await page.route('**/api/v1/health', async (route) => {
     await route.fulfill({
       json: {
         ok: true,
@@ -65,7 +130,7 @@ async function setupMockMonitorApi(page: Page): Promise<void> {
     });
   });
 
-  await page.route('**/api/status', async (route) => {
+  await page.route('**/api/v1/status', async (route) => {
     await route.fulfill({
       json: {
         ok: true,
@@ -83,7 +148,7 @@ async function setupMockMonitorApi(page: Page): Promise<void> {
     });
   });
 
-  await page.route('**/api/sessions', async (route) => {
+  await page.route('**/api/v1/sessions', async (route) => {
     await route.fulfill({
       json: {
         ok: true,
@@ -130,7 +195,7 @@ async function setupMockMonitorApi(page: Page): Promise<void> {
     });
   });
 
-  await page.route('**/api/analytics?range=*', async (route) => {
+  await page.route('**/api/v1/analytics?range=*', async (route) => {
     const requestUrl = new URL(route.request().url());
     const range = requestUrl.searchParams.get('range') || '24h';
 
@@ -162,7 +227,10 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('loads dashboard and handles core interactions', async ({ page }) => {
-  await page.goto('/');
+  const runtimeTraffic = trackRuntimeTraffic(page);
+  const navigationResponse = await page.goto('/');
+  expect(navigationResponse).not.toBeNull();
+  const pageOrigin = new URL(navigationResponse!.url()).origin;
 
   await expect(page.getByRole('heading', { name: 'Moraine Monitor' })).toBeVisible();
 
@@ -213,6 +281,8 @@ test('loads dashboard and handles core interactions', async ({ page }) => {
   await page.locator(otherTheme === 'dark' ? '#themeDark' : '#themeLight').click();
   const htmlThemeAfter = await page.locator('html').getAttribute('data-theme');
   expect(htmlThemeAfter).toBe(otherTheme);
+
+  await expectVersionedRuntimeTraffic(runtimeTraffic, pageOrigin);
 });
 
 test('keeps dashboard and detail views inside the mobile viewport', async ({ page }) => {

--- a/web/monitor/src/lib/api/client.test.ts
+++ b/web/monitor/src/lib/api/client.test.ts
@@ -1,13 +1,29 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fetchHealth } from './client';
+import { fetchAnalytics, fetchHealth, fetchStatus } from './client';
 
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
-describe('fetchHealth', () => {
-  it('returns parsed json for successful responses', async () => {
+describe('versioned monitor requests', () => {
+  it.each([
+    {
+      label: 'health',
+      request: () => fetchHealth(),
+      expectedPath: '/api/v1/health',
+    },
+    {
+      label: 'status',
+      request: () => fetchStatus(),
+      expectedPath: '/api/v1/status',
+    },
+    {
+      label: 'analytics',
+      request: () => fetchAnalytics('7d'),
+      expectedPath: '/api/v1/analytics?range=7d',
+    },
+  ])('fetches $label with the canonical URL and JSON header', async ({ request, expectedPath }) => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), {
         status: 200,
@@ -16,11 +32,15 @@ describe('fetchHealth', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(fetchHealth()).resolves.toEqual({ ok: true });
-    expect(fetchMock).toHaveBeenCalledWith('/api/health', {
+    await expect(request()).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(expectedPath, {
       headers: { Accept: 'application/json' },
     });
   });
+});
+
+describe('request errors', () => {
 
   it('uses API error text from json error payloads', async () => {
     vi.stubGlobal(

--- a/web/monitor/src/lib/api/client.ts
+++ b/web/monitor/src/lib/api/client.ts
@@ -31,13 +31,13 @@ async function requestJson<T>(path: string): Promise<T> {
 }
 
 export function fetchHealth(): Promise<HealthResponse> {
-  return requestJson<HealthResponse>('/api/health');
+  return requestJson<HealthResponse>('/api/v1/health');
 }
 
 export function fetchStatus(): Promise<StatusResponse> {
-  return requestJson<StatusResponse>('/api/status');
+  return requestJson<StatusResponse>('/api/v1/status');
 }
 
 export function fetchAnalytics(range: AnalyticsRangeKey): Promise<AnalyticsResponse> {
-  return requestJson<AnalyticsResponse>(`/api/analytics?range=${encodeURIComponent(range)}`);
+  return requestJson<AnalyticsResponse>(`/api/v1/analytics?range=${encodeURIComponent(range)}`);
 }

--- a/web/monitor/src/lib/api/sessions.test.ts
+++ b/web/monitor/src/lib/api/sessions.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import type { Session } from '../types/sessions';
+import { fetchSessions } from './sessions';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+it('fetches sessions from the canonical URL with the JSON header', async () => {
+  const session: Session = {
+    id: 'session-1',
+    title: 'Canonical API session',
+    harness: { id: 'codex', label: 'Codex', short: 'C', hue: 150 },
+    startedAt: 1_700_000_000_000,
+    endedAt: 1_700_000_001_000,
+    durationMs: 1_000,
+    status: 'completed',
+    models: ['gpt-5'],
+    turns: [],
+    totalTokens: 0,
+    totalToolCalls: 0,
+    tags: [],
+    traceId: 'trace-1',
+  };
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ ok: true, sessions: [session] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  await expect(fetchSessions({ allowMock: false })).resolves.toEqual([session]);
+  expect(fetchMock).toHaveBeenCalledOnce();
+  expect(fetchMock).toHaveBeenCalledWith('/api/v1/sessions', {
+    headers: { Accept: 'application/json' },
+  });
+});

--- a/web/monitor/src/lib/api/sessions.ts
+++ b/web/monitor/src/lib/api/sessions.ts
@@ -9,7 +9,7 @@ export async function fetchSessions(options: FetchSessionsOptions = {}): Promise
   const { allowMock = true } = options;
 
   try {
-    const response = await fetch('/api/sessions', {
+    const response = await fetch('/api/v1/sessions', {
       headers: { Accept: 'application/json' },
     });
 
@@ -31,22 +31,4 @@ export async function fetchSessions(options: FetchSessionsOptions = {}): Promise
   }
 
   return generateMockSessions();
-}
-
-export async function fetchSessionDetail(id: string): Promise<Session | null> {
-  try {
-    const response = await fetch(`/api/sessions/${encodeURIComponent(id)}`, {
-      headers: { Accept: 'application/json' },
-    });
-    if (!response.ok) {
-      return null;
-    }
-    const data = (await response.json()) as { ok: boolean; session?: Session; error?: string };
-    if (data.ok && data.session) {
-      return data.session;
-    }
-  } catch {
-    // fall through
-  }
-  return null;
 }

--- a/zensical.toml
+++ b/zensical.toml
@@ -13,6 +13,7 @@ nav = [
   { "Introduction" = "introduction.md" },
   { "Quickstart and Installation" = "quickstart.md" },
   { "Configuration" = "configuration.md" },
+  { "Monitor HTTP API" = "monitor-http-api.md" },
   { "Remote ClickHouse" = "remote-clickhouse.md" },
   { "Analytics Export" = "export.md" },
   { "Agent MCP Search" = [


### PR DESCRIPTION
## Description

**What.** Versions the monitor dashboard HTTP surface under `/api/v1`, adds runtime capabilities discovery, and migrates the shipped dashboard and operational clients to the canonical paths.

**Why.** Dashboard and future daemon clients need a stable, discoverable HTTP contract without changing the MCP Unix-socket protocol.

- Mounts all seven existing dashboard JSON handlers under `/api/v1` without changing their payloads.
- Keeps the prior `/api/*` paths as direct one-release aliases, preserving status codes, query handling, and response bodies without redirects.
- Adds `/api/v1/capabilities` with the Moraine server version, highest applied schema migration identifier (or `null` when unavailable), and implemented analytics, sessions, table-inspection, and web-search feature flags.
- Moves the Svelte dashboard, sandbox health checks, benchmark consumers, and stack checks to `/api/v1`.
- Documents the v1 route matrix, query bounds, capabilities semantics, errors, aliases, static assets, and unchanged MCP transport.

## Usage

Query server capabilities:

```bash
curl -fsS http://127.0.0.1:8080/api/v1/capabilities
```

Dashboard clients should use routes such as `/api/v1/health`, `/api/v1/status`, `/api/v1/analytics`, and `/api/v1/sessions`. The old `/api/*` dashboard paths remain direct aliases for one release.

## Changelog

- Adds the stable monitor dashboard HTTP API v1 and capabilities discovery endpoint.
- Migrates the bundled web dashboard and operational consumers to the v1 routes.
- Preserves one-release compatibility aliases and leaves the MCP socket protocol unchanged.

## Validation

After rebasing onto the merged daemon-consolidation prerequisite, `cargo test --locked -p moraine-monitor-core -p moraine-mcp-core -p moraine-mcp` passed 98 tests across five suites. Focused Vitest coverage passed 6 API-client tests; Svelte type checking reported 0 errors and 0 warnings; the production Vite build succeeded; and the mocked production-build Playwright smoke passed both Chromium tests.

`bash scripts/ci/e2e-stack.sh` passed against the complete live stack. It exercised all seven canonical routes, the exact server-version/schema-level/feature capabilities contract, every direct legacy alias, static UI delivery, unified backend topology, shared-daemon cache behavior, bounded ClickHouse ownership, and the unchanged MCP search/open/list/fallback flows. A separate real Chromium sandbox smoke observed only `/api/v1/health`, `/api/v1/status`, `/api/v1/analytics`, and `/api/v1/sessions` from the rendered dashboard; `/`, `/app.js`, `/styles.css`, and `/api/v1/capabilities` all returned HTTP 200.

`make docs-build`, focused Rust formatting checks, shell syntax checks, and patch whitespace checks also passed. The full seven-persona code review completed; its mutable live-snapshot alias assertion and remaining legacy sandbox runbook path findings were fixed and re-reviewed clean.

Resolves #459
