### PR TITLE
fix(monitor): serve retained listeners

### DIFF
--- a/crates/moraine-conversations/tests/live_clickhouse.rs
+++ b/crates/moraine-conversations/tests/live_clickhouse.rs
@@ -540,11 +540,10 @@ async fn start_owned_monitor(
     tokio::task::JoinHandle<Result<()>>,
     std::path::PathBuf,
 )> {
-    let reservation = tokio::net::TcpListener::bind("127.0.0.1:0")
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
-        .context("failed to reserve monitor port")?;
-    let port = reservation.local_addr()?.port();
-    drop(reservation);
+        .context("failed to bind monitor listener")?;
+    let port = listener.local_addr()?.port();
 
     let base = Url::parse(&format!("http://127.0.0.1:{port}/api/v1/"))?;
     let health_url = base.join("health")?;
@@ -566,10 +565,9 @@ async fn start_owned_monitor(
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let server_static_dir = static_dir.clone();
     let server = tokio::spawn(async move {
-        moraine_monitor_core::run_server_with_router(
+        moraine_monitor_core::run_server_with_listener(
             router,
-            "127.0.0.1".to_string(),
-            port,
+            listener,
             server_static_dir,
             async move {
                 let _ = shutdown_rx.await;

--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -85,6 +85,41 @@ where
         }
     })?;
 
+    serve_on_listener(listener, app, bind, static_dir_display, shutdown).await
+}
+
+/// Run the monitor HTTP server on an already-bound listener.
+///
+/// Ownership of the listener transfers to the server and is released after
+/// shutdown completes or startup fails.
+pub async fn run_server_with_listener<S>(
+    backend_router: Arc<BackendRepositoryRouter>,
+    listener: tokio::net::TcpListener,
+    static_dir: PathBuf,
+    shutdown: S,
+) -> Result<()>
+where
+    S: Future<Output = ()> + Send + 'static,
+{
+    let static_dir_display = static_dir.display().to_string();
+    let app = router_with_backend_router(backend_router, static_dir)?;
+    let bind = listener
+        .local_addr()
+        .map_err(|error| anyhow!("failed to read monitor listener address: {error}"))?;
+
+    serve_on_listener(listener, app, bind, static_dir_display, shutdown).await
+}
+
+async fn serve_on_listener<S>(
+    listener: tokio::net::TcpListener,
+    app: Router,
+    bind: SocketAddr,
+    static_dir_display: String,
+    shutdown: S,
+) -> Result<()>
+where
+    S: Future<Output = ()> + Send + 'static,
+{
     println!("moraine-monitor running at http://{bind}");
     println!("serving UI from {static_dir_display}");
 
@@ -2170,6 +2205,107 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn host_port_startup_validates_static_dir_before_binding() {
+        let occupied = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind occupied address");
+        let address = occupied.local_addr().expect("occupied address");
+        let missing_static_dir = temp_path("host-port-validation-order");
+        let (state, _) = fake_state(InMemoryConversationResponses::default());
+
+        let error = run_server_with_router(
+            state.backend_router.clone(),
+            address.ip().to_string(),
+            address.port(),
+            missing_static_dir,
+            std::future::pending(),
+        )
+        .await
+        .expect_err("missing static directory should fail before bind");
+        assert!(error.to_string().contains("is unavailable"));
+        assert!(!error.to_string().contains("address already in use"));
+    }
+
+    #[tokio::test]
+    async fn supplied_listener_is_owned_until_shutdown_then_released() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let address = listener.local_addr().expect("listener address");
+        let static_dir = static_root("listener-ownership", b"<!doctype html>");
+        let (state, _) = fake_state(InMemoryConversationResponses::default());
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let server_static_dir = static_dir.clone();
+        let server = tokio::spawn(run_server_with_listener(
+            state.backend_router.clone(),
+            listener,
+            server_static_dir,
+            async move {
+                let _ = shutdown_rx.await;
+            },
+        ));
+
+        let bind_error = tokio::net::TcpListener::bind(address)
+            .await
+            .expect_err("server must retain exclusive ownership of listener address");
+        assert_eq!(bind_error.kind(), ErrorKind::AddrInUse);
+
+        let mut stream = tokio::net::TcpStream::connect(address)
+            .await
+            .expect("connect to supplied listener");
+        stream
+            .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .await
+            .expect("write monitor request");
+        let mut response = Vec::new();
+        stream
+            .read_to_end(&mut response)
+            .await
+            .expect("read monitor response");
+        assert!(response.starts_with(b"HTTP/1.1 200 OK\r\n"));
+
+        shutdown_tx.send(()).expect("signal shutdown");
+        tokio::time::timeout(std::time::Duration::from_secs(2), server)
+            .await
+            .expect("server shutdown timed out")
+            .expect("server task panicked")
+            .expect("server shutdown failed");
+
+        let rebound = tokio::net::TcpListener::bind(address)
+            .await
+            .expect("listener address should be reusable after shutdown");
+        drop(rebound);
+        let _ = fs::remove_dir_all(static_dir);
+    }
+
+    #[tokio::test]
+    async fn supplied_listener_is_released_when_startup_fails() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let address = listener.local_addr().expect("listener address");
+        let missing_static_dir = temp_path("listener-startup-failure");
+        let (state, _) = fake_state(InMemoryConversationResponses::default());
+
+        let error = run_server_with_listener(
+            state.backend_router.clone(),
+            listener,
+            missing_static_dir,
+            std::future::pending(),
+        )
+        .await
+        .expect_err("missing static directory should fail startup");
+        assert!(error.to_string().contains("is unavailable"));
+
+        let rebound = tokio::net::TcpListener::bind(address)
+            .await
+            .expect("listener address should be reusable after startup failure");
+        drop(rebound);
     }
 
     #[test]


### PR DESCRIPTION
## Description

**What.** Adds a production monitor startup API that serves an already-bound Tokio TCP listener and migrates live monitor parity startup to retain its port-0 listener.

**Why.** The live parity helper previously reserved an ephemeral port, dropped the reservation, and rebound by port number, leaving a race where another process could claim the address.

The existing host/port API preserves its validation and bind diagnostics, then delegates bound-listener serving to the shared implementation. Router construction remains private and no test-only feature is added.

## Usage

Library callers that already own a listener can transfer it directly:

```rust
moraine_monitor_core::run_server_with_listener(
    backend_router,
    listener,
    static_dir,
    shutdown,
).await?;
```

Existing `run_server_with_router(host, port, ...)` callers require no changes.

## Bug Evidence

Before this PR, `start_owned_monitor` bound `127.0.0.1:0`, read the assigned port, dropped that listener, and called the host/port API to bind the same numeric port again. The reserve/drop/rebind interval allowed a competing process to take the port.

After this PR, the original port-0 listener moves into `run_server_with_listener` and then directly into `axum::serve`. The regression test verifies that a concurrent bind fails with `AddrInUse` while the server owns the address, an HTTP request succeeds on the supplied listener, and the same address can be rebound after graceful shutdown. A second test verifies release after startup failure, and a legacy-path test preserves static-directory validation before host/port binding.

## Changelog

- Adds production support for starting the monitor on an already-bound Tokio TCP listener.
- Removes the reserve/drop/rebind race from live ClickHouse monitor parity startup.
- Preserves the existing host/port startup API and behavior.

## Validation

Ran `cargo test -p moraine-monitor-core`: all 23 tests passed, including listener ownership, cleanup, address reuse, HTTP serving, and legacy startup validation ordering.

Ran `cargo test -p moraine-conversations --test live_clickhouse --no-run`: the live parity integration target compiled successfully. The ignored destructive live ClickHouse test was not executed because it requires wrapper-owned live ClickHouse and explicit destructive opt-in.

The required seven-persona review completed. One completeness finding about legacy validation-before-bind ordering was accepted, fixed, regression-tested, and confirmed resolved on follow-up; elegance, idiom, correctness, security, YAGNI, and scope reviews returned no findings.

Closes #497
