### PR TITLE
fix(bench): require two-sided comparison policy

### DIFF
--- a/scripts/bench/benchmark_protocol.py
+++ b/scripts/bench/benchmark_protocol.py
@@ -600,9 +600,9 @@ def compare_artifacts(
 
     baseline_policy = baseline["timing"].get("comparison_policy")
     candidate_policy = candidate["timing"].get("comparison_policy")
-    if candidate_policy is None:
+    if baseline_policy is None or candidate_policy is None:
         return {"status": "not_evaluated", "non_blocking": True, "reason": "missing_comparison_policy"}
-    if baseline_policy is not None and baseline_policy != candidate_policy:
+    if baseline_policy != candidate_policy:
         raise IncomparableError("incomparable timing.comparison_policy")
     policy = candidate_policy
     measurement_name = _select_measurement(baseline, candidate, measurement)

--- a/scripts/bench/tests/test_benchmark_protocol.py
+++ b/scripts/bench/tests/test_benchmark_protocol.py
@@ -500,6 +500,13 @@ class BenchmarkComparatorTests(unittest.TestCase):
         self.assertEqual(result["status"], "not_evaluated")
         self.assertEqual(result["reason"], "missing_comparison_policy")
 
+        baseline = self.fixture()
+        candidate = self.fixture()
+        baseline["timing"] = {"status": "not_evaluated", "non_blocking": True}
+        result = protocol.compare_artifacts(baseline, candidate)
+        self.assertEqual(result["status"], "not_evaluated")
+        self.assertEqual(result["reason"], "missing_comparison_policy")
+
     def test_scenario_fingerprint_mismatches_are_rejected(self) -> None:
         mutations = {
             "smoke_full": lambda value: value["scenario"].update(profile="smoke"),


### PR DESCRIPTION
## Description

**What.** Requires both baseline and candidate benchmark artifacts to declare the same complete comparison policy before timing can be evaluated.

**Why.** A policy-less baseline cannot establish the statistic, run-pair count, threshold, error policy, or variability contract for an evaluated comparison; adopting only the candidate policy could produce a false `pass`.

## Usage

No command change. `benchmark_protocol.py compare` now returns `not_evaluated` with `missing_comparison_policy` when either artifact omits the policy.

## Changelog

- Tightens the non-blocking benchmark comparator contract.
- No producer, runtime, or timing threshold change.

## Validation

`python3 -m unittest scripts.bench.tests.test_benchmark_protocol` passed 30 tests, including both candidate-missing and baseline-missing policy cases. The repository pre-commit fmt/clippy baseline passed.

Final review fix for #477; stack after #496.
