### PR TITLE
feat(status): prefer daemon API with direct DB fallback

### DIFF
--- a/apps/moraine/src/commands/status.rs
+++ b/apps/moraine/src/commands/status.rs
@@ -4,15 +4,68 @@ use crate::managed_clickhouse::{
 };
 use crate::paths::RuntimePaths;
 use crate::process::{
-    backend_endpoint_status, legacy_service_running, service_running, BackendEndpointStatus,
-    LEGACY_MCP_PID_FILE, LEGACY_MONITOR_PID_FILE,
+    backend_endpoint_status, backend_http_connect_host, legacy_service_running, service_running,
+    BackendEndpointStatus, LEGACY_MCP_PID_FILE, LEGACY_MONITOR_PID_FILE,
 };
-use crate::render::{HeartbeatSnapshot, ServiceRuntimeState, ServiceRuntimeStatus, StatusSnapshot};
+use crate::render::{
+    HeartbeatSnapshot, ServiceRuntimeState, ServiceRuntimeStatus, StatusDataSource, StatusSnapshot,
+};
 use crate::service::Service;
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use moraine_clickhouse::DoctorReport;
 use moraine_config::AppConfig;
 use moraine_conversations::{ConversationRepository, IngestHeartbeatRead, StoreDiagnostics};
+use std::time::Duration;
+
+const STATUS_API_TIMEOUT: Duration = Duration::from_secs(2);
+const STATUS_API_MAX_RESPONSE_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(transparent)]
+struct RequiredNullable<T>(Option<T>);
+
+#[derive(Debug, serde::Deserialize)]
+struct DaemonStatusResponse {
+    ok: bool,
+    clickhouse: DaemonClickhouseStatus,
+    database: DaemonDatabaseStatus,
+    ingestor: DaemonIngestorStatus,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct DaemonClickhouseStatus {
+    url: String,
+    database: String,
+    healthy: bool,
+    version: RequiredNullable<String>,
+    error: RequiredNullable<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct DaemonDatabaseStatus {
+    exists: bool,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct DaemonIngestorStatus {
+    present: bool,
+    latest: RequiredNullable<DaemonHeartbeat>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct DaemonHeartbeat {
+    ts: String,
+    queue_depth: u64,
+    files_active: u64,
+}
+
+struct StatusData {
+    report: DoctorReport,
+    heartbeat: HeartbeatSnapshot,
+    source: StatusDataSource,
+    fallback_note: Option<String>,
+    clickhouse_health_url: String,
+}
 
 fn service_runtime_running(services: &[ServiceRuntimeStatus], service: Service) -> bool {
     services
@@ -73,6 +126,107 @@ fn format_http_url(host: &str, port: u16) -> String {
 
 fn monitor_runtime_url(cfg: &AppConfig) -> String {
     format_http_url(&cfg.monitor.host, cfg.monitor.port)
+}
+fn monitor_api_status_url(cfg: &AppConfig) -> String {
+    format!(
+        "{}/api/v1/status",
+        format_http_url(
+            backend_http_connect_host(&cfg.monitor.host),
+            cfg.monitor.port
+        )
+    )
+}
+
+fn daemon_status_data(payload: DaemonStatusResponse) -> Result<StatusData> {
+    if !payload.ok {
+        bail!("daemon API reported ok=false");
+    }
+    let version_present = payload.clickhouse.version.0.is_some();
+    let error_present = payload.clickhouse.error.0.is_some();
+    if payload.clickhouse.healthy && (!payload.database.exists || !version_present || error_present)
+    {
+        bail!("daemon API returned contradictory healthy ClickHouse fields");
+    }
+    if !payload.clickhouse.healthy && !error_present {
+        bail!("daemon API returned an unhealthy ClickHouse without an error");
+    }
+
+    let latest = payload.ingestor.latest.0;
+    if payload.ingestor.present != latest.is_some() {
+        bail!("daemon API returned inconsistent ingestor presence");
+    }
+    let heartbeat = match latest {
+        Some(latest) => HeartbeatSnapshot::Available {
+            latest: latest.ts,
+            queue_depth: latest.queue_depth,
+            files_active: latest.files_active,
+            watcher_backend: "unknown".to_string(),
+            watcher_error_count: 0,
+            watcher_reset_count: 0,
+            watcher_last_reset_unix_ms: 0,
+        },
+        None => HeartbeatSnapshot::Unavailable,
+    };
+    let report = DoctorReport {
+        clickhouse_healthy: payload.clickhouse.healthy,
+        clickhouse_version: payload.clickhouse.version.0,
+        database: payload.clickhouse.database,
+        database_exists: payload.database.exists,
+        applied_migrations: Vec::new(),
+        pending_migrations: Vec::new(),
+        missing_tables: Vec::new(),
+        errors: payload.clickhouse.error.0.into_iter().collect(),
+    };
+
+    Ok(StatusData {
+        report,
+        heartbeat,
+        source: StatusDataSource::DaemonApi,
+        fallback_note: None,
+        clickhouse_health_url: payload.clickhouse.url,
+    })
+}
+
+async fn read_daemon_status(cfg: &AppConfig, timeout: Duration) -> Result<StatusData> {
+    let api_url = monitor_api_status_url(cfg);
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .connect_timeout(timeout)
+        .timeout(timeout)
+        .build()
+        .context("build daemon status API client")?;
+    let mut response = client
+        .get(&api_url)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
+        .await
+        .with_context(|| format!("request {api_url}"))?
+        .error_for_status()
+        .with_context(|| format!("request {api_url}"))?;
+    if response
+        .content_length()
+        .is_some_and(|length| length > STATUS_API_MAX_RESPONSE_BYTES as u64)
+    {
+        bail!("daemon status API response exceeds {STATUS_API_MAX_RESPONSE_BYTES} bytes");
+    }
+    let capacity = response
+        .content_length()
+        .unwrap_or_default()
+        .min(STATUS_API_MAX_RESPONSE_BYTES as u64) as usize;
+    let mut body = Vec::with_capacity(capacity);
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .with_context(|| format!("read {api_url} response"))?
+    {
+        if chunk.len() > STATUS_API_MAX_RESPONSE_BYTES - body.len() {
+            bail!("daemon status API response exceeds {STATUS_API_MAX_RESPONSE_BYTES} bytes");
+        }
+        body.extend_from_slice(&chunk);
+    }
+    let payload = serde_json::from_slice(&body)
+        .with_context(|| format!("decode {api_url} response as JSON"))?;
+    daemon_status_data(payload)
 }
 
 fn build_status_notes(
@@ -160,6 +314,39 @@ async fn read_repository_status(
     };
     Ok((report, heartbeat))
 }
+async fn read_preferred_status(
+    cfg: &AppConfig,
+    repository: &dyn ConversationRepository,
+    api_available: bool,
+    timeout: Duration,
+) -> Result<StatusData> {
+    if api_available {
+        match read_daemon_status(cfg, timeout).await {
+            Ok(status) => return Ok(status),
+            Err(error) => {
+                let (report, heartbeat) = read_repository_status(repository).await?;
+                return Ok(StatusData {
+                    report,
+                    heartbeat,
+                    source: StatusDataSource::DirectDb,
+                    fallback_note: Some(format!(
+                        "daemon status API failed ({error:#}); using direct DB fallback"
+                    )),
+                    clickhouse_health_url: cfg.clickhouse.url.clone(),
+                });
+            }
+        }
+    }
+
+    let (report, heartbeat) = read_repository_status(repository).await?;
+    Ok(StatusData {
+        report,
+        heartbeat,
+        source: StatusDataSource::DirectDb,
+        fallback_note: None,
+        clickhouse_health_url: cfg.clickhouse.url.clone(),
+    })
+}
 
 pub(super) async fn cmd_status(
     paths: &RuntimePaths,
@@ -177,9 +364,23 @@ pub(super) async fn cmd_status(
     ];
     let managed_server = managed_clickhouse_bin(paths, "clickhouse-server");
     let (source, source_path) = active_clickhouse_source(paths);
-    let (report, heartbeat) = read_repository_status(repository).await?;
-    let clickhouse_health_url = cfg.clickhouse.url.clone();
+    let StatusData {
+        report,
+        heartbeat,
+        source: data_source,
+        fallback_note,
+        clickhouse_health_url,
+    } = read_preferred_status(
+        cfg,
+        repository,
+        backend_endpoints.http_listening,
+        STATUS_API_TIMEOUT,
+    )
+    .await?;
     let mut status_notes = build_status_notes(&services, &report, &clickhouse_health_url);
+    if let Some(note) = fallback_note {
+        status_notes.push(note);
+    }
     for (name, pid_file) in [
         ("monitor", LEGACY_MONITOR_PID_FILE),
         ("MCP", LEGACY_MCP_PID_FILE),
@@ -197,6 +398,7 @@ pub(super) async fn cmd_status(
     Ok(StatusSnapshot {
         services,
         monitor_url,
+        data_source,
         managed_clickhouse_installed: managed_server.exists(),
         managed_clickhouse_path: managed_server.display().to_string(),
         managed_clickhouse_version: managed_clickhouse_version(paths),
@@ -218,6 +420,87 @@ mod tests {
         RepoResult,
     };
     use serde_json::{json, Value};
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+    use std::time::Instant;
+
+    fn test_config(monitor_port: u16) -> AppConfig {
+        let mut cfg = AppConfig::default();
+        cfg.monitor.host = "127.0.0.1".to_string();
+        cfg.monitor.port = monitor_port;
+        cfg
+    }
+
+    fn test_repository() -> InMemoryConversationRepository {
+        InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            InMemoryConversationResponses {
+                latest_ingest_heartbeat: Some(Ok(IngestHeartbeatRead::default())),
+                read_store_diagnostics: Some(Ok(StoreDiagnostics {
+                    healthy: true,
+                    version: Some("direct-db-version".to_string()),
+                    database: "direct_db".to_string(),
+                    database_exists: true,
+                    applied_schema_versions: vec!["001".to_string()],
+                    pending_schema_versions: Vec::new(),
+                    missing_tables: Vec::new(),
+                    errors: Vec::new(),
+                })),
+                ..InMemoryConversationResponses::default()
+            },
+        )
+    }
+
+    fn daemon_status_body(healthy: bool) -> String {
+        json!({
+            "ok": true,
+            "clickhouse": {
+                "url": "http://api-clickhouse:8123",
+                "database": "api_db",
+                "healthy": healthy,
+                "version": "26.1.2.3",
+                "error": if healthy {
+                    Value::Null
+                } else {
+                    Value::String("API-reported database failure".to_string())
+                }
+            },
+            "database": {"exists": true},
+            "ingestor": {
+                "present": true,
+                "latest": {
+                    "ts": "2026-07-10 12:34:56.789",
+                    "queue_depth": 17,
+                    "files_active": 2
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn spawn_api_response(body: &str, delay: Duration) -> (u16, thread::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind daemon API fixture");
+        let port = listener.local_addr().expect("daemon API address").port();
+        let body = body.to_string();
+        let worker = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept daemon API request");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(1)))
+                .expect("set request timeout");
+            let mut request = [0_u8; 2048];
+            let request_len = stream.read(&mut request).expect("read daemon API request");
+            thread::sleep(delay);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+            String::from_utf8_lossy(&request[..request_len]).into_owned()
+        });
+        (port, worker)
+    }
 
     async fn status_json(heartbeat: RepoResult<IngestHeartbeatRead>) -> Value {
         let mut cfg = AppConfig::default();
@@ -283,6 +566,183 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn daemon_api_precedes_direct_db_even_when_api_reports_unhealthy() {
+        let repository = test_repository();
+        let (port, worker) =
+            spawn_api_response(&daemon_status_body(false), Duration::from_millis(0));
+        let status = read_preferred_status(
+            &test_config(port),
+            &repository,
+            true,
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("read preferred daemon status");
+
+        assert_eq!(status.source, StatusDataSource::DaemonApi);
+        assert_eq!(status.clickhouse_health_url, "http://api-clickhouse:8123");
+        assert!(!status.report.clickhouse_healthy);
+        assert_eq!(status.report.database, "api_db");
+        assert_eq!(status.report.errors, vec!["API-reported database failure"]);
+        assert!(matches!(
+            status.heartbeat,
+            HeartbeatSnapshot::Available {
+                ref latest,
+                queue_depth: 17,
+                files_active: 2,
+                ..
+            } if latest == "2026-07-10 12:34:56.789"
+        ));
+        let calls = repository.calls();
+        assert_eq!(calls.read_store_diagnostics, 0);
+        assert_eq!(calls.latest_ingest_heartbeat, 0);
+        let request = worker.join().expect("daemon API worker");
+        assert!(
+            request.starts_with("GET /api/v1/status HTTP/1.1"),
+            "{request}"
+        );
+        assert!(request.contains("accept: application/json"), "{request}");
+    }
+
+    #[tokio::test]
+    async fn malformed_and_partial_api_responses_fall_back_to_direct_db() {
+        for body in ["{", r#"{"ok":true}"#] {
+            let repository = test_repository();
+            let (port, worker) = spawn_api_response(body, Duration::from_millis(0));
+            let status = read_preferred_status(
+                &test_config(port),
+                &repository,
+                true,
+                Duration::from_secs(1),
+            )
+            .await
+            .expect("fall back after invalid daemon response");
+
+            assert_eq!(status.source, StatusDataSource::DirectDb);
+            assert_eq!(status.report.database, "direct_db");
+            assert!(
+                status
+                    .fallback_note
+                    .as_deref()
+                    .is_some_and(|note| note.contains("using direct DB fallback")),
+                "{:?}",
+                status.fallback_note
+            );
+            let calls = repository.calls();
+            assert_eq!(calls.read_store_diagnostics, 1);
+            assert_eq!(calls.latest_ingest_heartbeat, 1);
+            let request = worker.join().expect("daemon API worker");
+            assert!(request.starts_with("GET /api/v1/status HTTP/1.1"));
+        }
+    }
+    #[tokio::test]
+    async fn contradictory_api_health_fields_fall_back_to_direct_db() {
+        let mut missing_version: Value =
+            serde_json::from_str(&daemon_status_body(true)).expect("valid fixture");
+        missing_version["clickhouse"]["version"] = Value::Null;
+        let mut healthy_with_error: Value =
+            serde_json::from_str(&daemon_status_body(true)).expect("valid fixture");
+        healthy_with_error["clickhouse"]["error"] = Value::String("contradiction".to_string());
+        let mut unhealthy_without_error: Value =
+            serde_json::from_str(&daemon_status_body(false)).expect("valid fixture");
+        unhealthy_without_error["clickhouse"]["error"] = Value::Null;
+
+        for payload in [missing_version, healthy_with_error, unhealthy_without_error] {
+            let repository = test_repository();
+            let (port, worker) = spawn_api_response(&payload.to_string(), Duration::from_millis(0));
+            let status = read_preferred_status(
+                &test_config(port),
+                &repository,
+                true,
+                Duration::from_secs(1),
+            )
+            .await
+            .expect("fall back after contradictory daemon response");
+
+            assert_eq!(status.source, StatusDataSource::DirectDb);
+            let calls = repository.calls();
+            assert_eq!(calls.read_store_diagnostics, 1);
+            assert_eq!(calls.latest_ingest_heartbeat, 1);
+            worker.join().expect("daemon API worker");
+        }
+    }
+
+    #[tokio::test]
+    async fn oversized_api_response_falls_back_before_buffering_the_body() {
+        let repository = test_repository();
+        let body = "x".repeat(STATUS_API_MAX_RESPONSE_BYTES + 1);
+        let (port, worker) = spawn_api_response(&body, Duration::from_millis(0));
+        let status = read_preferred_status(
+            &test_config(port),
+            &repository,
+            true,
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("fall back after oversized daemon response");
+
+        assert_eq!(status.source, StatusDataSource::DirectDb);
+        assert!(
+            status
+                .fallback_note
+                .as_deref()
+                .is_some_and(|note| note.contains("exceeds 262144 bytes")),
+            "{:?}",
+            status.fallback_note
+        );
+        let calls = repository.calls();
+        assert_eq!(calls.read_store_diagnostics, 1);
+        assert_eq!(calls.latest_ingest_heartbeat, 1);
+        worker.join().expect("daemon API worker");
+    }
+
+    #[tokio::test]
+    async fn daemon_api_timeout_is_bounded_and_falls_back() {
+        let repository = test_repository();
+        let (port, worker) =
+            spawn_api_response(&daemon_status_body(true), Duration::from_millis(300));
+        let started = Instant::now();
+        let status = read_preferred_status(
+            &test_config(port),
+            &repository,
+            true,
+            Duration::from_millis(20),
+        )
+        .await
+        .expect("fall back after daemon timeout");
+        let elapsed = started.elapsed();
+
+        assert_eq!(status.source, StatusDataSource::DirectDb);
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "API timeout took {elapsed:?}"
+        );
+        let calls = repository.calls();
+        assert_eq!(calls.read_store_diagnostics, 1);
+        assert_eq!(calls.latest_ingest_heartbeat, 1);
+        worker.join().expect("daemon API worker");
+    }
+
+    #[tokio::test]
+    async fn unavailable_daemon_uses_direct_db_without_api_failure_warning() {
+        let repository = test_repository();
+        let status = read_preferred_status(
+            &test_config(9),
+            &repository,
+            false,
+            Duration::from_millis(20),
+        )
+        .await
+        .expect("read direct fallback status");
+
+        assert_eq!(status.source, StatusDataSource::DirectDb);
+        assert!(status.fallback_note.is_none());
+        let calls = repository.calls();
+        assert_eq!(calls.read_store_diagnostics, 1);
+        assert_eq!(calls.latest_ingest_heartbeat, 1);
+    }
+
+    #[tokio::test]
     async fn healthy_status_preserves_stale_heartbeat_json_output() {
         let status = status_json(Ok(IngestHeartbeatRead {
             table_present: true,
@@ -290,6 +750,7 @@ mod tests {
         }))
         .await;
 
+        assert_eq!(status["data_source"], "direct_db");
         assert_eq!(
             status["doctor"],
             json!({

--- a/apps/moraine/src/process.rs
+++ b/apps/moraine/src/process.rs
@@ -148,7 +148,7 @@ pub(crate) struct BackendEndpointStatus {
     pub(crate) http_listening: bool,
 }
 
-fn backend_http_connect_host(host: &str) -> &str {
+pub(crate) fn backend_http_connect_host(host: &str) -> &str {
     let host = host
         .strip_prefix('[')
         .and_then(|host| host.strip_suffix(']'))

--- a/apps/moraine/src/render.rs
+++ b/apps/moraine/src/render.rs
@@ -53,6 +53,22 @@ pub(crate) struct ServiceRuntimeStatus {
     pub(crate) http_listening: Option<bool>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum StatusDataSource {
+    DaemonApi,
+    DirectDb,
+}
+
+impl StatusDataSource {
+    fn label(self) -> &'static str {
+        match self {
+            Self::DaemonApi => "daemon API",
+            Self::DirectDb => "direct DB",
+        }
+    }
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(tag = "state", rename_all = "snake_case")]
 pub(crate) enum HeartbeatSnapshot {
@@ -75,6 +91,7 @@ pub(crate) enum HeartbeatSnapshot {
 pub(crate) struct StatusSnapshot {
     pub(crate) services: Vec<ServiceRuntimeStatus>,
     pub(crate) monitor_url: Option<String>,
+    pub(crate) data_source: StatusDataSource,
     pub(crate) managed_clickhouse_installed: bool,
     pub(crate) managed_clickhouse_path: String,
     pub(crate) managed_clickhouse_version: Option<String>,
@@ -429,6 +446,7 @@ pub(crate) fn render_status(output: &CliOutput, snapshot: &StatusSnapshot) -> Re
     if let Some(version) = &snapshot.doctor.clickhouse_version {
         doctor_lines[0].push_str(&format!("  (v{version})"));
     }
+    doctor_lines.push(format!("source: {}", snapshot.data_source.label()));
     if !snapshot.doctor.pending_migrations.is_empty() {
         doctor_lines.push(format!(
             "  pending migrations: {}",

--- a/apps/moraine/tests/status_cli.rs
+++ b/apps/moraine/tests/status_cli.rs
@@ -1,10 +1,11 @@
 use std::fs;
 #[cfg(unix)]
-use std::io::Write;
+use std::io::{Read, Write};
 #[cfg(unix)]
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(unix)]
 use std::thread;
 #[cfg(unix)]
@@ -13,12 +14,16 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 
+static NEXT_TEMP_DIR: AtomicU64 = AtomicU64::new(0);
+
 fn temp_dir() -> PathBuf {
     let stamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system time")
         .as_nanos();
-    let path = std::env::temp_dir().join(format!("moraine-st-{}-{stamp}", std::process::id()));
+    let nonce = NEXT_TEMP_DIR.fetch_add(1, Ordering::Relaxed);
+    let path =
+        std::env::temp_dir().join(format!("moraine-st-{}-{stamp}-{nonce}", std::process::id()));
     fs::create_dir_all(&path).expect("create temp dir");
     path
 }
@@ -71,9 +76,19 @@ fn run_status(config: &Path) -> Output {
         .output()
         .expect("run moraine status")
 }
+fn run_plain_status(config: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_moraine"))
+        .args(["--output", "plain", "--config"])
+        .arg(config)
+        .arg("status")
+        .output()
+        .expect("run plain moraine status")
+}
 
 #[cfg(unix)]
-fn spawn_http_endpoint() -> (u16, thread::JoinHandle<()>) {
+fn spawn_http_responses(
+    responses: Vec<(&'static str, String)>,
+) -> (u16, thread::JoinHandle<Vec<String>>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind HTTP endpoint");
     let port = listener.local_addr().expect("HTTP endpoint address").port();
     listener
@@ -81,25 +96,51 @@ fn spawn_http_endpoint() -> (u16, thread::JoinHandle<()>) {
         .expect("nonblocking HTTP endpoint");
     let worker = thread::spawn(move || {
         let deadline = Instant::now() + Duration::from_secs(3);
-        loop {
-            match listener.accept() {
-                Ok((mut stream, _)) => {
-                    let _ = stream.write_all(
-                        b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
-                    );
-                    return;
-                }
-                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                    if Instant::now() >= deadline {
-                        return;
+        let mut requests = Vec::new();
+        for (status, body) in responses {
+            loop {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream
+                            .set_nonblocking(false)
+                            .expect("set HTTP fixture blocking mode");
+                        stream
+                            .set_read_timeout(Some(Duration::from_secs(1)))
+                            .expect("set HTTP fixture read timeout");
+                        let mut request = [0_u8; 2048];
+                        let request_len = stream.read(&mut request).expect("read HTTP request");
+                        requests
+                            .push(String::from_utf8_lossy(&request[..request_len]).into_owned());
+                        let response = format!(
+                            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len()
+                        );
+                        stream
+                            .write_all(response.as_bytes())
+                            .expect("write HTTP response");
+                        break;
                     }
-                    thread::sleep(Duration::from_millis(10));
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        if Instant::now() >= deadline {
+                            return requests;
+                        }
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => return requests,
                 }
-                Err(_) => return,
             }
         }
+        requests
     });
     (port, worker)
+}
+
+#[cfg(unix)]
+fn spawn_http_endpoint() -> (u16, thread::JoinHandle<Vec<String>>) {
+    spawn_http_responses(vec![
+        ("503 Service Unavailable", String::new()),
+        ("503 Service Unavailable", String::new()),
+    ])
 }
 
 #[cfg(unix)]
@@ -126,6 +167,7 @@ fn heartbeat_read_error_remains_visible_without_failing_status() {
     let status: Value = serde_json::from_slice(&output.stdout).expect("status JSON output");
 
     assert_eq!(status["doctor"]["clickhouse_healthy"], false);
+    assert_eq!(status["data_source"], "direct_db");
     assert_eq!(status["heartbeat"]["state"], "error");
     assert!(
         status["heartbeat"]["message"]
@@ -136,6 +178,104 @@ fn heartbeat_read_error_remains_visible_without_failing_status() {
         status["heartbeat"]
     );
 
+    let plain_output = run_plain_status(&config);
+    assert!(
+        plain_output.status.success(),
+        "plain status failed: {}",
+        String::from_utf8_lossy(&plain_output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&plain_output.stdout).contains("source: direct DB"),
+        "{}",
+        String::from_utf8_lossy(&plain_output.stdout)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn status_prefers_canonical_daemon_api_and_preserves_json_schema() {
+    let api_body = serde_json::json!({
+        "ok": true,
+        "clickhouse": {
+            "url": "http://127.0.0.1:8123",
+            "database": "api_db",
+            "healthy": true,
+            "version": "26.1.2.3",
+            "ping_ms": 3,
+            "error": null,
+            "connections": {"total": 1}
+        },
+        "database": {
+            "exists": true,
+            "table_count": 1,
+            "estimated_total_rows": 7,
+            "tables": []
+        },
+        "ingestor": {
+            "present": true,
+            "alive": true,
+            "latest": {
+                "ts": "2026-07-10 12:34:56.789",
+                "ts_unix_ms": 1783686896789_i64,
+                "host": "fixture",
+                "service_version": "0.6.4",
+                "queue_depth": 17,
+                "files_active": 2,
+                "files_watched": 3,
+                "rows_raw_written": 8,
+                "rows_events_written": 7,
+                "rows_errors_written": 1,
+                "flush_latency_ms": 4,
+                "append_to_visible_p50_ms": 5,
+                "append_to_visible_p95_ms": 6,
+                "last_error": ""
+            },
+            "age_seconds": 1
+        }
+    })
+    .to_string();
+    let (monitor_port, worker) =
+        spawn_http_responses(vec![("200 OK", String::new()), ("200 OK", api_body)]);
+    let root = temp_dir();
+    let config = write_config(&root, monitor_port);
+
+    let output = run_status(&config);
+    assert!(
+        output.status.success(),
+        "status failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let status: Value = serde_json::from_slice(&output.stdout).expect("status JSON output");
+
+    assert_eq!(status["data_source"], "daemon_api");
+    assert_eq!(status["clickhouse_health_url"], "http://127.0.0.1:8123");
+    assert_eq!(status["doctor"]["clickhouse_healthy"], true);
+    assert_eq!(status["doctor"]["clickhouse_version"], "26.1.2.3");
+    assert_eq!(status["doctor"]["database"], "api_db");
+    assert_eq!(
+        status["doctor"]["applied_migrations"],
+        serde_json::json!([])
+    );
+    assert_eq!(status["heartbeat"]["state"], "available");
+    assert_eq!(status["heartbeat"]["queue_depth"], 17);
+    assert_eq!(status["heartbeat"]["watcher_backend"], "unknown");
+
+    let requests = worker.join().expect("HTTP endpoint worker");
+    assert_eq!(requests.len(), 2, "{requests:?}");
+    assert!(requests[0].starts_with("GET / HTTP/1.1"), "{}", requests[0]);
+    assert!(
+        requests[1].starts_with("GET /api/v1/status HTTP/1.1"),
+        "{}",
+        requests[1]
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| !request.contains("GET /api/status")),
+        "{requests:?}"
+    );
     let _ = fs::remove_dir_all(root);
 }
 
@@ -184,6 +324,7 @@ fn backend_status_distinguishes_endpoint_combinations_and_gates_monitor_url() {
         assert_eq!(backend["socket_listening"], socket_live);
         assert_eq!(backend["http_listening"], http_live);
         assert_eq!(status["monitor_url"].is_string(), http_live);
+        assert_eq!(status["data_source"], "direct_db");
 
         drop(socket_listener);
         if let Some(worker) = http_worker {

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -84,6 +84,12 @@ Check service health:
 moraine status
 ```
 
+`moraine status` prefers the live backend's `/api/v1/status` response and
+automatically falls back to a direct database read when the backend is
+unreachable. Human output labels the source as `daemon API` or `direct DB`;
+JSON output adds the compatible top-level `data_source` field with
+`daemon_api` or `direct_db`.
+
 For a local ClickHouse process started by `moraine up`, Moraine keeps a small
 supervisor running after startup. If ClickHouse exits unexpectedly, the
 supervisor waits 1, 2, 4, 8, then 16 seconds between at most five consecutive

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -1490,6 +1490,50 @@ PY
       --dry-run
   fi
 
+  echo "[e2e] checking full-stack status prefers the daemon v1 API"
+  local daemon_status_path="$tmp_root/daemon-status.json"
+  "$moraine_bin" --output json --config "$config_path" status > "$daemon_status_path"
+  "$python_bin" - "$daemon_status_path" "$backend_pid" "$monitor_port" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+status = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+expected_backend_pid = int(sys.argv[2])
+expected_monitor_url = f"http://127.0.0.1:{int(sys.argv[3])}"
+services = {
+    row.get("service"): row
+    for row in status.get("services", [])
+    if isinstance(row, dict) and isinstance(row.get("service"), str)
+}
+
+if status.get("data_source") != "daemon_api":
+    raise SystemExit(f"full-stack status did not prefer daemon API: {status.get('data_source')!r}")
+backend = services.get("backend")
+if (
+    not isinstance(backend, dict)
+    or backend.get("state") != "running"
+    or backend.get("pid") != expected_backend_pid
+    or backend.get("socket_listening") is not True
+    or backend.get("http_listening") is not True
+):
+    raise SystemExit(f"full-stack status did not report the backend running: {backend!r}")
+doctor = status.get("doctor")
+if (
+    not isinstance(doctor, dict)
+    or doctor.get("clickhouse_healthy") is not True
+    or doctor.get("database_exists") is not True
+):
+    raise SystemExit(f"full-stack API status did not report a healthy database: {doctor!r}")
+heartbeat = status.get("heartbeat")
+if not isinstance(heartbeat, dict) or heartbeat.get("state") != "available":
+    raise SystemExit(f"full-stack API status did not report an available heartbeat: {heartbeat!r}")
+if status.get("monitor_url") != expected_monitor_url:
+    raise SystemExit(
+        f"full-stack status monitor URL mismatch: {status.get('monitor_url')!r}"
+    )
+PY
+
   echo "[e2e] killing only the unified backend (crash/fallback scenario)"
   kill -KILL "$backend_pid"
   wait_for_backend_crash \
@@ -1553,6 +1597,10 @@ from pathlib import Path
 import sys
 
 status = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+if status.get("data_source") != "direct_db":
+    raise SystemExit(
+        f"backend-down status did not use direct DB fallback: {status.get('data_source')!r}"
+    )
 expected_ingest_pid = int(sys.argv[2])
 expected_clickhouse_pid = int(sys.argv[3])
 services = {
@@ -1604,6 +1652,44 @@ if status.get("monitor_url") is not None:
     raise SystemExit(f"final status retained a stopped monitor URL: {status.get('monitor_url')!r}")
 PY
   cat "$final_status_path"
+  echo "[e2e] stopping remaining services and checking all-down status"
+  local all_down_transition_path="$tmp_root/all-down-transition.json"
+  local all_down_status_path="$tmp_root/all-down-status.json"
+  "$moraine_bin" --output json --config "$config_path" down > "$all_down_transition_path"
+  "$moraine_bin" --output json --config "$config_path" status > "$all_down_status_path"
+  "$python_bin" - "$all_down_status_path" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+status = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+services = {
+    row.get("service"): row
+    for row in status.get("services", [])
+    if isinstance(row, dict) and isinstance(row.get("service"), str)
+}
+
+if status.get("data_source") != "direct_db":
+    raise SystemExit(f"all-down status did not use direct DB: {status.get('data_source')!r}")
+for service in ("backend", "ingest", "clickhouse"):
+    row = services.get(service)
+    if (
+        not isinstance(row, dict)
+        or row.get("state") != "stopped"
+        or row.get("pid") is not None
+    ):
+        raise SystemExit(f"all-down status did not report {service} stopped: {row!r}")
+doctor = status.get("doctor")
+if not isinstance(doctor, dict) or doctor.get("clickhouse_healthy") is not False:
+    raise SystemExit(f"all-down status did not preserve database diagnosis: {doctor!r}")
+heartbeat = status.get("heartbeat")
+if not isinstance(heartbeat, dict) or heartbeat.get("state") != "error":
+    raise SystemExit(f"all-down status did not preserve heartbeat failure: {heartbeat!r}")
+if status.get("monitor_url") is not None:
+    raise SystemExit(f"all-down status retained a monitor URL: {status.get('monitor_url')!r}")
+PY
+  cat "$all_down_status_path"
+
   E2E_SUCCESS=1
 }
 


### PR DESCRIPTION
## Description

**What.** Makes `moraine status` prefer the unified backend's canonical `/api/v1/status` API and deliberately fall back to the shared direct-database repository when the daemon is unavailable or its response is unusable.

**Why.** Status is the operator's diagnostic path for full, partial, and stopped stacks, so it must use the daemon when available without losing the ability to diagnose a daemon outage.

The CLI now labels the selected source as `daemon API` or `direct DB` in human output and adds the compatible top-level `data_source` value (`daemon_api` or `direct_db`) to JSON. Valid API-reported unhealthy storage remains an API result rather than triggering a hidden database probe. Transport failures, non-success responses, invalid or contradictory payloads, timeouts, and responses over 256 KiB fall back to the direct repository. The local status client disables ambient proxies and uses the ClickHouse URL reported by the daemon when rendering API-backed health.

The shipped monitor client remains on canonical `/api/v1` routes. Administrative `db *`, `doctor`, and `export` commands remain direct-database operations; this change is isolated to status reads.

### State matrix

| Stack state | Selected source | Observable diagnosis |
| --- | --- | --- |
| Backend + ingest + ClickHouse up | `daemon_api` | Backend running, database healthy, heartbeat available, monitor URL present |
| Backend down; ingest + ClickHouse up | `direct_db` | Backend stopped, surviving services and healthy database/heartbeat reported, monitor URL absent |
| All services down | `direct_db` | All services stopped, database unhealthy and heartbeat error retained, monitor URL absent; status still returns useful output |

## Usage

```bash
moraine status
moraine --output json status
```

Human output includes `source: daemon API` or `source: direct DB`. JSON callers can inspect `data_source` without losing any existing fields.

## Changelog

- Prefer `/api/v1/status` for `moraine status` when the backend HTTP endpoint is live.
- Fall back deliberately to the shared direct-database repository when the daemon API is unavailable or unusable.
- Identify the selected status source in human and JSON output while preserving existing status fields and exit behavior.
- Extend the stack smoke test across full, half-up, and all-down states.

## Validation

The reviewed implementation passed `cargo test -p moraine --locked` with 155 tests, `cargo test -p moraine-monitor-core --locked` with 15 tests, and `bun run test -- src/lib/api/client.test.ts src/lib/api/sessions.test.ts` with 6 monitor client tests. `bun run test:e2e -- e2e/monitor.smoke.spec.ts` passed 2 real Chromium tests that assert canonical `/api/v1` traffic and no legacy API traffic.

`bash scripts/ci/e2e-stack.sh` passed the full three-state stack matrix: `daemon_api` with the full stack, `direct_db` after killing only the backend while ClickHouse and ingest remained live, and `direct_db` with stopped services plus preserved unhealthy-database/heartbeat diagnostics after shutdown. The full stack was not repeated during publication recovery because no production code changed after that grounded run.

Recovery reran the focused status paths: `cargo test -p moraine --locked commands::status::tests` passed 13 tests, and `cargo test -p moraine --locked --test status_cli` passed all 3 parallel CLI tests. The first focused CLI run exposed a same-timestamp temporary-directory collision; the fixture now adds a process-local atomic nonce, and the rerun passed. `rustfmt --edition 2021 --check apps/moraine/tests/status_cli.rs` and `git diff --check` also passed.

## Review outcome

All seven review facets—correctness, completeness, security, elegance, idiomatic Rust, YAGNI, and scope—returned no unresolved findings against the final diff. Accepted review hardening carries the daemon-reported ClickHouse URL, rejects contradictory API health fields, bypasses ambient proxies, bounds streamed responses to 256 KiB, and makes raw-TCP fixtures deterministic. Correctness follow-up agreed that probing the direct database for every valid API `present:false` heartbeat would violate API preference and source accuracy; changing the v1 payload is outside this issue.

## Residual risks

The CLI's private strict response projection must evolve with incompatible daemon payload changes; incompatibility fails safely to the direct repository. The preserved v1 heartbeat payload cannot distinguish an absent heartbeat from a repository heartbeat-read error, so API-backed `present:false` remains unavailable rather than performing a hidden direct probe. The cumulative chunked-response size guard is explicit in code but does not have a separate no-`Content-Length` fixture.

Resolves #460
