### PR TITLE
fix(bench): bind MCP tools to seed oracle

### DIFF
--- a/scripts/bench/mcp_two_tool_sla.py
+++ b/scripts/bench/mcp_two_tool_sla.py
@@ -77,6 +77,13 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="Query to benchmark. May be repeated.",
     )
     parser.add_argument(
+        "--oracle-json",
+        help=(
+            "Owned seed oracle JSON. Required when search or list_sessions is measured; "
+            "declares expected query results, open IDs, and list-window results."
+        ),
+    )
+    parser.add_argument(
         "--top-n-log-queries",
         type=non_negative_int,
         default=0,
@@ -110,7 +117,7 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         choices=["event", "turn", "session", "none"],
         default=[],
         help=(
-            "Open ID kind from the first search hit. May be repeated. "
+            "Open ID kind declared by the query oracle. May be repeated. "
             "Defaults to event, turn, and session."
         ),
     )
@@ -619,40 +626,250 @@ def structured_data(sample: Any, tool_name: str) -> dict[str, Any]:
     return data
 
 
-def first_hit_open_ids(search_data: dict[str, Any]) -> dict[str, str]:
-    results = search_data.get("results", [])
-    if not isinstance(results, list) or not results:
-        return {}
-    first = results[0]
-    if not isinstance(first, dict):
-        return {}
-    open_block = first.get("open")
-    if not isinstance(open_block, dict):
-        return {}
-    keys = {
-        "event": "event_id",
-        "turn": "turn_id",
-        "session": "session_id",
-    }
-    return {
-        kind: value
-        for kind, key in keys.items()
-        if isinstance((value := open_block.get(key)), str) and value
+class OracleConfigurationError(RuntimeError):
+    def __init__(self, diagnostic_code: str, message: str) -> None:
+        super().__init__(message)
+        self.diagnostic_code = diagnostic_code
+
+
+def normalize_query(value: str) -> str:
+    return " ".join(value.split()).casefold()
+
+
+def load_benchmark_oracles(
+    path_value: Optional[str],
+    queries: list[str],
+    open_kinds: list[str],
+    require_list_sessions: bool,
+) -> tuple[dict[str, dict[str, Any]], Optional[dict[str, Any]]]:
+    if not queries and not require_list_sessions:
+        return {}, None
+    if not path_value:
+        code = "missing-search-oracle" if queries else "missing-list-oracle"
+        raise OracleConfigurationError(
+            code, "--oracle-json is required when search or list_sessions is measured"
+        )
+
+    path = Path(path_value).expanduser().resolve()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise OracleConfigurationError(
+            "invalid-benchmark-oracle", f"cannot read benchmark oracle {path}: {exc}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise OracleConfigurationError(
+            "invalid-benchmark-oracle", "benchmark oracle root must be an object"
+        )
+    if payload.get("schema_version") != "moraine-mcp-two-tool-oracle-v1":
+        raise OracleConfigurationError(
+            "invalid-benchmark-oracle",
+            "benchmark oracle schema_version must be 'moraine-mcp-two-tool-oracle-v1'",
+        )
+    entries = payload.get("queries")
+    if not isinstance(entries, list):
+        raise OracleConfigurationError(
+            "invalid-benchmark-oracle", "benchmark oracle queries must be an array"
+        )
+
+    by_query: dict[str, dict[str, Any]] = {}
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise RuntimeError(f"query oracle entry {index} must be an object")
+        raw_query = entry.get("query")
+        if not isinstance(raw_query, str) or not normalize_query(raw_query):
+            raise RuntimeError(f"query oracle entry {index} must have a non-empty query")
+        query_key = normalize_query(raw_query)
+        if query_key in by_query:
+            raise RuntimeError(f"query oracle contains duplicate query at entry {index}")
+
+        expected = entry.get("expected")
+        if not isinstance(expected, dict):
+            raise RuntimeError(f"query oracle entry {index} expected must be an object")
+        result_count = expected.get("result_count")
+        if result_count is not None and (
+            isinstance(result_count, bool)
+            or not isinstance(result_count, int)
+            or result_count < 0
+        ):
+            raise RuntimeError(
+                f"query oracle entry {index} expected.result_count must be a non-negative integer"
+            )
+        open_ids = expected.get("open_ids", {})
+        if not isinstance(open_ids, dict):
+            raise RuntimeError(f"query oracle entry {index} expected.open_ids must be an object")
+        unknown_kinds = set(open_ids) - {"event", "turn", "session"}
+        if unknown_kinds:
+            raise RuntimeError(
+                f"query oracle entry {index} has unknown open ID kinds: {sorted(unknown_kinds)}"
+            )
+        for kind, entity_id in open_ids.items():
+            if not isinstance(entity_id, str) or not entity_id:
+                raise RuntimeError(
+                    f"query oracle entry {index} expected.open_ids.{kind} must be non-empty"
+                )
+        marker = expected.get("result_marker")
+        if marker is not None and (not isinstance(marker, dict) or not marker):
+            raise RuntimeError(
+                f"query oracle entry {index} expected.result_marker must be a non-empty object"
+            )
+        if result_count is None and not open_ids and marker is None:
+            raise RuntimeError(
+                f"query oracle entry {index} must declare result_count, open_ids, or result_marker"
+            )
+        missing_kinds = [kind for kind in open_kinds if kind not in open_ids]
+        if missing_kinds:
+            raise RuntimeError(
+                f"query oracle entry {index} lacks open IDs for kinds: {missing_kinds}"
+            )
+        by_query[query_key] = {
+            "result_count": result_count,
+            "open_ids": dict(open_ids),
+            "result_marker": marker,
+        }
+
+    missing_queries = [query for query in queries if normalize_query(query) not in by_query]
+    if missing_queries:
+        raise OracleConfigurationError(
+            "missing-search-oracle",
+            f"query oracle has no entry for {len(missing_queries)} selected quer"
+            f"{'y' if len(missing_queries) == 1 else 'ies'}",
+        )
+    query_oracles = {query: by_query[normalize_query(query)] for query in queries}
+
+    if not require_list_sessions:
+        return query_oracles, None
+    list_oracle = payload.get("list_sessions")
+    if not isinstance(list_oracle, dict):
+        raise OracleConfigurationError(
+            "missing-list-oracle",
+            "benchmark oracle must declare list_sessions for the measured window",
+        )
+    result_count = list_oracle.get("result_count")
+    if result_count is not None and (
+        isinstance(result_count, bool)
+        or not isinstance(result_count, int)
+        or result_count < 0
+    ):
+        raise OracleConfigurationError(
+            "invalid-benchmark-oracle",
+            "list_sessions.result_count must be a non-negative integer",
+        )
+    session_ids = list_oracle.get("session_ids", [])
+    if (
+        not isinstance(session_ids, list)
+        or any(not isinstance(value, str) or not value for value in session_ids)
+        or len(session_ids) != len(set(session_ids))
+    ):
+        raise OracleConfigurationError(
+            "invalid-benchmark-oracle",
+            "list_sessions.session_ids must be an array of unique non-empty strings",
+        )
+    marker = list_oracle.get("result_marker")
+    if marker is not None and (not isinstance(marker, dict) or not marker):
+        raise OracleConfigurationError(
+            "invalid-benchmark-oracle",
+            "list_sessions.result_marker must be a non-empty object",
+        )
+    if result_count is None and not session_ids and marker is None:
+        raise OracleConfigurationError(
+            "missing-list-oracle",
+            "list_sessions must declare result_count, session_ids, or result_marker",
+        )
+    return query_oracles, {
+        "result_count": result_count,
+        "session_ids": list(session_ids),
+        "result_marker": marker,
     }
 
 
-def first_list_session_open_id(list_data: dict[str, Any]) -> Optional[str]:
-    sessions = list_data.get("sessions", [])
-    if not isinstance(sessions, list) or not sessions:
-        return None
-    first = sessions[0]
-    if not isinstance(first, dict):
-        return None
-    open_block = first.get("open")
-    if not isinstance(open_block, dict):
-        return None
-    value = open_block.get("session_id")
-    return value if isinstance(value, str) and value else None
+def contains_marker(value: Any, marker: Any) -> bool:
+    if isinstance(marker, dict):
+        return isinstance(value, dict) and all(
+            key in value and contains_marker(value[key], expected)
+            for key, expected in marker.items()
+        )
+    if isinstance(marker, list):
+        return (
+            isinstance(value, list)
+            and len(value) == len(marker)
+            and all(contains_marker(actual, expected) for actual, expected in zip(value, marker))
+        )
+    return value == marker
+
+
+def validate_search_oracle(
+    search_data: dict[str, Any],
+    oracle: dict[str, Any],
+) -> None:
+    results = search_data.get("results")
+    if not isinstance(results, list):
+        raise RuntimeError("search_sessions data.results must be an array")
+
+    result_count = oracle["result_count"]
+    if result_count is not None and len(results) != result_count:
+        raise RuntimeError(
+            f"search_sessions returned {len(results)} results, expected {result_count}"
+        )
+
+    open_ids = oracle["open_ids"]
+    marker = oracle["result_marker"]
+    if open_ids or marker is not None:
+        matched = False
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            open_block = result.get("open")
+            ids_match = not open_ids or (
+                isinstance(open_block, dict)
+                and all(
+                    open_block.get(f"{kind}_id") == entity_id
+                    for kind, entity_id in open_ids.items()
+                )
+            )
+            marker_matches = marker is None or contains_marker(result, marker)
+            if ids_match and marker_matches:
+                matched = True
+                break
+        if not matched:
+            raise RuntimeError("search_sessions did not return the oracle-selected result")
+
+
+def validate_list_oracle(
+    list_data: dict[str, Any],
+    oracle: dict[str, Any],
+) -> None:
+    sessions = list_data.get("sessions")
+    if not isinstance(sessions, list):
+        raise RuntimeError("list_sessions data.sessions must be an array")
+
+    result_count = oracle["result_count"]
+    if result_count is not None and len(sessions) != result_count:
+        raise RuntimeError(
+            f"list_sessions returned {len(sessions)} sessions, expected {result_count}"
+        )
+
+    expected_ids = set(oracle["session_ids"])
+    if expected_ids:
+        observed_ids = {
+            open_block["session_id"]
+            for session in sessions
+            if isinstance(session, dict)
+            and isinstance((open_block := session.get("open")), dict)
+            and isinstance(open_block.get("session_id"), str)
+        }
+        missing_ids = expected_ids - observed_ids
+        if missing_ids:
+            raise RuntimeError(
+                f"list_sessions omitted {len(missing_ids)} oracle session IDs"
+            )
+
+    marker = oracle["result_marker"]
+    if marker is not None and not any(
+        isinstance(session, dict) and contains_marker(session, marker)
+        for session in sessions
+    ):
+        raise RuntimeError("list_sessions did not return the oracle semantic marker")
 
 
 def validate_open_oracle(
@@ -988,8 +1205,45 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     oracle_mismatches = 0
     warmup_failures = 0
     init_ms: Optional[float] = None
-    search_oracles: dict[int, tuple[tuple[str, str], ...]] = {}
-    list_oracle: Optional[str] = None
+    try:
+        query_oracles, list_sessions_oracle = load_benchmark_oracles(
+            args.oracle_json,
+            queries,
+            open_kinds,
+            list_sessions_args is not None,
+        )
+    except Exception as exc:
+        diagnostic_codes.append(
+            getattr(exc, "diagnostic_code", "invalid-benchmark-oracle")
+        )
+        oracle_mismatches += 1
+        failures.append(f"benchmark oracle prerequisite failed: {exc}")
+        try:
+            payload = build_artifact(
+                args=args,
+                counts=counts,
+                corpus_identity=corpus_identity,
+                queries=queries,
+                open_kinds=open_kinds,
+                list_sessions_args=list_sessions_args,
+                samples=samples,
+                planned=planned,
+                attempted=attempted,
+                errors=errors,
+                initialization_ms=init_ms,
+                diagnostic_codes=diagnostic_codes,
+                oracle_mismatches=oracle_mismatches,
+                warmup_failures=warmup_failures,
+            )
+            benchmark_protocol.write_artifact(Path(args.output_json).expanduser(), payload)
+        except Exception as artifact_exc:
+            print(
+                f"fatal: benchmark artifact validation/write failed: {artifact_exc}",
+                file=sys.stderr,
+            )
+            return 2
+        print(f"fatal: {failures[-1]}", file=sys.stderr)
+        return 1
     service_bin_dir = resolve_service_bin_dir(args.moraine_bin, args.service_bin_dir)
 
     try:
@@ -1058,34 +1312,26 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     )
                     continue
 
-                open_ids = first_hit_open_ids(search_data)
-                if measured and open_kinds and all(kind in open_ids for kind in open_kinds):
-                    signature = tuple((kind, open_ids[kind]) for kind in open_kinds)
-                    expected_signature = search_oracles.setdefault(query_index, signature)
-                    if signature != expected_signature:
+                oracle = query_oracles[query]
+                try:
+                    validate_search_oracle(search_data, oracle)
+                except Exception as exc:
+                    if measured:
                         oracle_mismatches += 1
-                        diagnostic_codes.append("oracle-instability")
-                        failures.append(
-                            f"query_index={query_index} returned unstable search-to-open ids"
-                        )
+                    else:
+                        warmup_failures += 1
+                        diagnostic_codes.append("warmup-error")
+                    diagnostic_codes.append("search-oracle-mismatch")
+                    failures.append(
+                        f"query_index={query_index} run={run_idx} search_sessions: {exc}"
+                    )
                 if measured:
                     sample = dict(search_sample)
                     sample.pop("structured", None)
                     samples.append(sample)
 
                 for kind in open_kinds:
-                    target_id = open_ids.get(kind)
-                    if not target_id:
-                        if measured:
-                            oracle_mismatches += 1
-                            diagnostic_codes.append("missing-open-id")
-                        else:
-                            warmup_failures += 1
-                            diagnostic_codes.extend(["missing-open-id", "warmup-error"])
-                        failures.append(
-                            f"query_index={query_index} produced no {kind} id to open"
-                        )
-                        continue
+                    target_id = oracle["open_ids"][kind]
                     if measured:
                         attempted += 1
                     try:
@@ -1161,22 +1407,16 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                         diagnostic_codes.extend(["malformed-tool-data", "warmup-error"])
                     failures.append(f"list_sessions run={run_idx}: {exc}")
                     continue
-                current_list_oracle = first_list_session_open_id(list_data)
-                if measured and current_list_oracle is not None:
-                    if list_oracle is None:
-                        list_oracle = current_list_oracle
-                    elif current_list_oracle != list_oracle:
-                        oracle_mismatches += 1
-                        diagnostic_codes.append("oracle-instability")
-                        failures.append("list_sessions returned an unstable open.session_id")
-                if current_list_oracle is None:
+                try:
+                    validate_list_oracle(list_data, list_sessions_oracle)
+                except Exception as exc:
                     if measured:
                         oracle_mismatches += 1
-                        diagnostic_codes.append("list-oracle-mismatch")
                     else:
                         warmup_failures += 1
-                        diagnostic_codes.extend(["list-oracle-mismatch", "warmup-error"])
-                    failures.append("list_sessions returned no open.session_id")
+                        diagnostic_codes.append("warmup-error")
+                    diagnostic_codes.append("list-oracle-mismatch")
+                    failures.append(f"list_sessions run={run_idx}: {exc}")
                 if measured:
                     sample = dict(list_sample)
                     sample.pop("structured", None)

--- a/scripts/bench/test_mcp_two_tool_sla.py
+++ b/scripts/bench/test_mcp_two_tool_sla.py
@@ -30,6 +30,30 @@ CORPUS_IDENTITY = {
     "content_xor": "101",
     "content_sum": "202",
 }
+SEARCH_ORACLE = {
+    "schema_version": "moraine-mcp-two-tool-oracle-v1",
+    "queries": [
+        {
+            "query": "raw secret query",
+            "expected": {
+                "result_count": 1,
+                "open_ids": {
+                    "event": "evt-1",
+                    "turn": "turn-1",
+                    "session": "session-1",
+                },
+            },
+        }
+    ],
+}
+LIST_ORACLE = {
+    **SEARCH_ORACLE,
+    "list_sessions": {
+        "result_count": 1,
+        "session_ids": ["seed-session"],
+        "result_marker": {"title": "seed marker"},
+    },
+}
 
 
 def sample(*, met_sla: bool = True, structured: dict[str, object] | None = None) -> dict[str, object]:
@@ -76,6 +100,27 @@ def open_sample(
                 "kind": kind,
                 kind: {"id": returned_id},
             },
+        },
+    }
+
+
+def list_sample(*, session_id: str = "seed-session", title: str = "seed marker") -> dict[str, object]:
+    return {
+        "tool": "list_sessions",
+        "arguments": {"limit": 20},
+        "e2e_ms": 2.75,
+        "server_elapsed_ms": 1.75,
+        "sla_target_ms": 500.0,
+        "met_sla": True,
+        "structured": {
+            "data": {
+                "sessions": [
+                    {
+                        "title": title,
+                        "open": {"session_id": session_id},
+                    }
+                ]
+            }
         },
     }
 
@@ -266,6 +311,8 @@ class MainTests(unittest.TestCase):
         repeats: int = 1,
         warmup: int = 0,
         corpus_identity: dict[str, object] = CORPUS_IDENTITY,
+        oracle: dict[str, object] | None = SEARCH_ORACLE,
+        skip_list: bool = True,
     ) -> int:
         fake_proc = SimpleNamespace()
         self.start_mcp = mock.Mock(return_value=fake_proc)
@@ -274,7 +321,10 @@ class MainTests(unittest.TestCase):
             if method == "initialize":
                 return {}
             if method == "tools/list":
-                return {"tools": [{"name": "search_sessions"}, {"name": "open"}]}
+                names = ["search_sessions", "open"]
+                if not skip_list:
+                    names.append("list_sessions")
+                return {"tools": [{"name": name} for name in names]}
             raise AssertionError(method)
 
         argv = [
@@ -284,7 +334,6 @@ class MainTests(unittest.TestCase):
             "smoke",
             "--query",
             "raw secret query",
-            "--skip-list-sessions",
             "--open-kind",
             open_kind,
             "--min-docs",
@@ -299,16 +348,31 @@ class MainTests(unittest.TestCase):
             "--output-json",
             str(output),
         ]
+        if skip_list:
+            argv.append("--skip-list-sessions")
+        if oracle is not None:
+            oracle_path = output.with_name("query-oracle.json")
+            oracle_path.write_text(json.dumps(oracle), encoding="utf-8")
+            argv.extend(["--oracle-json", str(oracle_path)])
         if isinstance(measured_side_effect, BaseException):
             measured_call = mock.Mock(side_effect=measured_side_effect)
         elif isinstance(measured_side_effect, list):
             measured_call = mock.Mock(side_effect=measured_side_effect)
         else:
             measured_call = mock.Mock(return_value=measured_side_effect)
+        self.measured_call = measured_call
         with (
             mock.patch.object(bench, "read_clickhouse_config", return_value={}),
             mock.patch.object(bench, "corpus_counts", return_value=COUNTS),
             mock.patch.object(bench, "search_corpus_identity", return_value=corpus_identity),
+            mock.patch.object(
+                bench,
+                "corpus_session_window",
+                return_value={
+                    "start_datetime": "2026-01-01T00:00:00.000Z",
+                    "end_datetime": "2026-01-02T00:00:00.000Z",
+                },
+            ),
             mock.patch.object(bench, "select_log_queries", return_value=[]),
             mock.patch.object(bench, "resolve_service_bin_dir", return_value=None),
             mock.patch.object(bench, "start_mcp", self.start_mcp),
@@ -357,27 +421,37 @@ class MainTests(unittest.TestCase):
             self.assertEqual(payload["semantic"]["status"], "fail")
             self.assertIn({"code": "tool-call-error"}, payload["diagnostics"])
 
-    def test_missing_open_oracle_fails_and_exposes_insufficient_sample(self) -> None:
+    def test_missing_search_hit_fails_semantics_but_opens_seed_entity(self) -> None:
         search_without_hits = sample(structured={"data": {"results": []}})
         with tempfile.TemporaryDirectory() as temporary:
             output = Path(temporary) / "result.json"
-            result = self.run_main(output, (2, search_without_hits), open_kind="event")
+            result = self.run_main(
+                output,
+                [(2, search_without_hits), (3, open_sample())],
+                open_kind="event",
+            )
             self.assertEqual(result, 1)
             payload = json.loads(output.read_text(encoding="utf-8"))
             benchmark_protocol.validate_artifact(payload)
+            self.assertEqual(payload["samples"]["successful"], 2)
+            self.assertEqual(payload["samples"]["errors"], 0)
             self.assertEqual(payload["metrics"]["quality"]["mismatches"], 1)
-            self.assertIn({"code": "missing-open-id"}, payload["diagnostics"])
-            self.assertIn({"code": "insufficient-samples"}, payload["diagnostics"])
+            self.assertIn({"code": "search-oracle-mismatch"}, payload["diagnostics"])
+            open_calls = [
+                call
+                for call in self.measured_call.call_args_list
+                if call.args[3] == "open"
+            ]
+            self.assertEqual(open_calls[0].args[4], {"id": "evt-1"})
 
-    def test_unstable_search_oracle_fails_even_when_every_call_succeeds(self) -> None:
-        first = sample()
-        second = sample(
+    def test_repeatable_wrong_search_ids_fail_independent_oracle(self) -> None:
+        wrong = sample(
             structured={
                 "data": {
                     "results": [
                         {
                             "open": {
-                                "event_id": "evt-2",
+                                "event_id": "evt-wrong",
                                 "turn_id": "turn-1",
                                 "session_id": "session-1",
                             }
@@ -386,13 +460,11 @@ class MainTests(unittest.TestCase):
                 }
             }
         )
-        first_open = open_sample(returned_id="evt-1")
-        second_open = open_sample(returned_id="evt-2")
         with tempfile.TemporaryDirectory() as temporary:
             output = Path(temporary) / "result.json"
             result = self.run_main(
                 output,
-                [(2, first), (3, first_open), (4, second), (5, second_open)],
+                [(2, wrong), (3, open_sample()), (4, wrong), (5, open_sample())],
                 open_kind="event",
                 repeats=2,
             )
@@ -401,8 +473,58 @@ class MainTests(unittest.TestCase):
             benchmark_protocol.validate_artifact(payload)
             self.assertEqual(payload["samples"]["successful"], 4)
             self.assertEqual(payload["samples"]["errors"], 0)
+            self.assertEqual(payload["metrics"]["quality"]["mismatches"], 2)
+            self.assertIn({"code": "search-oracle-mismatch"}, payload["diagnostics"])
+            self.assertNotIn({"code": "oracle-instability"}, payload["diagnostics"])
+            open_calls = [
+                call
+                for call in self.measured_call.call_args_list
+                if call.args[3] == "open"
+            ]
+            self.assertEqual([call.args[4] for call in open_calls], [{"id": "evt-1"}] * 2)
+
+    def test_repeatable_wrong_list_results_fail_independent_oracle(self) -> None:
+        wrong_list = list_sample(session_id="wrong-session", title="wrong marker")
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "result.json"
+            result = self.run_main(
+                output,
+                [(2, sample()), (3, sample()), (4, wrong_list), (5, wrong_list)],
+                oracle=LIST_ORACLE,
+                skip_list=False,
+                repeats=2,
+            )
+
+            self.assertEqual(result, 1)
+            payload = benchmark_protocol.load_artifact(output)
+            self.assertEqual(payload["samples"]["planned"], 4)
+            self.assertEqual(payload["samples"]["successful"], 4)
+            self.assertEqual(payload["samples"]["errors"], 0)
+            self.assertEqual(payload["metrics"]["quality"]["mismatches"], 2)
+            self.assertIn({"code": "list-oracle-mismatch"}, payload["diagnostics"])
+            self.assertNotIn({"code": "oracle-instability"}, payload["diagnostics"])
+
+    def test_missing_list_oracle_fails_closed_with_valid_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "result.json"
+            result = self.run_main(
+                output,
+                (2, sample()),
+                oracle=SEARCH_ORACLE,
+                skip_list=False,
+            )
+
+            self.assertEqual(result, 1)
+            self.start_mcp.assert_not_called()
+            self.measured_call.assert_not_called()
+            payload = benchmark_protocol.load_artifact(output)
+            self.assertEqual(payload["samples"]["planned"], 2)
+            self.assertEqual(payload["samples"]["attempted"], 0)
+            self.assertEqual(payload["samples"]["successful"], 0)
+            self.assertEqual(payload["samples"]["errors"], 0)
+            self.assertEqual(payload["semantic"]["status"], "fail")
             self.assertEqual(payload["metrics"]["quality"]["mismatches"], 1)
-            self.assertIn({"code": "oracle-instability"}, payload["diagnostics"])
+            self.assertIn({"code": "missing-list-oracle"}, payload["diagnostics"])
 
     def test_wrong_open_entity_or_kind_is_a_failed_attempt(self) -> None:
         wrong_responses = [
@@ -482,6 +604,33 @@ class MainTests(unittest.TestCase):
             self.assertEqual(payload["semantic"]["status"], "fail")
             self.assertEqual(payload["scenario"]["fingerprints"]["cache_state"], "mixed")
             self.assertIn({"code": "warmup-error"}, payload["diagnostics"])
+
+    def test_missing_oracle_fails_closed_with_valid_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "result.json"
+            result = self.run_main(output, (2, sample()), oracle=None)
+
+            self.assertEqual(result, 1)
+            self.start_mcp.assert_not_called()
+            self.measured_call.assert_not_called()
+            payload = benchmark_protocol.load_artifact(output)
+            self.assertEqual(
+                payload["samples"],
+                {
+                    "planned": 1,
+                    "attempted": 0,
+                    "successful": 0,
+                    "errors": 0,
+                    "measurements": {
+                        "latency_ms": [],
+                        "server_elapsed_ms": [],
+                        "sla_target_ms": [],
+                    },
+                },
+            )
+            self.assertEqual(payload["semantic"]["status"], "fail")
+            self.assertEqual(payload["metrics"]["quality"]["mismatches"], 1)
+            self.assertIn({"code": "missing-search-oracle"}, payload["diagnostics"])
 
     def test_missing_config_and_corpus_threshold_fail_before_live_process(self) -> None:
         missing = bench.main(["--config", "/definitely/missing/config.toml", "--dry-run"])


### PR DESCRIPTION
## Description

**What.** Requires a seed-owned oracle for search, open, and list_sessions in the two-tool MCP benchmark. Search cardinality/IDs/object markers, open identity/kind, and list count/session IDs/object marker are checked independently on every run.

**Why.** First measured search/list output is not an oracle. Consistently wrong results must fail even when stable.

## Operational impact

Measured invocations now require `--oracle-json`; list_sessions requires a root list oracle. Missing/incomplete truth fails before MCP startup with a valid semantic-failure artifact. Historical latency remains diagnostic and non-blocking.

## Validation

`python3 scripts/bench/test_mcp_two_tool_sla.py` passed 25 tests. Python compilation passed. Part of #477; stack predecessor is the replay-oracle PR.