### PR TITLE
ci(monitor): add deterministic frontend checks

### DIFF
--- a/.github/workflows/ci-monitor-frontend.yml
+++ b/.github/workflows/ci-monitor-frontend.yml
@@ -1,0 +1,51 @@
+name: ci-monitor-frontend
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/ci-monitor-frontend.yml'
+      - 'web/monitor/**'
+      # moraine-monitor-core owns the HTTP routes and response serialization
+      # consumed by web/monitor/src/lib/api and web/monitor/src/lib/types.
+      - 'crates/moraine-monitor-core/**'
+      # Workspace metadata and lockfile changes can alter the monitor API
+      # package graph resolved from crates/moraine-monitor-core/Cargo.toml.
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  monitor-frontend:
+    name: monitor-frontend-bun
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        working-directory: web/monitor
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Bun 1.3.9
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Verify pinned Bun
+        run: test "$(bun --version)" = "1.3.9"
+
+      - name: Install frozen dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck monitor
+        run: bun run typecheck
+
+      - name: Run monitor unit tests
+        # vitest.config.ts explicitly sets passWithNoTests=false, so selection
+        # is fail-closed when no frontend test executes.
+        run: bun run test

--- a/web/monitor/vitest.config.ts
+++ b/web/monitor/vitest.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
     include: ['src/**/*.test.ts'],
+    passWithNoTests: false,
   },
 });


### PR DESCRIPTION
## Description

**What.** Adds a visible, path-filtered Bun job for monitor typecheck and Vitest.

**Why.** The existing 17 frontend tests were not executed by repository workflows and selected suites must fail on zero collection.

## Usage

```bash
cd web/monitor
bun install --frozen-lockfile
bun run typecheck
bun run test
```

## Changelog

- Pins Bun 1.3.9 in a dedicated non-required frontend job.
- Explicitly rejects zero Vitest tests.

## Validation

Typecheck completed with 0 errors and 0 warnings. Vitest passed 17 tests across 6 files. Workflow YAML/actionlint validation passed during implementation.

Part of #477.