### PR TITLE
feat(backend): centralize named read routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,6 +1199,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "url",
  "uuid",
 ]
 
@@ -1283,6 +1284,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,9 +1243,11 @@ version = "0.6.4"
 dependencies = [
  "anyhow",
  "moraine-config",
+ "moraine-conversations",
  "moraine-mcp-core",
  "moraine-monitor-core",
  "tokio",
+ "tracing",
  "tracing-subscriber",
 ]
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -17,7 +17,9 @@ tokio = { version = "1.40", features = [
     "sync",
     "time",
 ] }
+tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 moraine-config = { path = "../../crates/moraine-config" }
+moraine-conversations = { path = "../../crates/moraine-conversations" }
 moraine-mcp-core = { path = "../../crates/moraine-mcp-core" }
 moraine-monitor-core = { path = "../../crates/moraine-monitor-core" }

--- a/apps/moraine-mcp/src/rpc.rs
+++ b/apps/moraine-mcp/src/rpc.rs
@@ -1,11 +1,13 @@
 use crate::cli::ServeMode;
 use anyhow::{anyhow, bail, Context, Result};
 use moraine_config::AppConfig;
-use moraine_mcp_core::SessionOriginScope;
-use std::{net::IpAddr, path::PathBuf};
+use moraine_conversations::{BackendRepositoryRouter, RepoConfig};
+use moraine_mcp_core::{PrivateRouteNegotiation, SessionOriginScope};
+use std::{net::IpAddr, path::PathBuf, sync::Arc};
 use tokio::runtime::Builder;
 use tokio::sync::watch;
 use tokio::task::{JoinError, JoinSet};
+use tracing::{debug, warn};
 
 #[derive(Debug, Default)]
 pub struct BackendOptions {
@@ -81,22 +83,115 @@ pub fn run(
             runtime.block_on(run_backend(cfg, socket_path, host, port, static_dir))
         }
         // Only the unscoped, central-enabled path can become a thin proxy, so
-        // it is the only one that gets the lightweight current-thread runtime.
         ServeMode::Stdio if session_scope.is_none() && cfg.mcp.use_central_server => {
             let runtime = Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .context("failed to build current-thread runtime")?;
-            runtime.block_on(moraine_mcp_core::run_mcp_entry(cfg, None))
+            runtime.block_on(run_stdio_entry(cfg, None))
         }
         ServeMode::Stdio => {
             let runtime = Builder::new_multi_thread()
                 .enable_all()
                 .build()
                 .context("failed to build multi-threaded runtime")?;
-            runtime.block_on(moraine_mcp_core::run_mcp_entry(cfg, session_scope))
+            runtime.block_on(run_stdio_entry(cfg, session_scope))
         }
     }
+}
+
+fn repository_config(cfg: &AppConfig, session_scope: Option<SessionOriginScope>) -> RepoConfig {
+    RepoConfig {
+        max_results: cfg.mcp.max_results,
+        preview_chars: cfg.mcp.preview_chars,
+        default_context_before: cfg.mcp.default_context_before,
+        default_context_after: cfg.mcp.default_context_after,
+        default_include_tool_events: cfg.mcp.default_include_tool_events,
+        default_exclude_codex_mcp: cfg.mcp.default_exclude_codex_mcp,
+        async_log_writes: cfg.mcp.async_log_writes,
+        bm25_k1: cfg.bm25.k1,
+        bm25_b: cfg.bm25.b,
+        bm25_default_min_score: cfg.bm25.default_min_score,
+        bm25_default_min_should_match: cfg.bm25.default_min_should_match,
+        bm25_max_query_terms: cfg.bm25.max_query_terms,
+        session_scope,
+    }
+}
+
+fn backend_router(
+    cfg: Arc<AppConfig>,
+    session_scope: Option<SessionOriginScope>,
+    role: &str,
+) -> Result<Arc<BackendRepositoryRouter>> {
+    let user_agent = format!(
+        "{role}/{} (pid={})",
+        env!("CARGO_PKG_VERSION"),
+        std::process::id()
+    );
+    Ok(Arc::new(BackendRepositoryRouter::new(
+        cfg.clone(),
+        repository_config(&cfg, session_scope),
+        user_agent,
+    )?))
+}
+
+async fn run_stdio_entry(cfg: AppConfig, session_scope: Option<SessionOriginScope>) -> Result<()> {
+    let cwd = std::env::current_dir()
+        .map(|dir| dir.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    #[cfg(unix)]
+    if session_scope.is_none() && cfg.mcp.use_central_server {
+        use tokio::net::UnixStream;
+
+        let socket_path = PathBuf::from(&cfg.mcp.central_socket_path);
+        let connect_deadline = std::time::Duration::from_millis(cfg.mcp.central_connect_timeout_ms);
+        match tokio::time::timeout(connect_deadline, UnixStream::connect(&socket_path)).await {
+            Ok(Ok(stream)) => {
+                let route_deadline = moraine_mcp_core::private_route_deadline(&cfg)?;
+                match moraine_mcp_core::negotiate_private_route(stream, &cwd, route_deadline).await {
+                    PrivateRouteNegotiation::Accepted(connection) => {
+                        debug!(
+                            "proxying stdio to central MCP server at {}",
+                            socket_path.display()
+                        );
+                        return moraine_mcp_core::run_proxy(connection).await;
+                    }
+                    PrivateRouteNegotiation::Rejected { message } => {
+                        return Err(anyhow!(message))
+                            .context("central backend rejected the project route");
+                    }
+                    PrivateRouteNegotiation::Incompatible { reason } => warn!(
+                        "central MCP server at {} cannot negotiate project routing ({}); using embedded server",
+                        socket_path.display(),
+                        reason
+                    ),
+                }
+            }
+            Ok(Err(error)) => warn!(
+                "central MCP server unreachable at {} ({}); using embedded server",
+                socket_path.display(),
+                error
+            ),
+            Err(_) => warn!(
+                "central MCP server connect timed out at {} after {}ms; using embedded server",
+                socket_path.display(),
+                cfg.mcp.central_connect_timeout_ms
+            ),
+        }
+    }
+
+    let cfg = Arc::new(cfg);
+    let router = backend_router(cfg.clone(), session_scope, "moraine-mcp")?;
+    let backend = router
+        .repository_for_project_dir(Some(&cwd))
+        .await
+        .context("failed to construct embedded conversation repository")?;
+    moraine_mcp_core::run_stdio_with_repository(
+        Arc::unwrap_or_clone(cfg),
+        backend.repository().clone(),
+    )
+    .await
 }
 
 async fn run_backend(
@@ -108,26 +203,27 @@ async fn run_backend(
 ) -> Result<()> {
     validate_backend_bind_policy(&host, cfg.backend.auth_token.as_deref())?;
     let host = normalize_listener_bind(host);
-    // This is the daemon mode's sole repository factory call. Both services
-    // receive clones of this exact Arc, sharing its HTTP pool and caches.
-    let user_agent = format!(
-        "moraine-backend/{} (pid={})",
-        env!("CARGO_PKG_VERSION"),
-        std::process::id()
-    );
-    let repository = moraine_mcp_core::build_repository_with_user_agent(&cfg, None, user_agent)
-        .context("failed to build backend conversation repository")?;
-    let socket_repository = repository.clone();
+    // This is the daemon mode's sole routing/factory owner. Both services
+    // receive clones of this exact router Arc; each selected backend therefore
+    // shares one checked client, repository, and cache set across MCP and HTTP.
+    let cfg = Arc::new(cfg);
+    let router = backend_router(cfg.clone(), None, "moraine-backend")
+        .context("failed to build backend repository router")?;
+    router
+        .default_repository()
+        .await
+        .context("failed to build default backend conversation repository")?;
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let mut services = JoinSet::new();
 
     let socket_cfg = cfg.clone();
+    let socket_router = router.clone();
     let socket_shutdown = shutdown_rx.clone();
     services.spawn(async move {
-        let result = moraine_mcp_core::run_socket_with_repository(
+        let result = moraine_mcp_core::run_socket_with_router(
             socket_cfg,
-            socket_repository,
+            socket_router,
             socket_path,
             wait_for_shutdown(socket_shutdown),
         )
@@ -136,9 +232,8 @@ async fn run_backend(
     });
 
     services.spawn(async move {
-        let result = moraine_monitor_core::run_server_with_repository(
-            cfg,
-            repository,
+        let result = moraine_monitor_core::run_server_with_router(
+            router,
             host,
             port,
             static_dir,

--- a/apps/moraine-mcp/src/rpc.rs
+++ b/apps/moraine-mcp/src/rpc.rs
@@ -2,7 +2,9 @@ use crate::cli::ServeMode;
 use anyhow::{anyhow, bail, Context, Result};
 use moraine_config::AppConfig;
 use moraine_conversations::{BackendRepositoryRouter, RepoConfig};
-use moraine_mcp_core::{PrivateRouteNegotiation, SessionOriginScope};
+#[cfg(unix)]
+use moraine_mcp_core::PrivateRouteNegotiation;
+use moraine_mcp_core::SessionOriginScope;
 use std::{net::IpAddr, path::PathBuf, sync::Arc};
 use tokio::runtime::Builder;
 use tokio::sync::watch;
@@ -187,11 +189,10 @@ async fn run_stdio_entry(cfg: AppConfig, session_scope: Option<SessionOriginScop
         .repository_for_project_dir(Some(&cwd))
         .await
         .context("failed to construct embedded conversation repository")?;
-    moraine_mcp_core::run_stdio_with_repository(
-        Arc::unwrap_or_clone(cfg),
-        backend.repository().clone(),
-    )
-    .await
+    let repository = backend.repository().clone();
+    drop(backend);
+    drop(router);
+    moraine_mcp_core::run_stdio_with_repository(Arc::unwrap_or_clone(cfg), repository).await
 }
 
 async fn run_backend(

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.40", features = ["macros", "rt", "sync"] }
 tracing = "0.1"
+url = "2.5"
 uuid = { version = "1.11", features = ["v4"] }
 moraine-clickhouse = { path = "../moraine-clickhouse" }
 moraine-config = { path = "../moraine-config" }

--- a/crates/moraine-conversations/src/backend_router.rs
+++ b/crates/moraine-conversations/src/backend_router.rs
@@ -1,0 +1,902 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context as _, Result};
+use moraine_clickhouse::{enforce_remote_schema_policy, ClickHouseClient};
+use moraine_config::{AppConfig, ClickHouseConfig, DEFAULT_BACKEND_NAME};
+use tokio::sync::{watch, Mutex};
+use tracing::warn;
+
+use crate::{
+    build_clickhouse_repository_with_user_agent, ClickHouseConversationRepository,
+    ConversationRepository, RepoConfig,
+};
+
+/// An immutable repository handle together with the configured backend identity
+/// that produced it.
+///
+/// Handles are cached by [`BackendRepositoryRouter`]. Cloning the outer `Arc`
+/// preserves both the repository instance and its metadata as one unit.
+pub struct BackendRepository {
+    backend_name: Arc<str>,
+    repository: Arc<dyn ConversationRepository>,
+    clickhouse_url: Arc<str>,
+    clickhouse_database: Arc<str>,
+}
+
+impl BackendRepository {
+    fn new(
+        backend_name: Arc<str>,
+        repository: Arc<dyn ConversationRepository>,
+        clickhouse: &ClickHouseConfig,
+    ) -> Self {
+        Self {
+            backend_name,
+            repository,
+            clickhouse_url: Arc::from(clickhouse.url.as_str()),
+            clickhouse_database: Arc::from(clickhouse.database.as_str()),
+        }
+    }
+
+    pub fn backend_name(&self) -> &str {
+        &self.backend_name
+    }
+
+    pub fn repository(&self) -> &Arc<dyn ConversationRepository> {
+        &self.repository
+    }
+
+    pub fn clickhouse_url(&self) -> &str {
+        &self.clickhouse_url
+    }
+
+    pub fn clickhouse_database(&self) -> &str {
+        &self.clickhouse_database
+    }
+}
+
+type SharedInitialization = std::result::Result<Arc<BackendRepository>, Arc<str>>;
+
+struct BuildAttempt {
+    result: watch::Sender<Option<SharedInitialization>>,
+}
+
+impl BuildAttempt {
+    fn new() -> Self {
+        let (result, _) = watch::channel(None);
+        Self { result }
+    }
+
+    async fn wait(&self) -> Result<Arc<BackendRepository>> {
+        let mut result = self.result.subscribe();
+        loop {
+            if let Some(result) = result.borrow_and_update().clone() {
+                return result.map_err(|message| anyhow!(message.to_string()));
+            }
+            result
+                .changed()
+                .await
+                .map_err(|_| anyhow!("backend repository initialization ended without a result"))?;
+        }
+    }
+}
+
+enum SlotState {
+    Empty,
+    Building(Arc<BuildAttempt>),
+    Ready(Arc<BackendRepository>),
+}
+
+struct BackendSlot {
+    backend_name: Arc<str>,
+    clickhouse: ClickHouseConfig,
+    checked: bool,
+    state: Mutex<SlotState>,
+}
+
+impl BackendSlot {
+    fn new(
+        backend_name: String,
+        clickhouse: ClickHouseConfig,
+        checked: bool,
+        preloaded: Option<Arc<dyn ConversationRepository>>,
+    ) -> Self {
+        let backend_name: Arc<str> = Arc::from(backend_name);
+        let state = match preloaded {
+            Some(repository) => SlotState::Ready(Arc::new(BackendRepository::new(
+                backend_name.clone(),
+                repository,
+                &clickhouse,
+            ))),
+            None => SlotState::Empty,
+        };
+        Self {
+            backend_name,
+            clickhouse,
+            checked,
+            state: Mutex::new(state),
+        }
+    }
+
+    async fn repository(
+        self: &Arc<Self>,
+        repo_config: RepoConfig,
+        user_agent: Arc<str>,
+    ) -> Result<Arc<BackendRepository>> {
+        let attempt = {
+            let mut state = self.state.lock().await;
+            match &*state {
+                SlotState::Ready(repository) => return Ok(repository.clone()),
+                SlotState::Building(attempt) => attempt.clone(),
+                SlotState::Empty => {
+                    let attempt = Arc::new(BuildAttempt::new());
+                    *state = SlotState::Building(attempt.clone());
+
+                    let slot = self.clone();
+                    let published_attempt = attempt.clone();
+                    tokio::spawn(async move {
+                        let result = slot
+                            .build(repo_config, &user_agent)
+                            .await
+                            .map_err(|error| Arc::<str>::from(format!("{error:#}")));
+
+                        // Retain the result even if every initiating caller was
+                        // cancelled before subscribing to this attempt.
+                        published_attempt.result.send_replace(Some(result.clone()));
+
+                        let mut state = slot.state.lock().await;
+                        let is_current_attempt = matches!(
+                            &*state,
+                            SlotState::Building(current)
+                                if Arc::ptr_eq(current, &published_attempt)
+                        );
+                        if is_current_attempt {
+                            *state = match result {
+                                Ok(repository) => SlotState::Ready(repository),
+                                Err(_) => SlotState::Empty,
+                            };
+                        }
+                    });
+                    attempt
+                }
+            }
+        };
+
+        attempt.wait().await
+    }
+
+    async fn build(
+        &self,
+        repo_config: RepoConfig,
+        user_agent: &str,
+    ) -> Result<Arc<BackendRepository>> {
+        let repository = if self.checked {
+            build_checked_clickhouse_repository_with_user_agent(
+                &self.backend_name,
+                self.clickhouse.clone(),
+                repo_config,
+                user_agent,
+            )
+            .await?
+        } else {
+            build_clickhouse_repository_with_user_agent(
+                self.clickhouse.clone(),
+                repo_config,
+                user_agent,
+            )?
+        };
+
+        Ok(Arc::new(BackendRepository::new(
+            self.backend_name.clone(),
+            repository,
+            &self.clickhouse,
+        )))
+    }
+}
+
+/// Lazy repository factory and cwd router shared by daemon read surfaces.
+///
+/// One slot is predeclared for every normalized backend. The default slot is
+/// constructed without a remote schema handshake because Moraine owns and
+/// migrates it. Every named slot is checked exactly once per successful
+/// initialization. Concurrent callers share an in-flight result; failures are
+/// returned to those callers but are not cached, so a later call retries.
+pub struct BackendRepositoryRouter {
+    config: Arc<AppConfig>,
+    repo_config: RepoConfig,
+    user_agent: Arc<str>,
+    slots: BTreeMap<String, Arc<BackendSlot>>,
+}
+
+impl BackendRepositoryRouter {
+    pub fn new(
+        config: Arc<AppConfig>,
+        repo_config: RepoConfig,
+        user_agent: impl Into<Arc<str>>,
+    ) -> Result<Self> {
+        Self::new_inner(config, repo_config, user_agent.into(), BTreeMap::new())
+    }
+
+    /// Construct a router with already-built repositories for consumer tests.
+    /// Production composition roots must use [`Self::new`].
+    #[doc(hidden)]
+    pub fn from_preloaded_for_testing(
+        config: Arc<AppConfig>,
+        repositories: impl IntoIterator<Item = (String, Arc<dyn ConversationRepository>)>,
+    ) -> Result<Self> {
+        Self::new_inner(
+            config,
+            RepoConfig::default(),
+            Arc::from("moraine-conversations-test"),
+            repositories.into_iter().collect(),
+        )
+    }
+
+    fn new_inner(
+        config: Arc<AppConfig>,
+        repo_config: RepoConfig,
+        user_agent: Arc<str>,
+        mut preloaded: BTreeMap<String, Arc<dyn ConversationRepository>>,
+    ) -> Result<Self> {
+        if !config.backends.contains_key(DEFAULT_BACKEND_NAME) {
+            return Err(anyhow!(
+                "normalized app config is missing the '{}' backend",
+                DEFAULT_BACKEND_NAME
+            ));
+        }
+
+        let mut slots = BTreeMap::new();
+        for (backend_name, clickhouse) in &config.backends {
+            let repository = preloaded.remove(backend_name);
+            slots.insert(
+                backend_name.clone(),
+                Arc::new(BackendSlot::new(
+                    backend_name.clone(),
+                    clickhouse.clone(),
+                    backend_name != DEFAULT_BACKEND_NAME,
+                    repository,
+                )),
+            );
+        }
+        if let Some(unknown) = preloaded.keys().next() {
+            return Err(anyhow!(
+                "preloaded repository names unconfigured backend '{unknown}'"
+            ));
+        }
+
+        Ok(Self {
+            config,
+            repo_config,
+            user_agent,
+            slots,
+        })
+    }
+
+    pub async fn default_repository(&self) -> Result<Arc<BackendRepository>> {
+        self.repository_for_backend(DEFAULT_BACKEND_NAME).await
+    }
+
+    /// Select a repository for a process/project cwd.
+    ///
+    /// Ordered home-config routes win over the nearest repo `.moraine.toml`
+    /// reference. A route that names `default`, an unknown repo reference, no
+    /// route, a missing cwd, or a blank cwd all select the default repository.
+    /// A matching home route owns the decision even when its backend name is
+    /// unknown; it never falls through to the repo file.
+    pub async fn repository_for_project_dir(
+        &self,
+        project_dir: Option<&str>,
+    ) -> Result<Arc<BackendRepository>> {
+        self.repository_for_project_dir_with_lookup(project_dir, |dir| {
+            moraine_config::find_repo_backend_ref(dir)
+        })
+        .await
+    }
+
+    async fn repository_for_project_dir_with_lookup<F>(
+        &self,
+        project_dir: Option<&str>,
+        repo_lookup: F,
+    ) -> Result<Arc<BackendRepository>>
+    where
+        F: FnOnce(String) -> Option<String> + Send + 'static,
+    {
+        // The normal single-backend install does no filesystem walk.
+        if self.slots.len() == 1 {
+            return self.default_repository().await;
+        }
+
+        let Some(project_dir) = project_dir.map(str::trim).filter(|dir| !dir.is_empty()) else {
+            return self.default_repository().await;
+        };
+
+        // A matching home route decides the name even when validation below
+        // fails. First match wins; do not consult a repo file for that cwd.
+        let backend_name = if let Some(route) = self.config.route_for_dir(project_dir) {
+            Some(route.backend.clone())
+        } else {
+            let project_dir = project_dir.to_string();
+            tokio::task::spawn_blocking(move || repo_lookup(project_dir))
+                .await
+                .context("repo backend reference lookup task failed")?
+        };
+
+        let Some(backend_name) = backend_name else {
+            return self.default_repository().await;
+        };
+        if backend_name == DEFAULT_BACKEND_NAME {
+            return self.default_repository().await;
+        }
+        if self.slots.contains_key(&backend_name) {
+            return self.repository_for_backend(&backend_name).await;
+        }
+
+        warn!(
+            backend = %backend_name,
+            cwd = project_dir,
+            "route names a backend with no [backends.{}] entry in the home config; serving against the default backend",
+            backend_name
+        );
+        self.default_repository().await
+    }
+
+    async fn repository_for_backend(&self, backend_name: &str) -> Result<Arc<BackendRepository>> {
+        let slot = self
+            .slots
+            .get(backend_name)
+            .ok_or_else(|| anyhow!("backend '{backend_name}' is not configured"))?;
+        slot.repository(self.repo_config.clone(), self.user_agent.clone())
+            .await
+    }
+}
+
+/// Build a named ClickHouse repository after enforcing the read-only remote
+/// schema policy.
+///
+/// The same attributed client performs the skew probe and is then moved into
+/// the repository. Named backends are never migrated here.
+pub async fn build_checked_clickhouse_repository_with_user_agent(
+    backend_name: &str,
+    clickhouse: ClickHouseConfig,
+    config: RepoConfig,
+    user_agent: impl AsRef<str>,
+) -> Result<Arc<dyn ConversationRepository>> {
+    let allow_newer_server = clickhouse.allow_newer_server;
+    let client =
+        ClickHouseClient::new_with_user_agent(clickhouse, user_agent).with_context(|| {
+            format!("backend '{backend_name}': failed to construct ClickHouse client")
+        })?;
+    let skew = client.schema_skew().await.with_context(|| {
+        format!("backend '{backend_name}': schema handshake failed (is the server reachable?)")
+    })?;
+    enforce_remote_schema_policy(backend_name, &skew, allow_newer_server)?;
+
+    Ok(Arc::new(ClickHouseConversationRepository::new(
+        client, config,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex as StdMutex};
+    use std::time::Duration;
+
+    use axum::{
+        extract::{Query, State},
+        http::{HeaderMap, Method, StatusCode},
+        routing::get,
+        Router,
+    };
+    use moraine_clickhouse::bundled_migrations;
+    use moraine_config::{RouteConfig, ROUTE_MODE_MIRROR};
+    use serde_json::json;
+    use tokio::sync::{Barrier, Notify};
+
+    use super::*;
+    use crate::InMemoryConversationRepository;
+
+    #[derive(Clone)]
+    struct CapturedRequest {
+        method: Method,
+        query: String,
+        user_agent: Option<String>,
+    }
+
+    struct FirstRequestBlock {
+        reached: Arc<Barrier>,
+        release: Arc<Notify>,
+    }
+
+    struct SchemaServerState {
+        ledger_exists: bool,
+        versions: Vec<String>,
+        fail_first: AtomicBool,
+        requests: AtomicUsize,
+        captured: StdMutex<Vec<CapturedRequest>>,
+        first_request_block: Option<FirstRequestBlock>,
+    }
+
+    async fn spawn_schema_server(
+        ledger_exists: bool,
+        versions: Vec<String>,
+        fail_first: bool,
+        first_request_block: Option<FirstRequestBlock>,
+    ) -> (String, Arc<SchemaServerState>) {
+        async fn handler(
+            State(state): State<Arc<SchemaServerState>>,
+            method: Method,
+            Query(params): Query<HashMap<String, String>>,
+            headers: HeaderMap,
+        ) -> (StatusCode, String) {
+            let query = params.get("query").cloned().unwrap_or_default();
+            let request_index = state.requests.fetch_add(1, Ordering::SeqCst);
+            state
+                .captured
+                .lock()
+                .expect("captured request lock")
+                .push(CapturedRequest {
+                    method,
+                    query: query.clone(),
+                    user_agent: headers
+                        .get("user-agent")
+                        .and_then(|value| value.to_str().ok())
+                        .map(ToOwned::to_owned),
+                });
+
+            if request_index == 0 {
+                if let Some(block) = &state.first_request_block {
+                    block.reached.wait().await;
+                    block.release.notified().await;
+                }
+            }
+            if state.fail_first.swap(false, Ordering::SeqCst) {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "temporary schema probe failure".to_string(),
+                );
+            }
+
+            if query.contains("FROM system.tables") {
+                return (
+                    StatusCode::OK,
+                    json!({"data": [{"exists": u8::from(state.ledger_exists)}]}).to_string(),
+                );
+            }
+            if query.contains("schema_migrations GROUP BY version") {
+                let rows = state
+                    .versions
+                    .iter()
+                    .map(|version| json!({"version": version}))
+                    .collect::<Vec<_>>();
+                return (StatusCode::OK, json!({"data": rows}).to_string());
+            }
+
+            (
+                StatusCode::BAD_REQUEST,
+                format!("unexpected query: {query}"),
+            )
+        }
+
+        let state = Arc::new(SchemaServerState {
+            ledger_exists,
+            versions,
+            fail_first: AtomicBool::new(fail_first),
+            requests: AtomicUsize::new(0),
+            captured: StdMutex::new(Vec::new()),
+            first_request_block,
+        });
+        let app = Router::new()
+            .route("/", get(handler).post(handler))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind schema server");
+        let address = listener.local_addr().expect("schema server address");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (format!("http://{address}"), state)
+    }
+
+    fn bundled_versions() -> Vec<String> {
+        bundled_migrations()
+            .into_iter()
+            .map(|migration| migration.version.to_string())
+            .collect()
+    }
+
+    fn clickhouse_config(url: String, allow_newer_server: bool) -> ClickHouseConfig {
+        ClickHouseConfig {
+            url,
+            database: "moraine_team".to_string(),
+            timeout_seconds: 2.0,
+            allow_newer_server,
+            ..ClickHouseConfig::default()
+        }
+    }
+
+    fn routed_config(url: String, allow_newer_server: bool) -> Arc<AppConfig> {
+        let mut config = AppConfig::default();
+        config.backends.insert(
+            "team-ch".to_string(),
+            clickhouse_config(url, allow_newer_server),
+        );
+        config.routes.push(RouteConfig {
+            dir: "/work/team/**".to_string(),
+            backend: "team-ch".to_string(),
+            mode: ROUTE_MODE_MIRROR.to_string(),
+        });
+        Arc::new(config)
+    }
+
+    fn preloaded_router(config: Arc<AppConfig>) -> BackendRepositoryRouter {
+        let default: Arc<dyn ConversationRepository> =
+            Arc::new(InMemoryConversationRepository::new(RepoConfig::default()));
+        let named: Arc<dyn ConversationRepository> =
+            Arc::new(InMemoryConversationRepository::new(RepoConfig::default()));
+        BackendRepositoryRouter::from_preloaded_for_testing(
+            config,
+            [
+                (DEFAULT_BACKEND_NAME.to_string(), default),
+                ("team-ch".to_string(), named),
+            ],
+        )
+        .expect("preloaded router")
+    }
+
+    #[tokio::test]
+    async fn checked_factory_accepts_clean_schema_and_only_reads() {
+        let (url, state) = spawn_schema_server(true, bundled_versions(), false, None).await;
+        let repository = build_checked_clickhouse_repository_with_user_agent(
+            "team-ch",
+            clickhouse_config(url, false),
+            RepoConfig::default(),
+            "moraine-backend/test",
+        )
+        .await
+        .expect("clean named backend");
+
+        assert_eq!(
+            repository.config().max_results,
+            RepoConfig::default().max_results
+        );
+        let captured = state.captured.lock().expect("captured request lock");
+        assert_eq!(captured.len(), 2);
+        assert!(captured
+            .iter()
+            .all(|request| request.query.trim_start().starts_with("SELECT")));
+        assert!(captured
+            .iter()
+            .all(|request| request.method == Method::POST));
+        assert!(captured
+            .iter()
+            .all(|request| { request.user_agent.as_deref() == Some("moraine-backend/test") }));
+    }
+
+    #[tokio::test]
+    async fn checked_factory_rejects_older_schema() {
+        let mut versions = bundled_versions();
+        let missing = versions.pop().expect("at least one bundled migration");
+        let (url, _) = spawn_schema_server(true, versions, false, None).await;
+        let error = build_checked_clickhouse_repository_with_user_agent(
+            "team-ch",
+            clickhouse_config(url, true),
+            RepoConfig::default(),
+            "moraine-backend/test",
+        )
+        .await
+        .err()
+        .expect("older backend must be rejected");
+
+        let message = format!("{error:#}");
+        assert!(message.contains("team-ch"));
+        assert!(message.contains(&missing));
+        assert!(message.contains("never migrates"));
+    }
+
+    #[tokio::test]
+    async fn checked_factory_rejects_newer_schema_without_opt_in() {
+        let mut versions = bundled_versions();
+        versions.push("999".to_string());
+        let (url, _) = spawn_schema_server(true, versions, false, None).await;
+        let error = build_checked_clickhouse_repository_with_user_agent(
+            "team-ch",
+            clickhouse_config(url, false),
+            RepoConfig::default(),
+            "moraine-backend/test",
+        )
+        .await
+        .err()
+        .expect("newer backend must require opt-in");
+
+        let message = format!("{error:#}");
+        assert!(message.contains("999"));
+        assert!(message.contains("allow_newer_server"));
+    }
+
+    #[tokio::test]
+    async fn checked_factory_allows_newer_schema_with_opt_in() {
+        let mut versions = bundled_versions();
+        versions.push("999".to_string());
+        let (url, _) = spawn_schema_server(true, versions, false, None).await;
+        build_checked_clickhouse_repository_with_user_agent(
+            "team-ch",
+            clickhouse_config(url, true),
+            RepoConfig::default(),
+            "moraine-backend/test",
+        )
+        .await
+        .expect("allow_newer_server accepts a server-ahead ledger");
+    }
+
+    #[tokio::test]
+    async fn checked_factory_does_not_create_a_missing_ledger() {
+        let (url, state) = spawn_schema_server(false, Vec::new(), false, None).await;
+        let error = build_checked_clickhouse_repository_with_user_agent(
+            "team-ch",
+            clickhouse_config(url, false),
+            RepoConfig::default(),
+            "moraine-backend/test",
+        )
+        .await
+        .err()
+        .expect("missing ledger means server is behind");
+        assert!(error.to_string().contains("behind"));
+
+        let captured = state.captured.lock().expect("captured request lock");
+        assert_eq!(captured.len(), 1);
+        assert!(captured[0].query.starts_with("SELECT"));
+        assert!(!captured[0].query.contains("CREATE"));
+        assert!(!captured[0].query.contains("INSERT"));
+    }
+
+    #[tokio::test]
+    async fn default_slot_is_lazy_and_unchecked() {
+        let mut config = AppConfig::default();
+        config.backends.get_mut(DEFAULT_BACKEND_NAME).unwrap().url =
+            "http://127.0.0.1:1".to_string();
+        let router = BackendRepositoryRouter::new(
+            Arc::new(config),
+            RepoConfig::default(),
+            "moraine-backend/test",
+        )
+        .expect("router");
+
+        let first = router
+            .default_repository()
+            .await
+            .expect("default construction does not probe schema");
+        let second = router.default_repository().await.expect("cached default");
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(first.backend_name(), DEFAULT_BACKEND_NAME);
+        assert_eq!(first.clickhouse_url(), "http://127.0.0.1:1");
+        assert_eq!(
+            first.clickhouse_database(),
+            ClickHouseConfig::default().database
+        );
+        assert!(Arc::ptr_eq(first.repository(), second.repository()));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn named_slot_shares_failure_then_retries_and_caches_success() {
+        let reached = Arc::new(Barrier::new(2));
+        let release = Arc::new(Notify::new());
+        let (url, state) = spawn_schema_server(
+            true,
+            bundled_versions(),
+            true,
+            Some(FirstRequestBlock {
+                reached: reached.clone(),
+                release: release.clone(),
+            }),
+        )
+        .await;
+        let router = Arc::new(
+            BackendRepositoryRouter::new(
+                routed_config(url, false),
+                RepoConfig::default(),
+                "moraine-backend/test",
+            )
+            .expect("router"),
+        );
+
+        let start = Arc::new(Barrier::new(9));
+        let mut callers = Vec::new();
+        for _ in 0..8 {
+            let router = router.clone();
+            let start = start.clone();
+            callers.push(tokio::spawn(async move {
+                start.wait().await;
+                router
+                    .repository_for_project_dir(Some("/work/team/project"))
+                    .await
+            }));
+        }
+        start.wait().await;
+        reached.wait().await;
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        release.notify_one();
+
+        for caller in callers {
+            let error = caller
+                .await
+                .expect("caller task")
+                .err()
+                .expect("shared attempt must fail");
+            assert!(format!("{error:#}").contains("temporary schema probe failure"));
+        }
+        assert_eq!(state.requests.load(Ordering::SeqCst), 1);
+
+        let recovered = router
+            .repository_for_project_dir(Some("/work/team/project"))
+            .await
+            .expect("later call retries failed slot");
+        let cached = router
+            .repository_for_project_dir(Some("/work/team/project"))
+            .await
+            .expect("successful slot is cached");
+        assert!(Arc::ptr_eq(&recovered, &cached));
+        assert_eq!(state.requests.load(Ordering::SeqCst), 3);
+    }
+
+    fn panicking_lookup(dir: String) -> Option<String> {
+        panic!("repo lookup must not be consulted (cwd: {dir})")
+    }
+
+    #[tokio::test]
+    async fn route_skips_lookup_when_only_default_backend() {
+        let config = Arc::new(AppConfig::default());
+        let default: Arc<dyn ConversationRepository> =
+            Arc::new(InMemoryConversationRepository::new(RepoConfig::default()));
+        let router = BackendRepositoryRouter::from_preloaded_for_testing(
+            config,
+            [(DEFAULT_BACKEND_NAME.to_string(), default)],
+        )
+        .expect("default-only router");
+
+        let selected = router
+            .repository_for_project_dir_with_lookup(Some("/work/team/x"), panicking_lookup)
+            .await
+            .expect("default selection");
+        assert_eq!(selected.backend_name(), DEFAULT_BACKEND_NAME);
+    }
+
+    #[tokio::test]
+    async fn route_prefers_home_route_over_repo_file() {
+        let router = preloaded_router(routed_config("http://team.invalid".to_string(), false));
+        let selected = router
+            .repository_for_project_dir_with_lookup(Some("/work/team/x"), panicking_lookup)
+            .await
+            .expect("home route selection");
+        assert_eq!(selected.backend_name(), "team-ch");
+    }
+
+    #[tokio::test]
+    async fn route_falls_back_to_repo_reference() {
+        let router = preloaded_router(routed_config("http://team.invalid".to_string(), false));
+        let selected = router
+            .repository_for_project_dir_with_lookup(Some("/elsewhere/proj"), |dir| {
+                assert_eq!(dir, "/elsewhere/proj");
+                Some("team-ch".to_string())
+            })
+            .await
+            .expect("repo route selection");
+        assert_eq!(selected.backend_name(), "team-ch");
+    }
+
+    #[tokio::test]
+    async fn route_unknown_repo_name_uses_default() {
+        let router = preloaded_router(routed_config("http://team.invalid".to_string(), false));
+        let selected = router
+            .repository_for_project_dir_with_lookup(Some("/elsewhere/proj"), |_| {
+                Some("ghost".to_string())
+            })
+            .await
+            .expect("unknown repo route falls back");
+        assert_eq!(selected.backend_name(), DEFAULT_BACKEND_NAME);
+    }
+
+    #[tokio::test]
+    async fn route_treats_default_reference_as_no_route() {
+        let mut config = (*routed_config("http://team.invalid".to_string(), false)).clone();
+        config.routes.insert(
+            0,
+            RouteConfig {
+                dir: "/work/local/**".to_string(),
+                backend: DEFAULT_BACKEND_NAME.to_string(),
+                mode: ROUTE_MODE_MIRROR.to_string(),
+            },
+        );
+        let router = preloaded_router(Arc::new(config));
+
+        let home_selected = router
+            .repository_for_project_dir_with_lookup(Some("/work/local/x"), panicking_lookup)
+            .await
+            .expect("explicit default home route");
+        assert_eq!(home_selected.backend_name(), DEFAULT_BACKEND_NAME);
+        let repo_selected = router
+            .repository_for_project_dir_with_lookup(Some("/elsewhere/proj"), |_| {
+                Some(DEFAULT_BACKEND_NAME.to_string())
+            })
+            .await
+            .expect("explicit default repo route");
+        assert_eq!(repo_selected.backend_name(), DEFAULT_BACKEND_NAME);
+    }
+
+    #[tokio::test]
+    async fn route_unknown_home_name_does_not_fall_through() {
+        let mut config = (*routed_config("http://team.invalid".to_string(), false)).clone();
+        config.routes[0].backend = "ghost".to_string();
+        let router = preloaded_router(Arc::new(config));
+        let selected = router
+            .repository_for_project_dir_with_lookup(Some("/work/team/x"), panicking_lookup)
+            .await
+            .expect("unknown home route falls back");
+        assert_eq!(selected.backend_name(), DEFAULT_BACKEND_NAME);
+    }
+
+    #[tokio::test]
+    async fn route_ignores_missing_or_blank_cwd() {
+        let router = preloaded_router(routed_config("http://team.invalid".to_string(), false));
+        for cwd in [None, Some(""), Some("   ")] {
+            let selected = router
+                .repository_for_project_dir_with_lookup(cwd, panicking_lookup)
+                .await
+                .expect("blank cwd uses default");
+            assert_eq!(selected.backend_name(), DEFAULT_BACKEND_NAME);
+        }
+    }
+
+    #[tokio::test]
+    async fn route_lookup_runs_on_blocking_pool() {
+        let router = preloaded_router(routed_config("http://team.invalid".to_string(), false));
+        let async_thread = std::thread::current().id();
+        let selected = router
+            .repository_for_project_dir_with_lookup(Some("/elsewhere/proj"), move |_| {
+                assert_ne!(std::thread::current().id(), async_thread);
+                Some("team-ch".to_string())
+            })
+            .await
+            .expect("blocking lookup route");
+        assert_eq!(selected.backend_name(), "team-ch");
+    }
+
+    #[tokio::test]
+    async fn route_metadata_matches_selected_backend_config() {
+        let router = preloaded_router(routed_config("http://team.invalid".to_string(), false));
+        let selected = router
+            .repository_for_project_dir(Some("/work/team/project"))
+            .await
+            .expect("preloaded named route");
+        assert_eq!(selected.backend_name(), "team-ch");
+        assert_eq!(selected.clickhouse_url(), "http://team.invalid");
+        assert_eq!(selected.clickhouse_database(), "moraine_team");
+    }
+
+    #[tokio::test]
+    async fn later_success_is_reused_without_an_expiry() {
+        let (url, state) = spawn_schema_server(true, bundled_versions(), false, None).await;
+        let router = BackendRepositoryRouter::new(
+            routed_config(url, false),
+            RepoConfig::default(),
+            "moraine-backend/test",
+        )
+        .expect("router");
+        let first = router
+            .repository_for_project_dir(Some("/work/team/project"))
+            .await
+            .expect("first named repository");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let second = router
+            .repository_for_project_dir(Some("/work/team/project"))
+            .await
+            .expect("cached named repository");
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(Arc::ptr_eq(first.repository(), second.repository()));
+        assert_eq!(state.requests.load(Ordering::SeqCst), 2);
+    }
+}

--- a/crates/moraine-conversations/src/backend_router.rs
+++ b/crates/moraine-conversations/src/backend_router.rs
@@ -6,11 +6,22 @@ use moraine_clickhouse::{enforce_remote_schema_policy, ClickHouseClient};
 use moraine_config::{AppConfig, ClickHouseConfig, DEFAULT_BACKEND_NAME};
 use tokio::sync::{watch, Mutex};
 use tracing::warn;
+use url::Url;
 
 use crate::{
     build_clickhouse_repository_with_user_agent, ClickHouseConversationRepository,
     ConversationRepository, RepoConfig,
 };
+
+fn clickhouse_display_url(raw_url: &str) -> Arc<str> {
+    let Ok(url) = Url::parse(raw_url) else {
+        return Arc::from("<invalid ClickHouse URL>");
+    };
+    if !matches!(url.scheme(), "http" | "https") || url.host().is_none() {
+        return Arc::from("<invalid ClickHouse URL>");
+    }
+    Arc::from(url.origin().ascii_serialization())
+}
 
 /// An immutable repository handle together with the configured backend identity
 /// that produced it.
@@ -33,7 +44,7 @@ impl BackendRepository {
         Self {
             backend_name,
             repository,
-            clickhouse_url: Arc::from(clickhouse.url.as_str()),
+            clickhouse_url: clickhouse_display_url(&clickhouse.url),
             clickhouse_database: Arc::from(clickhouse.database.as_str()),
         }
     }
@@ -135,10 +146,18 @@ impl BackendSlot {
                     let slot = self.clone();
                     let published_attempt = attempt.clone();
                     tokio::spawn(async move {
-                        let result = slot
-                            .build(repo_config, &user_agent)
-                            .await
-                            .map_err(|error| Arc::<str>::from(format!("{error:#}")));
+                        let build_slot = slot.clone();
+                        let build = tokio::spawn(async move {
+                            build_slot.build(repo_config, &user_agent).await
+                        });
+                        let result = match build.await {
+                            Ok(result) => {
+                                result.map_err(|error| Arc::<str>::from(error.to_string()))
+                            }
+                            Err(error) => Err(Arc::<str>::from(format!(
+                                "backend repository initialization task failed: {error}"
+                            ))),
+                        };
 
                         // Retain the result even if every initiating caller was
                         // cancelled before subscribing to this attempt.
@@ -355,7 +374,7 @@ impl BackendRepositoryRouter {
 ///
 /// The same attributed client performs the skew probe and is then moved into
 /// the repository. Named backends are never migrated here.
-pub async fn build_checked_clickhouse_repository_with_user_agent(
+async fn build_checked_clickhouse_repository_with_user_agent(
     backend_name: &str,
     clickhouse: ClickHouseConfig,
     config: RepoConfig,
@@ -727,7 +746,9 @@ mod tests {
                 .expect("caller task")
                 .err()
                 .expect("shared attempt must fail");
-            assert!(format!("{error:#}").contains("temporary schema probe failure"));
+            let message = error.to_string();
+            assert!(message.contains("schema handshake failed"));
+            assert!(!message.contains("temporary schema probe failure"));
         }
         assert_eq!(state.requests.load(Ordering::SeqCst), 1);
 
@@ -741,6 +762,36 @@ mod tests {
             .expect("successful slot is cached");
         assert!(Arc::ptr_eq(&recovered, &cached));
         assert_eq!(state.requests.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn panicked_build_attempt_releases_waiters_and_retries() {
+        let mut config = (*routed_config("http://127.0.0.1:1".to_string(), false)).clone();
+        config
+            .backends
+            .get_mut("team-ch")
+            .expect("named backend")
+            .timeout_seconds = f64::INFINITY;
+        let router = BackendRepositoryRouter::new(
+            Arc::new(config),
+            RepoConfig::default(),
+            "moraine-backend/test",
+        )
+        .expect("router");
+
+        for _ in 0..2 {
+            let result = tokio::time::timeout(
+                Duration::from_secs(1),
+                router.repository_for_project_dir(Some("/work/team/project")),
+            )
+            .await
+            .expect("panicked build attempt must publish instead of hanging");
+            let error = match result {
+                Ok(_) => panic!("invalid timeout must fail construction"),
+                Err(error) => error,
+            };
+            assert!(error.to_string().contains("initialization task failed"));
+        }
     }
 
     fn panicking_lookup(dir: String) -> Option<String> {
@@ -866,14 +917,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn route_metadata_matches_selected_backend_config() {
-        let router = preloaded_router(routed_config("http://team.invalid".to_string(), false));
+    async fn route_metadata_redacts_credentials_and_query_parameters() {
+        let router = preloaded_router(routed_config(
+            "https://user:secret@team.invalid:8443\\signed\\secret?token=secret#fragment"
+                .to_string(),
+            false,
+        ));
         let selected = router
             .repository_for_project_dir(Some("/work/team/project"))
             .await
             .expect("preloaded named route");
         assert_eq!(selected.backend_name(), "team-ch");
-        assert_eq!(selected.clickhouse_url(), "http://team.invalid");
+        assert_eq!(selected.clickhouse_url(), "https://team.invalid:8443");
         assert_eq!(selected.clickhouse_database(), "moraine_team");
     }
 

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -6,9 +6,7 @@ mod error;
 mod in_memory_repo;
 mod repo;
 
-pub use backend_router::{
-    build_checked_clickhouse_repository_with_user_agent, BackendRepository, BackendRepositoryRouter,
-};
+pub use backend_router::{BackendRepository, BackendRepositoryRouter};
 pub use clickhouse_repo::ClickHouseConversationRepository;
 pub use domain::{
     is_user_facing_content_event, Conversation, ConversationDetailOptions, ConversationListFilter,

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -1,5 +1,4 @@
-use anyhow::Context as _;
-
+mod backend_router;
 mod clickhouse_repo;
 mod cursor;
 mod domain;
@@ -7,6 +6,9 @@ mod error;
 mod in_memory_repo;
 mod repo;
 
+pub use backend_router::{
+    build_checked_clickhouse_repository_with_user_agent, BackendRepository, BackendRepositoryRouter,
+};
 pub use clickhouse_repo::ClickHouseConversationRepository;
 pub use domain::{
     is_user_facing_content_event, Conversation, ConversationDetailOptions, ConversationListFilter,
@@ -61,20 +63,6 @@ pub fn build_clickhouse_repository_with_user_agent(
     Ok(std::sync::Arc::new(ClickHouseConversationRepository::new(
         client, config,
     )))
-}
-/// Validate that a non-default ClickHouse backend's migration ledger is
-/// compatible with this Moraine build. Storage construction and schema reads
-/// stay behind the conversations boundary.
-pub async fn validate_remote_clickhouse_schema(
-    backend_name: &str,
-    clickhouse: moraine_config::ClickHouseConfig,
-) -> anyhow::Result<()> {
-    let allow_newer_server = clickhouse.allow_newer_server;
-    let client = moraine_clickhouse::ClickHouseClient::new(clickhouse)?;
-    let skew = client.schema_skew().await.with_context(|| {
-        format!("backend '{backend_name}': schema handshake failed (is the server reachable?)")
-    })?;
-    moraine_clickhouse::enforce_remote_schema_policy(backend_name, &skew, allow_newer_server)
 }
 
 #[cfg(test)]

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -440,7 +440,6 @@ pub(crate) fn internal_id_error(error: contract::ContractError) -> contract::Con
     )
 }
 
-
 impl AppState {
     fn with_repository(
         cfg: Arc<AppConfig>,
@@ -871,7 +870,7 @@ async fn serve_socket_connection(state: SocketState, stream: tokio::net::UnixStr
 
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
-    let Some(first_line) = private_proxy::read_bounded_line(&mut reader).await? else {
+    let Some(first_line) = private_proxy::read_server_first_line(&mut reader).await? else {
         return Ok(());
     };
 
@@ -1520,6 +1519,49 @@ mod tests {
             !sock.exists(),
             "socket path must be removed before shutdown completes"
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn router_socket_preserves_oversized_legacy_first_request() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+        let (cfg, router) = default_test_router();
+        let (sock, shutdown_tx, server) = spawn_test_socket("oversized-legacy", cfg, router).await;
+        let mut stream = connect_to_test_socket(&sock).await;
+        let mut request = serde_json::to_vec(&json!({
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "initialize",
+            "params": {
+                "padding": "x".repeat(private_proxy::PRIVATE_ROUTE_MAX_LINE_BYTES + 1)
+            },
+        }))
+        .expect("oversized raw request JSON");
+        request.push(b'\n');
+        assert!(request.len() > private_proxy::PRIVATE_ROUTE_MAX_LINE_BYTES);
+        stream
+            .write_all(&request)
+            .await
+            .expect("write oversized legacy request");
+
+        let mut response = String::new();
+        BufReader::new(stream)
+            .read_line(&mut response)
+            .await
+            .expect("read oversized legacy response");
+        let response: Value = serde_json::from_str(response.trim()).expect("response JSON");
+        assert_eq!(response["id"], json!(9));
+        assert_eq!(
+            response["result"]["serverInfo"]["name"],
+            json!("moraine-mcp")
+        );
+
+        shutdown_tx.send(()).expect("request server shutdown");
+        server
+            .await
+            .expect("server task")
+            .expect("clean server shutdown");
     }
 
     #[cfg(unix)]

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -4,15 +4,16 @@ pub mod contract;
 mod file_attention_v1;
 mod list_sessions_v1;
 mod open_v1;
+mod private_proxy;
 mod search_sessions_v1;
 
 use anyhow::{anyhow, Context, Result};
-use moraine_config::{AppConfig, DEFAULT_BACKEND_NAME};
-use moraine_conversations::{
-    build_clickhouse_repository, build_clickhouse_repository_with_user_agent,
-    validate_remote_clickhouse_schema, RepoConfig, RepoError,
-};
+use moraine_config::AppConfig;
+use moraine_conversations::{BackendRepositoryRouter, RepoError};
 pub use moraine_conversations::{ConversationRepository, SessionOriginScope};
+pub use private_proxy::private_route_deadline;
+#[cfg(unix)]
+pub use private_proxy::{negotiate_private_route, PrivateProxyConnection, PrivateRouteNegotiation};
 use serde::Deserialize;
 use serde_json::{json, Value};
 #[cfg(all(test, unix))]
@@ -24,7 +25,7 @@ use std::sync::{
     Arc,
 };
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 #[derive(Debug, Deserialize)]
 struct RpcRequest {
@@ -44,7 +45,7 @@ struct ToolCallParams {
 
 #[derive(Clone)]
 struct AppState {
-    cfg: AppConfig,
+    cfg: Arc<AppConfig>,
     repo: Arc<dyn ConversationRepository>,
     prewarm_started: Arc<AtomicBool>,
 }
@@ -439,129 +440,106 @@ pub(crate) fn internal_id_error(error: contract::ContractError) -> contract::Con
     )
 }
 
-fn repository_config(cfg: &AppConfig, session_scope: Option<SessionOriginScope>) -> RepoConfig {
-    RepoConfig {
-        max_results: cfg.mcp.max_results,
-        preview_chars: cfg.mcp.preview_chars,
-        default_context_before: cfg.mcp.default_context_before,
-        default_context_after: cfg.mcp.default_context_after,
-        default_include_tool_events: cfg.mcp.default_include_tool_events,
-        default_exclude_codex_mcp: cfg.mcp.default_exclude_codex_mcp,
-        async_log_writes: cfg.mcp.async_log_writes,
-        bm25_k1: cfg.bm25.k1,
-        bm25_b: cfg.bm25.b,
-        bm25_default_min_score: cfg.bm25.default_min_score,
-        bm25_default_min_should_match: cfg.bm25.default_min_should_match,
-        bm25_max_query_terms: cfg.bm25.max_query_terms,
-        session_scope,
-    }
-}
-
-/// Build the production conversation repository with the default reader
-/// identity for embedded stdio serving.
-fn build_repository(
-    cfg: &AppConfig,
-    session_scope: Option<SessionOriginScope>,
-) -> Result<Arc<dyn ConversationRepository>> {
-    build_clickhouse_repository(
-        cfg.clickhouse.clone(),
-        repository_config(cfg, session_scope),
-    )
-}
-
-/// Build the production repository with the owning process's HTTP identity.
-///
-/// The unified backend calls this factory exactly once, then injects clones of
-/// the returned `Arc` into both cores. That makes the ClickHouse connection
-/// pool and repository caches process-wide rather than per listener while
-/// allowing diagnostics to attribute that pool to the backend role.
-pub fn build_repository_with_user_agent(
-    cfg: &AppConfig,
-    session_scope: Option<SessionOriginScope>,
-    user_agent: impl AsRef<str>,
-) -> Result<Arc<dyn ConversationRepository>> {
-    build_clickhouse_repository_with_user_agent(
-        cfg.clickhouse.clone(),
-        repository_config(cfg, session_scope),
-        user_agent,
-    )
-}
 
 impl AppState {
-    fn with_repository(cfg: AppConfig, repo: Arc<dyn ConversationRepository>) -> Arc<AppState> {
+    fn with_repository(
+        cfg: Arc<AppConfig>,
+        repo: Arc<dyn ConversationRepository>,
+        prewarm_started: Arc<AtomicBool>,
+    ) -> Arc<AppState> {
         Arc::new(AppState {
             cfg,
             repo,
-            prewarm_started: Arc::new(AtomicBool::new(false)),
+            prewarm_started,
         })
     }
 
-    /// Build the shared MCP application state: one ClickHouse client (and its
-    /// reqwest connection pool) and one conversation repository (and its
-    /// caches). Embedded stdio serving owns this state directly; the unified
-    /// backend uses [`build_repository_with_user_agent`] and
-    /// the monitor and MCP listeners share the same repository.
-    ///
-    /// `session_scope` restricts every retrieval tool to sessions originating
-    /// under the given roots (`--project-only`). Scoped states are only ever
-    /// built for embedded per-session servers — the central server is shared
-    /// across projects and must stay unscoped.
-    fn build(cfg: AppConfig, session_scope: Option<SessionOriginScope>) -> Result<Arc<AppState>> {
-        let repo = build_repository(&cfg, session_scope)?;
-        Ok(Self::with_repository(cfg, repo))
+    fn embedded(cfg: AppConfig, repo: Arc<dyn ConversationRepository>) -> Arc<AppState> {
+        Self::with_repository(cfg.into(), repo, Arc::new(AtomicBool::new(false)))
     }
 }
 
 /// Drive a single newline-delimited JSON-RPC connection to completion.
 ///
-/// This is the one source of truth for the MCP wire framing: one JSON object
-/// per line in, one JSON object + `\n` per response out, blank lines skipped.
-/// `run_stdio` drives it over stdin/stdout; the central server drives one of
-/// these per accepted socket connection, all sharing a single `Arc<AppState>`.
-async fn serve_connection<R, W>(state: Arc<AppState>, reader: R, mut writer: W) -> Result<()>
+/// This is the one source of truth for the public MCP wire framing: one JSON
+/// object per line in, one JSON object plus `\n` per response out, with blank
+/// lines skipped. Socket connections may provide a first line that was already
+/// read while discriminating the daemon-private route request; that line is
+/// replayed here exactly once for compatibility with older raw clients.
+async fn serve_connection_with_first_line<R, W>(
+    state: Arc<AppState>,
+    mut reader: R,
+    mut writer: W,
+    first_line: Option<Vec<u8>>,
+) -> Result<()>
 where
     R: AsyncBufRead + Unpin,
     W: AsyncWrite + Unpin,
 {
-    let mut lines = reader.lines();
+    if let Some(first_line) = first_line {
+        let first_line =
+            std::str::from_utf8(&first_line).context("incoming RPC line is not valid UTF-8")?;
+        serve_rpc_line(&state, first_line, &mut writer).await?;
+    }
 
-    while let Some(line) = lines.next_line().await? {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).await? == 0 {
+            break;
         }
-
-        debug!("incoming rpc line: {}", line);
-
-        let parsed = serde_json::from_str::<RpcRequest>(line);
-        let req = match parsed {
-            Ok(req) => req,
-            Err(err) => {
-                warn!("failed to parse rpc request: {}", err);
-                continue;
-            }
-        };
-
-        if let Some(resp) = state.handle_request(req).await {
-            let payload = serde_json::to_vec(&resp)?;
-            writer.write_all(&payload).await?;
-            writer.write_all(b"\n").await?;
-            writer.flush().await?;
-        }
+        serve_rpc_line(&state, &line, &mut writer).await?;
     }
 
     Ok(())
 }
 
-/// Run an embedded MCP server over stdin/stdout. This is the pre-central
-/// behavior: one full server (ClickHouse client + caches) per process, owned
-/// by the agent session that spawned it. Used directly when the central server
-/// is disabled, and as the transparent fallback when it is unreachable.
+async fn serve_connection<R, W>(state: Arc<AppState>, reader: R, writer: W) -> Result<()>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    serve_connection_with_first_line(state, reader, writer, None).await
+}
+
+async fn serve_rpc_line<W>(state: &Arc<AppState>, line: &str, writer: &mut W) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let line = line.trim();
+    if line.is_empty() {
+        return Ok(());
+    }
+
+    debug!("incoming rpc line: {}", line);
+    let req = match serde_json::from_str::<RpcRequest>(line) {
+        Ok(req) => req,
+        Err(err) => {
+            warn!("failed to parse rpc request: {}", err);
+            return Ok(());
+        }
+    };
+
+    if let Some(resp) = state.handle_request(req).await {
+        let payload = serde_json::to_vec(&resp)?;
+        writer.write_all(&payload).await?;
+        writer.write_all(b"\n").await?;
+        writer.flush().await?;
+    }
+    Ok(())
+}
+
+/// Run an embedded MCP server over stdin/stdout using a repository selected and
+/// constructed by the owning application.
 ///
-/// `session_scope` carries the `--project-only` restriction; it is `None` for
-/// ordinary unscoped serving.
-pub async fn run_stdio(cfg: AppConfig, session_scope: Option<SessionOriginScope>) -> Result<()> {
-    let state = AppState::build(cfg, session_scope)?;
+/// Repository construction, project routing, schema policy, and scoped
+/// fallback all live outside mcp-core. The injected repository remains fixed
+/// for the lifetime of this stdio connection.
+pub async fn run_stdio_with_repository(
+    cfg: AppConfig,
+    repository: Arc<dyn ConversationRepository>,
+) -> Result<()> {
+    let state = AppState::embedded(cfg, repository);
     serve_connection(
         state,
         BufReader::new(tokio::io::stdin()),
@@ -570,19 +548,54 @@ pub async fn run_stdio(cfg: AppConfig, session_scope: Option<SessionOriginScope>
     .await
 }
 
-/// Run the shared MCP server on a Unix domain socket using an injected
-/// repository.
+#[cfg(unix)]
+#[derive(Clone)]
+struct BackendPrewarmGates {
+    by_backend: Arc<std::collections::HashMap<String, Arc<AtomicBool>>>,
+}
+
+#[cfg(unix)]
+impl BackendPrewarmGates {
+    fn new(cfg: &AppConfig) -> Self {
+        let by_backend = cfg
+            .backends
+            .keys()
+            .map(|name| (name.clone(), Arc::new(AtomicBool::new(false))))
+            .collect();
+        Self {
+            by_backend: Arc::new(by_backend),
+        }
+    }
+
+    fn for_backend(&self, backend_name: &str) -> Result<Arc<AtomicBool>> {
+        self.by_backend
+            .get(backend_name)
+            .cloned()
+            .ok_or_else(|| anyhow!("selected backend '{backend_name}' has no MCP prewarm gate"))
+    }
+}
+
+#[cfg(unix)]
+#[derive(Clone)]
+struct SocketState {
+    cfg: Arc<AppConfig>,
+    router: Arc<BackendRepositoryRouter>,
+    prewarm_gates: BackendPrewarmGates,
+}
+
+/// Run the shared MCP server on a Unix domain socket using the daemon-owned
+/// backend repository router.
 ///
 /// The caller owns process supervision and supplies `shutdown`; this core
-/// never installs signal handlers or terminates the process. Every accepted
-/// connection shares the exact repository `Arc` supplied by the composition
-/// root. When shutdown resolves, accepting stops, connection tasks are
-/// cancelled, and the public socket path is unlinked before this future
-/// returns.
+/// never installs signal handlers or terminates the process. Each accepted
+/// connection negotiates and pins one repository handle, while connections to
+/// the same backend share both its repository and its MCP prewarm gate. When
+/// shutdown resolves, accepting stops, connection tasks are cancelled, and the
+/// public socket path is unlinked before this future returns.
 #[cfg(unix)]
-pub async fn run_socket_with_repository<S>(
-    cfg: AppConfig,
-    repository: Arc<dyn ConversationRepository>,
+pub async fn run_socket_with_router<S>(
+    cfg: Arc<AppConfig>,
+    router: Arc<BackendRepositoryRouter>,
     socket_path: PathBuf,
     shutdown: S,
 ) -> Result<()>
@@ -592,7 +605,11 @@ where
     use tokio::net::{UnixListener, UnixStream};
     use tokio::task::JoinSet;
 
-    let state = AppState::with_repository(cfg, repository);
+    let state = SocketState {
+        prewarm_gates: BackendPrewarmGates::new(&cfg),
+        cfg,
+        router,
+    };
 
     if let Some(parent) = socket_path.parent().filter(|p| !p.as_os_str().is_empty()) {
         use std::os::unix::fs::DirBuilderExt;
@@ -849,45 +866,82 @@ fn rename_socket_noreplace(_from: &std::path::Path, _to: &std::path::Path) -> st
 }
 
 #[cfg(unix)]
-async fn serve_socket_connection(
-    state: Arc<AppState>,
-    stream: tokio::net::UnixStream,
-) -> Result<()> {
-    let (read_half, write_half) = stream.into_split();
-    serve_connection(state, BufReader::new(read_half), write_half).await
+async fn serve_socket_connection(state: SocketState, stream: tokio::net::UnixStream) -> Result<()> {
+    use private_proxy::ServerFirstLine;
+
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+    let Some(first_line) = private_proxy::read_bounded_line(&mut reader).await? else {
+        return Ok(());
+    };
+
+    let (backend, replay_first_line, negotiated) =
+        match private_proxy::classify_server_first_line(&first_line) {
+            ServerFirstLine::Route { cwd } => {
+                match state.router.repository_for_project_dir(Some(&cwd)).await {
+                    Ok(backend) => (backend, None, true),
+                    Err(error) => {
+                        let message = format!("{error:#}");
+                        private_proxy::write_route_error(&mut write_half, &message).await?;
+                        return Ok(());
+                    }
+                }
+            }
+            ServerFirstLine::Incompatible => {
+                private_proxy::write_incompatible_error(&mut write_half).await?;
+                return Ok(());
+            }
+            ServerFirstLine::Raw => {
+                let backend = state.router.default_repository().await?;
+                (backend, Some(first_line), false)
+            }
+        };
+
+    let prewarm_started = match state.prewarm_gates.for_backend(backend.backend_name()) {
+        Ok(gate) => gate,
+        Err(error) if negotiated => {
+            private_proxy::write_route_error(&mut write_half, &error.to_string()).await?;
+            return Ok(());
+        }
+        Err(error) => return Err(error),
+    };
+    let app_state =
+        AppState::with_repository(state.cfg, backend.repository().clone(), prewarm_started);
+    if negotiated {
+        private_proxy::write_ack(&mut write_half).await?;
+    }
+    serve_connection_with_first_line(app_state, reader, write_half, replay_first_line).await
 }
 
-/// Run a near-zero-cost stdio<->socket proxy for a single agent session.
+/// Run the stdio byte pumps after a private route negotiation was accepted.
 ///
-/// No ClickHouse client, no caches, no multi-threaded runtime: just two byte
-/// pumps. Because it never parses the JSON, it cannot perturb the framing
-/// (id presence, compact spacing, etc.) — it forwards bytes verbatim.
-///
-/// Half-close semantics matter: when the agent closes stdin we must *not* abort
-/// the downstream copy, or a large in-flight `tools/call` response would be
-/// truncated. So the downstream pump (server -> stdout) is authoritative for
-/// exit; on stdin EOF we shut down the socket write half (signalling EOF to the
-/// server) and keep draining downstream until the server closes its side.
+/// The accepted connection retains the buffered daemon reader used for the
+/// private ACK. No agent stdin is consumed before this function starts.
 #[cfg(unix)]
-pub async fn run_proxy(stream: tokio::net::UnixStream) -> Result<()> {
-    proxy_streams(tokio::io::stdin(), tokio::io::stdout(), stream).await
+pub async fn run_proxy(connection: PrivateProxyConnection) -> Result<()> {
+    let (sock_read, sock_write) = connection.into_parts();
+    proxy_streams_with_halves(
+        tokio::io::stdin(),
+        tokio::io::stdout(),
+        sock_read,
+        sock_write,
+    )
+    .await
 }
 
-/// Core of [`run_proxy`], generic over the client side so it can be exercised
-/// with in-memory streams in tests. `client_in`/`client_out` are stdin/stdout
-/// in production; `stream` is the connection to the central server.
 #[cfg(unix)]
-async fn proxy_streams<I, O>(
+async fn proxy_streams_with_halves<I, O, R, W>(
     mut client_in: I,
     mut client_out: O,
-    stream: tokio::net::UnixStream,
+    mut sock_read: R,
+    mut sock_write: W,
 ) -> Result<()>
 where
     I: AsyncRead + Unpin,
     O: AsyncWrite + Unpin,
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
 {
-    let (mut sock_read, mut sock_write) = stream.into_split();
-
     let upstream = async {
         let _ = tokio::io::copy(&mut client_in, &mut sock_write).await;
         // Signal EOF to the server so it can finish any in-flight response and
@@ -916,145 +970,18 @@ where
     Ok(())
 }
 
-/// Resolve the non-default backend a stdio entry should serve against, given
-/// the process working directory: home-config `[[routes]]` win over a repo
-/// `.moraine.toml` reference, a reference to an unknown backend name warns
-/// and falls back to default behavior (the trust boundary: a cloned repo can
-/// only name backends the user already configured), and routing to
-/// `"default"` is a no-op. `None` means keep the default entry behavior.
-fn resolve_stdio_backend(cfg: &AppConfig, cwd: &str) -> Option<String> {
-    resolve_stdio_backend_with_lookup(cfg, cwd, |dir| moraine_config::find_repo_backend_ref(dir))
-}
-
-/// Core of [`resolve_stdio_backend`], with the repo `.moraine.toml` lookup
-/// injectable so the decision is testable without a filesystem walk-up.
-fn resolve_stdio_backend_with_lookup(
-    cfg: &AppConfig,
-    cwd: &str,
-    repo_lookup: impl Fn(&str) -> Option<String>,
-) -> Option<String> {
-    // With only the default backend configured there is nothing to route to;
-    // skip resolution (and the repo-file filesystem walk) entirely so the
-    // common single-backend install pays nothing at startup.
-    if !cfg.backends.keys().any(|name| name != DEFAULT_BACKEND_NAME) {
-        return None;
-    }
-    let cwd = cwd.trim();
-    if cwd.is_empty() {
-        return None;
-    }
-    // A matching home route decides the name even when it fails validation
-    // below: first match wins, it never falls through to the repo file.
-    let name = match cfg.route_for_dir(cwd) {
-        Some(route) => route.backend.clone(),
-        None => repo_lookup(cwd)?,
-    };
-    if name == DEFAULT_BACKEND_NAME {
-        // Explicitly routing to default is the default behavior already.
-        return None;
-    }
-    if cfg.backends.contains_key(&name) {
-        return Some(name);
-    }
-    warn!(
-        backend = %name,
-        cwd,
-        "route names a backend with no [backends.{}] entry in the home config; \
-         serving against the default backend",
-        name
-    );
-    None
-}
-
-/// Run an embedded stdio server against a named non-default backend.
-///
-/// The schema handshake runs first and fails fast: moraine never migrates
-/// non-default backends, so a skewed (or unreachable) server must error
-/// loudly at startup rather than degrade at query time. Only after the
-/// handshake passes is the backend's config swapped in as `cfg.clickhouse`,
-/// which is all `AppState::build` reads.
-async fn run_stdio_for_backend(
-    mut cfg: AppConfig,
-    backend: &str,
-    session_scope: Option<SessionOriginScope>,
-) -> Result<()> {
-    let backend_cfg = cfg
-        .backends
-        .get(backend)
-        .cloned()
-        .ok_or_else(|| anyhow!("backend '{backend}' is not configured"))?;
-
-    validate_remote_clickhouse_schema(backend, backend_cfg.clone()).await?;
-
-    cfg.clickhouse = backend_cfg;
-    run_stdio(cfg, session_scope).await
-}
-
-/// Entry point used by `moraine run mcp` (the command agents register).
-///
-/// First, per-project routing: when the process cwd routes to a non-default
-/// backend (home-config routes, then the repo `.moraine.toml` walk-up), the
-/// central proxy is skipped — the central server only serves the default
-/// backend — and an embedded server runs against the routed backend instead,
-/// failing fast on schema skew.
-///
-/// Otherwise, when the central server is enabled (the default), connect to its
-/// socket and proxy; if the socket is missing, refused, or slow to answer,
-/// fall back to an embedded stdio server so correctness never depends on the
-/// daemon being up. When central mode is disabled, run embedded directly
-/// (pre-central behavior).
-///
-/// `session_scope` carries the `--project-only` restriction. A scoped session
-/// never proxies — the central server is shared across projects and the proxy
-/// forwards bytes verbatim, so the scope could not be enforced through it — but
-/// it still honors per-project backend routing: the scope is applied to an
-/// embedded server against whichever backend the cwd routes to.
-pub async fn run_mcp_entry(
-    cfg: AppConfig,
-    session_scope: Option<SessionOriginScope>,
-) -> Result<()> {
-    let cwd = std::env::current_dir()
-        .map(|dir| dir.to_string_lossy().into_owned())
-        .unwrap_or_default();
-    if let Some(backend) = resolve_stdio_backend(&cfg, &cwd) {
-        info!(
-            backend = %backend,
-            cwd,
-            scoped = session_scope.is_some(),
-            "cwd routes to a non-default backend; serving embedded against it"
-        );
-        return run_stdio_for_backend(cfg, &backend, session_scope).await;
-    }
-
-    // A scoped session always runs embedded; skip the proxy entirely.
-    #[cfg(unix)]
-    if session_scope.is_none() && cfg.mcp.use_central_server {
-        use tokio::net::UnixStream;
-
-        let socket_path = PathBuf::from(&cfg.mcp.central_socket_path);
-        let dur = std::time::Duration::from_millis(cfg.mcp.central_connect_timeout_ms);
-        match tokio::time::timeout(dur, UnixStream::connect(&socket_path)).await {
-            Ok(Ok(stream)) => {
-                debug!(
-                    "proxying stdio to central MCP server at {}",
-                    socket_path.display()
-                );
-                return run_proxy(stream).await;
-            }
-            Ok(Err(err)) => warn!(
-                "central MCP server unreachable at {} ({}); using embedded server",
-                socket_path.display(),
-                err
-            ),
-            Err(_) => warn!(
-                "central MCP server connect timed out at {} after {}ms; using embedded server",
-                socket_path.display(),
-                cfg.mcp.central_connect_timeout_ms
-            ),
-        }
-    }
-
-    run_stdio(cfg, session_scope).await
+#[cfg(all(test, unix))]
+async fn proxy_streams<I, O>(
+    client_in: I,
+    client_out: O,
+    stream: tokio::net::UnixStream,
+) -> Result<()>
+where
+    I: AsyncRead + Unpin,
+    O: AsyncWrite + Unpin,
+{
+    let (read_half, write_half) = stream.into_split();
+    proxy_streams_with_halves(client_in, client_out, BufReader::new(read_half), write_half).await
 }
 
 /// Resolve the `--project-only` scope from the directory this process was
@@ -1097,9 +1024,9 @@ pub fn project_scope_from_launch_dir() -> Result<SessionOriginScope> {
 /// Non-Unix platforms expose the same injected API so composition roots can
 /// compile portably, but attempting to start the socket listener fails.
 #[cfg(not(unix))]
-pub async fn run_socket_with_repository<S>(
-    _cfg: AppConfig,
-    _repository: Arc<dyn ConversationRepository>,
+pub async fn run_socket_with_router<S>(
+    _cfg: Arc<AppConfig>,
+    _router: Arc<BackendRepositoryRouter>,
     _socket_path: PathBuf,
     _shutdown: S,
 ) -> Result<()>
@@ -1112,23 +1039,25 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use moraine_conversations::InMemoryConversationRepository;
+    use moraine_conversations::{InMemoryConversationRepository, RepoConfig};
 
-    fn test_state() -> AppState {
-        let cfg = AppConfig::default();
-        let repo: Arc<dyn ConversationRepository> =
-            Arc::new(InMemoryConversationRepository::default());
-        AppState {
-            cfg,
-            repo,
-            prewarm_started: Arc::new(AtomicBool::new(false)),
-        }
+    fn repository_with_scope(
+        session_scope: Option<SessionOriginScope>,
+    ) -> Arc<dyn ConversationRepository> {
+        Arc::new(InMemoryConversationRepository::new(RepoConfig {
+            session_scope,
+            ..RepoConfig::default()
+        }))
+    }
+
+    fn test_state() -> Arc<AppState> {
+        AppState::embedded(AppConfig::default(), repository_with_scope(None))
     }
 
     #[tokio::test]
     async fn initialize_advertises_project_scope_in_instructions() {
         let scope = SessionOriginScope::from_roots(["/work/project"]).expect("valid scope");
-        let state = AppState::build(AppConfig::default(), Some(scope)).expect("build state");
+        let state = AppState::embedded(AppConfig::default(), repository_with_scope(Some(scope)));
         let response = state
             .handle_request(RpcRequest {
                 id: Some(json!(1)),
@@ -1144,7 +1073,7 @@ mod tests {
         assert!(instructions.contains("/work/project"));
 
         // Unscoped servers must not grow an instructions field.
-        let unscoped = AppState::build(AppConfig::default(), None).expect("build state");
+        let unscoped = AppState::embedded(AppConfig::default(), repository_with_scope(None));
         let response = unscoped
             .handle_request(RpcRequest {
                 id: Some(json!(1)),
@@ -1298,166 +1227,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn app_state_build_succeeds_without_live_clickhouse() {
-        // Building state only constructs the HTTP client and caches; it must
-        // not require ClickHouse to be reachable.
-        let state = AppState::build(AppConfig::default(), None).expect("build state");
-        assert!(!state.prewarm_started.load(Ordering::Acquire));
-    }
-
-    #[test]
-    fn app_state_injection_preserves_repository_arc() {
-        let repository: Arc<dyn ConversationRepository> =
-            Arc::new(InMemoryConversationRepository::default());
-        let state = AppState::with_repository(AppConfig::default(), repository.clone());
-
-        assert!(Arc::ptr_eq(&state.repo, &repository));
-    }
-
-    /// Config with one non-default backend (`team-ch`) and a single home
-    /// route mapping `/work/team/**` to it.
-    fn routed_config() -> AppConfig {
-        let mut cfg = AppConfig::default();
-        cfg.backends.insert(
-            "team-ch".to_string(),
-            moraine_config::ClickHouseConfig {
-                url: "http://127.0.0.1:1".to_string(),
-                database: "moraine_team".to_string(),
-                ..Default::default()
-            },
-        );
-        cfg.routes.push(moraine_config::RouteConfig {
-            dir: "/work/team/**".to_string(),
-            backend: "team-ch".to_string(),
-            mode: moraine_config::ROUTE_MODE_MIRROR.to_string(),
-        });
-        cfg
-    }
-
-    /// Repo lookup that fails the test if consulted; used to prove a branch
-    /// never reaches the filesystem walk-up.
-    fn panicking_lookup(dir: &str) -> Option<String> {
-        panic!("repo lookup must not be consulted (cwd: {dir})");
-    }
-
-    #[test]
-    fn resolve_stdio_backend_skips_lookup_when_only_default_backend() {
-        let cfg = AppConfig::default();
-        assert_eq!(
-            resolve_stdio_backend_with_lookup(&cfg, "/work/team/x", panicking_lookup),
-            None
-        );
-    }
-
-    #[test]
-    fn resolve_stdio_backend_prefers_home_route_over_repo_file() {
-        let cfg = routed_config();
-        assert_eq!(
-            resolve_stdio_backend_with_lookup(&cfg, "/work/team/x", panicking_lookup),
-            Some("team-ch".to_string())
-        );
-    }
-
-    #[test]
-    fn resolve_stdio_backend_falls_back_to_repo_reference() {
-        let cfg = routed_config();
-        let resolved = resolve_stdio_backend_with_lookup(&cfg, "/elsewhere/proj", |dir| {
-            assert_eq!(dir, "/elsewhere/proj");
-            Some("team-ch".to_string())
-        });
-        assert_eq!(resolved, Some("team-ch".to_string()));
-    }
-
-    #[test]
-    fn resolve_stdio_backend_warns_and_continues_on_unknown_repo_name() {
-        let cfg = routed_config();
-        let resolved = resolve_stdio_backend_with_lookup(&cfg, "/elsewhere/proj", |_| {
-            Some("ghost".to_string())
-        });
-        assert_eq!(resolved, None);
-    }
-
-    #[test]
-    fn resolve_stdio_backend_treats_default_reference_as_no_route() {
-        let mut cfg = routed_config();
-        cfg.routes.insert(
-            0,
-            moraine_config::RouteConfig {
-                dir: "/work/local/**".to_string(),
-                backend: DEFAULT_BACKEND_NAME.to_string(),
-                mode: moraine_config::ROUTE_MODE_MIRROR.to_string(),
-            },
-        );
-
-        // Via a home route...
-        assert_eq!(
-            resolve_stdio_backend_with_lookup(&cfg, "/work/local/x", panicking_lookup),
-            None
-        );
-        // ...and via a repo reference.
-        let resolved = resolve_stdio_backend_with_lookup(&cfg, "/elsewhere/proj", |_| {
-            Some(DEFAULT_BACKEND_NAME.to_string())
-        });
-        assert_eq!(resolved, None);
-    }
-
-    #[test]
-    fn resolve_stdio_backend_home_route_to_unknown_name_does_not_fall_through() {
-        // First match wins even when its backend name fails validation: the
-        // repo file must not be consulted for a cwd a home route claimed.
-        let mut cfg = routed_config();
-        cfg.routes[0].backend = "ghost".to_string();
-        assert_eq!(
-            resolve_stdio_backend_with_lookup(&cfg, "/work/team/x", panicking_lookup),
-            None
-        );
-    }
-
-    #[test]
-    fn resolve_stdio_backend_ignores_empty_cwd() {
-        let cfg = routed_config();
-        assert_eq!(
-            resolve_stdio_backend_with_lookup(&cfg, "", panicking_lookup),
-            None
-        );
-        assert_eq!(
-            resolve_stdio_backend_with_lookup(&cfg, "   ", panicking_lookup),
-            None
-        );
-    }
-
-    #[tokio::test]
-    async fn run_stdio_for_backend_fails_fast_when_backend_unreachable() {
-        // The handshake against a connection-refused backend must fail at
-        // startup with an error naming the backend, never fall back to the
-        // default backend or start serving stdio.
-        let cfg = routed_config();
-        let err = run_stdio_for_backend(cfg, "team-ch", None)
-            .await
-            .expect_err("unreachable backend must fail the handshake");
-        let chain = format!("{err:#}");
-        assert!(
-            chain.contains("team-ch"),
-            "error names the backend: {chain}"
-        );
-        assert!(
-            chain.contains("schema handshake failed"),
-            "error explains the handshake: {chain}"
-        );
-    }
-
-    #[tokio::test]
-    async fn run_stdio_for_backend_rejects_unconfigured_backend() {
-        let err = run_stdio_for_backend(AppConfig::default(), "ghost", None)
-            .await
-            .expect_err("unknown backend must error");
-        assert!(err.to_string().contains("'ghost' is not configured"));
-    }
-
     #[tokio::test]
     async fn serve_connection_frames_one_response_per_request() {
-        let state = AppState::build(AppConfig::default(), None).expect("build state");
+        let state = test_state();
 
         // Two requests separated by a blank line (which must be skipped).
         let input = concat!(
@@ -1500,6 +1272,103 @@ mod tests {
             "/tmp/moraine-{tag}-{}-{nanos}-{n}.sock",
             std::process::id()
         ))
+    }
+
+    #[cfg(unix)]
+    fn default_test_router() -> (Arc<AppConfig>, Arc<BackendRepositoryRouter>) {
+        let cfg = Arc::new(AppConfig::default());
+        let repository: Arc<dyn ConversationRepository> =
+            Arc::new(InMemoryConversationRepository::default());
+        let router = BackendRepositoryRouter::from_preloaded_for_testing(
+            cfg.clone(),
+            [("default".to_string(), repository)],
+        )
+        .expect("preloaded default router");
+        (cfg, Arc::new(router))
+    }
+
+    #[cfg(unix)]
+    fn routed_test_router(
+        prewarm_on_initialize: bool,
+    ) -> (
+        Arc<AppConfig>,
+        Arc<BackendRepositoryRouter>,
+        Arc<InMemoryConversationRepository>,
+        Arc<InMemoryConversationRepository>,
+    ) {
+        let mut cfg = AppConfig::default();
+        cfg.mcp.prewarm_on_initialize = prewarm_on_initialize;
+        cfg.backends.insert(
+            "team-ch".to_string(),
+            moraine_config::ClickHouseConfig {
+                url: "http://team.invalid".to_string(),
+                database: "moraine_team".to_string(),
+                ..Default::default()
+            },
+        );
+        cfg.routes.push(moraine_config::RouteConfig {
+            dir: "/work/team/**".to_string(),
+            backend: "team-ch".to_string(),
+            mode: moraine_config::ROUTE_MODE_MIRROR.to_string(),
+        });
+        let cfg = Arc::new(cfg);
+
+        let default = Arc::new(InMemoryConversationRepository::default());
+        let named_scope =
+            SessionOriginScope::from_roots(["/named-repository"]).expect("named scope");
+        let named = Arc::new(InMemoryConversationRepository::new(RepoConfig {
+            session_scope: Some(named_scope),
+            ..RepoConfig::default()
+        }));
+        let router = BackendRepositoryRouter::from_preloaded_for_testing(
+            cfg.clone(),
+            [
+                (
+                    "default".to_string(),
+                    default.clone() as Arc<dyn ConversationRepository>,
+                ),
+                (
+                    "team-ch".to_string(),
+                    named.clone() as Arc<dyn ConversationRepository>,
+                ),
+            ],
+        )
+        .expect("preloaded routed router");
+        (cfg, Arc::new(router), default, named)
+    }
+
+    #[cfg(unix)]
+    async fn spawn_test_socket(
+        tag: &str,
+        cfg: Arc<AppConfig>,
+        router: Arc<BackendRepositoryRouter>,
+    ) -> (
+        PathBuf,
+        tokio::sync::oneshot::Sender<()>,
+        tokio::task::JoinHandle<Result<()>>,
+    ) {
+        let sock = unique_socket_path(tag);
+        let _ = std::fs::remove_file(&sock);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let server_sock = sock.clone();
+        let server = tokio::spawn(async move {
+            run_socket_with_router(cfg, router, server_sock, async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+        });
+        (sock, shutdown_tx, server)
+    }
+
+    #[cfg(unix)]
+    async fn connect_to_test_socket(sock: &std::path::Path) -> tokio::net::UnixStream {
+        for _ in 0..50 {
+            match tokio::net::UnixStream::connect(sock).await {
+                Ok(stream) => return stream,
+                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+            }
+        }
+        panic!("failed to connect to test socket {}", sock.display());
     }
 
     #[cfg(any(
@@ -1571,13 +1440,10 @@ mod tests {
         let sock = unique_socket_path("live");
         let _ = std::fs::remove_file(&sock);
         let owner = UnixListener::bind(&sock).expect("bind existing owner");
-        let repository: Arc<dyn ConversationRepository> =
-            Arc::new(InMemoryConversationRepository::default());
-
-        let error =
-            run_socket_with_repository(AppConfig::default(), repository, sock.clone(), pending())
-                .await
-                .expect_err("second backend must fail");
+        let (cfg, router) = default_test_router();
+        let error = run_socket_with_router(cfg, router, sock.clone(), pending())
+            .await
+            .expect_err("second backend must fail");
         assert!(
             error
                 .to_string()
@@ -1595,43 +1461,12 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn injected_socket_serves_and_cancellation_cleans_up() {
-        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
-        use tokio::net::UnixStream;
-        use tokio::sync::oneshot;
+    async fn router_socket_replays_raw_client_and_cleans_up() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-        let sock = unique_socket_path("serve");
-        let _ = std::fs::remove_file(&sock);
-        let repository: Arc<dyn ConversationRepository> =
-            Arc::new(InMemoryConversationRepository::default());
-        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
-
-        let server_sock = sock.clone();
-        let server_repository = repository.clone();
-        let server = tokio::spawn(async move {
-            run_socket_with_repository(
-                AppConfig::default(),
-                server_repository,
-                server_sock,
-                async {
-                    let _ = shutdown_rx.await;
-                },
-            )
-            .await
-        });
-
-        // Connect with a few retries while the listener comes up.
-        let mut stream = None;
-        for _ in 0..50 {
-            match UnixStream::connect(&sock).await {
-                Ok(s) => {
-                    stream = Some(s);
-                    break;
-                }
-                Err(_) => tokio::time::sleep(std::time::Duration::from_millis(10)).await,
-            }
-        }
-        let mut stream = stream.expect("connect to central socket");
+        let (cfg, router) = default_test_router();
+        let (sock, shutdown_tx, server) = spawn_test_socket("serve", cfg, router).await;
+        let mut stream = connect_to_test_socket(&sock).await;
 
         // The bind-restrict-rename dance must leave the public path user-only.
         {
@@ -1644,17 +1479,37 @@ mod tests {
         }
 
         stream
-            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"initialize\",\"params\":{}}\n")
+            .write_all(
+                concat!(
+                    "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"initialize\",\"params\":{}}\n",
+                    "{\"jsonrpc\":\"2.0\",\"id\":8,\"method\":\"ping\"}\n",
+                )
+                .as_bytes(),
+            )
             .await
-            .expect("write request");
+            .expect("write pipelined raw requests");
+        stream.shutdown().await.expect("half-close raw client");
 
-        let mut reader = BufReader::new(stream);
-        let mut line = String::new();
-        reader.read_line(&mut line).await.expect("read response");
-
-        let resp: Value = serde_json::from_str(line.trim()).expect("json response");
-        assert_eq!(resp["id"], json!(7));
-        assert_eq!(resp["result"]["serverInfo"]["name"], json!("moraine-mcp"));
+        let mut output = String::new();
+        stream
+            .read_to_string(&mut output)
+            .await
+            .expect("read raw responses");
+        let responses = output.lines().collect::<Vec<_>>();
+        assert_eq!(
+            responses.len(),
+            2,
+            "first line must be replayed exactly once and buffered input retained: {output}"
+        );
+        let initialize: Value = serde_json::from_str(responses[0]).expect("initialize response");
+        assert_eq!(initialize["id"], json!(7));
+        assert_eq!(
+            initialize["result"]["serverInfo"]["name"],
+            json!("moraine-mcp")
+        );
+        let ping: Value = serde_json::from_str(responses[1]).expect("ping response");
+        assert_eq!(ping["id"], json!(8));
+        assert_eq!(ping["result"], json!({}));
 
         shutdown_tx.send(()).expect("request server shutdown");
         server
@@ -1665,6 +1520,260 @@ mod tests {
             !sock.exists(),
             "socket path must be removed before shutdown completes"
         );
+    }
+
+    #[cfg(unix)]
+    async fn accepted_test_connection(sock: &std::path::Path, cwd: &str) -> PrivateProxyConnection {
+        let stream = connect_to_test_socket(sock).await;
+        match negotiate_private_route(stream, cwd, std::time::Duration::from_secs(3)).await {
+            PrivateRouteNegotiation::Accepted(connection) => connection,
+            PrivateRouteNegotiation::Incompatible { reason } => {
+                panic!("test daemon must be compatible: {reason}")
+            }
+            PrivateRouteNegotiation::Rejected { message } => {
+                panic!("test route must be accepted: {message}")
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    async fn proxy_test_requests(connection: PrivateProxyConnection, requests: Vec<u8>) -> Vec<u8> {
+        let (sock_read, sock_write) = connection.into_parts();
+        let mut output = Vec::new();
+        proxy_streams_with_halves(
+            std::io::Cursor::new(requests),
+            &mut output,
+            sock_read,
+            sock_write,
+        )
+        .await
+        .expect("proxy test requests");
+        output
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn negotiated_socket_selects_named_and_default_without_exposing_ack() {
+        let (cfg, router, _default, _named) = routed_test_router(false);
+        let (sock, shutdown_tx, server) = spawn_test_socket("route-select", cfg, router).await;
+
+        let named = accepted_test_connection(&sock, "/work/team/project").await;
+        let named_output = proxy_test_requests(
+            named,
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}\n".to_vec(),
+        )
+        .await;
+        let named_lines = String::from_utf8(named_output).expect("named output UTF-8");
+        let named_responses = named_lines.lines().collect::<Vec<_>>();
+        assert_eq!(
+            named_responses.len(),
+            1,
+            "private ACK must not reach agent stdout: {named_lines}"
+        );
+        let named_response: Value =
+            serde_json::from_str(named_responses[0]).expect("named initialize");
+        assert_eq!(named_response["id"], json!(1));
+        assert!(named_response["result"]["instructions"]
+            .as_str()
+            .expect("named repository marker")
+            .contains("/named-repository"));
+
+        let default = accepted_test_connection(&sock, "").await;
+        let default_output = proxy_test_requests(
+            default,
+            b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"initialize\",\"params\":{}}\n".to_vec(),
+        )
+        .await;
+        let default_response: Value =
+            serde_json::from_slice(&default_output).expect("default initialize");
+        assert_eq!(default_response["id"], json!(2));
+        assert!(default_response["result"].get("instructions").is_none());
+
+        shutdown_tx.send(()).expect("shutdown route server");
+        server
+            .await
+            .expect("route server task")
+            .expect("route server shutdown");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn connection_stays_pinned_after_private_route_ack() {
+        let (cfg, router, default, named) = routed_test_router(false);
+        let (sock, shutdown_tx, server) = spawn_test_socket("route-pin", cfg, router).await;
+
+        let connection = accepted_test_connection(&sock, "/work/team/project").await;
+        let requests = concat!(
+            "{\"jsonrpc\":\"2.0\",\"id\":\"moraine-route-v1\",\"method\":\"moraine/private/route\",\"params\":{\"version\":1,\"cwd\":\"\"}}\n",
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"initialize\",\"params\":{}}\n",
+            "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"search_sessions\",\"arguments\":{\"query\":\"pin-check\"}}}\n",
+            "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"list_sessions\",\"arguments\":{\"start_datetime\":\"2026-01-01T00:00:00Z\",\"end_datetime\":\"2026-01-02T00:00:00Z\"}}}\n",
+        )
+        .as_bytes()
+        .to_vec();
+        let output = proxy_test_requests(connection, requests).await;
+        let text = String::from_utf8(output).expect("pinned output UTF-8");
+        let responses = text.lines().collect::<Vec<_>>();
+        assert_eq!(
+            responses.len(),
+            4,
+            "one response per public request: {text}"
+        );
+        let reselection: Value =
+            serde_json::from_str(responses[0]).expect("midstream route response");
+        assert_eq!(reselection["error"]["code"], json!(-32601));
+        let initialize: Value =
+            serde_json::from_str(responses[1]).expect("pinned initialize response");
+        assert!(initialize["result"]["instructions"]
+            .as_str()
+            .expect("named repository remains selected")
+            .contains("/named-repository"));
+
+        let named_calls = named.calls();
+        assert_eq!(named_calls.search_mcp_events.len(), 1);
+        assert_eq!(named_calls.list_mcp_sessions.len(), 1);
+        let default_calls = default.calls();
+        assert!(default_calls.search_mcp_events.is_empty());
+        assert!(default_calls.list_mcp_sessions.is_empty());
+
+        shutdown_tx.send(()).expect("shutdown pin server");
+        server
+            .await
+            .expect("pin server task")
+            .expect("pin server shutdown");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn prewarm_gate_is_shared_per_backend_and_isolated_between_backends() {
+        let (cfg, router, default, named) = routed_test_router(true);
+        let (sock, shutdown_tx, server) = spawn_test_socket("prewarm", cfg, router).await;
+        let initialize =
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}\n";
+
+        for _ in 0..2 {
+            let connection = accepted_test_connection(&sock, "/work/team/project").await;
+            let _ = proxy_test_requests(connection, initialize.to_vec()).await;
+        }
+        let default_connection = accepted_test_connection(&sock, "").await;
+        let _ = proxy_test_requests(default_connection, initialize.to_vec()).await;
+
+        for _ in 0..50 {
+            if named.calls().prewarm_mcp_search_state == 1
+                && default.calls().prewarm_mcp_search_state == 1
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(named.calls().prewarm_mcp_search_state, 1);
+        assert_eq!(default.calls().prewarm_mcp_search_state, 1);
+
+        shutdown_tx.send(()).expect("shutdown prewarm server");
+        server
+            .await
+            .expect("prewarm server task")
+            .expect("prewarm server shutdown");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unsupported_private_version_gets_structured_incompatible_error() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+        let (cfg, router) = default_test_router();
+        let (sock, shutdown_tx, server) = spawn_test_socket("incompatible", cfg, router).await;
+        let mut stream = connect_to_test_socket(&sock).await;
+        stream
+            .write_all(
+                b"{\"jsonrpc\":\"2.0\",\"id\":\"moraine-route-v1\",\"method\":\"moraine/private/route\",\"params\":{\"version\":2,\"cwd\":\"/work\"}}\n",
+            )
+            .await
+            .expect("write unsupported hello");
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .await
+            .expect("read incompatible response");
+        let response: Value = serde_json::from_str(line.trim()).expect("incompatible JSON");
+        assert_eq!(response["id"], json!("moraine-route-v1"));
+        assert_eq!(response["error"]["code"], json!(-32001));
+        assert_eq!(response["error"]["data"]["kind"], json!("incompatible"));
+        assert_eq!(response["error"]["data"]["version"], json!(1));
+
+        shutdown_tx.send(()).expect("shutdown incompatible server");
+        server
+            .await
+            .expect("incompatible server task")
+            .expect("incompatible server shutdown");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn named_repository_build_failure_is_typed_route_rejection() {
+        let mut cfg = AppConfig::default();
+        cfg.clickhouse.timeout_seconds = 0.1;
+        cfg.backends
+            .get_mut("default")
+            .expect("default backend")
+            .timeout_seconds = 0.1;
+        cfg.backends.insert(
+            "team-ch".to_string(),
+            moraine_config::ClickHouseConfig {
+                url: "http://127.0.0.1:1".to_string(),
+                database: "moraine_team".to_string(),
+                timeout_seconds: 0.1,
+                ..Default::default()
+            },
+        );
+        cfg.routes.push(moraine_config::RouteConfig {
+            dir: "/work/team/**".to_string(),
+            backend: "team-ch".to_string(),
+            mode: moraine_config::ROUTE_MODE_MIRROR.to_string(),
+        });
+        let cfg = Arc::new(cfg);
+        let default: Arc<dyn ConversationRepository> =
+            Arc::new(InMemoryConversationRepository::default());
+        let router = BackendRepositoryRouter::from_preloaded_for_testing(
+            cfg.clone(),
+            [("default".to_string(), default)],
+        )
+        .expect("router with lazy failing named backend");
+        let (sock, shutdown_tx, server) =
+            spawn_test_socket("route-reject", cfg, Arc::new(router)).await;
+
+        let stream = connect_to_test_socket(&sock).await;
+        let outcome = negotiate_private_route(
+            stream,
+            "/work/team/project",
+            std::time::Duration::from_secs(3),
+        )
+        .await;
+        match outcome {
+            PrivateRouteNegotiation::Rejected { message } => {
+                assert!(
+                    message.contains("team-ch"),
+                    "backend named in error: {message}"
+                );
+                assert!(
+                    message.contains("schema handshake failed"),
+                    "handshake named in error: {message}"
+                );
+            }
+            PrivateRouteNegotiation::Incompatible { reason } => {
+                panic!("route failures must not become fallback-compatible: {reason}")
+            }
+            PrivateRouteNegotiation::Accepted(_) => {
+                panic!("unreachable named backend must not be accepted")
+            }
+        }
+
+        shutdown_tx.send(()).expect("shutdown rejection server");
+        server
+            .await
+            .expect("rejection server task")
+            .expect("rejection server shutdown");
     }
 
     #[cfg(unix)]

--- a/crates/moraine-mcp-core/src/list_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/list_sessions_v1.rs
@@ -325,7 +325,7 @@ mod tests {
     use moraine_conversations::{
         ConversationMode, InMemoryConversationRepository, InMemoryConversationResponses, RepoConfig,
     };
-    use std::sync::{atomic::AtomicBool, Arc};
+    use std::sync::Arc;
 
     #[test]
     fn parses_and_canonicalizes_list_sessions_args() {
@@ -428,11 +428,7 @@ mod tests {
                 ..InMemoryConversationResponses::default()
             },
         ));
-        let state = AppState {
-            cfg: AppConfig::default(),
-            repo: repository.clone(),
-            prewarm_started: Arc::new(AtomicBool::new(false)),
-        };
+        let state = AppState::embedded(AppConfig::default(), repository.clone());
 
         let result = state
             .list_sessions_v1(json!({

--- a/crates/moraine-mcp-core/src/private_proxy.rs
+++ b/crates/moraine-mcp-core/src/private_proxy.rs
@@ -1,0 +1,865 @@
+use anyhow::{anyhow, bail, Context, Result};
+use moraine_config::AppConfig;
+use serde_json::{json, Value};
+use std::time::Duration;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
+
+pub const PRIVATE_ROUTE_MAX_LINE_BYTES: usize = 64 * 1024;
+const PRIVATE_ROUTE_ID: &str = "moraine-route-v1";
+const PRIVATE_ROUTE_METHOD: &str = "moraine/private/route";
+const PRIVATE_ROUTE_VERSION: u64 = 1;
+const PRIVATE_ROUTE_ERROR_CODE: i64 = -32000;
+const PRIVATE_ROUTE_INCOMPATIBLE_CODE: i64 = -32001;
+
+/// Maximum time a proxy waits for the daemon's private route response.
+///
+/// A named-backend schema probe performs at most two sequential ClickHouse
+/// requests. The extra second covers routing and control-message overhead.
+/// ClickHouse applies a one-second floor to every configured request timeout;
+/// this calculation intentionally applies the same floor.
+pub fn private_route_deadline(cfg: &AppConfig) -> Result<Duration> {
+    let mut max_timeout_seconds = 1.0_f64;
+
+    for (backend_name, backend) in cfg.backends.iter() {
+        let seconds = backend.timeout_seconds;
+        if !seconds.is_finite() {
+            bail!(
+                "backend '{backend_name}' timeout_seconds must be finite to derive the private route deadline"
+            );
+        }
+        max_timeout_seconds = max_timeout_seconds.max(seconds.max(1.0));
+    }
+
+    // Preserve the AppConfig invariant defensively for programmatic configs
+    // whose `backends` map may have been cleared or desynchronized.
+    let default_seconds = cfg.clickhouse.timeout_seconds;
+    if !default_seconds.is_finite() {
+        bail!(
+            "default backend timeout_seconds must be finite to derive the private route deadline"
+        );
+    }
+    max_timeout_seconds = max_timeout_seconds.max(default_seconds.max(1.0));
+
+    let deadline_seconds = max_timeout_seconds.mul_add(2.0, 1.0);
+    if !deadline_seconds.is_finite() {
+        bail!("private route deadline is out of range");
+    }
+    Duration::try_from_secs_f64(deadline_seconds)
+        .map_err(|_| anyhow!("private route deadline is out of range"))
+}
+
+/// Opaque socket halves retained after the daemon acknowledges a private route.
+///
+/// Pass this directly to [`crate::run_proxy`]; exposing only the accepted
+/// connection makes it impossible to begin consuming agent stdin before the
+/// ACK barrier.
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct PrivateProxyConnection {
+    reader: tokio::io::BufReader<tokio::net::unix::OwnedReadHalf>,
+    writer: tokio::net::unix::OwnedWriteHalf,
+}
+
+#[cfg(unix)]
+impl PrivateProxyConnection {
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        tokio::io::BufReader<tokio::net::unix::OwnedReadHalf>,
+        tokio::net::unix::OwnedWriteHalf,
+    ) {
+        (self.reader, self.writer)
+    }
+}
+
+/// Result of the daemon-private cwd negotiation performed before proxying any
+/// agent bytes.
+///
+/// `Incompatible` is safe for the app to replace with a locally selected
+/// embedded server because no agent input has been consumed. `Rejected` is a
+/// recognized route/build/skew failure from a new daemon and is fatal: falling
+/// back would silently change the selected backend. Only `Accepted` carries a
+/// connection that can be passed to [`crate::run_proxy`].
+#[cfg(unix)]
+#[derive(Debug)]
+pub enum PrivateRouteNegotiation {
+    Accepted(PrivateProxyConnection),
+    Incompatible { reason: String },
+    Rejected { message: String },
+}
+
+/// Negotiate a cwd-selected repository with a connected central daemon.
+///
+/// The request and response are bounded to 64 KiB and the complete exchange is
+/// limited by `deadline`. Every pre-ACK transport/protocol failure is returned
+/// as [`PrivateRouteNegotiation::Incompatible`]; only an exact structured route
+/// error becomes [`PrivateRouteNegotiation::Rejected`].
+#[cfg(unix)]
+pub async fn negotiate_private_route(
+    stream: tokio::net::UnixStream,
+    cwd: &str,
+    deadline: Duration,
+) -> PrivateRouteNegotiation {
+    use tokio::io::BufReader;
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": PRIVATE_ROUTE_ID,
+        "method": PRIVATE_ROUTE_METHOD,
+        "params": {
+            "version": PRIVATE_ROUTE_VERSION,
+            "cwd": cwd,
+        },
+    });
+    let mut payload = match serde_json::to_vec(&request) {
+        Ok(payload) => payload,
+        Err(error) => {
+            return PrivateRouteNegotiation::Incompatible {
+                reason: format!("failed to encode private route request: {error}"),
+            };
+        }
+    };
+    payload.push(b'\n');
+    if payload.len() > PRIVATE_ROUTE_MAX_LINE_BYTES {
+        return PrivateRouteNegotiation::Incompatible {
+            reason: format!(
+                "private route request exceeds {} bytes",
+                PRIVATE_ROUTE_MAX_LINE_BYTES
+            ),
+        };
+    }
+
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+    let exchange = async {
+        write_half
+            .write_all(&payload)
+            .await
+            .context("failed to write private route request")?;
+        write_half
+            .flush()
+            .await
+            .context("failed to flush private route request")?;
+        read_bounded_line(&mut reader)
+            .await?
+            .ok_or_else(|| anyhow!("daemon closed before the private route response"))
+    };
+
+    let response = match tokio::time::timeout(deadline, exchange).await {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) => {
+            return PrivateRouteNegotiation::Incompatible {
+                reason: error.to_string(),
+            };
+        }
+        Err(_) => {
+            return PrivateRouteNegotiation::Incompatible {
+                reason: format!(
+                    "private route negotiation timed out after {:.3}s",
+                    deadline.as_secs_f64()
+                ),
+            };
+        }
+    };
+
+    match classify_client_response(&response) {
+        ClientResponse::Accepted => PrivateRouteNegotiation::Accepted(PrivateProxyConnection {
+            reader,
+            writer: write_half,
+        }),
+        ClientResponse::Incompatible(reason) => PrivateRouteNegotiation::Incompatible { reason },
+        ClientResponse::Rejected(message) => PrivateRouteNegotiation::Rejected { message },
+    }
+}
+
+#[cfg(unix)]
+enum ClientResponse {
+    Accepted,
+    Incompatible(String),
+    Rejected(String),
+}
+
+#[cfg(unix)]
+fn classify_client_response(line: &[u8]) -> ClientResponse {
+    let response: Value = match serde_json::from_slice(line) {
+        Ok(response) => response,
+        Err(error) => {
+            return ClientResponse::Incompatible(format!(
+                "daemon returned malformed private route JSON: {error}"
+            ));
+        }
+    };
+
+    if response.get("jsonrpc").and_then(Value::as_str) != Some("2.0")
+        || response.get("id").and_then(Value::as_str) != Some(PRIVATE_ROUTE_ID)
+    {
+        return ClientResponse::Incompatible(
+            "daemon returned a mismatched private route response".to_string(),
+        );
+    }
+
+    if response.get("error").is_none()
+        && response
+            .get("result")
+            .and_then(|result| result.get("version"))
+            .and_then(Value::as_u64)
+            == Some(PRIVATE_ROUTE_VERSION)
+    {
+        return ClientResponse::Accepted;
+    }
+
+    let Some(error) = response.get("error") else {
+        return ClientResponse::Incompatible(
+            "daemon returned an unrecognized private route response".to_string(),
+        );
+    };
+    if error.get("code").and_then(Value::as_i64) == Some(-32601) {
+        return ClientResponse::Incompatible(
+            "daemon does not support private route negotiation".to_string(),
+        );
+    }
+
+    let data = error.get("data");
+    let version = data
+        .and_then(|data| data.get("version"))
+        .and_then(Value::as_u64);
+    let kind = data
+        .and_then(|data| data.get("kind"))
+        .and_then(Value::as_str);
+    let code = error.get("code").and_then(Value::as_i64);
+    if version != Some(PRIVATE_ROUTE_VERSION) {
+        return ClientResponse::Incompatible(
+            "daemon returned a private route response for an unsupported version".to_string(),
+        );
+    }
+
+    match (code, kind) {
+        (Some(PRIVATE_ROUTE_ERROR_CODE), Some("route")) => ClientResponse::Rejected(
+            error
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("daemon rejected the private route")
+                .to_string(),
+        ),
+        (Some(PRIVATE_ROUTE_INCOMPATIBLE_CODE), Some("incompatible")) => {
+            ClientResponse::Incompatible(
+                error
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("daemon rejected the private route protocol version")
+                    .to_string(),
+            )
+        }
+        _ => ClientResponse::Incompatible(
+            "daemon returned an unrecognized private route error".to_string(),
+        ),
+    }
+}
+
+#[cfg(unix)]
+pub(crate) enum ServerFirstLine {
+    Route { cwd: String },
+    Incompatible,
+    Raw,
+}
+
+#[cfg(unix)]
+pub(crate) fn classify_server_first_line(line: &[u8]) -> ServerFirstLine {
+    let request: Value = match serde_json::from_slice(line) {
+        Ok(request) => request,
+        Err(_) => return ServerFirstLine::Raw,
+    };
+
+    if request.get("jsonrpc").and_then(Value::as_str) != Some("2.0")
+        || request.get("id").and_then(Value::as_str) != Some(PRIVATE_ROUTE_ID)
+        || request.get("method").and_then(Value::as_str) != Some(PRIVATE_ROUTE_METHOD)
+    {
+        return ServerFirstLine::Raw;
+    }
+
+    let params = request.get("params");
+    let version = params
+        .and_then(|params| params.get("version"))
+        .and_then(Value::as_u64);
+    if version != Some(PRIVATE_ROUTE_VERSION) {
+        return ServerFirstLine::Incompatible;
+    }
+    let Some(cwd) = params
+        .and_then(|params| params.get("cwd"))
+        .and_then(Value::as_str)
+    else {
+        return ServerFirstLine::Incompatible;
+    };
+
+    ServerFirstLine::Route {
+        cwd: cwd.to_string(),
+    }
+}
+
+#[cfg(unix)]
+pub(crate) async fn write_ack<W>(writer: &mut W) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    write_control_response(
+        writer,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": PRIVATE_ROUTE_ID,
+            "result": { "version": PRIVATE_ROUTE_VERSION },
+        }),
+    )
+    .await
+}
+
+#[cfg(unix)]
+pub(crate) async fn write_route_error<W>(writer: &mut W, message: &str) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    // Eight KiB remains under the 64-KiB control-line limit even if every
+    // input byte needs serde_json's six-byte `\u00XX` escape.
+    const MAX_ROUTE_ERROR_MESSAGE_BYTES: usize = 8 * 1024;
+    let message = if message.len() <= MAX_ROUTE_ERROR_MESSAGE_BYTES {
+        std::borrow::Cow::Borrowed(message)
+    } else {
+        let mut end = MAX_ROUTE_ERROR_MESSAGE_BYTES - 3;
+        while !message.is_char_boundary(end) {
+            end -= 1;
+        }
+        std::borrow::Cow::Owned(format!("{}...", &message[..end]))
+    };
+    write_control_response(
+        writer,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": PRIVATE_ROUTE_ID,
+            "error": {
+                "code": PRIVATE_ROUTE_ERROR_CODE,
+                "message": message,
+                "data": {
+                    "kind": "route",
+                    "version": PRIVATE_ROUTE_VERSION,
+                },
+            },
+        }),
+    )
+    .await
+}
+
+#[cfg(unix)]
+pub(crate) async fn write_incompatible_error<W>(writer: &mut W) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    write_control_response(
+        writer,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": PRIVATE_ROUTE_ID,
+            "error": {
+                "code": PRIVATE_ROUTE_INCOMPATIBLE_CODE,
+                "message": "unsupported private route protocol version",
+                "data": {
+                    "kind": "incompatible",
+                    "version": PRIVATE_ROUTE_VERSION,
+                },
+            },
+        }),
+    )
+    .await
+}
+
+#[cfg(unix)]
+async fn write_control_response<W>(writer: &mut W, response: &Value) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut payload = serde_json::to_vec(response)?;
+    payload.push(b'\n');
+    if payload.len() > PRIVATE_ROUTE_MAX_LINE_BYTES {
+        bail!(
+            "private route response exceeds {} bytes",
+            PRIVATE_ROUTE_MAX_LINE_BYTES
+        );
+    }
+    writer.write_all(&payload).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Read one line without ever allowing its allocation to exceed the private
+/// control protocol's bound. The newline, when present, is retained.
+pub(crate) async fn read_bounded_line<R>(reader: &mut R) -> Result<Option<Vec<u8>>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut line = Vec::with_capacity(512);
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return Ok((!line.is_empty()).then_some(line));
+        }
+
+        if let Some(newline) = available.iter().position(|byte| *byte == b'\n') {
+            let consumed = newline + 1;
+            if line.len() + consumed > PRIVATE_ROUTE_MAX_LINE_BYTES {
+                bail!(
+                    "private route control line exceeds {} bytes",
+                    PRIVATE_ROUTE_MAX_LINE_BYTES
+                );
+            }
+            line.extend_from_slice(&available[..consumed]);
+            reader.consume(consumed);
+            return Ok(Some(line));
+        }
+
+        if line.len() + available.len() > PRIVATE_ROUTE_MAX_LINE_BYTES {
+            bail!(
+                "private route control line exceeds {} bytes",
+                PRIVATE_ROUTE_MAX_LINE_BYTES
+            );
+        }
+        line.extend_from_slice(available);
+        let consumed = available.len();
+        reader.consume(consumed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    #[test]
+    fn deadline_uses_effective_max_backend_timeout() {
+        let mut cfg = AppConfig::default();
+        assert_eq!(
+            private_route_deadline(&cfg).expect("default deadline"),
+            Duration::from_secs(61)
+        );
+
+        cfg.backends.insert(
+            "slow".to_string(),
+            moraine_config::ClickHouseConfig {
+                timeout_seconds: 45.0,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            private_route_deadline(&cfg).expect("slow deadline"),
+            Duration::from_secs(91)
+        );
+
+        cfg.clickhouse.timeout_seconds = 0.2;
+        for backend in cfg.backends.values_mut() {
+            backend.timeout_seconds = 0.2;
+        }
+        assert_eq!(
+            private_route_deadline(&cfg).expect("floored deadline"),
+            Duration::from_secs(3)
+        );
+    }
+
+    #[test]
+    fn deadline_rejects_non_finite_and_out_of_range_values() {
+        let mut cfg = AppConfig::default();
+        cfg.backends
+            .get_mut("default")
+            .expect("default backend")
+            .timeout_seconds = f64::INFINITY;
+        assert!(private_route_deadline(&cfg)
+            .expect_err("infinite timeout must fail")
+            .to_string()
+            .contains("must be finite"));
+
+        cfg.backends
+            .get_mut("default")
+            .expect("default backend")
+            .timeout_seconds = f64::MAX;
+        assert!(private_route_deadline(&cfg)
+            .expect_err("overflowing timeout must fail")
+            .to_string()
+            .contains("out of range"));
+    }
+
+    #[tokio::test]
+    async fn bounded_line_accepts_limit_and_rejects_one_byte_over() {
+        let mut exact = vec![b'x'; PRIVATE_ROUTE_MAX_LINE_BYTES - 1];
+        exact.push(b'\n');
+        let mut exact_reader = BufReader::new(std::io::Cursor::new(exact.clone()));
+        assert_eq!(
+            read_bounded_line(&mut exact_reader)
+                .await
+                .expect("exact line"),
+            Some(exact)
+        );
+
+        let mut oversized = vec![b'x'; PRIVATE_ROUTE_MAX_LINE_BYTES];
+        oversized.push(b'\n');
+        let mut oversized_reader = BufReader::new(std::io::Cursor::new(oversized));
+        assert!(read_bounded_line(&mut oversized_reader)
+            .await
+            .expect_err("oversized line must fail")
+            .to_string()
+            .contains("exceeds"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn server_discriminates_only_exact_private_hello() {
+        let exact = serde_json::to_vec(&json!({
+            "jsonrpc": "2.0",
+            "id": "moraine-route-v1",
+            "method": "moraine/private/route",
+            "params": {"version": 1, "cwd": "/work/team"},
+        }))
+        .expect("exact hello");
+        match classify_server_first_line(&exact) {
+            ServerFirstLine::Route { cwd } => assert_eq!(cwd, "/work/team"),
+            _ => panic!("exact hello must route"),
+        }
+
+        let unsupported = serde_json::to_vec(&json!({
+            "jsonrpc": "2.0",
+            "id": "moraine-route-v1",
+            "method": "moraine/private/route",
+            "params": {"version": 2, "cwd": "/work/team"},
+        }))
+        .expect("unsupported hello");
+        assert!(matches!(
+            classify_server_first_line(&unsupported),
+            ServerFirstLine::Incompatible
+        ));
+
+        let wrong_id = serde_json::to_vec(&json!({
+            "jsonrpc": "2.0",
+            "id": "agent-request",
+            "method": "moraine/private/route",
+            "params": {"version": 1, "cwd": "/work/team"},
+        }))
+        .expect("raw request");
+        assert!(matches!(
+            classify_server_first_line(&wrong_id),
+            ServerFirstLine::Raw
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn server_emits_exact_ack_and_structured_errors() {
+        let mut ack = Vec::new();
+        write_ack(&mut ack).await.expect("ack");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&ack).expect("ack json"),
+            json!({
+                "jsonrpc": "2.0",
+                "id": "moraine-route-v1",
+                "result": {"version": 1},
+            })
+        );
+
+        let mut route = Vec::new();
+        write_route_error(&mut route, "backend 'team-ch' is older")
+            .await
+            .expect("route error");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&route).expect("route json"),
+            json!({
+                "jsonrpc": "2.0",
+                "id": "moraine-route-v1",
+                "error": {
+                    "code": -32000,
+                    "message": "backend 'team-ch' is older",
+                    "data": {"kind": "route", "version": 1},
+                },
+            })
+        );
+
+        let mut bounded_route = Vec::new();
+        let escape_heavy_message = format!("backend team-ch: {}", "\u{1}".repeat(20_000));
+        write_route_error(&mut bounded_route, &escape_heavy_message)
+            .await
+            .expect("oversized route error is truncated, not dropped");
+        assert!(bounded_route.len() <= PRIVATE_ROUTE_MAX_LINE_BYTES);
+        let bounded_route: Value =
+            serde_json::from_slice(&bounded_route).expect("bounded route JSON");
+        assert_eq!(bounded_route["error"]["data"]["kind"], json!("route"));
+        assert!(bounded_route["error"]["message"]
+            .as_str()
+            .expect("bounded route message")
+            .starts_with("backend team-ch"));
+
+        let mut incompatible = Vec::new();
+        write_incompatible_error(&mut incompatible)
+            .await
+            .expect("incompatible error");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&incompatible).expect("incompatible json"),
+            json!({
+                "jsonrpc": "2.0",
+                "id": "moraine-route-v1",
+                "error": {
+                    "code": -32001,
+                    "message": "unsupported private route protocol version",
+                    "data": {"kind": "incompatible", "version": 1},
+                },
+            })
+        );
+    }
+
+    #[cfg(unix)]
+    async fn negotiation_with_response(response: Value) -> PrivateRouteNegotiation {
+        let (client, server) = tokio::net::UnixStream::pair().expect("socket pair");
+        tokio::spawn(async move {
+            let (read_half, mut write_half) = server.into_split();
+            let mut reader = BufReader::new(read_half);
+            let mut request = String::new();
+            reader
+                .read_line(&mut request)
+                .await
+                .expect("read private request");
+            write_half
+                .write_all(&serde_json::to_vec(&response).expect("response json"))
+                .await
+                .expect("write private response");
+            write_half.write_all(b"\n").await.expect("write newline");
+        });
+        negotiate_private_route(client, "/work/team", Duration::from_secs(1)).await
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn client_classifies_old_incompatible_and_route_rejection_exactly() {
+        let old = negotiation_with_response(json!({
+            "jsonrpc": "2.0",
+            "id": "moraine-route-v1",
+            "error": {"code": -32601, "message": "method not found"},
+        }))
+        .await;
+        assert!(matches!(old, PrivateRouteNegotiation::Incompatible { .. }));
+
+        let wrong_version = negotiation_with_response(json!({
+            "jsonrpc": "2.0",
+            "id": "moraine-route-v1",
+            "result": {"version": 2},
+        }))
+        .await;
+        assert!(matches!(
+            wrong_version,
+            PrivateRouteNegotiation::Incompatible { .. }
+        ));
+
+        let rejected = negotiation_with_response(json!({
+            "jsonrpc": "2.0",
+            "id": "moraine-route-v1",
+            "error": {
+                "code": -32000,
+                "message": "backend 'team-ch' is older",
+                "data": {"kind": "route", "version": 1},
+            },
+        }))
+        .await;
+        match rejected {
+            PrivateRouteNegotiation::Rejected { message } => {
+                assert_eq!(message, "backend 'team-ch' is older")
+            }
+            _ => panic!("structured route error must be fatal"),
+        }
+
+        let wrong_code = negotiation_with_response(json!({
+            "jsonrpc": "2.0",
+            "id": "moraine-route-v1",
+            "error": {
+                "code": -32099,
+                "message": "not the private route error contract",
+                "data": {"kind": "route", "version": 1},
+            },
+        }))
+        .await;
+        assert!(matches!(
+            wrong_code,
+            PrivateRouteNegotiation::Incompatible { .. }
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn client_emits_exact_private_route_request() {
+        let (client, server) = tokio::net::UnixStream::pair().expect("socket pair");
+        let (request_tx, request_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let (read_half, mut write_half) = server.into_split();
+            let mut reader = BufReader::new(read_half);
+            let mut request = String::new();
+            reader
+                .read_line(&mut request)
+                .await
+                .expect("read private request");
+            request_tx
+                .send(serde_json::from_str::<Value>(request.trim()).expect("request JSON"))
+                .expect("capture request");
+            write_half
+                .write_all(
+                    b"{\"jsonrpc\":\"2.0\",\"id\":\"moraine-route-v1\",\"result\":{\"version\":1}}\n",
+                )
+                .await
+                .expect("write ACK");
+        });
+
+        let outcome = negotiate_private_route(client, "/work/team", Duration::from_secs(1)).await;
+        assert!(matches!(outcome, PrivateRouteNegotiation::Accepted(_)));
+        assert_eq!(
+            request_rx.await.expect("captured request"),
+            json!({
+                "jsonrpc": "2.0",
+                "id": "moraine-route-v1",
+                "method": "moraine/private/route",
+                "params": {"version": 1, "cwd": "/work/team"},
+            })
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn delayed_ack_beyond_connect_timeout_remains_acceptable() {
+        let (client, server) = tokio::net::UnixStream::pair().expect("socket pair");
+        tokio::spawn(async move {
+            let (read_half, mut write_half) = server.into_split();
+            let mut reader = BufReader::new(read_half);
+            let mut request = String::new();
+            reader
+                .read_line(&mut request)
+                .await
+                .expect("read private request");
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            write_half
+                .write_all(
+                    b"{\"jsonrpc\":\"2.0\",\"id\":\"moraine-route-v1\",\"result\":{\"version\":1}}\n",
+                )
+                .await
+                .expect("write delayed ACK");
+        });
+
+        let outcome = negotiate_private_route(client, "/work/team", Duration::from_secs(1)).await;
+        assert!(matches!(outcome, PrivateRouteNegotiation::Accepted(_)));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn eof_malformed_response_and_deadline_are_incompatible() {
+        let (eof_client, eof_server) = tokio::net::UnixStream::pair().expect("EOF socket pair");
+        tokio::spawn(async move {
+            let (read_half, _write_half) = eof_server.into_split();
+            let mut reader = BufReader::new(read_half);
+            let mut request = String::new();
+            reader
+                .read_line(&mut request)
+                .await
+                .expect("read EOF request");
+        });
+        let eof = negotiate_private_route(eof_client, "/work/team", Duration::from_secs(1)).await;
+        assert!(matches!(eof, PrivateRouteNegotiation::Incompatible { .. }));
+
+        let (malformed_client, malformed_server) =
+            tokio::net::UnixStream::pair().expect("malformed socket pair");
+        tokio::spawn(async move {
+            let (read_half, mut write_half) = malformed_server.into_split();
+            let mut reader = BufReader::new(read_half);
+            let mut request = String::new();
+            reader
+                .read_line(&mut request)
+                .await
+                .expect("read malformed request");
+            write_half
+                .write_all(b"{not-json}\n")
+                .await
+                .expect("write malformed response");
+        });
+        let malformed =
+            negotiate_private_route(malformed_client, "/work/team", Duration::from_secs(1)).await;
+        assert!(matches!(
+            malformed,
+            PrivateRouteNegotiation::Incompatible { .. }
+        ));
+
+        let (timeout_client, timeout_server) =
+            tokio::net::UnixStream::pair().expect("timeout socket pair");
+        tokio::spawn(async move {
+            let (read_half, _write_half) = timeout_server.into_split();
+            let mut reader = BufReader::new(read_half);
+            let mut request = String::new();
+            reader
+                .read_line(&mut request)
+                .await
+                .expect("read timeout request");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        });
+        let timed_out =
+            negotiate_private_route(timeout_client, "/work/team", Duration::from_millis(10)).await;
+        match timed_out {
+            PrivateRouteNegotiation::Incompatible { reason } => {
+                assert!(reason.contains("timed out"), "unexpected reason: {reason}");
+            }
+            _ => panic!("private response deadline must be incompatible"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn accepted_negotiation_retains_bytes_buffered_after_ack() {
+        let (client, server) = tokio::net::UnixStream::pair().expect("socket pair");
+        tokio::spawn(async move {
+            let (read_half, mut write_half) = server.into_split();
+            let mut reader = BufReader::new(read_half);
+            let mut request = String::new();
+            reader
+                .read_line(&mut request)
+                .await
+                .expect("read private request");
+            write_half
+                .write_all(
+                    b"{\"jsonrpc\":\"2.0\",\"id\":\"moraine-route-v1\",\"result\":{\"version\":1}}\nafter-ack\n",
+                )
+                .await
+                .expect("write ack and data");
+        });
+
+        let accepted = negotiate_private_route(client, "/work/team", Duration::from_secs(1)).await;
+        let PrivateRouteNegotiation::Accepted(connection) = accepted else {
+            panic!("valid ACK must be accepted");
+        };
+        let (mut reader, _writer) = connection.into_parts();
+        let mut line = String::new();
+        reader.read_line(&mut line).await.expect("retained line");
+        assert_eq!(line, "after-ack\n");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn oversized_client_response_is_incompatible() {
+        let (client, server) = tokio::net::UnixStream::pair().expect("socket pair");
+        tokio::spawn(async move {
+            let (read_half, mut write_half) = server.into_split();
+            let mut reader = BufReader::new(read_half);
+            let mut request = String::new();
+            reader
+                .read_line(&mut request)
+                .await
+                .expect("read private request");
+            write_half
+                .write_all(&vec![b'x'; PRIVATE_ROUTE_MAX_LINE_BYTES + 1])
+                .await
+                .expect("write oversized response");
+            write_half.write_all(b"\n").await.expect("write newline");
+        });
+
+        let outcome = negotiate_private_route(client, "/work/team", Duration::from_secs(1)).await;
+        match outcome {
+            PrivateRouteNegotiation::Incompatible { reason } => {
+                assert!(reason.contains("exceeds"), "unexpected reason: {reason}");
+            }
+            _ => panic!("oversized response must be incompatible"),
+        }
+    }
+}

--- a/crates/moraine-mcp-core/src/private_proxy.rs
+++ b/crates/moraine-mcp-core/src/private_proxy.rs
@@ -265,6 +265,9 @@ pub(crate) enum ServerFirstLine {
 
 #[cfg(unix)]
 pub(crate) fn classify_server_first_line(line: &[u8]) -> ServerFirstLine {
+    if line.len() > PRIVATE_ROUTE_MAX_LINE_BYTES {
+        return ServerFirstLine::Raw;
+    }
     let request: Value = match serde_json::from_slice(line) {
         Ok(request) => request,
         Err(_) => return ServerFirstLine::Raw,
@@ -386,6 +389,19 @@ where
     writer.write_all(&payload).await?;
     writer.flush().await?;
     Ok(())
+}
+
+/// Read the first daemon-side line with the public MCP transport's historical
+/// unbounded framing. Oversized lines are classified as raw MCP rather than as
+/// private control messages, so the 64-KiB control bound never truncates a
+/// legacy client's first request.
+pub(crate) async fn read_server_first_line<R>(reader: &mut R) -> Result<Option<Vec<u8>>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut line = Vec::new();
+    let bytes = reader.read_until(b'\n', &mut line).await?;
+    Ok((bytes != 0).then_some(line))
 }
 
 /// Read one line without ever allowing its allocation to exceed the private

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -10,6 +10,7 @@ axum = "0.7"
 mime_guess = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tracing = "0.1"
 tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "fs", "net"] }
 moraine-config = { path = "../moraine-config" }
 moraine-conversations = { path = "../moraine-conversations" }

--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -25,6 +25,7 @@ use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::fs;
+use tracing::warn;
 
 struct AppState {
     backend_router: Arc<BackendRepositoryRouter>,
@@ -94,7 +95,7 @@ where
 }
 
 /// Build the complete monitor router around the daemon-owned backend router.
-pub fn router_with_backend_router(
+fn router_with_backend_router(
     backend_router: Arc<BackendRepositoryRouter>,
     static_dir: PathBuf,
 ) -> Result<Router> {
@@ -188,9 +189,13 @@ async fn select_backend_repository(
 
     let backend = match selected {
         Ok(backend) => backend,
-        Err(error) => {
+        Err(_) => {
+            warn!("backend project route selection failed; selected backend unavailable or schema-incompatible");
             return json_response(
-                json!({"ok": false, "error": format!("backend selection failed: {error}")}),
+                json!({
+                    "ok": false,
+                    "error": "selected backend is unavailable or schema-incompatible"
+                }),
                 StatusCode::SERVICE_UNAVAILABLE,
             );
         }
@@ -1929,8 +1934,7 @@ mod tests {
         let app =
             router_with_backend_router(backend_router, root.clone()).expect("routing test app");
 
-        let default =
-            response_json(get_with_project_dir(&app, "/api/v1/tables", None).await).await;
+        let default = response_json(get_with_project_dir(&app, "/api/v1/tables", None).await).await;
         assert_eq!(default_repository.calls().list_table_summaries, 1);
         assert_eq!(named_repository.calls().list_table_summaries, 0);
 
@@ -2005,8 +2009,7 @@ mod tests {
             Some(HeaderValue::from_static("/work/team/project")),
             Some(HeaderValue::from_static("malformed-relative-path")),
         ] {
-            let response =
-                get_with_project_dir(&app, "/api/v1/capabilities", header).await;
+            let response = get_with_project_dir(&app, "/api/v1/capabilities", header).await;
             assert_eq!(response.status(), StatusCode::OK);
             let payload = response_json(response).await;
             assert_eq!(payload["schema_migration_level"], json!("025"));
@@ -2028,8 +2031,13 @@ mod tests {
             RepoConfig::default(),
             successful_responses(),
         ));
-        let backend_router =
-            preloaded_backend_router(routing_config(), default_repository, named_repository);
+        let mut config = routing_config();
+        config
+            .backends
+            .get_mut("team-ch")
+            .expect("named backend")
+            .url = "http://user:secret@team.example:8123/path?token=secret#fragment".to_string();
+        let backend_router = preloaded_backend_router(config, default_repository, named_repository);
         let app =
             router_with_backend_router(backend_router, root.clone()).expect("metadata test app");
 
@@ -2156,9 +2164,10 @@ mod tests {
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         let payload = response_json(response).await;
         assert_eq!(payload["ok"], json!(false));
-        assert!(payload["error"]
-            .as_str()
-            .is_some_and(|error| error.contains("team-ch")));
+        assert_eq!(
+            payload["error"],
+            json!("selected backend is unavailable or schema-incompatible")
+        );
 
         let _ = fs::remove_dir_all(root);
     }

--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -1,17 +1,20 @@
 use anyhow::{anyhow, Result};
 use axum::{
     body::Body,
-    extract::{Path, Query, State},
-    http::{header, HeaderValue, StatusCode, Uri},
+    extract::{Extension, Path, Query, State},
+    http::{header, HeaderValue, Request, StatusCode, Uri},
+    middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::get,
     Json, Router,
 };
+#[cfg(test)]
 use moraine_config::AppConfig;
 use moraine_conversations::{
-    AnalyticsRange, ConversationRepository, IngestHeartbeat, IngestHeartbeatRead, RepoError,
-    SessionAnalytics, SessionAnalyticsQuery, SessionLookback, SessionStep, SessionTurn,
-    StoreConnectionMetrics, StoreHealth, StoreProbe, TablePreviewQuery, TableSummaries,
+    AnalyticsRange, BackendRepository, BackendRepositoryRouter, IngestHeartbeat,
+    IngestHeartbeatRead, RepoError, SessionAnalytics, SessionAnalyticsQuery, SessionLookback,
+    SessionStep, SessionTurn, StoreConnectionMetrics, StoreHealth, StoreProbe, TablePreviewQuery,
+    TableSummaries,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -24,10 +27,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::fs;
 
 struct AppState {
-    repository: Arc<dyn ConversationRepository>,
+    backend_router: Arc<BackendRepositoryRouter>,
     static_dir: PathBuf,
-    clickhouse_url: String,
-    clickhouse_database: String,
 }
 
 #[derive(Deserialize)]
@@ -54,11 +55,11 @@ struct MonitorTableSummary {
     rows: u64,
 }
 
-/// Run the monitor HTTP server using a repository owned by the composition
-/// root. The supplied shutdown future stops the listener gracefully.
-pub async fn run_server_with_repository<S>(
-    cfg: AppConfig,
-    repository: Arc<dyn ConversationRepository>,
+/// Run the monitor HTTP server using the daemon-owned backend router.
+///
+/// The supplied shutdown future stops the listener gracefully.
+pub async fn run_server_with_router<S>(
+    backend_router: Arc<BackendRepositoryRouter>,
     host: String,
     port: u16,
     static_dir: PathBuf,
@@ -68,7 +69,7 @@ where
     S: Future<Output = ()> + Send + 'static,
 {
     let static_dir_display = static_dir.display().to_string();
-    let app = router_with_repository(&cfg, repository, static_dir)?;
+    let app = router_with_backend_router(backend_router, static_dir)?;
     let bind = format!("{host}:{port}")
         .parse::<SocketAddr>()
         .map_err(|err| anyhow!("invalid bind address: {err}"))?;
@@ -92,33 +93,36 @@ where
     Ok(())
 }
 
-/// Build the complete monitor router around an injected repository.
-///
-/// All API routes and static-file behavior live here so the server can use the
-/// injected repository without constructing a second storage client.
-fn router_with_repository(
-    cfg: &AppConfig,
-    repository: Arc<dyn ConversationRepository>,
+/// Build the complete monitor router around the daemon-owned backend router.
+pub fn router_with_backend_router(
+    backend_router: Arc<BackendRepositoryRouter>,
     static_dir: PathBuf,
 ) -> Result<Router> {
     validate_static_dir(&static_dir)?;
     let state = Arc::new(AppState {
-        repository,
+        backend_router,
         static_dir,
-        clickhouse_url: cfg.clickhouse.url.clone(),
-        clickhouse_database: cfg.clickhouse.database.clone(),
     });
     Ok(monitor_router(state))
 }
 
 fn monitor_router(state: Arc<AppState>) -> Router {
-    let versioned_routes = dashboard_routes().route("/capabilities", get(api_capabilities));
+    let data_routes = dashboard_routes().route_layer(middleware::from_fn_with_state(
+        state.backend_router.clone(),
+        select_backend_repository,
+    ));
+    // Capabilities is daemon/default-global metadata, not a project-routed data
+    // endpoint. It intentionally remains outside project selection middleware.
+    let versioned_routes = data_routes
+        .clone()
+        .route("/capabilities", get(api_capabilities));
 
     Router::new()
         .nest("/api/v1", versioned_routes)
         // One-release compatibility surface. These are direct aliases so
-        // status codes, query handling, and response payloads remain identical.
-        .nest("/api", dashboard_routes())
+        // status codes, query handling, response payloads, and backend
+        // selection remain identical.
+        .nest("/api", data_routes)
         .fallback(get(static_fallback))
         .with_state(state)
 }
@@ -132,6 +136,67 @@ fn dashboard_routes() -> Router<Arc<AppState>> {
         .route("/web-searches", get(api_web_searches))
         .route("/tables/:table", get(api_table_rows))
         .route("/sessions", get(api_sessions))
+}
+
+/// Optional project context for repository-backed data endpoints. The value is
+/// resolved only through configured cwd routes/repo references; it never names
+/// a backend endpoint or credentials. Capabilities and static routes ignore it.
+const PROJECT_DIR_HEADER: &str = "x-moraine-project-dir";
+
+fn project_dir_header(
+    headers: &axum::http::HeaderMap,
+) -> std::result::Result<Option<&str>, &'static str> {
+    let mut values = headers.get_all(PROJECT_DIR_HEADER).iter();
+    let Some(value) = values.next() else {
+        return Ok(None);
+    };
+    if values.next().is_some() {
+        return Err("X-Moraine-Project-Dir must be provided exactly once");
+    }
+    let value = value
+        .to_str()
+        .map_err(|_| "X-Moraine-Project-Dir must be valid UTF-8")?
+        .trim();
+    if value.is_empty() {
+        return Err("X-Moraine-Project-Dir must not be empty");
+    }
+    if !FsPath::new(value).is_absolute() {
+        return Err("X-Moraine-Project-Dir must be an absolute path");
+    }
+    Ok(Some(value))
+}
+
+async fn select_backend_repository(
+    State(backend_router): State<Arc<BackendRepositoryRouter>>,
+    mut request: Request<Body>,
+    next: Next,
+) -> Response {
+    let selected = match project_dir_header(request.headers()) {
+        Ok(None) => backend_router.default_repository().await,
+        Ok(Some(project_dir)) => {
+            backend_router
+                .repository_for_project_dir(Some(project_dir))
+                .await
+        }
+        Err(error) => {
+            return json_response(
+                json!({"ok": false, "error": error}),
+                StatusCode::BAD_REQUEST,
+            );
+        }
+    };
+
+    let backend = match selected {
+        Ok(backend) => backend,
+        Err(error) => {
+            return json_response(
+                json!({"ok": false, "error": format!("backend selection failed: {error}")}),
+                StatusCode::SERVICE_UNAVAILABLE,
+            );
+        }
+    };
+    request.extensions_mut().insert(backend);
+    next.run(request).await
 }
 
 const MONITOR_DIST_ENV_KEYS: &[&str] = &["MORAINE_MONITOR_DIST", "MORAINE_MONITOR_STATIC_DIR"];
@@ -223,13 +288,20 @@ fn json_response<T: Serialize>(payload: T, status: StatusCode) -> Response {
     *response.status_mut() = status;
     response
 }
+/// Daemon-wide capabilities intentionally report the owned default backend's
+/// schema level. Project routing selects externally managed data stores, not a
+/// different daemon protocol or feature set, so this endpoint ignores
+/// `X-Moraine-Project-Dir` and remains outside routing middleware.
 async fn api_capabilities(State(state): State<Arc<AppState>>) -> Response {
-    let schema_migration_level = state
-        .repository
-        .read_store_diagnostics()
-        .await
-        .ok()
-        .and_then(|diagnostics| diagnostics.applied_schema_versions.into_iter().max());
+    let schema_migration_level = match state.backend_router.default_repository().await {
+        Ok(default_backend) => default_backend
+            .repository()
+            .read_store_diagnostics()
+            .await
+            .ok()
+            .and_then(|diagnostics| diagnostics.applied_schema_versions.into_iter().max()),
+        Err(_) => None,
+    };
 
     json_response(
         json!({
@@ -247,10 +319,10 @@ async fn api_capabilities(State(state): State<Arc<AppState>>) -> Response {
     )
 }
 
-async fn api_health(State(state): State<Arc<AppState>>) -> Response {
+async fn api_health(Extension(backend): Extension<Arc<BackendRepository>>) -> Response {
     let (health, heartbeat) = tokio::join!(
-        state.repository.read_store_health(),
-        state.repository.latest_ingest_heartbeat()
+        backend.repository().read_store_health(),
+        backend.repository().latest_ingest_heartbeat()
     );
     let health = match health {
         Ok(health) => health,
@@ -259,8 +331,8 @@ async fn api_health(State(state): State<Arc<AppState>>) -> Response {
             return json_response(
                 json!({
                     "ok": false,
-                    "url": state.clickhouse_url,
-                    "database": state.clickhouse_database,
+                    "url": backend.clickhouse_url(),
+                    "database": backend.clickhouse_database(),
                     "error": message,
                     "connections": {"total": Value::Null, "error": message},
                 }),
@@ -273,13 +345,13 @@ async fn api_health(State(state): State<Arc<AppState>>) -> Response {
     let ping_ms = match &health.ping {
         StoreProbe::Available(value) => *value,
         StoreProbe::Failed { message } => {
-            return health_failure_response(&state, message, connections);
+            return health_failure_response(&backend, message, connections);
         }
     };
     let version = match &health.version {
         StoreProbe::Available(value) => value,
         StoreProbe::Failed { message } => {
-            return health_failure_response(&state, message, connections);
+            return health_failure_response(&backend, message, connections);
         }
     };
     let heartbeat = heartbeat.map(monitor_heartbeat_status).unwrap_or_default();
@@ -287,8 +359,8 @@ async fn api_health(State(state): State<Arc<AppState>>) -> Response {
     json_response(
         json!({
             "ok": true,
-            "url": state.clickhouse_url,
-            "database": state.clickhouse_database,
+            "url": backend.clickhouse_url(),
+            "database": backend.clickhouse_database(),
             "version": version,
             "ping_ms": ping_ms,
             "connections": connections,
@@ -298,12 +370,16 @@ async fn api_health(State(state): State<Arc<AppState>>) -> Response {
     )
 }
 
-fn health_failure_response(state: &AppState, message: &str, connections: Value) -> Response {
+fn health_failure_response(
+    backend: &BackendRepository,
+    message: &str,
+    connections: Value,
+) -> Response {
     json_response(
         json!({
             "ok": false,
-            "url": state.clickhouse_url,
-            "database": state.clickhouse_database,
+            "url": backend.clickhouse_url(),
+            "database": backend.clickhouse_database(),
             "error": message,
             "connections": connections,
         }),
@@ -311,9 +387,9 @@ fn health_failure_response(state: &AppState, message: &str, connections: Value) 
     )
 }
 
-async fn api_status(State(state): State<Arc<AppState>>) -> Response {
-    let health = state
-        .repository
+async fn api_status(Extension(backend): Extension<Arc<BackendRepository>>) -> Response {
+    let health = backend
+        .repository()
         .read_store_health()
         .await
         .unwrap_or_else(|error| unavailable_store_health(error.to_string()));
@@ -321,8 +397,8 @@ async fn api_status(State(state): State<Arc<AppState>>) -> Response {
 
     let (tables, heartbeat) = if database_exists {
         let (tables, heartbeat) = tokio::join!(
-            state.repository.list_table_summaries(),
-            state.repository.latest_ingest_heartbeat()
+            backend.repository().list_table_summaries(),
+            backend.repository().latest_ingest_heartbeat()
         );
         let tables = match tables {
             Ok(tables) => monitor_table_summaries(tables),
@@ -340,7 +416,7 @@ async fn api_status(State(state): State<Arc<AppState>>) -> Response {
     };
 
     let estimated_total_rows = tables.iter().map(|table| table.rows).sum::<u64>();
-    let clickhouse = status_clickhouse_payload(&state, &health, database_exists);
+    let clickhouse = status_clickhouse_payload(&backend, &health, database_exists);
 
     json_response(
         json!({
@@ -381,14 +457,14 @@ fn probe_bool(probe: &StoreProbe<bool>) -> Option<bool> {
 }
 
 fn status_clickhouse_payload(
-    state: &AppState,
+    backend: &BackendRepository,
     health: &StoreHealth,
     database_exists: bool,
 ) -> Value {
     if !database_exists {
         return json!({
-            "url": state.clickhouse_url,
-            "database": state.clickhouse_database,
+            "url": backend.clickhouse_url(),
+            "database": backend.clickhouse_database(),
             "healthy": false,
             "version": Value::Null,
             "ping_ms": Value::Null,
@@ -406,8 +482,8 @@ fn status_clickhouse_payload(
     };
 
     json!({
-        "url": state.clickhouse_url,
-        "database": state.clickhouse_database,
+        "url": backend.clickhouse_url(),
+        "database": backend.clickhouse_database(),
         "healthy": healthy,
         "version": version,
         "ping_ms": ping_ms,
@@ -425,8 +501,8 @@ fn connection_payload(probe: &StoreProbe<StoreConnectionMetrics>) -> Value {
     }
 }
 
-async fn api_tables(State(state): State<Arc<AppState>>) -> Response {
-    match state.repository.list_table_summaries().await {
+async fn api_tables(Extension(backend): Extension<Arc<BackendRepository>>) -> Response {
+    match backend.repository().list_table_summaries().await {
         Ok(tables) => json_response(
             json!({"ok": true, "tables": monitor_table_summaries(tables)}),
             StatusCode::OK,
@@ -453,10 +529,10 @@ fn monitor_table_summaries(summaries: TableSummaries) -> Vec<MonitorTableSummary
 
 async fn api_web_searches(
     Query(params): Query<LimitQuery>,
-    State(state): State<Arc<AppState>>,
+    Extension(backend): Extension<Arc<BackendRepository>>,
 ) -> Response {
     let limit = params.limit.unwrap_or(100).clamp(1, 1000) as u16;
-    let rows = match state.repository.list_web_searches(limit).await {
+    let rows = match backend.repository().list_web_searches(limit).await {
         Ok(rows) => rows,
         Err(error) => {
             return json_response(
@@ -490,10 +566,10 @@ async fn api_web_searches(
 
 async fn api_analytics(
     Query(params): Query<AnalyticsQuery>,
-    State(state): State<Arc<AppState>>,
+    Extension(backend): Extension<Arc<BackendRepository>>,
 ) -> Response {
     let range = resolve_analytics_range(params.range.as_deref());
-    let snapshot = match state.repository.analytics_series(range).await {
+    let snapshot = match backend.repository().analytics_series(range).await {
         Ok(snapshot) => snapshot,
         Err(error) => {
             return json_response(
@@ -538,13 +614,13 @@ fn resolve_analytics_range(value: Option<&str>) -> AnalyticsRange {
 
 async fn api_sessions(
     Query(params): Query<SessionsQuery>,
-    State(state): State<Arc<AppState>>,
+    Extension(backend): Extension<Arc<BackendRepository>>,
 ) -> Response {
     let query = SessionAnalyticsQuery {
         lookback: resolve_session_lookback(params.since.as_deref()),
         limit: params.limit.unwrap_or(50).clamp(1, 200) as u16,
     };
-    let sessions = match state.repository.list_session_analytics(query).await {
+    let sessions = match backend.repository().list_session_analytics(query).await {
         Ok(sessions) => sessions,
         Err(error) => {
             return json_response(
@@ -898,11 +974,11 @@ fn unix_now_ms() -> i64 {
 async fn api_table_rows(
     Path(table): Path<String>,
     Query(params): Query<LimitQuery>,
-    State(state): State<Arc<AppState>>,
+    Extension(backend): Extension<Arc<BackendRepository>>,
 ) -> Response {
     let limit = params.limit.unwrap_or(25).clamp(1, 500) as u16;
-    match state
-        .repository
+    match backend
+        .repository()
         .preview_table(TablePreviewQuery {
             table: table.clone(),
             limit,
@@ -1016,12 +1092,14 @@ async fn static_fallback(State(state): State<Arc<AppState>>, uri: Uri) -> Respon
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{body::to_bytes, http::Request};
+    use axum::body::to_bytes;
+    use moraine_config::{ClickHouseConfig, RouteConfig, DEFAULT_BACKEND_NAME, ROUTE_MODE_MIRROR};
     use moraine_conversations::{
         AnalyticsConcurrencyPoint, AnalyticsSnapshot, AnalyticsTokenPoint, AnalyticsTurnPoint,
-        AnalyticsWindow, ConversationMode, ConversationSummary, InMemoryConversationRepository,
-        InMemoryConversationResponses, IngestHeartbeat, RepoConfig, SessionStep, StoreDiagnostics,
-        TableColumn, TablePreview, TableSummary, ToolResult, TurnSummary, WebSearchEvent,
+        AnalyticsWindow, ConversationMode, ConversationRepository, ConversationSummary,
+        InMemoryConversationRepository, InMemoryConversationResponses, IngestHeartbeat, RepoConfig,
+        SessionStep, StoreDiagnostics, TableColumn, TablePreview, TableSummary, ToolResult,
+        TurnSummary, WebSearchEvent,
     };
     use std::collections::BTreeMap;
     use std::fs;
@@ -1038,6 +1116,26 @@ mod tests {
         ))
     }
 
+    async fn fake_backend(
+        responses: InMemoryConversationResponses,
+    ) -> (Arc<BackendRepository>, Arc<InMemoryConversationRepository>) {
+        let repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            responses,
+        ));
+        let injected: Arc<dyn ConversationRepository> = repository.clone();
+        let router = BackendRepositoryRouter::from_preloaded_for_testing(
+            Arc::new(AppConfig::default()),
+            [(DEFAULT_BACKEND_NAME.to_string(), injected)],
+        )
+        .expect("preloaded default router");
+        let backend = router
+            .default_repository()
+            .await
+            .expect("preloaded default backend");
+        (backend, repository)
+    }
+
     fn fake_state(
         responses: InMemoryConversationResponses,
     ) -> (Arc<AppState>, Arc<InMemoryConversationRepository>) {
@@ -1045,13 +1143,92 @@ mod tests {
             RepoConfig::default(),
             responses,
         ));
-        let state = Arc::new(AppState {
-            repository: repository.clone(),
-            static_dir: PathBuf::new(),
-            clickhouse_url: "http://127.0.0.1:8123".to_string(),
-            clickhouse_database: "moraine".to_string(),
-        });
-        (state, repository)
+        let injected: Arc<dyn ConversationRepository> = repository.clone();
+        let backend_router = Arc::new(
+            BackendRepositoryRouter::from_preloaded_for_testing(
+                Arc::new(AppConfig::default()),
+                [(DEFAULT_BACKEND_NAME.to_string(), injected)],
+            )
+            .expect("preloaded default router"),
+        );
+        (
+            Arc::new(AppState {
+                backend_router,
+                static_dir: PathBuf::new(),
+            }),
+            repository,
+        )
+    }
+
+    fn routing_config() -> AppConfig {
+        let mut config = AppConfig::default();
+        config.clickhouse.url = "http://default.example:8123".to_string();
+        config.clickhouse.database = "moraine_default".to_string();
+        config
+            .backends
+            .insert(DEFAULT_BACKEND_NAME.to_string(), config.clickhouse.clone());
+        config.backends.insert(
+            "team-ch".to_string(),
+            ClickHouseConfig {
+                url: "http://team.example:8123".to_string(),
+                database: "moraine_team".to_string(),
+                ..ClickHouseConfig::default()
+            },
+        );
+        config.routes = vec![
+            RouteConfig {
+                dir: "/work/team/**".to_string(),
+                backend: "team-ch".to_string(),
+                mode: ROUTE_MODE_MIRROR.to_string(),
+            },
+            RouteConfig {
+                dir: "/work/ghost/**".to_string(),
+                backend: "not-configured".to_string(),
+                mode: ROUTE_MODE_MIRROR.to_string(),
+            },
+        ];
+        config
+    }
+
+    fn preloaded_backend_router(
+        config: AppConfig,
+        default_repository: Arc<InMemoryConversationRepository>,
+        named_repository: Arc<InMemoryConversationRepository>,
+    ) -> Arc<BackendRepositoryRouter> {
+        let default_repository: Arc<dyn ConversationRepository> = default_repository;
+        let named_repository: Arc<dyn ConversationRepository> = named_repository;
+        Arc::new(
+            BackendRepositoryRouter::from_preloaded_for_testing(
+                Arc::new(config),
+                [
+                    (DEFAULT_BACKEND_NAME.to_string(), default_repository),
+                    ("team-ch".to_string(), named_repository),
+                ],
+            )
+            .expect("preloaded routing backend"),
+        )
+    }
+
+    fn static_root(suffix: &str, index: &[u8]) -> PathBuf {
+        let root = temp_path(suffix);
+        fs::create_dir_all(&root).expect("create static root");
+        fs::write(root.join("index.html"), index).expect("write index");
+        root
+    }
+
+    async fn get_with_project_dir(
+        app: &Router,
+        uri: &str,
+        project_dir: Option<HeaderValue>,
+    ) -> Response {
+        let mut request = Request::builder().uri(uri);
+        if let Some(project_dir) = project_dir {
+            request = request.header(PROJECT_DIR_HEADER, project_dir);
+        }
+        app.clone()
+            .oneshot(request.body(Body::empty()).expect("request"))
+            .await
+            .expect("response")
     }
 
     async fn response_json(response: Response) -> Value {
@@ -1347,9 +1524,9 @@ mod tests {
 
     #[tokio::test]
     async fn handlers_delegate_to_shared_repository_and_preserve_json_contracts() {
-        let (state, repository) = fake_state(successful_responses());
+        let (backend, repository) = fake_backend(successful_responses()).await;
 
-        let response = api_health(State(state.clone())).await;
+        let response = api_health(Extension(backend.clone())).await;
         assert_eq!(response.status(), StatusCode::OK);
         let health = response_json(response).await;
         assert_eq!(health["ok"], json!(true));
@@ -1360,7 +1537,7 @@ mod tests {
             json!({"backend_sinks": {"team-ch": "healthy"}})
         );
 
-        let response = api_status(State(state.clone())).await;
+        let response = api_status(Extension(backend.clone())).await;
         assert_eq!(response.status(), StatusCode::OK);
         let status = response_json(response).await;
         assert_eq!(status["database"]["exists"], json!(true));
@@ -1375,14 +1552,14 @@ mod tests {
         assert!(!status_latest.contains_key("watcher_reset_count"));
         assert!(!status_latest.contains_key("watcher_last_reset_unix_ms"));
 
-        let response = api_tables(State(state.clone())).await;
+        let response = api_tables(Extension(backend.clone())).await;
         assert_eq!(response.status(), StatusCode::OK);
         let tables = response_json(response).await;
         assert_eq!(tables["tables"][0]["is_temporary"], json!(0));
 
         let response = api_web_searches(
             Query(LimitQuery { limit: Some(2_500) }),
-            State(state.clone()),
+            Extension(backend.clone()),
         )
         .await;
         assert_eq!(response.status(), StatusCode::OK);
@@ -1395,7 +1572,7 @@ mod tests {
             Query(AnalyticsQuery {
                 range: Some("7d".to_string()),
             }),
-            State(state.clone()),
+            Extension(backend.clone()),
         )
         .await;
         assert_eq!(response.status(), StatusCode::OK);
@@ -1409,7 +1586,7 @@ mod tests {
                 limit: Some(0),
                 since: Some("not-a-window".to_string()),
             }),
-            State(state.clone()),
+            Extension(backend.clone()),
         )
         .await;
         assert_eq!(response.status(), StatusCode::OK);
@@ -1430,7 +1607,7 @@ mod tests {
         let response = api_table_rows(
             Path("events".to_string()),
             Query(LimitQuery { limit: Some(999) }),
-            State(state),
+            Extension(backend),
         )
         .await;
         assert_eq!(response.status(), StatusCode::OK);
@@ -1463,7 +1640,7 @@ mod tests {
 
     #[tokio::test]
     async fn repository_failures_keep_existing_http_status_envelopes() {
-        let (state, _) = fake_state(InMemoryConversationResponses {
+        let (backend, _) = fake_backend(InMemoryConversationResponses {
             list_session_analytics: Some(Err(RepoError::backend("sessions unavailable"))),
             analytics_series: Some(Err(RepoError::backend("analytics unavailable"))),
             list_web_searches: Some(Err(RepoError::backend("web unavailable"))),
@@ -1476,17 +1653,21 @@ mod tests {
                 ..sample_health()
             })),
             ..Default::default()
-        });
+        })
+        .await;
 
-        let health = api_health(State(state.clone())).await;
+        let health = api_health(Extension(backend.clone())).await;
         assert_eq!(health.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(
             response_json(health).await["error"],
             json!("ping unavailable")
         );
 
-        let analytics =
-            api_analytics(Query(AnalyticsQuery { range: None }), State(state.clone())).await;
+        let analytics = api_analytics(
+            Query(AnalyticsQuery { range: None }),
+            Extension(backend.clone()),
+        )
+        .await;
         assert_eq!(analytics.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(response_json(analytics).await["ok"], json!(false));
 
@@ -1495,21 +1676,25 @@ mod tests {
                 limit: None,
                 since: None,
             }),
-            State(state.clone()),
+            Extension(backend.clone()),
         )
         .await;
         assert_eq!(sessions.status(), StatusCode::SERVICE_UNAVAILABLE);
 
-        let web = api_web_searches(Query(LimitQuery { limit: None }), State(state.clone())).await;
+        let web = api_web_searches(
+            Query(LimitQuery { limit: None }),
+            Extension(backend.clone()),
+        )
+        .await;
         assert_eq!(web.status(), StatusCode::SERVICE_UNAVAILABLE);
 
-        let tables = api_tables(State(state.clone())).await;
+        let tables = api_tables(Extension(backend.clone())).await;
         assert_eq!(tables.status(), StatusCode::SERVICE_UNAVAILABLE);
 
         let preview = api_table_rows(
             Path("events;drop".to_string()),
             Query(LimitQuery { limit: None }),
-            State(state),
+            Extension(backend),
         )
         .await;
         assert_eq!(preview.status(), StatusCode::BAD_REQUEST);
@@ -1557,12 +1742,13 @@ mod tests {
 
     #[tokio::test]
     async fn api_health_redacts_full_heartbeat_internals() {
-        let (state, _) = fake_state(InMemoryConversationResponses {
+        let (backend, _) = fake_backend(InMemoryConversationResponses {
             read_store_health: Some(Ok(sample_health())),
             latest_ingest_heartbeat: Some(Ok(sample_heartbeat())),
             ..Default::default()
-        });
-        let payload = response_json(api_health(State(state)).await).await;
+        })
+        .await;
+        let payload = response_json(api_health(Extension(backend)).await).await;
         let latest = payload["ingestor"]["latest"].as_object().expect("latest");
 
         assert_eq!(latest.len(), 1);
@@ -1576,16 +1762,17 @@ mod tests {
         let mut heartbeat = sample_heartbeat();
         let latest = heartbeat.latest.as_mut().expect("latest heartbeat");
         latest.backend_sinks = None;
-        let (state, _) = fake_state(InMemoryConversationResponses {
+        let (backend, _) = fake_backend(InMemoryConversationResponses {
             read_store_health: Some(Ok(sample_health())),
             latest_ingest_heartbeat: Some(Ok(heartbeat)),
             ..Default::default()
-        });
+        })
+        .await;
 
-        let health = response_json(api_health(State(state.clone())).await).await;
+        let health = response_json(api_health(Extension(backend.clone())).await).await;
         assert_eq!(health["ingestor"]["latest"]["backend_sinks"], json!({}));
 
-        let status = response_json(api_status(State(state)).await).await;
+        let status = response_json(api_status(Extension(backend)).await).await;
         let latest = status["ingestor"]["latest"].as_object().expect("latest");
         assert!(!latest.contains_key("backend_sinks"));
         assert!(!latest.contains_key("watcher_backend"));
@@ -1612,19 +1799,22 @@ mod tests {
             responses,
         ));
         let injected: Arc<dyn ConversationRepository> = repository.clone();
-        let app = router_with_repository(&AppConfig::default(), injected, root.clone())
+        let backend_router = Arc::new(
+            BackendRepositoryRouter::from_preloaded_for_testing(
+                Arc::new(AppConfig::default()),
+                [(DEFAULT_BACKEND_NAME.to_string(), injected)],
+            )
+            .expect("preloaded default router"),
+        );
+        let app = router_with_backend_router(backend_router, root.clone())
             .expect("build injected router");
 
-        let static_response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .uri("/")
-                    .body(Body::empty())
-                    .expect("static request"),
-            )
-            .await
-            .expect("static response");
+        let static_response = get_with_project_dir(
+            &app,
+            "/",
+            Some(HeaderValue::from_static("malformed-relative-path")),
+        )
+        .await;
         assert_eq!(static_response.status(), StatusCode::OK);
         assert_eq!(
             static_response.headers().get(header::CONTENT_TYPE),
@@ -1680,7 +1870,6 @@ mod tests {
         let (status, missing) = router_json(&app, "/api/v1/not-a-route").await;
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(missing, json!({"ok": false, "error": "not found"}));
-
         let calls = repository.calls();
         assert_eq!(calls.read_store_health, 4);
         assert_eq!(calls.read_store_diagnostics, 1);
@@ -1717,6 +1906,259 @@ mod tests {
                 },
             ]
         );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn data_routes_select_default_named_unknown_and_reuse_repositories() {
+        let root = static_root("routing-selection", b"<!doctype html>");
+        let default_repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            successful_responses(),
+        ));
+        let named_repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            successful_responses(),
+        ));
+        let backend_router = preloaded_backend_router(
+            routing_config(),
+            default_repository.clone(),
+            named_repository.clone(),
+        );
+        let app =
+            router_with_backend_router(backend_router, root.clone()).expect("routing test app");
+
+        let default =
+            response_json(get_with_project_dir(&app, "/api/v1/tables", None).await).await;
+        assert_eq!(default_repository.calls().list_table_summaries, 1);
+        assert_eq!(named_repository.calls().list_table_summaries, 0);
+
+        let named = response_json(
+            get_with_project_dir(
+                &app,
+                "/api/v1/tables",
+                Some(HeaderValue::from_static("  /work/team/project  ")),
+            )
+            .await,
+        )
+        .await;
+        let unknown = response_json(
+            get_with_project_dir(
+                &app,
+                "/api/tables",
+                Some(HeaderValue::from_static("/work/ghost/project")),
+            )
+            .await,
+        )
+        .await;
+        let named_again = response_json(
+            get_with_project_dir(
+                &app,
+                "/api/tables",
+                Some(HeaderValue::from_static("/work/team/other")),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(default, named);
+        assert_eq!(default, unknown);
+        assert_eq!(default, named_again);
+        assert_eq!(default_repository.calls().list_table_summaries, 2);
+        assert_eq!(named_repository.calls().list_table_summaries, 2);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn capabilities_ignore_project_selector_and_use_default_schema() {
+        let root = static_root("routing-capabilities", b"<!doctype html>");
+        let mut default_responses = successful_responses();
+        default_responses.read_store_diagnostics = Some(Ok(StoreDiagnostics {
+            applied_schema_versions: vec!["025".to_string()],
+            ..Default::default()
+        }));
+        let mut named_responses = successful_responses();
+        named_responses.read_store_diagnostics = Some(Ok(StoreDiagnostics {
+            applied_schema_versions: vec!["999".to_string()],
+            ..Default::default()
+        }));
+        let default_repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            default_responses,
+        ));
+        let named_repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            named_responses,
+        ));
+        let backend_router = preloaded_backend_router(
+            routing_config(),
+            default_repository.clone(),
+            named_repository.clone(),
+        );
+        let app = router_with_backend_router(backend_router, root.clone())
+            .expect("capabilities routing test app");
+
+        for header in [
+            None,
+            Some(HeaderValue::from_static("/work/team/project")),
+            Some(HeaderValue::from_static("malformed-relative-path")),
+        ] {
+            let response =
+                get_with_project_dir(&app, "/api/v1/capabilities", header).await;
+            assert_eq!(response.status(), StatusCode::OK);
+            let payload = response_json(response).await;
+            assert_eq!(payload["schema_migration_level"], json!("025"));
+        }
+        assert_eq!(default_repository.calls().read_store_diagnostics, 3);
+        assert_eq!(named_repository.calls().read_store_diagnostics, 0);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn health_and_status_report_selected_backend_metadata() {
+        let root = static_root("routing-metadata", b"<!doctype html>");
+        let default_repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            successful_responses(),
+        ));
+        let named_repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            successful_responses(),
+        ));
+        let backend_router =
+            preloaded_backend_router(routing_config(), default_repository, named_repository);
+        let app =
+            router_with_backend_router(backend_router, root.clone()).expect("metadata test app");
+
+        let default_health =
+            response_json(get_with_project_dir(&app, "/api/health", None).await).await;
+        assert_eq!(default_health["url"], json!("http://default.example:8123"));
+        assert_eq!(default_health["database"], json!("moraine_default"));
+
+        let named_header = HeaderValue::from_static("/work/team/project");
+        let named_health = response_json(
+            get_with_project_dir(&app, "/api/health", Some(named_header.clone())).await,
+        )
+        .await;
+        assert_eq!(named_health["url"], json!("http://team.example:8123"));
+        assert_eq!(named_health["database"], json!("moraine_team"));
+
+        let named_status =
+            response_json(get_with_project_dir(&app, "/api/status", Some(named_header)).await)
+                .await;
+        assert_eq!(
+            named_status["clickhouse"]["url"],
+            json!("http://team.example:8123")
+        );
+        assert_eq!(
+            named_status["clickhouse"]["database"],
+            json!("moraine_team")
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn project_dir_header_validation_rejects_bad_data_requests() {
+        let root = static_root("routing-validation", b"<!doctype html>");
+        let default_repository =
+            Arc::new(InMemoryConversationRepository::new(RepoConfig::default()));
+        let named_repository = Arc::new(InMemoryConversationRepository::new(RepoConfig::default()));
+        let backend_router = preloaded_backend_router(
+            routing_config(),
+            default_repository.clone(),
+            named_repository.clone(),
+        );
+        let app =
+            router_with_backend_router(backend_router, root.clone()).expect("validation test app");
+
+        let mut repeated = Request::builder()
+            .uri("/api/health")
+            .body(Body::empty())
+            .expect("repeated header request");
+        repeated.headers_mut().append(
+            PROJECT_DIR_HEADER,
+            HeaderValue::from_static("/work/team/one"),
+        );
+        repeated.headers_mut().append(
+            PROJECT_DIR_HEADER,
+            HeaderValue::from_static("/work/team/two"),
+        );
+        let requests = vec![
+            repeated,
+            Request::builder()
+                .uri("/api/health")
+                .header(PROJECT_DIR_HEADER, HeaderValue::from_static("   "))
+                .body(Body::empty())
+                .expect("empty header request"),
+            Request::builder()
+                .uri("/api/health")
+                .header(
+                    PROJECT_DIR_HEADER,
+                    HeaderValue::from_static("relative/project"),
+                )
+                .body(Body::empty())
+                .expect("relative header request"),
+            Request::builder()
+                .uri("/api/health")
+                .header(
+                    PROJECT_DIR_HEADER,
+                    HeaderValue::from_bytes(&[0xff]).expect("opaque header"),
+                )
+                .body(Body::empty())
+                .expect("non-UTF-8 header request"),
+        ];
+
+        for request in requests {
+            let response = app.clone().oneshot(request).await.expect("response");
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let payload = response_json(response).await;
+            assert_eq!(payload["ok"], json!(false));
+            assert!(payload["error"]
+                .as_str()
+                .is_some_and(|error| !error.is_empty()));
+        }
+        assert_eq!(default_repository.calls().read_store_health, 0);
+        assert_eq!(named_repository.calls().read_store_health, 0);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn named_backend_construction_errors_return_service_unavailable() {
+        let root = static_root("routing-construction-error", b"<!doctype html>");
+        let mut config = routing_config();
+        config
+            .backends
+            .get_mut("team-ch")
+            .expect("named backend")
+            .url = "://invalid".to_string();
+        let backend_router = Arc::new(
+            BackendRepositoryRouter::new(
+                Arc::new(config),
+                RepoConfig::default(),
+                "moraine-monitor-core/test",
+            )
+            .expect("lazy backend router"),
+        );
+        let app = router_with_backend_router(backend_router, root.clone())
+            .expect("construction error test app");
+
+        let response = get_with_project_dir(
+            &app,
+            "/api/health",
+            Some(HeaderValue::from_static("/work/team/project")),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let payload = response_json(response).await;
+        assert_eq!(payload["ok"], json!(false));
+        assert!(payload["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("team-ch")));
 
         let _ = fs::remove_dir_all(root);
     }

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -633,6 +633,11 @@ main() {
   # MCP server from inside it.
   local claude_project_dir="$tmp_root/claude-project"
   mkdir -p "$claude_project_dir"
+  # A client-only launch directory routed to a named read backend. No fixture
+  # session originates here, so ingest never mirrors duplicate rows when this
+  # test points the named backend at the same isolated ClickHouse database.
+  local routed_project_dir="$tmp_root/routed-project"
+  mkdir -p "$routed_project_dir"
 
   mkdir -p "$(dirname "$codex_fixture_file")"
   mkdir -p "$(dirname "$claude_fixture_file")"
@@ -885,10 +890,18 @@ EOF
 EOF
 
   cat > "$config_path" <<EOF
-[clickhouse]
+[backends.default]
 url = "${clickhouse_url}"
 database = "${clickhouse_database}"
 
+[backends.routed]
+url = "${clickhouse_url}"
+database = "${clickhouse_database}"
+
+[[routes]]
+dir = "${routed_project_dir}/**"
+backend = "routed"
+mode = "mirror"
 [backend]
 bind = "127.0.0.1"
 start_on_up = true
@@ -1373,6 +1386,41 @@ PY
   echo "[e2e] checking shared-daemon MCP cache miss -> hit markers"
   wait_for_mcp_cache_sequence "$python_bin" "$backend_log" "$cache_log_baseline" 20
 
+  local routed_cache_log_baseline
+  routed_cache_log_baseline="$("$python_bin" - "$backend_log" <<'PY'
+from pathlib import Path
+import sys
+
+log_path = Path(sys.argv[1])
+print(log_path.stat().st_size if log_path.is_file() else 0)
+PY
+)"
+
+  echo "[e2e] checking first named-backend MCP route through daemon"
+  "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
+    --moraine "$moraine_bin" \
+    --config "$config_path" \
+    --working-dir "$routed_project_dir" \
+    --query "$codex_keyword" \
+    --expect-session-id "$codex_session_id" \
+    --expect-open-text "$codex_trace_marker"
+
+  echo "[e2e] checking named-backend HTTP route through shared daemon router"
+  routed_sessions_body="$(curl -fsS \
+    -H "X-Moraine-Project-Dir: ${routed_project_dir}" \
+    "http://127.0.0.1:${monitor_port}/api/v1/sessions?since=all&limit=200")"
+  printf '%s' "$routed_sessions_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; sys.exit(0 if any(row.get("id")==sid for row in data.get("sessions", [])) else 1)' "$codex_session_id"
+
+  echo "[e2e] checking named-backend repository/cache reuse on second MCP route"
+  "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
+    --moraine "$moraine_bin" \
+    --config "$config_path" \
+    --working-dir "$routed_project_dir" \
+    --query "$codex_keyword" \
+    --expect-session-id "$codex_session_id" \
+    --expect-open-text "$codex_trace_marker"
+  wait_for_mcp_cache_sequence "$python_bin" "$backend_log" "$routed_cache_log_baseline" 20
+
   # The ingest heartbeat interval is one second. Leave enough room inside this
   # same bounded window for a fresh ingest INSERT, then force query_log durable
   # before asserting exact role + PID attribution.
@@ -1386,6 +1434,7 @@ PY
   echo "[e2e] checking bounded ClickHouse query ownership"
   wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Select' AND http_user_agent = '${expected_backend_ua}'" 30
   assert_clickhouse_count "$clickhouse_url" "all service SELECTs use the backend UA/PID" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Select' AND (${attributed_service_filter}) AND http_user_agent != '${expected_backend_ua}'" "0"
+  assert_clickhouse_count "$clickhouse_url" "named read schema handshake runs once despite MCP/HTTP reuse" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND http_user_agent = '${expected_backend_ua}' AND position(query, 'system.tables') > 0 AND position(query, 'schema_migrations') > 0" "1"
   wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Insert' AND http_user_agent = '${expected_ingest_ua}'" 30
   assert_clickhouse_count "$clickhouse_url" "all service INSERTs use the ingest UA/PID" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Insert' AND (${attributed_service_filter}) AND http_user_agent != '${expected_ingest_ua}'" "0"
 
@@ -1570,6 +1619,16 @@ PY
     --file-attention-path "Cargo.toml" \
     --require-embedded-fallback \
     --write-tools-snapshot "$embedded_tools_snapshot"
+
+  echo "[e2e] checking named-backend MCP route through embedded fallback"
+  "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
+    --moraine "$moraine_bin" \
+    --config "$config_path" \
+    --working-dir "$routed_project_dir" \
+    --query "$codex_keyword" \
+    --expect-session-id "$codex_session_id" \
+    --expect-open-text "$codex_trace_marker" \
+    --require-embedded-fallback
 
   echo "[e2e] comparing daemon and embedded canonical tools/list snapshots"
   "$python_bin" - "$daemon_tools_snapshot" "$embedded_tools_snapshot" <<'PY'

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -537,6 +537,7 @@ main() {
   local hermes_keyword="${base_keyword}_hermes_trajectory_${run_stamp}"
   local hermes_session_keyword="${base_keyword}_hermes_session_${run_stamp}"
   local clickhouse_database="moraine"
+  local routed_clickhouse_database="moraine_routed"
   local codex_session_suffix
   codex_session_suffix="$(printf '%06x%06x' "$RANDOM" "$RANDOM")"
   local codex_session_id="00000000-0000-4000-8000-${codex_session_suffix}"
@@ -618,6 +619,7 @@ main() {
   local fixtures_root="$tmp_root/fixtures"
   local runtime_root="$tmp_root/runtime"
   local config_path="$tmp_root/moraine-ci.toml"
+  local routed_bootstrap_config_path="$tmp_root/moraine-routed-bootstrap.toml"
   local codex_fixture_file="$fixtures_root/codex/sessions/2026/02/16/session-${codex_session_id}.jsonl"
   local claude_fixture_file="$fixtures_root/claude/projects/e2e/session-${claude_session_id}.jsonl"
   local kimi_fixture_file="$fixtures_root/kimi/sessions/${kimi_session_id}/wire.jsonl"
@@ -633,11 +635,6 @@ main() {
   # MCP server from inside it.
   local claude_project_dir="$tmp_root/claude-project"
   mkdir -p "$claude_project_dir"
-  # A client-only launch directory routed to a named read backend. No fixture
-  # session originates here, so ingest never mirrors duplicate rows when this
-  # test points the named backend at the same isolated ClickHouse database.
-  local routed_project_dir="$tmp_root/routed-project"
-  mkdir -p "$routed_project_dir"
 
   mkdir -p "$(dirname "$codex_fixture_file")"
   mkdir -p "$(dirname "$claude_fixture_file")"
@@ -896,18 +893,22 @@ database = "${clickhouse_database}"
 
 [backends.routed]
 url = "${clickhouse_url}"
-database = "${clickhouse_database}"
+database = "${routed_clickhouse_database}"
 
 [[routes]]
-dir = "${routed_project_dir}/**"
+dir = "${claude_project_dir}/**"
 backend = "routed"
 mode = "mirror"
+
 [backend]
 bind = "127.0.0.1"
 start_on_up = true
 
 [monitor]
 port = ${monitor_port}
+
+[identity]
+author = "routed-e2e"
 
 [ingest]
 backfill_on_start = true
@@ -995,6 +996,24 @@ clickhouse_auto_install = true
 clickhouse_start_timeout_seconds = 90.0
 EOF
 
+  cat > "$routed_bootstrap_config_path" <<EOF
+[clickhouse]
+url = "${clickhouse_url}"
+database = "${routed_clickhouse_database}"
+
+[backend]
+start_on_up = false
+
+[runtime]
+root_dir = "${runtime_root}"
+logs_dir = "logs"
+pids_dir = "run"
+service_bin_dir = "${service_bin_dir}"
+managed_clickhouse_dir = "${runtime_root}/managed-clickhouse"
+clickhouse_auto_install = true
+clickhouse_start_timeout_seconds = 90.0
+EOF
+
   trap "cleanup_e2e \"$moraine_bin\" \"$config_path\" \"$runtime_root\" \"$tmp_root\"" EXIT
 
   echo "[e2e] run id: ${run_stamp}"
@@ -1015,6 +1034,9 @@ EOF
 
   echo "[e2e] ensuring monitor frontend assets"
   ensure_monitor_frontend "$repo_root"
+
+  echo "[e2e] bootstrapping distinct named-backend schema"
+  "$moraine_bin" up --config "$routed_bootstrap_config_path" --no-ingest
 
   echo "[e2e] starting stack"
   "$moraine_bin" up --config "$config_path"
@@ -1061,6 +1083,8 @@ EOF
   wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.search_postings WHERE term = '${codex_keyword}'" 120
   wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.search_documents WHERE positionCaseInsensitiveUTF8(text_content, '${claude_keyword}') > 0" 120
   wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.search_postings WHERE term = '${claude_keyword}'" 120
+  wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${routed_clickhouse_database}.search_documents WHERE positionCaseInsensitiveUTF8(text_content, '${claude_keyword}') > 0" 120
+  assert_clickhouse_count "$clickhouse_url" "named backend excludes default-only codex session" "SELECT count() FROM ${routed_clickhouse_database}.search_documents WHERE positionCaseInsensitiveUTF8(text_content, '${codex_keyword}') > 0" "0"
   wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.search_documents WHERE positionCaseInsensitiveUTF8(text_content, '${kimi_keyword}') > 0" 120
   wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.search_postings WHERE term = '${kimi_keyword}'" 120
   wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.search_documents WHERE positionCaseInsensitiveUTF8(text_content, '${cursor_keyword}') > 0" 120
@@ -1400,26 +1424,40 @@ PY
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
     --moraine "$moraine_bin" \
     --config "$config_path" \
-    --working-dir "$routed_project_dir" \
-    --query "$codex_keyword" \
-    --expect-session-id "$codex_session_id" \
-    --expect-open-text "$codex_trace_marker"
+    --working-dir "$claude_project_dir" \
+    --query "$claude_keyword" \
+    --expect-session-id "$claude_session_id" \
+    --expect-open-text "$claude_trace_marker"
 
   echo "[e2e] checking named-backend HTTP route through shared daemon router"
   routed_sessions_body="$(curl -fsS \
-    -H "X-Moraine-Project-Dir: ${routed_project_dir}" \
+    -H "X-Moraine-Project-Dir: ${claude_project_dir}" \
     "http://127.0.0.1:${monitor_port}/api/v1/sessions?since=all&limit=200")"
-  printf '%s' "$routed_sessions_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; sys.exit(0 if any(row.get("id")==sid for row in data.get("sessions", [])) else 1)' "$codex_session_id"
+  printf '%s' "$routed_sessions_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); present=sys.argv[1]; absent=sys.argv[2]; ids={row.get("id") for row in data.get("sessions", [])}; sys.exit(0 if present in ids and absent not in ids else 1)' "$claude_session_id" "$codex_session_id"
+  routed_health_body="$(curl -fsS \
+    -H "X-Moraine-Project-Dir: ${claude_project_dir}" \
+    "http://127.0.0.1:${monitor_port}/api/v1/health")"
+  printf '%s' "$routed_health_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sys.exit(0 if data.get("database")==sys.argv[1] else 1)' "$routed_clickhouse_database"
 
   echo "[e2e] checking named-backend repository/cache reuse on second MCP route"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
     --moraine "$moraine_bin" \
     --config "$config_path" \
-    --working-dir "$routed_project_dir" \
-    --query "$codex_keyword" \
-    --expect-session-id "$codex_session_id" \
-    --expect-open-text "$codex_trace_marker"
+    --working-dir "$claude_project_dir" \
+    --query "$claude_keyword" \
+    --expect-session-id "$claude_session_id" \
+    --expect-open-text "$claude_trace_marker"
   wait_for_mcp_cache_sequence "$python_bin" "$backend_log" "$routed_cache_log_baseline" 20
+
+  echo "[e2e] checking named route excludes default-only content"
+  "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
+    --moraine "$moraine_bin" \
+    --config "$config_path" \
+    --working-dir "$claude_project_dir" \
+    --query "$codex_keyword" \
+    --expect-no-results \
+    --expect-session-id "$claude_session_id" \
+    --expect-absent-session-id "$codex_session_id"
 
   # The ingest heartbeat interval is one second. Leave enough room inside this
   # same bounded window for a fresh ingest INSERT, then force query_log durable
@@ -1624,10 +1662,11 @@ PY
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
     --moraine "$moraine_bin" \
     --config "$config_path" \
-    --working-dir "$routed_project_dir" \
-    --query "$codex_keyword" \
-    --expect-session-id "$codex_session_id" \
-    --expect-open-text "$codex_trace_marker" \
+    --working-dir "$claude_project_dir" \
+    --query "$claude_keyword" \
+    --expect-session-id "$claude_session_id" \
+    --expect-open-text "$claude_trace_marker" \
+    --expect-absent-session-id "$codex_session_id" \
     --require-embedded-fallback
 
   echo "[e2e] comparing daemon and embedded canonical tools/list snapshots"

--- a/scripts/ci/mcp_smoke.py
+++ b/scripts/ci/mcp_smoke.py
@@ -436,6 +436,7 @@ def run_smoke(
     expect_open_text: Optional[str],
     file_attention_path: Optional[str] = None,
     project_dir: Optional[str] = None,
+    working_dir: Optional[str] = None,
     absent_session_ids: Optional[list[str]] = None,
     expect_no_results: bool = False,
     expect_event_count: Optional[int] = None,
@@ -446,13 +447,15 @@ def run_smoke(
     absent_session_ids = absent_session_ids or []
     argv = [moraine, "run", "mcp", "--config", config]
     popen_kwargs: Dict[str, Any] = {}
+    launch_dir = project_dir or working_dir
     if project_dir is not None:
         argv.append("--project-only")
+    if launch_dir is not None:
         # Mimic a shell launching from the project directory: cwd is the
         # physical path and PWD carries the logical spelling, which may
         # differ through symlinks (e.g. /var vs /private/var on macOS).
-        popen_kwargs["cwd"] = project_dir
-        popen_kwargs["env"] = {**os.environ, "PWD": project_dir}
+        popen_kwargs["cwd"] = launch_dir
+        popen_kwargs["env"] = {**os.environ, "PWD": launch_dir}
 
     proc = subprocess.Popen(
         argv,
@@ -678,6 +681,13 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--working-dir",
+        help=(
+            "launch `moraine run mcp` from this directory without enabling "
+            "--project-only (used to exercise daemon-owned backend routing)"
+        ),
+    )
+    parser.add_argument(
         "--expect-absent-session-id",
         action="append",
         default=[],
@@ -717,6 +727,8 @@ def main() -> int:
         ),
     )
     args = parser.parse_args()
+    if args.project_dir and args.working_dir:
+        parser.error("--project-dir and --working-dir are mutually exclusive")
 
     run_smoke(
         args.moraine,
@@ -726,6 +738,7 @@ def main() -> int:
         args.expect_open_text,
         file_attention_path=args.file_attention_path,
         project_dir=args.project_dir,
+        working_dir=args.working_dir,
         absent_session_ids=args.expect_absent_session_id,
         expect_no_results=args.expect_no_results,
         expect_event_count=args.expect_event_count,


### PR DESCRIPTION
## Description

**What.** Centralizes per-project named-backend read routing and schema-skew enforcement in the unified backend daemon.

**Why.** MCP and monitor HTTP previously risked constructing and policing named ClickHouse backends independently; one daemon-owned router now gives both surfaces the same client, repository, skew decision, and cache lifecycle.

`BackendRepositoryRouter` owns a lazy slot for the default backend and each configured named backend. A named slot single-flights its first construction, runs the skew probe with the same attributed ClickHouse client that becomes the repository, publishes failures to every waiter, resets after failure or panic, and caches a successful repository for MCP and HTTP reuse. Named backends are never migrated.

The private Unix-socket negotiation selects repositories by project directory without exposing backend names, URLs, or credentials as client inputs. Existing raw MCP clients remain compatible, including first requests larger than the private 64-KiB control-frame limit. HTTP failures return a stable generic 503 body and log no backend request URL or remote response body; selected health/status metadata reports only the parsed HTTP(S) origin.

## Usage

Data routes under `/api/v1` and their one-release legacy aliases accept one optional selector header:

```text
X-Moraine-Project-Dir: /absolute/project/path
```

- No header selects the default backend.
- One absolute path resolves only through configured project-directory routes or the repository backend reference.
- Repeated, non-UTF-8, blank, or relative values return the existing JSON 400 error shape.
- An unavailable or schema-incompatible selected backend returns a generic JSON 503.
- `/api/v1/capabilities` and its alias remain default-global and ignore the selector header.
- Static monitor routes are not layered with backend selection.

Skew behavior is unchanged:

| Selected backend state | Result |
| --- | --- |
| Compatible schema | Build once and reuse the daemon-owned repository |
| Older/incomplete named schema | Fail fast; never migrate the named backend |
| Newer named schema, default policy | Fail fast |
| Newer named schema with `allow_newer_server = true` | Allow the read-only repository |
| Unreachable named backend | Reject MCP routing and return HTTP 503 |

## Changelog

- Routes named-backend MCP and monitor reads through one daemon-owned repository router.
- Adds strict `X-Moraine-Project-Dir` handling to versioned and legacy data routes while keeping capabilities and static routes global.
- Preserves legacy raw MCP framing and embedded fallback behavior.
- Redacts selected-backend metadata to HTTP(S) origin and stabilizes route-failure responses/logging.

## Validation

Ran `cargo test -p moraine-conversations backend_router::tests` (18 passed), `cargo test -p moraine-mcp-core` (73 passed), and `cargo test -p moraine-monitor-core` (20 passed). After rebasing onto the epic commits for #460 and #462, also ran `cargo test -p moraine-mcp rpc::tests` (7 passed), `cargo test -p moraine-config backend_` (20 passed), and `cargo test -p moraine setup_` (18 passed) to cover the combined router startup, bind/auth-token guard, canonical config, and setup migration paths. Built the exercised binaries with `cargo build --locked -p moraine -p moraine-mcp -p moraine-ingest`.

Ran `bash scripts/ci/e2e-stack.sh` successfully against managed ClickHouse after the final rebase. The E2E retained the merged backend-bind and daemon-status/direct-DB-fallback behavior, created a separate `moraine_routed` database, proved named-only/default exclusion through MCP and HTTP metadata, observed one named schema handshake plus shared repository/cache reuse, and repeated the named route through embedded fallback after terminating the daemon.

`cargo fmt --all -- --check` and `git diff --check origin/epic/451...HEAD` passed.

## Review

The final diff and the post-rebase RPC/E2E conflict resolution were reviewed through all seven delegated facets: Elegance, Idiomatic Rust/shell, Correctness, Completeness, Security, YAGNI, and Scope. Review fixes covered Unix-only import gating, embedded fallback lifetimes, private construction surfaces, panic-safe shared initialization/reset/retry, oversized legacy first-frame handling, origin-only metadata, sanitized failure propagation/logging, and a distinct named-database E2E. The resolved startup path preserves #462 bind/auth-token validation before constructing the shared router, and the combined E2E preserves #460/#462 behavior without inverse base churn. No actionable findings remain.

## Residual risks

- Mixed-version fallback was not exercised against a separately installed old daemon binary; private-negotiation compatibility has focused unit coverage and same-version process fallback has E2E coverage.
- The project-directory selector remains client-asserted. The merged #462 guard requires an explicit nonempty token before non-loopback startup, but request authentication beyond that startup prerequisite remains outside #461; Unix-socket trust continues to rely on the existing `0600` boundary.
- Origin normalization is covered with credential, query, fragment, and backslash-path regressions rather than a live credentialed reverse-proxy ClickHouse endpoint.
- The cancellation-safe slot state machine and compatibility first-frame discriminator remain bespoke code, with their failure, retry, pinning, and legacy behaviors covered by focused tests.

Resolves #461
