### PR TITLE
fix(bench): fingerprint two-tool oracle

### DIFF
--- a/scripts/bench/mcp_two_tool_sla.py
+++ b/scripts/bench/mcp_two_tool_sla.py
@@ -23,6 +23,7 @@ import benchmark_protocol
 
 WINDOW_RE = re.compile(r"^\s*(\d+)\s*([smhdw])\s*$", re.IGNORECASE)
 BENCHMARK_REPLAY_SOURCE = "benchmark-replay"
+ORACLE_SCHEMA_VERSION = "moraine-mcp-two-tool-oracle-v1"
 
 PROFILE_DEFAULTS = {
     "smoke": {"warmup": 0, "repeats": 1, "min_docs": 1},
@@ -636,14 +637,44 @@ def normalize_query(value: str) -> str:
     return " ".join(value.split()).casefold()
 
 
+def oracle_contract_fingerprint(
+    query_oracles: dict[str, dict[str, Any]],
+    list_sessions_oracle: Optional[dict[str, Any]],
+) -> str:
+    query_contracts = [
+        {
+            "query": normalize_query(query),
+            "expected": {
+                "result_count": oracle["result_count"],
+                "open_ids": dict(sorted(oracle["open_ids"].items())),
+                "result_marker": oracle["result_marker"],
+            },
+        }
+        for query, oracle in sorted(
+            query_oracles.items(), key=lambda item: normalize_query(item[0])
+        )
+    ]
+    contract: dict[str, Any] = {
+        "schema_version": ORACLE_SCHEMA_VERSION,
+        "queries": query_contracts,
+    }
+    if list_sessions_oracle is not None:
+        contract["list_sessions"] = {
+            "result_count": list_sessions_oracle["result_count"],
+            "session_ids": sorted(list_sessions_oracle["session_ids"]),
+            "result_marker": list_sessions_oracle["result_marker"],
+        }
+    return sha256_json(contract)
+
+
 def load_benchmark_oracles(
     path_value: Optional[str],
     queries: list[str],
     open_kinds: list[str],
     require_list_sessions: bool,
-) -> tuple[dict[str, dict[str, Any]], Optional[dict[str, Any]]]:
+) -> tuple[dict[str, dict[str, Any]], Optional[dict[str, Any]], str]:
     if not queries and not require_list_sessions:
-        return {}, None
+        return {}, None, oracle_contract_fingerprint({}, None)
     if not path_value:
         code = "missing-search-oracle" if queries else "missing-list-oracle"
         raise OracleConfigurationError(
@@ -661,10 +692,10 @@ def load_benchmark_oracles(
         raise OracleConfigurationError(
             "invalid-benchmark-oracle", "benchmark oracle root must be an object"
         )
-    if payload.get("schema_version") != "moraine-mcp-two-tool-oracle-v1":
+    if payload.get("schema_version") != ORACLE_SCHEMA_VERSION:
         raise OracleConfigurationError(
             "invalid-benchmark-oracle",
-            "benchmark oracle schema_version must be 'moraine-mcp-two-tool-oracle-v1'",
+            f"benchmark oracle schema_version must be '{ORACLE_SCHEMA_VERSION}'",
         )
     entries = payload.get("queries")
     if not isinstance(entries, list):
@@ -738,7 +769,7 @@ def load_benchmark_oracles(
     query_oracles = {query: by_query[normalize_query(query)] for query in queries}
 
     if not require_list_sessions:
-        return query_oracles, None
+        return query_oracles, None, oracle_contract_fingerprint(query_oracles, None)
     list_oracle = payload.get("list_sessions")
     if not isinstance(list_oracle, dict):
         raise OracleConfigurationError(
@@ -776,11 +807,16 @@ def load_benchmark_oracles(
             "missing-list-oracle",
             "list_sessions must declare result_count, session_ids, or result_marker",
         )
-    return query_oracles, {
+    validated_list_oracle = {
         "result_count": result_count,
         "session_ids": list(session_ids),
         "result_marker": marker,
     }
+    return (
+        query_oracles,
+        validated_list_oracle,
+        oracle_contract_fingerprint(query_oracles, validated_list_oracle),
+    )
 
 
 def contains_marker(value: Any, marker: Any) -> bool:
@@ -995,6 +1031,7 @@ def build_artifact(
     queries: list[str],
     open_kinds: list[str],
     list_sessions_args: Optional[dict[str, Any]],
+    oracle_fingerprint: Optional[str],
     samples: list[dict[str, Any]],
     planned: int,
     attempted: int,
@@ -1010,10 +1047,18 @@ def build_artifact(
         raise RuntimeError("attempted sample count does not equal successful plus errors")
     if attempted > planned:
         raise RuntimeError("attempted sample count exceeds planned samples")
+    if oracle_fingerprint is None and oracle_mismatches == 0:
+        raise RuntimeError("validated oracle fingerprint is required")
+    if oracle_fingerprint is not None and not re.fullmatch(
+        r"[0-9a-f]{64}", oracle_fingerprint
+    ):
+        raise RuntimeError("oracle fingerprint must be 64 lowercase hexadecimal characters")
 
     workload_shape = {
         "profile": args.profile,
-        "query_hashes": [hashlib.sha256(query.encode("utf-8")).hexdigest() for query in queries],
+        "query_hashes": [
+            hashlib.sha256(query.encode("utf-8")).hexdigest() for query in queries
+        ],
         "open_kinds": open_kinds,
         "list_sessions": list_sessions_args,
         "event_types": sorted(args.event_type),
@@ -1021,6 +1066,7 @@ def build_artifact(
         "warmup": args.warmup,
         "repeats": args.repeats,
     }
+    oracle_identity = oracle_fingerprint or "invalid"
     dataset_shape = {
         "cardinality": corpus_identity["cardinality"],
         "content_sum": corpus_identity["content_sum"],
@@ -1047,7 +1093,9 @@ def build_artifact(
         "runner": runner_identity(),
         "scenario": {
             "profile": args.profile,
-            "workload_id": f"two-tool-{sha256_json(workload_shape)[:24]}",
+            "workload_id": (
+                f"two-tool-{sha256_json(workload_shape)[:24]}-oracle-{oracle_identity}"
+            ),
             "measured_boundary": "json-rpc-stdio-tool-call",
             "dimensions": {
                 "dataset_backed": True,
@@ -1205,8 +1253,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     oracle_mismatches = 0
     warmup_failures = 0
     init_ms: Optional[float] = None
+    oracle_fingerprint: Optional[str] = None
     try:
-        query_oracles, list_sessions_oracle = load_benchmark_oracles(
+        (
+            query_oracles,
+            list_sessions_oracle,
+            oracle_fingerprint,
+        ) = load_benchmark_oracles(
             args.oracle_json,
             queries,
             open_kinds,
@@ -1226,6 +1279,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 queries=queries,
                 open_kinds=open_kinds,
                 list_sessions_args=list_sessions_args,
+                oracle_fingerprint=oracle_fingerprint,
                 samples=samples,
                 planned=planned,
                 attempted=attempted,
@@ -1455,6 +1509,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             queries=queries,
             open_kinds=open_kinds,
             list_sessions_args=list_sessions_args,
+            oracle_fingerprint=oracle_fingerprint,
             samples=samples,
             planned=planned,
             attempted=attempted,

--- a/scripts/bench/test_mcp_two_tool_sla.py
+++ b/scripts/bench/test_mcp_two_tool_sla.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import copy
 import json
 import sys
 import tempfile
@@ -54,6 +55,19 @@ LIST_ORACLE = {
         "result_marker": {"title": "seed marker"},
     },
 }
+VALIDATED_SEARCH_EXPECTATION = {
+    "result_count": 1,
+    "open_ids": {
+        "event": "evt-1",
+        "turn": "turn-1",
+        "session": "session-1",
+    },
+    "result_marker": None,
+}
+ORACLE_FINGERPRINT = bench.oracle_contract_fingerprint(
+    {"private raw query": VALIDATED_SEARCH_EXPECTATION},
+    None,
+)
 
 
 def sample(*, met_sla: bool = True, structured: dict[str, object] | None = None) -> dict[str, object]:
@@ -193,6 +207,7 @@ class ArtifactTests(unittest.TestCase):
         oracle_mismatches: int = 0,
         extra_args: tuple[str, ...] = (),
         corpus_identity: dict[str, object] = CORPUS_IDENTITY,
+        oracle_fingerprint: str = ORACLE_FINGERPRINT,
     ) -> dict[str, object]:
         return bench.build_artifact(
             args=self.args(*extra_args),
@@ -201,6 +216,7 @@ class ArtifactTests(unittest.TestCase):
             queries=["private raw query"],
             open_kinds=[],
             list_sessions_args=None,
+            oracle_fingerprint=oracle_fingerprint,
             samples=samples,
             planned=planned,
             attempted=attempted,
@@ -227,6 +243,12 @@ class ArtifactTests(unittest.TestCase):
         self.assertEqual(payload["semantic"]["status"], "pass")
         self.assertEqual(payload["timing"], {"status": "not_evaluated", "non_blocking": True})
         self.assertNotIn("model_tokens", payload["metrics"])
+        workload_id = payload["scenario"]["workload_id"]
+        self.assertRegex(
+            workload_id,
+            rf"^two-tool-[0-9a-f]{{24}}-oracle-{ORACLE_FINGERPRINT}$",
+        )
+        self.assertNotIn("private raw query", workload_id)
 
     def test_count_invariant_is_enforced_before_serialization(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "successful plus errors"):
@@ -290,6 +312,177 @@ class ArtifactTests(unittest.TestCase):
         self.assertNotEqual(
             original["scenario"]["fingerprints"]["dataset"]["fingerprint"],
             changed["scenario"]["fingerprints"]["dataset"]["fingerprint"],
+        )
+
+    def load_oracle_fingerprint(
+        self,
+        oracle: dict[str, object],
+        *,
+        require_list_sessions: bool,
+    ) -> str:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "oracle.json"
+            path.write_text(json.dumps(oracle), encoding="utf-8")
+            _, _, fingerprint = bench.load_benchmark_oracles(
+                str(path),
+                ["raw secret query"],
+                ["event", "turn", "session"],
+                require_list_sessions,
+            )
+        return fingerprint
+
+    def test_complete_validated_oracle_contract_determines_comparability(self) -> None:
+        oracle = copy.deepcopy(LIST_ORACLE)
+        oracle["queries"][0]["expected"]["result_marker"] = {
+            "summary": {"label": "sensitive search marker"}
+        }
+        oracle["list_sessions"]["result_marker"] = {
+            "title": {"label": "sensitive list marker"}
+        }
+        baseline_fingerprint = self.load_oracle_fingerprint(
+            oracle,
+            require_list_sessions=True,
+        )
+        mutations = {
+            "search result count": lambda value: value["queries"][0]["expected"].update(
+                result_count=2
+            ),
+            "search event ID": lambda value: value["queries"][0]["expected"]["open_ids"].update(
+                event="evt-changed"
+            ),
+            "search turn ID": lambda value: value["queries"][0]["expected"]["open_ids"].update(
+                turn="turn-changed"
+            ),
+            "search session ID": lambda value: value["queries"][0]["expected"]["open_ids"].update(
+                session="session-changed"
+            ),
+            "search object marker": lambda value: value["queries"][0]["expected"][
+                "result_marker"
+            ]["summary"].update(label="changed search marker"),
+            "list result count": lambda value: value["list_sessions"].update(
+                result_count=2
+            ),
+            "list session ID": lambda value: value["list_sessions"].update(
+                session_ids=["changed-session"]
+            ),
+            "list object marker": lambda value: value["list_sessions"]["result_marker"][
+                "title"
+            ].update(label="changed list marker"),
+        }
+        baseline = self.build(
+            samples=[sample()],
+            planned=1,
+            attempted=1,
+            errors=0,
+            oracle_fingerprint=baseline_fingerprint,
+        )
+        for name, mutate in mutations.items():
+            with self.subTest(field=name):
+                changed_oracle = copy.deepcopy(oracle)
+                mutate(changed_oracle)
+                changed_fingerprint = self.load_oracle_fingerprint(
+                    changed_oracle,
+                    require_list_sessions=True,
+                )
+                self.assertNotEqual(baseline_fingerprint, changed_fingerprint)
+                candidate = self.build(
+                    samples=[sample()],
+                    planned=1,
+                    attempted=1,
+                    errors=0,
+                    oracle_fingerprint=changed_fingerprint,
+                )
+                benchmark_protocol.validate_artifact(candidate)
+                with self.assertRaisesRegex(
+                    benchmark_protocol.IncomparableError,
+                    "scenario.workload_id",
+                ):
+                    benchmark_protocol.compare_artifacts(baseline, candidate)
+
+    def test_oracle_fingerprint_is_canonical_and_redaction_safe(self) -> None:
+        oracle = copy.deepcopy(LIST_ORACLE)
+        oracle["queries"][0]["expected"]["result_marker"] = {
+            "private": "raw oracle marker"
+        }
+        fingerprint = self.load_oracle_fingerprint(
+            oracle,
+            require_list_sessions=True,
+        )
+        reordered = {
+            "list_sessions": {
+                "result_marker": {"title": "seed marker"},
+                "session_ids": ["seed-session"],
+                "result_count": 1,
+            },
+            "queries": [
+                {
+                    "expected": {
+                        "result_marker": {"private": "raw oracle marker"},
+                        "open_ids": {
+                            "session": "session-1",
+                            "turn": "turn-1",
+                            "event": "evt-1",
+                        },
+                        "result_count": 1,
+                    },
+                    "query": "  RAW   SECRET QUERY  ",
+                }
+            ],
+            "schema_version": "moraine-mcp-two-tool-oracle-v1",
+        }
+        self.assertEqual(
+            fingerprint,
+            self.load_oracle_fingerprint(reordered, require_list_sessions=True),
+        )
+        payload = self.build(
+            samples=[sample()],
+            planned=1,
+            attempted=1,
+            errors=0,
+            oracle_fingerprint=fingerprint,
+        )
+        benchmark_protocol.validate_artifact(payload)
+        workload_id = payload["scenario"]["workload_id"]
+        self.assertTrue(workload_id.endswith(f"-oracle-{fingerprint}"))
+        encoded = json.dumps(payload)
+        for sensitive in (
+            "raw secret query",
+            "raw oracle marker",
+            "seed-session",
+            "seed marker",
+            "evt-1",
+            "turn-1",
+            "session-1",
+        ):
+            self.assertNotIn(sensitive, workload_id)
+            self.assertNotIn(sensitive, encoded)
+
+    def test_unselected_or_unmeasured_oracle_cases_do_not_change_identity(self) -> None:
+        oracle = copy.deepcopy(LIST_ORACLE)
+        oracle["queries"].append(
+            {
+                "query": "unselected private query",
+                "expected": {
+                    "result_count": 1,
+                    "open_ids": {
+                        "event": "unused-event",
+                        "turn": "unused-turn",
+                        "session": "unused-session",
+                    },
+                    "result_marker": {"unused": "private marker"},
+                },
+            }
+        )
+        baseline = self.load_oracle_fingerprint(
+            oracle,
+            require_list_sessions=False,
+        )
+        oracle["queries"][1]["expected"]["result_count"] = 99
+        oracle["queries"][1]["expected"]["open_ids"]["event"] = "changed-unused-event"
+        oracle["list_sessions"]["result_count"] = 99
+        self.assertEqual(
+            baseline,
+            self.load_oracle_fingerprint(oracle, require_list_sessions=False),
         )
 
     def test_output_uses_shared_atomic_writer(self) -> None:
@@ -392,6 +585,15 @@ class MainTests(unittest.TestCase):
             self.assertNotIn("raw secret query", json.dumps(payload))
             self.assertEqual(payload["samples"]["planned"], 1)
             self.assertEqual(payload["samples"]["successful"], 1)
+            expected_oracle_fingerprint = bench.oracle_contract_fingerprint(
+                {"raw secret query": VALIDATED_SEARCH_EXPECTATION},
+                None,
+            )
+            self.assertTrue(
+                payload["scenario"]["workload_id"].endswith(
+                    f"-oracle-{expected_oracle_fingerprint}"
+                )
+            )
 
     def test_sla_miss_exits_success_when_semantics_pass(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Description

**What.** Canonically hashes the complete selected two-tool oracle contract into `scenario.workload_id`. Counts, open IDs, object markers, and measured list expectations all participate; unrelated unselected cases do not.

**Why.** Baseline and candidate runs using different correctness contracts must be incomparable before timing evaluation, even when corpus and command arguments match.

## Operational impact

Artifact identity changes only. The artifact retains a full SHA-256 digest, never raw oracle/query data. Invalid prerequisite artifacts use a safe non-secret identity. Timing remains non-blocking.

## Validation

`python3 -m unittest scripts.bench.tests.test_benchmark_protocol scripts.bench.test_mcp_two_tool_sla` passed 58 tests, including schema, redaction, canonicalization, and pre-timing incomparability. Part of #477; predecessor #504.