### PR TITLE
fix(mcp): flag handled retrieval errors

### DIFF
--- a/crates/moraine-mcp-core/src/file_attention_v1.rs
+++ b/crates/moraine-mcp-core/src/file_attention_v1.rs
@@ -9,7 +9,10 @@
 //! It returns typed `session:` / `event:` IDs that drill down through `open`;
 //! it never reinvents inspection.
 
-use super::{internal_id_error, repo_error_to_contract_error, tool_ok_hybrid, AppState};
+use super::{
+    handled_tool_error_result, internal_id_error, repo_error_to_contract_error,
+    tool_success_result, AppState,
+};
 use crate::contract::{
     format_rfc3339_utc_millis, CanonicalFileAttentionArgs, ContractError, FileAttentionArgs,
     FileAttentionGranularity, FileAttentionScope, McpEventId, McpSessionId, McpTurnId, Performance,
@@ -155,7 +158,7 @@ impl AppState {
                 .with_warnings(warnings),
         )
         .context("failed to encode file_attention response envelope")?;
-        Ok(tool_ok_hybrid(format_text(&payload), payload))
+        Ok(tool_success_result(format_text(&payload), payload))
     }
 }
 
@@ -738,15 +741,10 @@ fn encode_error(request: Value, error: ContractError, performance: Performance) 
         performance,
     ))
     .context("failed to encode file_attention error envelope")?;
-    Ok(error_hybrid(format_error_text(&payload), payload))
-}
-
-fn error_hybrid(text: String, payload: Value) -> Value {
-    json!({
-        "content": [{ "type": "text", "text": text }],
-        "structuredContent": payload,
-        "isError": false
-    })
+    Ok(handled_tool_error_result(
+        format_error_text(&payload),
+        payload,
+    ))
 }
 
 fn format_text(payload: &Value) -> String {
@@ -864,6 +862,29 @@ fn format_error_text(payload: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn deadline_envelope_is_a_handled_tool_error() {
+        let result = encode_error(
+            json!({}),
+            ContractError::new(
+                ToolErrorCode::DeadlineExceeded,
+                "file_attention exceeded its response deadline",
+            ),
+            Performance::builder(FILE_ATTENTION_DEFAULT_SLA_TARGET_MS).finish(),
+        )
+        .expect("deadline response");
+
+        assert_eq!(result["isError"], true);
+        assert_eq!(
+            result["structuredContent"]["schema_version"],
+            crate::contract::ERROR_SCHEMA_VERSION
+        );
+        assert_eq!(
+            result["structuredContent"]["error"]["code"],
+            "deadline_exceeded"
+        );
+    }
 
     fn touch(
         session: &str,

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -108,7 +108,7 @@ impl AppState {
                     Ok(params) => {
                         let tool_result = match self.call_tool(params).await {
                             Ok(value) => value,
-                            Err(err) => tool_error_result(err.to_string()),
+                            Err(err) => unstructured_tool_error_result(err.to_string()),
                         };
                         Some(rpc_ok(msg_id, tool_result))
                     }
@@ -392,7 +392,15 @@ fn rpc_err(id: Value, code: i64, message: &str) -> Value {
     })
 }
 
-fn tool_ok_hybrid(text: String, payload: Value) -> Value {
+pub(crate) fn tool_success_result(text: String, payload: Value) -> Value {
+    structured_tool_result(text, payload, false)
+}
+
+pub(crate) fn handled_tool_error_result(text: String, payload: Value) -> Value {
+    structured_tool_result(text, payload, true)
+}
+
+fn structured_tool_result(text: String, payload: Value, is_error: bool) -> Value {
     json!({
         "content": [
             {
@@ -401,11 +409,11 @@ fn tool_ok_hybrid(text: String, payload: Value) -> Value {
             }
         ],
         "structuredContent": payload,
-        "isError": false
+        "isError": is_error
     })
 }
 
-fn tool_error_result(message: String) -> Value {
+fn unstructured_tool_error_result(message: String) -> Value {
     json!({
         "content": [
             {
@@ -1038,7 +1046,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use moraine_conversations::{InMemoryConversationRepository, RepoConfig};
+    use moraine_conversations::{
+        ConversationMode, InMemoryConversationRepository, InMemoryConversationResponses,
+        McpSessionOpen, RepoConfig, RepoError, SessionMetadata,
+    };
 
     fn repository_with_scope(
         session_scope: Option<SessionOriginScope>,
@@ -1051,6 +1062,105 @@ mod tests {
 
     fn test_state() -> Arc<AppState> {
         AppState::embedded(AppConfig::default(), repository_with_scope(None))
+    }
+
+    fn successful_test_state() -> Arc<AppState> {
+        let session = McpSessionOpen {
+            metadata: SessionMetadata {
+                session_id: "session-success".to_string(),
+                first_event_time: "2026-07-11 12:00:00.000".to_string(),
+                first_event_unix_ms: 1_783_771_200_000,
+                last_event_time: "2026-07-11 12:00:00.000".to_string(),
+                last_event_unix_ms: 1_783_771_200_000,
+                total_turns: 0,
+                total_events: 0,
+                user_messages: 0,
+                assistant_messages: 0,
+                tool_calls: 0,
+                tool_results: 0,
+                mode: ConversationMode::Chat,
+                first_event_uid: "event-first".to_string(),
+                last_event_uid: "event-last".to_string(),
+                last_actor_role: "assistant".to_string(),
+            },
+            title: Some("Successful retrieval".to_string()),
+            source: Some("test".to_string()),
+            harness: None,
+            inference_provider: None,
+            session_slug: None,
+            session_summary: None,
+            turns: Vec::new(),
+            completed: false,
+            terminal_event_uid: None,
+        };
+        let repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            InMemoryConversationResponses {
+                get_mcp_session: Some(Ok(Some(session))),
+                ..InMemoryConversationResponses::default()
+            },
+        ));
+        AppState::embedded(AppConfig::default(), repository)
+    }
+
+    fn repository_error_test_state() -> Arc<AppState> {
+        let repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            InMemoryConversationResponses {
+                get_mcp_session: Some(Err(RepoError::internal("open failed"))),
+                list_mcp_sessions: Some(Err(RepoError::backend("list failed"))),
+                search_mcp_events: Some(Err(RepoError::internal("search failed"))),
+                file_attention: Some(Err(RepoError::backend("attention failed"))),
+                ..InMemoryConversationResponses::default()
+            },
+        ));
+        AppState::embedded(AppConfig::default(), repository)
+    }
+
+    async fn call_tool_rpc(state: &AppState, id: u64, tool: &str, arguments: Value) -> Value {
+        state
+            .handle_request(RpcRequest {
+                id: Some(json!(id)),
+                method: "tools/call".to_string(),
+                params: json!({
+                    "name": tool,
+                    "arguments": arguments,
+                }),
+            })
+            .await
+            .expect("tools/call response")
+    }
+
+    fn assert_successful_tool_exchange(response: &Value, tool: &str) {
+        assert_eq!(response["jsonrpc"], "2.0");
+        assert!(
+            response.get("error").is_none(),
+            "handled tool success must use a JSON-RPC result: {response}"
+        );
+        assert_eq!(response["result"]["isError"], false);
+        assert_ne!(
+            response["result"]["structuredContent"]["schema_version"],
+            contract::ERROR_SCHEMA_VERSION
+        );
+        assert_eq!(response["result"]["structuredContent"]["tool"], tool);
+    }
+
+    fn assert_handled_tool_error_exchange(response: &Value, tool: &str, code: &str) {
+        assert_eq!(response["jsonrpc"], "2.0");
+        assert!(
+            response.get("error").is_none(),
+            "handled tool failure must remain a successful JSON-RPC exchange: {response}"
+        );
+        assert_eq!(response["result"]["isError"], true);
+        assert_eq!(
+            response["result"]["structuredContent"]["schema_version"],
+            contract::ERROR_SCHEMA_VERSION
+        );
+        assert_eq!(response["result"]["structuredContent"]["tool"], tool);
+        assert_eq!(
+            response["result"]["structuredContent"]["error"]["code"],
+            code
+        );
     }
 
     #[tokio::test]
@@ -1224,6 +1334,119 @@ mod tests {
                 "next_cursor"
             ])
         );
+    }
+
+    #[tokio::test]
+    async fn every_retrieval_tool_marks_success_results_as_non_errors() {
+        let state = successful_test_state();
+        let open_id = contract::McpSessionId::from_raw_session_id("session-success")
+            .expect("valid session id")
+            .to_string();
+        let cases = [
+            (
+                contract::SEARCH_SESSIONS_TOOL,
+                json!({ "query": "nothing" }),
+            ),
+            (
+                contract::LIST_SESSIONS_TOOL,
+                json!({
+                    "start_datetime": "2026-07-11T00:00:00Z",
+                    "end_datetime": "2026-07-12T00:00:00Z"
+                }),
+            ),
+            (contract::OPEN_TOOL, json!({ "id": open_id })),
+            (
+                contract::FILE_ATTENTION_TOOL,
+                json!({ "path": "crates/moraine-mcp-core/src/lib.rs" }),
+            ),
+        ];
+
+        for (index, (tool, arguments)) in cases.into_iter().enumerate() {
+            let response = call_tool_rpc(&state, index as u64 + 1, tool, arguments).await;
+            assert_successful_tool_exchange(&response, tool);
+        }
+    }
+
+    #[tokio::test]
+    async fn every_retrieval_tool_marks_invalid_requests_as_handled_errors() {
+        let state = test_state();
+        let cases = [
+            (
+                contract::SEARCH_SESSIONS_TOOL,
+                json!({ "n_hits": 1 }),
+                "invalid_request",
+            ),
+            (
+                contract::LIST_SESSIONS_TOOL,
+                json!({
+                    "start_datetime": "2026-07-12T00:00:00Z",
+                    "end_datetime": "2026-07-11T00:00:00Z"
+                }),
+                "invalid_request",
+            ),
+            (
+                contract::OPEN_TOOL,
+                json!({ "id": "session:not-valid-base64" }),
+                "invalid_id",
+            ),
+            (contract::FILE_ATTENTION_TOOL, json!({}), "invalid_request"),
+        ];
+
+        for (index, (tool, arguments, code)) in cases.into_iter().enumerate() {
+            let response = call_tool_rpc(&state, index as u64 + 1, tool, arguments).await;
+            assert_handled_tool_error_exchange(&response, tool, code);
+        }
+    }
+
+    #[tokio::test]
+    async fn scoped_search_and_open_not_found_are_handled_tool_errors() {
+        let state = test_state();
+        let missing_id = contract::McpSessionId::from_raw_session_id("missing-session")
+            .expect("valid session id")
+            .to_string();
+
+        let open = call_tool_rpc(&state, 1, contract::OPEN_TOOL, json!({ "id": missing_id })).await;
+        assert_handled_tool_error_exchange(&open, contract::OPEN_TOOL, "not_found");
+
+        let search = call_tool_rpc(
+            &state,
+            2,
+            contract::SEARCH_SESSIONS_TOOL,
+            json!({ "query": "nothing", "within_id": missing_id }),
+        )
+        .await;
+        assert_handled_tool_error_exchange(&search, contract::SEARCH_SESSIONS_TOOL, "not_found");
+    }
+
+    #[tokio::test]
+    async fn every_retrieval_tool_marks_repository_failures_as_handled_errors() {
+        let state = repository_error_test_state();
+        let open_id = contract::McpSessionId::from_raw_session_id("session-error")
+            .expect("valid session id")
+            .to_string();
+        let cases = [
+            (
+                contract::SEARCH_SESSIONS_TOOL,
+                json!({ "query": "nothing" }),
+            ),
+            (
+                contract::LIST_SESSIONS_TOOL,
+                json!({
+                    "start_datetime": "2026-07-11T00:00:00Z",
+                    "end_datetime": "2026-07-12T00:00:00Z"
+                }),
+            ),
+            (contract::OPEN_TOOL, json!({ "id": open_id })),
+            (
+                contract::FILE_ATTENTION_TOOL,
+                json!({ "path": "crates/moraine-mcp-core/src/lib.rs" }),
+            ),
+        ];
+
+        for (index, (tool, arguments)) in cases.into_iter().enumerate() {
+            let response = call_tool_rpc(&state, index as u64 + 1, tool, arguments).await;
+            assert_handled_tool_error_exchange(&response, tool, "internal_error");
+        }
     }
 
     #[tokio::test]

--- a/crates/moraine-mcp-core/src/list_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/list_sessions_v1.rs
@@ -1,4 +1,7 @@
-use super::{internal_id_error, repo_error_to_contract_error, tool_ok_hybrid, AppState};
+use super::{
+    handled_tool_error_result, internal_id_error, repo_error_to_contract_error,
+    tool_success_result, AppState,
+};
 use crate::contract::{
     format_rfc3339_utc_millis, CanonicalListSessionsArgs, ContractError, ListSessionsArgs,
     ListSessionsMode, ListSessionsSort, McpSessionId, Performance, ToolEnvelope, ToolErrorCode,
@@ -90,7 +93,10 @@ impl AppState {
             performance,
         ))
         .context("failed to encode list_sessions response envelope")?;
-        Ok(tool_ok_hybrid(format_list_sessions_text(&payload), payload))
+        Ok(tool_success_result(
+            format_list_sessions_text(&payload),
+            payload,
+        ))
     }
 }
 
@@ -225,23 +231,10 @@ fn encode_list_sessions_error(
         performance,
     ))
     .context("failed to encode list_sessions error envelope")?;
-    Ok(tool_error_hybrid(
+    Ok(handled_tool_error_result(
         format_list_sessions_error_text(&payload),
         payload,
     ))
-}
-
-fn tool_error_hybrid(text: String, payload: Value) -> Value {
-    json!({
-        "content": [
-            {
-                "type": "text",
-                "text": text
-            }
-        ],
-        "structuredContent": payload,
-        "isError": false
-    })
 }
 
 fn format_list_sessions_text(payload: &Value) -> String {
@@ -326,6 +319,29 @@ mod tests {
         ConversationMode, InMemoryConversationRepository, InMemoryConversationResponses, RepoConfig,
     };
     use std::sync::Arc;
+
+    #[test]
+    fn deadline_envelope_is_a_handled_tool_error() {
+        let result = encode_list_sessions_error(
+            json!({}),
+            ContractError::new(
+                ToolErrorCode::DeadlineExceeded,
+                "list_sessions exceeded its response deadline",
+            ),
+            Performance::builder(LIST_SESSIONS_DEFAULT_SLA_TARGET_MS).finish(),
+        )
+        .expect("deadline response");
+
+        assert_eq!(result["isError"], true);
+        assert_eq!(
+            result["structuredContent"]["schema_version"],
+            crate::contract::ERROR_SCHEMA_VERSION
+        );
+        assert_eq!(
+            result["structuredContent"]["error"]["code"],
+            "deadline_exceeded"
+        );
+    }
 
     #[test]
     fn parses_and_canonicalizes_list_sessions_args() {

--- a/crates/moraine-mcp-core/src/open_v1.rs
+++ b/crates/moraine-mcp-core/src/open_v1.rs
@@ -2,7 +2,7 @@ use crate::contract::{
     ContractError, McpEntityKind, McpEventId, McpId, McpSessionId, McpTurnId, OpenV1Args,
     Performance, ToolEnvelope, ToolError, ToolErrorCode, ToolErrorEnvelope, OPEN_TOOL,
 };
-use crate::AppState;
+use crate::{handled_tool_error_result, tool_success_result, AppState};
 use anyhow::{Context, Result};
 use moraine_conversations::{
     McpEventOpen, McpEventRef, McpEventSummary, McpSessionOpen, McpTurnCompact, McpTurnOpen,
@@ -161,7 +161,7 @@ fn success_tool_response(
     let envelope =
         ToolEnvelope::success(OPEN_TOOL, request, data, performance).with_warnings(warnings);
     let payload = serde_json::to_value(envelope).context("failed to encode open envelope")?;
-    Ok(tool_result(open_result_text(&payload), payload, false))
+    Ok(tool_success_result(open_result_text(&payload), payload))
 }
 
 fn contract_error_tool_response(
@@ -250,20 +250,10 @@ fn error_tool_response(
     let performance = Performance::from_elapsed(started_at.elapsed(), sla_target_ms);
     let envelope = ToolErrorEnvelope::error(OPEN_TOOL, request, error, performance);
     let payload = serde_json::to_value(envelope).context("failed to encode open error envelope")?;
-    Ok(tool_result(open_result_text(&payload), payload, false))
-}
-
-fn tool_result(text: String, payload: Value, is_error: bool) -> Value {
-    json!({
-        "content": [
-            {
-                "type": "text",
-                "text": text
-            }
-        ],
-        "structuredContent": payload,
-        "isError": is_error
-    })
+    Ok(handled_tool_error_result(
+        open_result_text(&payload),
+        payload,
+    ))
 }
 
 fn open_result_text(payload: &Value) -> String {
@@ -960,7 +950,7 @@ mod tests {
         )
         .expect("error response");
 
-        assert_eq!(result["isError"], false);
+        assert_eq!(result["isError"], true);
         assert_eq!(
             result["structuredContent"]["schema_version"],
             "moraine.mcp.error.v1"

--- a/crates/moraine-mcp-core/src/search_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/search_sessions_v1.rs
@@ -1,4 +1,7 @@
-use super::{internal_id_error, repo_error_to_contract_error, tool_ok_hybrid, AppState};
+use super::{
+    handled_tool_error_result, internal_id_error, repo_error_to_contract_error,
+    tool_success_result, AppState,
+};
 use crate::contract::{
     format_rfc3339_utc_millis, CanonicalSearchSessionsArgs, ContractError, McpEventId, McpId,
     McpSessionId, McpTurnId, Performance, PerformanceBuilder, SearchSessionsArgs, ToolEnvelope,
@@ -77,7 +80,7 @@ impl AppState {
                 .with_warnings(warnings),
         )
         .context("failed to encode search_sessions response envelope")?;
-        Ok(tool_ok_hybrid(
+        Ok(tool_success_result(
             format_search_sessions_text(&payload),
             payload,
         ))
@@ -425,23 +428,10 @@ fn encode_search_sessions_error(
         performance,
     ))
     .context("failed to encode search_sessions error envelope")?;
-    Ok(tool_error_hybrid(
+    Ok(handled_tool_error_result(
         format_search_sessions_error_text(&payload),
         payload,
     ))
-}
-
-fn tool_error_hybrid(text: String, payload: Value) -> Value {
-    json!({
-        "content": [
-            {
-                "type": "text",
-                "text": text
-            }
-        ],
-        "structuredContent": payload,
-        "isError": false
-    })
 }
 
 fn format_search_sessions_text(payload: &Value) -> String {

--- a/scripts/ci/mcp_smoke.py
+++ b/scripts/ci/mcp_smoke.py
@@ -71,8 +71,8 @@ def assert_rpc_ok(response: Dict[str, Any], expected_id: int) -> Dict[str, Any]:
 
 
 def assert_tool_success(result: Dict[str, Any]) -> Dict[str, Any]:
-    if result.get("isError"):
-        raise AssertionError(f"tool call returned isError=true: {result}")
+    if result.get("isError") is not False:
+        raise AssertionError(f"tool call did not return isError=false: {result}")
     return result
 
 
@@ -95,6 +95,48 @@ def call_tool(
         },
     )
     return assert_tool_success(assert_rpc_ok(response, expected_id))
+
+
+def call_tool_expect_handled_error(
+    proc: subprocess.Popen[str],
+    expected_id: int,
+    name: str,
+    arguments: Dict[str, Any],
+    expected_code: str,
+) -> Dict[str, Any]:
+    response = send_request(
+        proc,
+        {
+            "jsonrpc": "2.0",
+            "id": expected_id,
+            "method": "tools/call",
+            "params": {
+                "name": name,
+                "arguments": arguments,
+            },
+        },
+    )
+    result = assert_rpc_ok(response, expected_id)
+    if result.get("isError") is not True:
+        raise AssertionError(f"{name} handled error must return isError=true: {result}")
+    payload = result.get("structuredContent")
+    if not isinstance(payload, dict):
+        raise AssertionError(f"{name} handled error structuredContent missing: {result}")
+    if payload.get("schema_version") != "moraine.mcp.error.v1":
+        raise AssertionError(
+            f"{name} handled error has wrong schema_version: "
+            f"{payload.get('schema_version')}"
+        )
+    if payload.get("tool") != name:
+        raise AssertionError(
+            f"{name} handled error has wrong tool: {payload.get('tool')}"
+        )
+    error = payload.get("error")
+    if not isinstance(error, dict) or error.get("code") != expected_code:
+        raise AssertionError(
+            f"{name} handled error must return {expected_code}, got: {error}"
+        )
+    return payload
 
 
 def assert_structured_content(result: Dict[str, Any], tool_name: str) -> Dict[str, Any]:
@@ -414,18 +456,10 @@ def assert_open_not_found(
 ) -> int:
     open_id = expected_mcp_session_id(raw_session_id)
     assert open_id is not None
-    open_result = call_tool(proc, next_id, "open", {"id": open_id})
-    next_id += 1
-    payload = open_result.get("structuredContent")
-    if not isinstance(payload, dict):
-        raise AssertionError(f"open structuredContent missing: {open_result}")
-    error_code = nested_string(payload, "error", "code")
-    if error_code != "not_found":
-        raise AssertionError(
-            f"open of out-of-scope session {raw_session_id} must return not_found, "
-            f"got: {payload.get('error') or payload.get('data')}"
-        )
-    return next_id
+    call_tool_expect_handled_error(
+        proc, next_id, "open", {"id": open_id}, "not_found"
+    )
+    return next_id + 1
 
 
 def run_smoke(

--- a/scripts/ci/test_mcp_smoke.py
+++ b/scripts/ci/test_mcp_smoke.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import mcp_smoke
+
+
+def handled_error_response() -> dict[str, object]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "result": {
+            "content": [{"type": "text", "text": "not found"}],
+            "structuredContent": {
+                "schema_version": "moraine.mcp.error.v1",
+                "tool": "open",
+                "request": {"id": "session:missing"},
+                "error": {"code": "not_found", "message": "not found"},
+            },
+            "isError": True,
+        },
+    }
+
+
+class ToolResultAssertionTests(unittest.TestCase):
+    def test_success_requires_explicit_false_error_flag(self) -> None:
+        result = {"isError": False, "structuredContent": {}}
+        self.assertIs(mcp_smoke.assert_tool_success(result), result)
+
+        for invalid in ({"isError": True}, {}, {"isError": None}):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(AssertionError):
+                    mcp_smoke.assert_tool_success(invalid)
+
+    def test_expected_handled_error_validates_response_and_contract(self) -> None:
+        response = handled_error_response()
+        with mock.patch.object(mcp_smoke, "send_request", return_value=response) as send:
+            payload = mcp_smoke.call_tool_expect_handled_error(
+                object(), 7, "open", {"id": "session:missing"}, "not_found"
+            )
+
+        self.assertEqual(payload["error"]["code"], "not_found")
+        sent = send.call_args.args[1]
+        self.assertEqual(sent["jsonrpc"], "2.0")
+        self.assertEqual(sent["id"], 7)
+        self.assertEqual(sent["method"], "tools/call")
+        self.assertEqual(sent["params"]["name"], "open")
+
+    def test_expected_handled_error_rejects_json_rpc_error(self) -> None:
+        response = {"jsonrpc": "2.0", "id": 7, "error": {"code": -32603}}
+        with mock.patch.object(mcp_smoke, "send_request", return_value=response):
+            with self.assertRaisesRegex(AssertionError, "rpc error"):
+                mcp_smoke.call_tool_expect_handled_error(
+                    object(), 7, "open", {"id": "session:missing"}, "not_found"
+                )
+
+    def test_expected_handled_error_rejects_contract_mismatches(self) -> None:
+        cases = (
+            ("isError", False, "isError=true"),
+            ("schema_version", "moraine.mcp.open.v1", "schema_version"),
+            ("tool", "search_sessions", "wrong tool"),
+            ("code", "invalid_id", "must return not_found"),
+        )
+        for field, value, message in cases:
+            with self.subTest(field=field):
+                response = handled_error_response()
+                result = response["result"]
+                assert isinstance(result, dict)
+                structured = result["structuredContent"]
+                assert isinstance(structured, dict)
+                if field == "isError":
+                    result[field] = value
+                elif field == "code":
+                    error = structured["error"]
+                    assert isinstance(error, dict)
+                    error[field] = value
+                else:
+                    structured[field] = value
+
+                with mock.patch.object(mcp_smoke, "send_request", return_value=response):
+                    with self.assertRaisesRegex(AssertionError, message):
+                        mcp_smoke.call_tool_expect_handled_error(
+                            object(),
+                            7,
+                            "open",
+                            {"id": "session:missing"},
+                            "not_found",
+                        )
+
+    def test_expected_handled_error_rejects_missing_envelope_objects(self) -> None:
+        for field, value, message in (
+            ("structuredContent", None, "structuredContent missing"),
+            ("error", None, "must return not_found"),
+        ):
+            with self.subTest(field=field):
+                response = handled_error_response()
+                result = response["result"]
+                assert isinstance(result, dict)
+                if field == "structuredContent":
+                    result[field] = value
+                else:
+                    structured = result["structuredContent"]
+                    assert isinstance(structured, dict)
+                    structured[field] = value
+
+                with mock.patch.object(mcp_smoke, "send_request", return_value=response):
+                    with self.assertRaisesRegex(AssertionError, message):
+                        mcp_smoke.call_tool_expect_handled_error(
+                            object(),
+                            7,
+                            "open",
+                            {"id": "session:missing"},
+                            "not_found",
+                        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

**What.** Centralizes structured MCP tool-result construction and marks every handled retrieval error with `isError: true`.

**Why.** The four retrieval tools returned `moraine.mcp.error.v1` payloads with `isError: false`, forcing generic MCP clients to inspect Moraine-specific structured content to detect failures.

The shared MCP core now exposes intent-specific constructors for successful and handled-error structured tool results. `search_sessions`, `list_sessions`, `open`, and `file_attention` all use those constructors, and their duplicated local response builders are removed. Error envelopes, error codes, and JSON-RPC transport behavior are unchanged.

The raw MCP CI harness now has a narrow expected-handled-error call path. Named-backend/project-scope not-found checks use it to require `isError: true`, `moraine.mcp.error.v1`, tool `open`, and code `not_found`; ordinary calls still require an explicit `isError: false`.

## Usage

No user-facing invocation changes. MCP clients can now rely on the standard result flag: successful retrieval results have `isError: false`, while handled retrieval failures have `isError: true` and still retain the existing structured error envelope.

## Bug Evidence

Before this change, an invalid typed ID produced a contradictory result:

```json
{
  "structuredContent": {
    "schema_version": "moraine.mcp.error.v1",
    "tool": "open",
    "error": { "code": "invalid_id" }
  },
  "isError": false
}
```

The root cause was duplicated search/list/open/file-attention result constructors that explicitly set handled error responses to false. After this change, dispatch-level regression tests invoke all four tools and enforce both directions of the contract:

```text
success schema  -> isError: false
error.v1 schema -> isError: true
```

The same tests verify that handled invalid arguments/IDs, not-found cases, and repository/internal failures remain successful JSON-RPC exchanges under `result`. Focused deadline-envelope tests cover the timeout-capable `list_sessions` and `file_attention` paths.

The first functional CI run exposed a harness regression at the named-backend exclusion check: `assert_open_not_found` routed the expected `not_found` result through the generic success assertion, which correctly rejected `isError: true`. The repaired harness validates the handled-error contract explicitly without weakening success assertions.

## Changelog

- Corrects MCP handled retrieval failures to set `isError: true`.
- Preserves existing error envelope fields, codes, and JSON-RPC success-response semantics.
- Updates the functional MCP smoke harness to distinguish expected handled errors from ordinary successful tool calls.

## Validation

Ran `cargo test -p moraine-mcp-core` after formatting; all 79 tests passed across 2 suites. The focused Rust coverage includes success and invalid-request results for all four retrieval tools, open/search not-found responses, repository/internal failures for every retrieval tool, and list/file-attention deadline envelopes.

Ran `python3 -m unittest -v scripts/ci/test_mcp_smoke.py`; all 5 focused harness tests passed. They cover strict success flags, successful JSON-RPC transport for handled errors, required handled-error schema/tool/code fields, and malformed-envelope rejection. A local `scripts/ci/e2e-stack.sh` run was not completed because this worktree did not contain the required prebuilt `target/debug/moraine`; the pushed `pr-fast-linux` rerun is the authoritative full-stack validation.

The required seven-persona review wave (elegance, idiomatic Rust/Python, correctness, completeness, security, YAGNI, and scope) completed with no unresolved findings.

Closes #482
