### PR TITLE
docs: point agents to canonical testing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,10 @@ Use Rust 2021 idioms and keep code `rustfmt`-clean.
 - For shell scripts, follow existing strict mode (`set -euo pipefail`) and clear error messages.
 
 ## Testing Guidelines
-Run `cargo test --workspace --locked` before opening a PR. CI also runs `scripts/ci/e2e-stack.sh`, so changes affecting ingest, monitor, MCP, or ClickHouse flows should be validated with that script locally when possible. Place tests close to the code they verify (`#[cfg(test)]` modules or crate-level integration tests).
+
+The canonical testing and benchmarking guide is [docs/development/testing.md](docs/development/testing.md). Treat it as the source of truth for suite selection, exact commands, CI tiers and path ownership, prerequisites, and result semantics. Do not duplicate its test matrix here or assume a single Rust or Make command provides repository-wide validation.
+
+Place tests close to the code they verify (`#[cfg(test)]` modules or crate-level integration tests), then run every path-relevant suite required by the canonical guide.
 
 For changes that touch ingest, MCP, monitor, or ClickHouse schema, run them inside a dev sandbox rather than against your host install. The sandbox is isolated from your live `~/.moraine/`; the host stack is not.
 


### PR DESCRIPTION
## Description

**What.** Points the agent contributor instructions to the canonical testing and benchmarking guide.

**Why.** A duplicated command summary in `AGENTS.md` can drift as the repository test matrix evolves.

This change makes `docs/development/testing.md` the explicit source of truth for suite selection, exact commands, CI tiers and path ownership, prerequisites, and result semantics. It directs agents to run every path-relevant suite while retaining the agent-specific test-placement and dev-sandbox safeguards.

## Usage

No user-facing usage change. Contributor agents reading `AGENTS.md` are now directed to `docs/development/testing.md` for current testing requirements.

## Changelog

- Directs contributor agents to the canonical testing and benchmarking documentation.
- Removes a duplicated testing-command summary that could become stale.
- No end-user runtime behavior change.

## Validation

Validated the change with `git diff --check`, confirmed `docs/development/testing.md` exists, and confirmed `CLAUDE.md` still symlinks to `AGENTS.md`. A seven-persona review found no actionable issues. Rust tests and the rendered documentation build were not run because the change affects only repository agent guidance; `AGENTS.md` is not part of the rendered documentation site.