### PR TITLE
docs(test): refresh oracle identity evidence

### DIFF
--- a/docs/development/test-architecture/candidate-issue-477/compile-measurements-darwin-arm64.json
+++ b/docs/development/test-architecture/candidate-issue-477/compile-measurements-darwin-arm64.json
@@ -36,8 +36,8 @@
             }
           ],
           "phase": "cold",
-          "started_at_utc": "2026-07-11T14:06:22.354Z",
-          "wall_time_seconds": 20.071608
+          "started_at_utc": "2026-07-11T14:24:55.808Z",
+          "wall_time_seconds": 29.049799
         },
         {
           "exit_code": 0,
@@ -72,8 +72,8 @@
             }
           ],
           "phase": "warm",
-          "started_at_utc": "2026-07-11T14:06:42.427Z",
-          "wall_time_seconds": 0.204112
+          "started_at_utc": "2026-07-11T14:25:24.864Z",
+          "wall_time_seconds": 0.402747
         }
       ],
       "topology": {
@@ -151,8 +151,8 @@
             }
           ],
           "phase": "cold",
-          "started_at_utc": "2026-07-11T14:06:42.646Z",
-          "wall_time_seconds": 24.128268
+          "started_at_utc": "2026-07-11T14:25:25.285Z",
+          "wall_time_seconds": 36.540221
         },
         {
           "exit_code": 0,
@@ -196,8 +196,8 @@
             }
           ],
           "phase": "warm",
-          "started_at_utc": "2026-07-11T14:07:06.775Z",
-          "wall_time_seconds": 0.209209
+          "started_at_utc": "2026-07-11T14:26:01.831Z",
+          "wall_time_seconds": 0.472429
         }
       ],
       "topology": {
@@ -248,11 +248,11 @@
   "command": "cargo test -p moraine-conversations --locked --no-run --message-format=json",
   "comparison": "same-host same-toolchain baseline versus candidate target topology",
   "delta": {
-    "cold_wall_time_seconds": 4.05666,
+    "cold_wall_time_seconds": 7.490422,
     "integration_test_target_count": 1,
     "linked_test_executable_count": 1,
     "package_target_count": 2,
-    "warm_wall_time_seconds": 0.005097
+    "warm_wall_time_seconds": 0.069682
   },
   "environment": {
     "baseline": {
@@ -315,8 +315,8 @@
     "candidate": {
       "commit_command": "git rev-parse --verify HEAD^{commit}",
       "description": "current working tree",
-      "head_commit": "3e8283e45217b630d5f968b799612b4986c4f378",
-      "head_tree": "7f1961949725f70b1d0da598693d1b71cfc751b2",
+      "head_commit": "3254e315dead7e20e35ec0fc515289874ac8f47a",
+      "head_tree": "9931067b1de5f407e07bfec953d79ac25c452bf3",
       "tree_command": "git rev-parse --verify HEAD^{tree}"
     }
   },

--- a/docs/development/test-architecture/candidate-issue-477/manifest.json
+++ b/docs/development/test-architecture/candidate-issue-477/manifest.json
@@ -1,15 +1,15 @@
 {
   "artifact_sha256": {
     "cargo-targets.json": "b4ee37536ccaaa92ac1abd918e3538ba2f251b2b3495b19a3006c72240ef8a3b",
-    "compile-measurements-darwin-arm64.json": "d819ba33b6620d22c543abf37b402dc9eff98fe1ca753dc849d44c121cb33919",
+    "compile-measurements-darwin-arm64.json": "88cb21d6412997d99b7ea496c70a76c47b91dac7e4bcc0033340721a4e4ff70b",
     "normal-dependencies.json": "b9c083277d9fdb82b2aa84c898e6b6fef28dbc20fa1012145f79d30e573b127f",
     "repository-migration.json": "2c8269ca99f2bd1178c886a0539c5b6f3d1855804ed2daefe885035292099db0",
-    "rust-libtest-darwin-arm64.json": "bacd2a79183f72f244f88e810825cc38bf77717bc9a8b231ab164796b4a52c95"
+    "rust-libtest-darwin-arm64.json": "ff0ae0464bbd37222fb411de560a3f2a4e0c17f04a2403244757b9e2d971c97d"
   },
   "baseline_commit": "77c90d6c572ba71bcfaa0362f7ead2cfa5e6712a",
   "baseline_tree": "0ae5df87300c6748161f2035394b6e0b9a92e627",
-  "candidate_head_commit": "3e8283e45217b630d5f968b799612b4986c4f378",
-  "candidate_head_tree": "7f1961949725f70b1d0da598693d1b71cfc751b2",
+  "candidate_head_commit": "3254e315dead7e20e35ec0fc515289874ac8f47a",
+  "candidate_head_tree": "9931067b1de5f407e07bfec953d79ac25c452bf3",
   "commands": {
     "baseline_archive": "git archive --format=tar --output $BASELINE_ARCHIVE 77c90d6c572ba71bcfaa0362f7ead2cfa5e6712a",
     "baseline_authenticate_commit": "git rev-parse --verify 77c90d6c572ba71bcfaa0362f7ead2cfa5e6712a^{commit}",
@@ -34,7 +34,7 @@
     "repository-migration.json",
     "rust-libtest-darwin-arm64.json"
   ],
-  "generated_at_utc": "2026-07-11T14:07:38.306Z",
+  "generated_at_utc": "2026-07-11T14:26:41.998Z",
   "generator": "docs/development/test-architecture/verify_candidate.py",
   "generator_sha256": "5c6cacbfb3c58483c3c75fb4f8a9b18634353c5a634469d969c115d949b63603",
   "host": {
@@ -57,22 +57,22 @@
   "source": "current working tree",
   "summary": {
     "baseline_cold_linked_test_executable_count": 3,
-    "baseline_cold_wall_time_seconds": 20.071608,
+    "baseline_cold_wall_time_seconds": 29.049799,
     "baseline_integration_test_target_count": 2,
     "baseline_package_target_count": 3,
     "baseline_source_tree": "0ae5df87300c6748161f2035394b6e0b9a92e627",
     "baseline_warm_linked_test_executable_count": 3,
-    "baseline_warm_wall_time_seconds": 0.204112,
+    "baseline_warm_wall_time_seconds": 0.402747,
     "candidate_cold_linked_test_executable_count": 4,
-    "candidate_cold_wall_time_seconds": 24.128268,
+    "candidate_cold_wall_time_seconds": 36.540221,
     "candidate_integration_test_target_count": 3,
     "candidate_package_target_count": 5,
     "candidate_repository_linked_executable_count": 1,
     "candidate_repository_target_count": 1,
     "candidate_warm_linked_test_executable_count": 4,
-    "candidate_warm_wall_time_seconds": 0.209209,
+    "candidate_warm_wall_time_seconds": 0.472429,
     "candidate_workspace_target_count": 22,
-    "cold_wall_time_seconds_delta": 4.05666,
+    "cold_wall_time_seconds_delta": 7.490422,
     "dependency_policy": "pass",
     "integration_test_target_count_delta": 1,
     "linked_test_executable_count_delta": 1,
@@ -86,7 +86,7 @@
     "package_target_count_delta": 2,
     "repository_contract_mismatch_count": 0,
     "repository_test_bijection_count": 67,
-    "warm_wall_time_seconds_delta": 0.005097
+    "warm_wall_time_seconds_delta": 0.069682
   },
   "tool_versions": {
     "cargo": "cargo 1.96.0 (30a34c682 2026-05-25) (Homebrew)",

--- a/docs/development/test-architecture/candidate-issue-477/rust-libtest-darwin-arm64.json
+++ b/docs/development/test-architecture/candidate-issue-477/rust-libtest-darwin-arm64.json
@@ -182,7 +182,7 @@
   },
   "method": "Cargo workspace no-run JSON artifacts followed by direct native libtest list modes; no test body is executed",
   "source": "current working tree",
-  "test_count": 747,
+  "test_count": 751,
   "tests": [
     {
       "executable": "$CARGO_TARGET_DIR/debug/deps/clickhouse_supervision-3219026b059eaaf7",
@@ -2850,6 +2850,16 @@
       "kind": [
         "test"
       ],
+      "name": "support::tests::changed_manifest_oracles_produce_incomparable_artifacts",
+      "package": "moraine-conversations",
+      "target": "analytics_benchmark_support"
+    },
+    {
+      "executable": "$CARGO_TARGET_DIR/debug/deps/analytics_benchmark_support-d103c633017316f0",
+      "ignored": false,
+      "kind": [
+        "test"
+      ],
       "name": "support::tests::cli_requires_explicit_profile_and_output",
       "package": "moraine-conversations",
       "target": "analytics_benchmark_support"
@@ -2881,6 +2891,16 @@
         "test"
       ],
       "name": "support::tests::manifest_missing_an_expected_scenario_fails_closed",
+      "package": "moraine-conversations",
+      "target": "analytics_benchmark_support"
+    },
+    {
+      "executable": "$CARGO_TARGET_DIR/debug/deps/analytics_benchmark_support-d103c633017316f0",
+      "ignored": false,
+      "kind": [
+        "test"
+      ],
+      "name": "support::tests::manifest_oracle_fingerprint_is_deterministic_and_semantics_sensitive",
       "package": "moraine-conversations",
       "target": "analytics_benchmark_support"
     },
@@ -3030,6 +3050,16 @@
       "kind": [
         "test"
       ],
+      "name": "support::tests::changed_manifest_oracles_produce_incomparable_artifacts",
+      "package": "moraine-conversations",
+      "target": "live_clickhouse"
+    },
+    {
+      "executable": "$CARGO_TARGET_DIR/debug/deps/live_clickhouse-ed5c7dcf4e405459",
+      "ignored": false,
+      "kind": [
+        "test"
+      ],
       "name": "support::tests::cli_requires_explicit_profile_and_output",
       "package": "moraine-conversations",
       "target": "live_clickhouse"
@@ -3061,6 +3091,16 @@
         "test"
       ],
       "name": "support::tests::manifest_missing_an_expected_scenario_fails_closed",
+      "package": "moraine-conversations",
+      "target": "live_clickhouse"
+    },
+    {
+      "executable": "$CARGO_TARGET_DIR/debug/deps/live_clickhouse-ed5c7dcf4e405459",
+      "ignored": false,
+      "kind": [
+        "test"
+      ],
+      "name": "support::tests::manifest_oracle_fingerprint_is_deterministic_and_semantics_sensitive",
       "package": "moraine-conversations",
       "target": "live_clickhouse"
     },


### PR DESCRIPTION
## Description

**What.** Refreshes the authenticated native collection and same-host compile evidence after the final benchmark oracle-identity tests landed.

**Why.** Issue #477's evidence must describe the exact final stack; newly collected analytics support tests cannot be represented by stale libtest inventories/checksums.

## Operational impact

Evidence only. No runtime or CI policy change.

## Validation

`python3 docs/development/test-architecture/verify_candidate.py` passed: 22 targets, 67/67 repository mappings, zero mismatches, linked executables 3 -> 4. Same-host baseline cold/warm 29.049799s/0.402747s; candidate 36.540221s/0.472429s. Final analytics support collection is 18; live_clickhouse remains 22 with exactly two ignored. SHA-256: compile evidence `88cb21d6412997d99b7ea496c70a76c47b91dac7e4bcc0033340721a4e4ff70b`; native libtest `ff0ae0464bbd37222fb411de560a3f2a4e0c17f04a2403244757b9e2d971c97d`; repository move map `2c8269ca99f2bd1178c886a0539c5b6f3d1855804ed2daefe885035292099db0`.

Part of #477; predecessor #506.

Post-fix aggregate validation: `cargo test --workspace --locked` passed 755 tests with the two supported live tests ignored; benchmark Python discovery passed 94 tests; `cargo fmt --all -- --check` and `make docs-build` passed.
