### PR TITLE
ci(binding): add provisioned Python smoke

### DIFF
--- a/.github/workflows/ci-python-binding.yml
+++ b/.github/workflows/ci-python-binding.yml
@@ -1,0 +1,97 @@
+name: ci-python-binding
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/ci-python-binding.yml'
+      - 'bindings/python/moraine_conversations/**'
+      - 'crates/moraine-clickhouse/**'
+      - 'crates/moraine-config/**'
+      - 'crates/moraine-conversations/**'
+      - 'sql/**'
+  workflow_dispatch:
+
+jobs:
+  python-binding-smoke:
+    name: python-binding-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    defaults:
+      run:
+        working-directory: bindings/python/moraine_conversations
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: bindings/python/moraine_conversations
+
+      - name: Provision hash-locked test environment
+        run: |
+          python -m venv .venv-test
+          .venv-test/bin/pip install --require-hashes -r requirements-test.lock
+
+      - name: Build and install the PyO3 binding
+        run: VIRTUAL_ENV="$PWD/.venv-test" .venv-test/bin/maturin develop --locked
+
+      - name: Assert smoke test collection is nonzero
+        run: |
+          collection="$(.venv-test/bin/pytest --collect-only -q tests/test_smoke.py)"
+          printf '%s\n' "$collection"
+          test_count="$(printf '%s\n' "$collection" | grep -Ec '^tests/test_smoke\.py::')"
+          if [ "$test_count" -le 0 ]; then
+            echo 'No binding smoke tests were collected.' >&2
+            exit 1
+          fi
+          printf 'BINDING_SMOKE_TEST_COUNT=%s\n' "$test_count" >> "$GITHUB_ENV"
+
+      - name: Run the exact binding smoke path
+        run: |
+          .venv-test/bin/pytest -q tests/test_smoke.py --junitxml=.pytest-smoke.xml
+          .venv-test/bin/python - <<'PY'
+          import os
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse('.pytest-smoke.xml').getroot()
+          suites = list(root.iter('testsuite'))
+          totals = {
+              outcome: sum(
+                  int(suite.attrib.get(outcome, '0')) for suite in suites
+              )
+              for outcome in ('tests', 'skipped', 'errors', 'failures')
+          }
+          collected = int(os.environ['BINDING_SMOKE_TEST_COUNT'])
+          if collected <= 0:
+              raise SystemExit('Pytest collected zero binding smoke tests.')
+          for outcome in ('skipped', 'errors', 'failures'):
+              if totals[outcome] != 0:
+                  raise SystemExit(
+                      f"Pytest reported {totals[outcome]} {outcome} "
+                      'in the binding smoke suite.'
+                  )
+          passed = (
+              totals['tests']
+              - totals['skipped']
+              - totals['errors']
+              - totals['failures']
+          )
+          if passed <= 0:
+              raise SystemExit('Pytest reported zero passed binding smoke tests.')
+          if passed != collected:
+              raise SystemExit(
+                  f'Pytest collected {collected} smoke tests but passed {passed}.'
+              )
+          print(f'Passed {passed} binding smoke test(s).')
+          PY

--- a/bindings/python/moraine_conversations/requirements-test.lock
+++ b/bindings/python/moraine_conversations/requirements-test.lock
@@ -1,0 +1,38 @@
+# Test/build dependencies for Python 3.12.
+# Top-level constraints mirror pyproject.toml's build-system and test extra.
+iniconfig==2.3.0 \
+    --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
+    --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
+    # via pytest
+maturin==1.14.1 \
+    --hash=sha256:15cea8fcb3ba47dd636f50092bb34baea8b04ac777392f23e6bf8a9a61efb894 \
+    --hash=sha256:1a04de0a20188f95c721b5702eed18140bdcccb28c386797093eca3f62f4d4e0 \
+    --hash=sha256:3c9f94640ecc4895e94abaf834a0684430032c865b2748a36c12461fd9252fdd \
+    --hash=sha256:522292398945442cdafa9daeb2271b2340fbde57027b818f923f88eab04174f8 \
+    --hash=sha256:5282dffd4b539d2be245f4e5b1a5ab6bc1033b58f4a4872f5833f9d43c954aa4 \
+    --hash=sha256:994a0c8ba3ad8a92b3a9ee1b02645d200d610216b15cff5102b0fe65e8e08666 \
+    --hash=sha256:9d6577a62cd08e0ceba7a0db06fb098e0c9b1b3429bad747a4f3a18215a1b3df \
+    --hash=sha256:a131d912b5267e640bc96d70f4914e10590aed64082ec9abacba7cea52004224 \
+    --hash=sha256:be18fc568fb76884c0205456336892a75105ec398e6b667cd777c6268bd06d69 \
+    --hash=sha256:be80866363e605d137991b491a741a84cde9ae350183c4c85f49690ca9aaaa65 \
+    --hash=sha256:cd457cd88961156e26379e1155bd287cc0ec1c8b2f1582b0660fb31b87c8842d \
+    --hash=sha256:dfc54ae32e6fcb18302193ab9a30b0b25eefffba994ae13238974805533ef75e \
+    --hash=sha256:f3306078070c1508fd715b9116070cbcaff5959024272a9f1e6f5cb29768b86c \
+    --hash=sha256:ffe5ad71f21d1e6603c4dd75f7fee34adf5ed5ebcebb692886549888ebb329ed
+    # via pyproject.toml build-system.requires
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
+    # via pytest
+pluggy==1.6.0 \
+    --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
+    --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+    # via pytest
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+    # via pytest
+pytest==9.1.1 \
+    --hash=sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313 \
+    --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
+    # via pyproject.toml project.optional-dependencies.test


### PR DESCRIPTION
## Description

**What.** Adds a path-filtered Python 3.12 job for the standalone PyO3 binding smoke.

**Why.** The compatibility surface was outside the root Cargo workspace and had no provisioned, locked CI owner.

## Usage

```bash
cd bindings/python/moraine_conversations
python3.12 -m venv .venv-test
.venv-test/bin/pip install --require-hashes -r requirements-test.lock
VIRTUAL_ENV=$PWD/.venv-test .venv-test/bin/maturin develop --locked
.venv-test/bin/pytest -q tests/test_smoke.py
```

## Changelog

- Adds hash-locked test provisioning and exact binding smoke execution.
- Rejects zero, skipped, failed, or mismatched JUnit execution counts.

## Validation

Hash-locked installation succeeded; `maturin develop --locked` built the abi3 extension; 1 smoke test passed. Synthetic skipped/error/failure/zero/mismatch JUnit cases failed accounting.

Part of #477.