### PR TITLE
fix(mcp): enforce canonical file-attention scope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,6 +1178,7 @@ dependencies = [
  "anyhow",
  "glob",
  "serde",
+ "sha2",
  "toml",
 ]
 

--- a/bindings/python/moraine_conversations/Cargo.lock
+++ b/bindings/python/moraine_conversations/Cargo.lock
@@ -66,6 +66,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,8 +115,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -117,6 +135,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -182,6 +220,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -553,6 +601,7 @@ dependencies = [
  "anyhow",
  "glob",
  "serde",
+ "sha2",
  "toml",
 ]
 
@@ -995,6 +1044,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1334,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -780,6 +780,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             name: "025_kimi_subagent_parent_links.sql",
             sql: include_str!("../../../sql/025_kimi_subagent_parent_links.sql"),
         },
+        Migration {
+            version: "026",
+            name: "026_file_attention_project_roots.sql",
+            sql: include_str!("../../../sql/026_file_attention_project_roots.sql"),
+        },
     ]
 }
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -8,4 +8,5 @@ description = "Shared Moraine configuration schema and loaders"
 anyhow = "1.0"
 glob = "0.3"
 serde = { version = "1.0", features = ["derive"] }
+sha2 = "0.10"
 toml = "0.8"

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -1,7 +1,12 @@
 use anyhow::{Context, Result};
 use serde::{de::DeserializeOwned, Deserialize};
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fmt;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(windows)]
+use std::os::windows::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 
 pub const KNOWN_INGEST_HARNESSES: &[&str] = &[
@@ -1397,6 +1402,108 @@ fn parse_repo_backend_ref(path: &Path) -> Option<String> {
     }
 }
 
+/// Stable, opaque identity for one Git repository and all of its linked
+/// worktrees. The repo backend marker is required, but its backend routing name
+/// is deliberately not the identity because multiple projects may share one
+/// backend.
+pub fn project_id_for_repo_root(root: impl AsRef<Path>) -> Option<String> {
+    let root = root.as_ref();
+    find_repo_backend_ref(root)?;
+    let common_dir = git_common_dir(root)?;
+    Some(project_id_for_common_dir(&common_dir))
+}
+
+fn project_id_for_common_dir(common_dir: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"moraine-git-common-dir\0");
+    #[cfg(unix)]
+    hasher.update(common_dir.as_os_str().as_bytes());
+    #[cfg(windows)]
+    for unit in common_dir.as_os_str().encode_wide() {
+        hasher.update(unit.to_le_bytes());
+    }
+    #[cfg(not(any(unix, windows)))]
+    hasher.update(common_dir.to_string_lossy().as_bytes());
+    format!("git:{:x}", hasher.finalize())
+}
+
+/// UTF-8 worktree roots currently registered under this repository's canonical
+/// Git common directory. These roots support a safe transition for normalized
+/// rows written before `project_id` became the common-directory digest.
+pub fn worktree_roots_for_repo_root(root: impl AsRef<Path>) -> Option<Vec<String>> {
+    let root = root.as_ref();
+    find_repo_backend_ref(root)?;
+    let common_dir = git_common_dir(root)?;
+    let mut roots = vec![root.to_path_buf()];
+
+    if common_dir.file_name().is_some_and(|name| name == ".git") {
+        if let Some(main_root) = common_dir.parent() {
+            roots.push(main_root.to_path_buf());
+        }
+    }
+
+    if let Ok(entries) = std::fs::read_dir(common_dir.join("worktrees")) {
+        for entry in entries.flatten() {
+            let gitdir_file = entry.path().join("gitdir");
+            let Ok(content) = std::fs::read_to_string(&gitdir_file) else {
+                continue;
+            };
+            let git_marker = Path::new(content.trim());
+            let git_marker = if git_marker.is_absolute() {
+                git_marker.to_path_buf()
+            } else {
+                entry.path().join(git_marker)
+            };
+            if let Some(worktree_root) = git_marker.parent() {
+                roots.push(worktree_root.to_path_buf());
+            }
+        }
+    }
+
+    roots.extend(
+        roots
+            .iter()
+            .filter_map(|root| root.canonicalize().ok())
+            .collect::<Vec<_>>(),
+    );
+    let mut roots = roots
+        .into_iter()
+        .filter_map(|root| root.to_str().map(str::to_owned))
+        .collect::<Vec<_>>();
+    roots.sort();
+    roots.dedup();
+    Some(roots)
+}
+
+fn git_common_dir(root: &Path) -> Option<PathBuf> {
+    let marker = root.join(".git");
+    let git_dir = if marker.is_dir() {
+        marker
+    } else {
+        let content = std::fs::read_to_string(marker).ok()?;
+        let path = content.trim().strip_prefix("gitdir:")?.trim();
+        let path = Path::new(path);
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            root.join(path)
+        }
+    };
+    let common_dir_file = git_dir.join("commondir");
+    let common_dir = if common_dir_file.is_file() {
+        let content = std::fs::read_to_string(common_dir_file).ok()?;
+        let path = Path::new(content.trim());
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            git_dir.join(path)
+        }
+    } else {
+        git_dir
+    };
+    common_dir.canonicalize().ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1419,6 +1526,73 @@ mod tests {
         let cfg = load_config(&path).expect("backend launch config should load");
         std::fs::remove_file(&path).ok();
         assert_eq!(cfg.backend.start_on_up, expected, "case `{label}`");
+    }
+
+    #[test]
+    fn project_id_unifies_linked_worktrees_but_not_other_repositories() {
+        let base = std::env::temp_dir().join(format!(
+            "moraine-project-id-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time after unix epoch")
+                .as_nanos()
+        ));
+        let main = base.join("main");
+        let linked = base.join("linked");
+        let other = base.join("other");
+        let linked_git_dir = main.join(".git/worktrees/linked");
+        std::fs::create_dir_all(&linked_git_dir).expect("create main git dirs");
+        std::fs::create_dir_all(&linked).expect("create linked worktree");
+        std::fs::create_dir_all(other.join(".git")).expect("create other git dir");
+        for root in [&main, &linked, &other] {
+            std::fs::write(root.join(REPO_BACKEND_FILE), "backend = \"shared\"\n")
+                .expect("write repo backend marker");
+        }
+        std::fs::write(linked_git_dir.join("commondir"), "../..\n")
+            .expect("write common-dir pointer");
+        std::fs::write(
+            linked_git_dir.join("gitdir"),
+            format!("{}\n", linked.join(".git").to_string_lossy()),
+        )
+        .expect("write linked worktree pointer");
+        std::fs::write(
+            linked.join(".git"),
+            format!("gitdir: {}\n", linked_git_dir.to_string_lossy()),
+        )
+        .expect("write linked git pointer");
+
+        let main_id = project_id_for_repo_root(&main).expect("main project id");
+        let linked_id = project_id_for_repo_root(&linked).expect("linked project id");
+        let other_id = project_id_for_repo_root(&other).expect("other project id");
+        assert!(main_id.starts_with("git:"));
+        assert_eq!(main_id, linked_id);
+        assert_ne!(main_id, other_id);
+        let main_roots =
+            worktree_roots_for_repo_root(&main).expect("main registered worktree roots");
+        let linked_roots =
+            worktree_roots_for_repo_root(&linked).expect("linked registered worktree roots");
+        let canonical_main = main.canonicalize().expect("canonical main");
+        let canonical_linked = linked.canonicalize().expect("canonical linked");
+        for roots in [&main_roots, &linked_roots] {
+            assert!(roots.contains(&canonical_main.to_string_lossy().to_string()));
+            assert!(roots.contains(&canonical_linked.to_string_lossy().to_string()));
+        }
+
+        std::fs::remove_dir_all(base).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn project_id_hashes_non_utf8_paths_losslessly() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let first = PathBuf::from(std::ffi::OsString::from_vec(b"/repo-\x80/.git".to_vec()));
+        let second = PathBuf::from(std::ffi::OsString::from_vec(b"/repo-\x81/.git".to_vec()));
+        assert_ne!(
+            project_id_for_common_dir(&first),
+            project_id_for_common_dir(&second)
+        );
     }
 
     #[test]

--- a/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
@@ -29,26 +29,59 @@ impl ClickHouseConversationRepository {
             ));
         }
 
-        let mut touches = Vec::<FileAttentionTouch>::new();
-        if !query.apply_project_scope
-            || query
+        if query.apply_project_scope
+            && query
                 .normalized_project_id
                 .as_deref()
-                .is_some_and(|project_id| !project_id.is_empty())
+                .is_none_or(str::is_empty)
         {
-            match self.file_attention_exact_impl(&query).await {
-                Ok(rows) => touches.extend(rows),
+            return Ok(Vec::new());
+        }
+
+        let mut touches = Vec::<FileAttentionTouch>::new();
+        let normalized_schema_available = match self.file_attention_exact_impl(&query).await {
+            Ok(rows) => {
+                touches.extend(rows);
+                true
+            }
+            Err(RepoError::Backend(message)) if is_file_attention_schema_skew(&message) => {
+                warn!(
+                    error = %message,
+                    "file_attention normalized lookup unavailable; using Tier-0 suffix scan where its scope can be proven"
+                );
+                false
+            }
+            Err(error) => return Err(error),
+        };
+        let project_root_mapping_available = if query.apply_project_scope
+            && normalized_schema_available
+        {
+            match self.record_file_attention_project_roots(&query).await {
+                Ok(()) => true,
                 Err(RepoError::Backend(message)) if is_file_attention_schema_skew(&message) => {
                     warn!(
                         error = %message,
-                        "file_attention normalized lookup unavailable; falling back to Tier-0 suffix scan"
+                        "file_attention durable project-root mapping unavailable; using registered roots for this request"
                     );
+                    false
                 }
                 Err(error) => return Err(error),
             }
-        }
+        } else {
+            false
+        };
 
-        touches.extend(self.file_attention_suffix_impl(&query).await?);
+        if query.apply_project_scope && !normalized_schema_available {
+            return Ok(touches);
+        }
+        touches.extend(
+            self.file_attention_suffix_impl(
+                &query,
+                normalized_schema_available,
+                project_root_mapping_available,
+            )
+            .await?,
+        );
         Ok(merge_file_attention_touches(
             touches,
             query.max_rows.saturating_add(1),
@@ -92,10 +125,8 @@ impl ClickHouseConversationRepository {
                 "lowerUTF8(tool_name) NOT IN ({FILE_ATTENTION_READ_TOOL_NAMES_SQL})"
             ));
         }
-        if query.apply_project_scope {
-            if let Some(scope_clause) = self.session_scope_clause("session_id") {
-                inner_clauses.push(scope_clause);
-            }
+        if let Some(scope_clause) = self.session_scope_clause("session_id") {
+            inner_clauses.push(scope_clause);
         }
         let match_predicate = inner_clauses.join("\n      AND ");
 
@@ -120,6 +151,8 @@ impl ClickHouseConversationRepository {
             ("join_use_nulls", "1"),
         ];
 
+        let normalized_root_condition = single_path_sql("ti.worktree_root");
+
         let sql = format!(
             "WITH matched AS (
     SELECT session_id, event_uid, tool_call_id, harness, tool_name, tool_phase, input_preview, output_preview, repo_rel_path, worktree_root
@@ -133,9 +166,9 @@ impl ClickHouseConversationRepository {
     ti.harness AS harness,
     ti.tool_name AS tool_name,
     ti.tool_phase AS tool_phase,
-    if(ti.worktree_root != '', concat(ti.worktree_root, '/', ti.repo_rel_path), ti.repo_rel_path) AS matched_path,
+    if({normalized_root_condition}, concat(ti.worktree_root, '/', ti.repo_rel_path), ti.repo_rel_path) AS matched_path,
     'path_suffix' AS match_kind,
-    ti.worktree_root AS worktree_root,
+    if({normalized_root_condition}, ti.worktree_root, '') AS worktree_root,
     ifNull(e.cwd, '') AS cwd,
     toInt64(toUnixTimestamp64Milli(tr.event_time)) AS event_unix_ms,
     toUInt64(ifNull(tr.event_order, toUInt64(0))) AS event_order,
@@ -163,9 +196,47 @@ impl ClickHouseConversationRepository {
         self.map_backend(self.query_rows_with_params(&sql, None, &params).await)
     }
 
+    async fn record_file_attention_project_roots(
+        &self,
+        query: &FileAttentionQuery,
+    ) -> RepoResult<()> {
+        let Some(project_id) = query
+            .normalized_project_id
+            .as_deref()
+            .filter(|project_id| !project_id.is_empty())
+        else {
+            return Ok(());
+        };
+        if query.normalized_project_roots.is_empty() {
+            return Ok(());
+        }
+
+        let roots = query
+            .normalized_project_roots
+            .iter()
+            .filter(|root| !root.is_empty())
+            .map(|root| sql_quote(root))
+            .collect::<Vec<_>>()
+            .join(", ");
+        if roots.is_empty() {
+            return Ok(());
+        }
+
+        let mappings = self.table_ref("file_attention_project_roots");
+        let sql = format!(
+            "INSERT INTO {mappings} (project_id, worktree_root, observed_version)
+SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
+            sql_quote(project_id)
+        );
+        self.map_backend(self.ch.request_text(&sql, None, None, false, None).await)
+            .map(|_| ())
+    }
+
     async fn file_attention_suffix_impl(
         &self,
         query: &FileAttentionQuery,
+        normalized_schema_available: bool,
+        project_root_mapping_available: bool,
     ) -> RepoResult<Vec<FileAttentionTouch>> {
         let rel = query.rel.as_str();
 
@@ -176,7 +247,6 @@ impl ClickHouseConversationRepository {
         let slash_rel_sql = sql_quote(&format!("/{rel}"));
         let rel_regex = regex::escape(rel);
         let slash_rel_regex = regex::escape(&format!("/{rel}"));
-        let rel_len = rel.len();
 
         const PATH_KEYS: [&str; 9] = [
             "file_path",
@@ -223,6 +293,15 @@ impl ClickHouseConversationRepository {
             "((JSONHas(input_json, 'command') OR JSONHas(input_json, 'cmd')) AND match({command_expr}, {shell_path_regex}))"
         );
 
+        let matched_path_is_single = single_path_sql("matched_path");
+        let normalized_root_is_single = single_path_sql("ti.worktree_root");
+        let event_root_expression = if normalized_schema_available {
+            "ifNull(e.worktree_root, '')"
+        } else {
+            "ifNull(e.cwd, '')"
+        };
+        let event_root_is_single = single_path_sql(event_root_expression);
+
         let mut inner_clauses = vec![format!(
             "tool_phase = 'request'\n      AND NOT (lowerUTF8(tool_name) = 'file_attention' OR endsWith(lowerUTF8(tool_name), '_file_attention'))\n      AND (\n        {ends_with_any}\n        OR {nested_path_match}\n        OR {shell_match}\n      )"
         )];
@@ -234,10 +313,8 @@ impl ClickHouseConversationRepository {
                 "lowerUTF8(tool_name) NOT IN ({FILE_ATTENTION_READ_TOOL_NAMES_SQL})"
             ));
         }
-        if query.apply_project_scope {
-            if let Some(scope_clause) = self.session_scope_clause("session_id") {
-                inner_clauses.push(scope_clause);
-            }
+        if let Some(scope_clause) = self.session_scope_clause("session_id") {
+            inner_clauses.push(scope_clause);
         }
         let match_predicate = inner_clauses.join("\n      AND ");
 
@@ -254,27 +331,32 @@ impl ClickHouseConversationRepository {
         let matched_path_expr =
             format!("multiIf(\n      {matched_path_arms},\n      {nested_path_expr})");
 
-        let exact_relative_root_condition = if rel.starts_with('/') {
+        let verified_event_root_condition = if rel.starts_with('/') {
             "0".to_string()
         } else {
-            format!("matched_path = {rel_sql} AND ifNull(e.cwd, '') != ''")
-        };
-
-        let worktree_root_expr = if query.derive_worktree_roots {
             format!(
-                "multiIf(
-      matched_path != ''
-      AND length(matched_path) > {rel_len} + 1
-      AND substring(matched_path, length(matched_path) - {rel_len}, 1) = '/',
-      substring(matched_path, 1, length(matched_path) - {rel_len} - 1),
-      {exact_relative_root_condition},
-      ifNull(e.cwd, ''),
-      ''
-    )"
+                "{matched_path_is_single}
+      AND {event_root_is_single}
+      AND (matched_path = {rel_sql} OR matched_path = concat({event_root_expression}, '/', {rel_sql}))"
+            )
+        };
+        let normalized_root_condition = if normalized_schema_available {
+            format!(
+                "ti.project_id != '' AND ti.repo_rel_path = {rel_sql} AND {normalized_root_is_single}"
             )
         } else {
-            format!("if({exact_relative_root_condition}, ifNull(e.cwd, ''), '')")
+            "0".to_string()
         };
+
+        let worktree_root_expr = format!(
+            "multiIf(
+      {normalized_root_condition},
+      ti.worktree_root,
+      {verified_event_root_condition},
+      {event_root_expression},
+      ''
+    )"
+        );
 
         let mut outer_clauses: Vec<String> = Vec::new();
         if let Some(start) = query.start_unix_ms {
@@ -283,6 +365,51 @@ impl ClickHouseConversationRepository {
         if let Some(end) = query.end_unix_ms {
             outer_clauses.push(format!("toUnixTimestamp64Milli(tr.event_time) < {end}"));
         }
+        if query.apply_project_scope {
+            let project_id = query
+                .normalized_project_id
+                .as_deref()
+                .expect("project scope identity checked before querying");
+            let project_id_sql = sql_quote(project_id);
+            let legacy_roots_sql = query
+                .normalized_project_roots
+                .iter()
+                .filter(|root| !root.is_empty())
+                .map(|root| sql_quote(root))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let durable_roots = self.table_ref("file_attention_project_roots");
+            let root_membership = |expression: &str| {
+                let mut predicates = Vec::with_capacity(2);
+                if !legacy_roots_sql.is_empty() {
+                    predicates.push(format!("{expression} IN ({legacy_roots_sql})"));
+                }
+                if project_root_mapping_available {
+                    predicates.push(format!(
+                        "{expression} IN (SELECT worktree_root FROM {durable_roots} FINAL WHERE project_id = {project_id_sql})"
+                    ));
+                }
+                if predicates.is_empty() {
+                    "0".to_string()
+                } else {
+                    format!("({})", predicates.join(" OR "))
+                }
+            };
+            let legacy_tool_scope = format!(
+                "(ti.project_id != '' AND NOT startsWith(ti.project_id, 'git:') AND {normalized_root_is_single} AND {})",
+                root_membership("ti.worktree_root")
+            );
+            let legacy_event_scope = format!(
+                "(e.project_id != '' AND NOT startsWith(e.project_id, 'git:') AND {event_root_is_single} AND {})",
+                root_membership(event_root_expression)
+            );
+            outer_clauses.push(format!(
+                "(ti.project_id = {project_id_sql}
+      OR {legacy_tool_scope}
+      OR (ti.project_id = '' AND (e.project_id = {project_id_sql} OR {legacy_event_scope}) AND {verified_event_root_condition}))"
+            ));
+        }
+
         let outer_where = if outer_clauses.is_empty() {
             "1".to_string()
         } else {
@@ -297,9 +424,20 @@ impl ClickHouseConversationRepository {
             ("join_use_nulls", "1"),
         ];
 
+        let normalized_tool_columns = if normalized_schema_available {
+            ", project_id, repo_rel_path, worktree_root"
+        } else {
+            ""
+        };
+        let normalized_event_columns = if normalized_schema_available {
+            ", any(project_id) AS project_id, any(worktree_root) AS worktree_root"
+        } else {
+            ""
+        };
+
         let sql = format!(
             "WITH matched AS (
-    SELECT session_id, event_uid, tool_call_id, harness, tool_name, tool_phase, input_json, input_preview, output_preview
+    SELECT session_id, event_uid, tool_call_id, harness, tool_name, tool_phase, input_json, input_preview, output_preview{normalized_tool_columns}
     FROM {tool_io} FINAL
     WHERE {match_predicate}
   )
@@ -326,7 +464,7 @@ impl ClickHouseConversationRepository {
     WHERE (session_id, event_uid) IN (SELECT session_id, event_uid FROM matched)
   ) AS tr ON tr.session_id = ti.session_id AND tr.event_uid = ti.event_uid
   ANY LEFT JOIN (
-    SELECT session_id, event_uid, any(cwd) AS cwd
+    SELECT session_id, event_uid, any(cwd) AS cwd{normalized_event_columns}
     FROM {events_source}
     WHERE (session_id, event_uid) IN (SELECT session_id, event_uid FROM matched)
     GROUP BY session_id, event_uid
@@ -351,11 +489,18 @@ impl ClickHouseConversationRepository {
     }
 }
 
+fn single_path_sql(expression: &str) -> String {
+    format!(
+        "({expression} != '' AND position({expression}, char(0)) = 0 AND position({expression}, char(10)) = 0 AND position({expression}, char(13)) = 0 AND position({expression}, ';') = 0 AND position({expression}, '|') = 0 AND position({expression}, '&') = 0 AND position({expression}, '`') = 0)"
+    )
+}
+
 fn is_file_attention_schema_skew(message: &str) -> bool {
     let lower = message.to_ascii_lowercase();
     lower.contains("project_id")
         || lower.contains("repo_rel_path")
         || lower.contains("worktree_root")
+        || lower.contains("file_attention_project_roots")
 }
 
 pub(super) fn merge_file_attention_touches(

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -71,18 +71,20 @@ pub struct FileAttentionQuery {
     /// Repo-relative tail to suffix-match against captured file paths. The tail
     /// is what unifies the same logical file across worktree roots.
     pub rel: String,
-    /// Best-effort project identity for exact Phase-1 normalized lookup. This
-    /// is a repo `.moraine.toml` backend name when the request path can be
-    /// resolved to one. `None` disables the exact branch and leaves Tier 0
-    /// suffix matching as the only source of results.
+    /// Canonical request-project identity used by both exact and fallback
+    /// lookup. It is an opaque digest of the Git common directory, so linked
+    /// worktrees agree while unrelated repositories sharing one backend do not.
+    /// `None` keeps project-scoped queries closed; only an explicit unscoped
+    /// query may omit this boundary.
     pub normalized_project_id: Option<String>,
-    /// Whether a structured matched path should be stripped by `rel` to report
-    /// a worktree root. Disabled for arbitrary suffixes that could otherwise
-    /// mislabel a source/package directory as a repository root.
-    pub derive_worktree_roots: bool,
-    /// When true the server's configured origin scope (`--project-only`) is
-    /// applied on top of the tail match; when false (`scope:"all"`) it is
-    /// dropped so touches in sibling and agent-isolation worktrees surface too.
+    /// Canonical registered roots for the request repository. These safely
+    /// admit rows written with the pre-digest project identity during the
+    /// transition without widening to another repository sharing the backend.
+    pub normalized_project_roots: Vec<String>,
+    /// When true normalized request-project identity is enforced in both query
+    /// paths. The repository's configured origin scope (`--project-only`) is an
+    /// independent hard floor. When false (`scope:"all"`), only request-project
+    /// narrowing is dropped.
     pub apply_project_scope: bool,
     pub start_unix_ms: Option<i64>,
     pub end_unix_ms: Option<i64>,

--- a/crates/moraine-conversations/tests/repository_integration/file_attention.rs
+++ b/crates/moraine-conversations/tests/repository_integration/file_attention.rs
@@ -9,7 +9,7 @@ async fn file_attention_merges_normalized_exact_lookup_with_suffix_fallback() {
             cancellation_token: "test-file-attention-normalized".to_string(),
             rel: "crates/foo.rs".to_string(),
             normalized_project_id: Some("project-a".to_string()),
-            derive_worktree_roots: true,
+            normalized_project_roots: vec!["/worktree-a".to_string()],
             apply_project_scope: true,
             start_unix_ms: None,
             end_unix_ms: None,
@@ -30,7 +30,7 @@ async fn file_attention_merges_normalized_exact_lookup_with_suffix_fallback() {
     assert_eq!(touches[0].match_kind, "path_suffix");
     assert_eq!(touches[1].session_id, "sess-legacy");
     assert_eq!(touches[1].event_uid, "evt-legacy");
-    assert_eq!(touches[1].match_kind, "shell_path");
+    assert_eq!(touches[1].match_kind, "path_suffix");
 
     let queries = state.queries.lock().expect("queries lock").clone();
     let exact_query = queries
@@ -43,10 +43,315 @@ async fn file_attention_merges_normalized_exact_lookup_with_suffix_fallback() {
         !exact_query.contains("JSONExtractString(input_json"),
         "exact lookup should not depend on legacy JSON suffix extraction: {exact_query}"
     );
+    assert!(
+        exact_query.contains("position(ti.worktree_root, ';') = 0"),
+        "normalized roots must still satisfy the one-path invariant: {exact_query}"
+    );
+    for fragment in ["char(0)", "char(10)", "char(13)", "'`'"] {
+        assert!(
+            exact_query.contains(fragment),
+            "normalized root guard must reject {fragment}: {exact_query}"
+        );
+    }
 
     let fallback_query = queries
         .iter()
         .find(|query| query.contains("JSONExtractString(input_json, 'path')"))
         .expect("Tier-0 suffix file_attention query should be captured");
     assert!(fallback_query.contains("crates/foo.rs"));
+    assert!(
+        fallback_query.contains("ti.project_id = 'project-a'")
+            && fallback_query.contains(
+                "ti.project_id != '' AND NOT startsWith(ti.project_id, 'git:')"
+            )
+            && fallback_query.contains("ti.worktree_root IN ('/worktree-a')")
+            && fallback_query.contains("ti.project_id = '' AND (e.project_id = 'project-a'")
+            && fallback_query.contains(
+                "matched_path = concat(ifNull(e.worktree_root, ''), '/', 'crates/foo.rs')"
+            ),
+        "project scope must admit current IDs and root-verified pre-digest rows without widening: {fallback_query}"
+    );
+    assert!(
+        fallback_query.contains("position(matched_path, ';') = 0"),
+        "legacy compound path captures must not become roots: {fallback_query}"
+    );
+    assert!(
+        !fallback_query.contains("substring(matched_path"),
+        "an arbitrary suffix prefix must not be reported as a repository root: {fallback_query}"
+    );
+    for fragment in ["char(0)", "char(10)", "char(13)", "'`'"] {
+        assert!(
+            fallback_query.contains(fragment),
+            "legacy root guard must reject {fragment}: {fallback_query}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn file_attention_project_scope_migrates_registered_pre_digest_sibling_root() {
+    let responses = vec![
+        ScriptedResponse::rows(&["repo_rel_path = 'crates/foo.rs'"], json!([])),
+        ScriptedResponse::raw(
+            &[
+                "INSERT INTO `moraine`.`file_attention_project_roots`",
+                "arrayJoin(['/worktree-a', '/worktree-b', '/worktree-''quoted'])",
+            ],
+            "",
+        ),
+        ScriptedResponse::rows(
+            &[
+                "NOT startsWith(ti.project_id, 'git:')",
+                "ti.worktree_root IN ('/worktree-a', '/worktree-b', '/worktree-''quoted')",
+                "SELECT worktree_root FROM `moraine`.`file_attention_project_roots` FINAL WHERE project_id = 'git:new-project-id'",
+            ],
+            json!([{
+                "session_id": "sess-pre-digest",
+                "event_uid": "evt-pre-digest",
+                "tool_call_id": "call-pre-digest",
+                "harness": "codex",
+                "tool_name": "read",
+                "tool_phase": "request",
+                "matched_path": "/worktree-b/crates/foo.rs",
+                "match_kind": "path_suffix",
+                "worktree_root": "/worktree-b",
+                "cwd": "/worktree-b",
+                "event_unix_ms": 1769940000000_i64,
+                "event_order": 10_u64,
+                "turn_seq": 1_u32,
+                "input_preview": "{\"path\":\"crates/foo.rs\"}",
+                "output_preview": ""
+            }]),
+        ),
+    ];
+    let (repo, _state) = build_scripted_repo(responses).await;
+
+    let touches = repo
+        .file_attention(FileAttentionQuery {
+            cancellation_token: "test-file-attention-pre-digest".to_string(),
+            rel: "crates/foo.rs".to_string(),
+            normalized_project_id: Some("git:new-project-id".to_string()),
+            normalized_project_roots: vec![
+                "/worktree-a".to_string(),
+                "/worktree-b".to_string(),
+                "/worktree-'quoted".to_string(),
+            ],
+            apply_project_scope: true,
+            start_unix_ms: None,
+            end_unix_ms: None,
+            tool: None,
+            mutations_only: false,
+            max_rows: 10,
+            execution_budget_secs: 3,
+        })
+        .await
+        .expect("registered pre-digest sibling row remains visible during migration");
+
+    assert_eq!(touches.len(), 1);
+    assert_eq!(touches[0].session_id, "sess-pre-digest");
+    assert_eq!(touches[0].worktree_root, "/worktree-b");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn file_attention_project_scope_excludes_unmapped_pruned_legacy_root() {
+    let responses = vec![
+        ScriptedResponse::rows(&["repo_rel_path = 'crates/foo.rs'"], json!([])),
+        ScriptedResponse::raw(
+            &[
+                "INSERT INTO `moraine`.`file_attention_project_roots`",
+                "arrayJoin(['/worktree-a'])",
+            ],
+            "",
+        ),
+        ScriptedResponse::rows(
+            &[
+                "ti.worktree_root IN ('/worktree-a')",
+                "SELECT worktree_root FROM `moraine`.`file_attention_project_roots` FINAL WHERE project_id = 'git:new-project-id'",
+            ],
+            json!([]),
+        )
+        .forbidding(&["'/worktree-b'"]),
+    ];
+    let (repo, _state) = build_scripted_repo(responses).await;
+
+    let touches = repo
+        .file_attention(FileAttentionQuery {
+            cancellation_token: "test-file-attention-unmapped-pruned".to_string(),
+            rel: "crates/foo.rs".to_string(),
+            normalized_project_id: Some("git:new-project-id".to_string()),
+            normalized_project_roots: vec!["/worktree-a".to_string()],
+            apply_project_scope: true,
+            start_unix_ms: None,
+            end_unix_ms: None,
+            tool: None,
+            mutations_only: false,
+            max_rows: 10,
+            execution_budget_secs: 3,
+        })
+        .await
+        .expect("unmappable pruned history must fail closed");
+
+    assert!(touches.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn file_attention_all_scope_is_the_only_unscoped_widening_path() {
+    let (repo, state) = build_repo().await;
+
+    repo.file_attention(FileAttentionQuery {
+        cancellation_token: "test-file-attention-all".to_string(),
+        rel: "crates/foo.rs".to_string(),
+        normalized_project_id: Some("project-a".to_string()),
+        normalized_project_roots: vec!["/worktree-a".to_string()],
+        apply_project_scope: false,
+        start_unix_ms: None,
+        end_unix_ms: None,
+        tool: None,
+        mutations_only: false,
+        max_rows: 10,
+        execution_budget_secs: 3,
+    })
+    .await
+    .expect("all-scope file_attention query succeeds");
+
+    let queries = state.queries.lock().expect("queries lock").clone();
+    let exact_query = queries
+        .iter()
+        .find(|query| query.contains("repo_rel_path = 'crates/foo.rs'"))
+        .expect("normalized exact file_attention query should be captured");
+    assert!(exact_query.contains("project_id != ''"));
+    assert!(!exact_query.contains("project_id = 'project-a'"));
+
+    let fallback_query = queries
+        .iter()
+        .find(|query| query.contains("JSONExtractString(input_json, 'path')"))
+        .expect("Tier-0 suffix file_attention query should be captured");
+    assert!(
+        !fallback_query.contains("coalesce(nullIf(ti.project_id"),
+        "scope=all must not retain the request project predicate: {fallback_query}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn file_attention_all_scope_keeps_the_configured_server_floor_only() {
+    let (repo, state) = build_scoped_repo(&["/work/project"]).await;
+
+    repo.file_attention(FileAttentionQuery {
+        cancellation_token: "test-file-attention-scoped-all".to_string(),
+        rel: "crates/foo.rs".to_string(),
+        normalized_project_id: Some("project-a".to_string()),
+        normalized_project_roots: vec!["/worktree-a".to_string()],
+        apply_project_scope: false,
+        start_unix_ms: None,
+        end_unix_ms: None,
+        tool: None,
+        mutations_only: false,
+        max_rows: 10,
+        execution_budget_secs: 3,
+    })
+    .await
+    .expect("all-scope query on scoped repository succeeds");
+
+    let queries = state.queries.lock().expect("queries lock").clone();
+    let attention_queries = queries
+        .iter()
+        .filter(|query| query.contains("FROM `moraine`.`tool_io` FINAL"))
+        .collect::<Vec<_>>();
+    assert_eq!(attention_queries.len(), 2);
+    for query in attention_queries {
+        assert!(query.contains("origin_cwd = '/work/project'"));
+        assert!(!query.contains("project_id = 'project-a'"));
+        assert!(!query.contains("coalesce(nullIf(ti.project_id"));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn file_attention_all_scope_preserves_legacy_suffix_fallback_on_schema_skew() {
+    let responses = vec![
+        ScriptedResponse::failure(
+            &["repo_rel_path = 'crates/foo.rs'"],
+            "Unknown identifier project_id",
+        ),
+        ScriptedResponse::rows(&["JSONExtractString(input_json, 'path')"], json!([])).forbidding(
+            &[
+                ", project_id, repo_rel_path, worktree_root",
+                "any(project_id) AS project_id",
+            ],
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let touches = repo
+        .file_attention(FileAttentionQuery {
+            cancellation_token: "test-file-attention-schema-skew-all".to_string(),
+            rel: "crates/foo.rs".to_string(),
+            normalized_project_id: Some("project-a".to_string()),
+            normalized_project_roots: vec!["/worktree-a".to_string()],
+            apply_project_scope: false,
+            start_unix_ms: None,
+            end_unix_ms: None,
+            tool: None,
+            mutations_only: false,
+            max_rows: 10,
+            execution_budget_secs: 3,
+        })
+        .await
+        .expect("legacy all-scope fallback succeeds");
+
+    assert!(touches.is_empty());
+    assert_eq!(state.queries.lock().expect("queries lock").len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn file_attention_project_scope_stays_closed_on_schema_skew() {
+    let responses = vec![ScriptedResponse::failure(
+        &["repo_rel_path = 'crates/foo.rs'"],
+        "Unknown identifier project_id",
+    )];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let touches = repo
+        .file_attention(FileAttentionQuery {
+            cancellation_token: "test-file-attention-schema-skew-project".to_string(),
+            rel: "crates/foo.rs".to_string(),
+            normalized_project_id: Some("project-a".to_string()),
+            normalized_project_roots: vec!["/worktree-a".to_string()],
+            apply_project_scope: true,
+            start_unix_ms: None,
+            end_unix_ms: None,
+            tool: None,
+            mutations_only: false,
+            max_rows: 10,
+            execution_budget_secs: 3,
+        })
+        .await
+        .expect("project-scoped schema-skew query stays closed");
+
+    assert!(touches.is_empty());
+    assert_eq!(state.queries.lock().expect("queries lock").len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn file_attention_project_scope_without_identity_stays_closed() {
+    let (repo, state) = build_repo().await;
+
+    repo.file_attention(FileAttentionQuery {
+        cancellation_token: "test-file-attention-unknown-project".to_string(),
+        rel: "crates/foo.rs".to_string(),
+        normalized_project_id: None,
+        normalized_project_roots: Vec::new(),
+        apply_project_scope: true,
+        start_unix_ms: None,
+        end_unix_ms: None,
+        tool: None,
+        mutations_only: false,
+        max_rows: 10,
+        execution_budget_secs: 3,
+    })
+    .await
+    .expect("closed project-scope file_attention query succeeds");
+
+    assert!(
+        state.queries.lock().expect("queries lock").is_empty(),
+        "an unknown request project must stay closed without issuing a backend query"
+    );
 }

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -158,6 +158,10 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
             return (response.status, response.body);
         }
 
+        if query.starts_with("INSERT INTO `moraine`.`file_attention_project_roots`") {
+            return (StatusCode::OK, String::new());
+        }
+
         // --project-only origin-scope gate: the point lookup issued by
         // `session_in_scope`. Sessions whose ID contains "out-of-scope" are
         // outside the scope; everything else is inside it. Only the
@@ -192,6 +196,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
         if query.contains("FROM `moraine`.`tool_io` FINAL")
             && query.contains("repo_rel_path = 'crates/foo.rs'")
             && query.contains("project_id = 'project-a'")
+            && !query.contains("JSONExtractString(input_json")
         {
             return (
                 StatusCode::OK,
@@ -246,16 +251,16 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                         "event_uid": "evt-legacy",
                         "tool_call_id": "call-legacy",
                         "harness": "codex",
-                        "tool_name": "bash",
+                        "tool_name": "read",
                         "tool_phase": "request",
-                        "matched_path": "",
-                        "match_kind": "shell_path",
-                        "worktree_root": "",
+                        "matched_path": "crates/foo.rs",
+                        "match_kind": "path_suffix",
+                        "worktree_root": "/legacy",
                         "cwd": "/legacy",
                         "event_unix_ms": 1769940000000_i64,
                         "event_order": 10_u64,
                         "turn_seq": 1_u32,
-                        "input_preview": "{\"command\":\"rg crates/foo.rs\"}",
+                        "input_preview": "{\"path\":\"crates/foo.rs\"}",
                         "output_preview": ""
                     }
                 ])),

--- a/crates/moraine-ingest-core/src/sources/shared.rs
+++ b/crates/moraine-ingest-core/src/sources/shared.rs
@@ -909,18 +909,16 @@ fn tool_file_attention_fields(
 
     let mut candidates = Vec::<String>::new();
     collect_structured_path_candidates(&input, &mut candidates);
-    for candidate in candidates {
-        if let Some(fields) = resolve_tool_path_fields(cwd, &candidate) {
-            return fields;
-        }
+    if candidates.len() != 1 {
+        return FileAttentionFields::default();
     }
 
-    FileAttentionFields::default()
+    resolve_tool_path_fields(cwd, &candidates[0]).unwrap_or_default()
 }
 
 fn resolve_tool_path_fields(cwd: &str, raw_path: &str) -> Option<FileAttentionFields> {
     let raw_path = raw_path.trim();
-    if raw_path.is_empty() || raw_path.contains('\0') {
+    if !is_single_path_candidate(raw_path) {
         return None;
     }
 
@@ -988,6 +986,14 @@ fn collect_path_values(value: &Value, out: &mut Vec<String>) {
     }
 }
 
+fn is_single_path_candidate(path: &str) -> bool {
+    !path.is_empty()
+        && !path.contains('\0')
+        && !path
+            .chars()
+            .any(|character| matches!(character, '\n' | '\r' | ';' | '|' | '&' | '`'))
+}
+
 fn normalize_path_text(path: &str) -> String {
     let absolute = path.starts_with('/');
     let mut parts: Vec<&str> = Vec::new();
@@ -1028,28 +1034,21 @@ fn find_file_attention_root(path: &Path) -> Option<String> {
     } else {
         path.parent()
     };
-    let mut git_fallback = None::<String>;
     while let Some(current) = dir {
-        if current.join(moraine_config::REPO_BACKEND_FILE).exists() {
+        if current.join(moraine_config::REPO_BACKEND_FILE).exists() || current.join(".git").exists()
+        {
             return Some(current.to_string_lossy().to_string());
-        }
-        if current.join(".git").exists() && git_fallback.is_none() {
-            git_fallback = Some(current.to_string_lossy().to_string());
         }
         if home.as_deref() == Some(current) {
             break;
         }
         dir = current.parent();
     }
-    git_fallback
+    None
 }
 
 fn project_id_for_root(root: &str) -> Option<String> {
-    let root = Path::new(root);
-    if root.join(moraine_config::REPO_BACKEND_FILE).is_file() {
-        return moraine_config::find_repo_backend_ref(root);
-    }
-    None
+    moraine_config::project_id_for_repo_root(root)
 }
 
 fn strip_root(path: &str, root: &str) -> Option<String> {
@@ -1380,6 +1379,7 @@ mod tests {
             std::process::id()
         ));
         std::fs::create_dir_all(root.join("src")).expect("create repo dirs");
+        std::fs::create_dir_all(root.join(".git")).expect("create git dir");
         std::fs::write(
             root.join(moraine_config::REPO_BACKEND_FILE),
             "backend = \"team\"\n",
@@ -1406,6 +1406,7 @@ mod tests {
         let cwd = root.join("src");
         let cwd_text = cwd.to_string_lossy().to_string();
         let ctx = test_record_context(&cwd_text);
+        let project_id = project_id_for_root(root.to_string_lossy().as_ref()).expect("project id");
 
         let row = Value::Object(base_event_obj(
             &ctx,
@@ -1417,9 +1418,44 @@ mod tests {
             "{}",
         ));
 
-        assert_eq!(row["project_id"], "team");
+        assert_eq!(row["project_id"], project_id);
         assert_eq!(row["worktree_root"], root.to_string_lossy().as_ref());
         assert_eq!(row["repo_rel_path"], "");
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn event_rows_keep_linked_worktree_root_with_enclosing_project_marker() {
+        let root = make_repo("linked-worktree");
+        let linked = root.join("worktrees/linked");
+        let linked_git_dir = root.join(".git/worktrees/linked");
+        let cwd = linked.join("src");
+        std::fs::create_dir_all(&linked_git_dir).expect("create linked git dir");
+        std::fs::create_dir_all(&cwd).expect("create linked cwd");
+        std::fs::write(linked_git_dir.join("commondir"), "../..\n").expect("write commondir");
+        std::fs::write(
+            linked.join(".git"),
+            format!("gitdir: {}\n", linked_git_dir.to_string_lossy()),
+        )
+        .expect("write linked git marker");
+        let cwd_text = cwd.to_string_lossy().to_string();
+        let ctx = test_record_context(&cwd_text);
+
+        let row = Value::Object(base_event_obj(
+            &ctx,
+            "e1",
+            "message",
+            "message",
+            "assistant",
+            "hello",
+            "{}",
+        ));
+
+        assert_eq!(
+            row["project_id"],
+            project_id_for_root(root.to_string_lossy().as_ref()).expect("project id")
+        );
+        assert_eq!(row["worktree_root"], linked.to_string_lossy().as_ref());
         std::fs::remove_dir_all(root).ok();
     }
 
@@ -1457,6 +1493,7 @@ mod tests {
         let cwd_text = root.to_string_lossy().to_string();
         let ctx = test_record_context(&cwd_text);
         let absolute = root.join("src/lib.rs").to_string_lossy().to_string();
+        let project_id = project_id_for_root(root.to_string_lossy().as_ref()).expect("project id");
 
         let absolute_row = build_tool_row(
             &ctx,
@@ -1470,7 +1507,7 @@ mod tests {
             "",
             "",
         );
-        assert_eq!(absolute_row["project_id"], "team");
+        assert_eq!(absolute_row["project_id"], project_id);
         assert_eq!(
             absolute_row["worktree_root"],
             root.to_string_lossy().as_ref()
@@ -1489,7 +1526,7 @@ mod tests {
             "",
             "",
         );
-        assert_eq!(relative_row["project_id"], "team");
+        assert_eq!(relative_row["project_id"], project_id);
         assert_eq!(
             relative_row["worktree_root"],
             root.to_string_lossy().as_ref()
@@ -1503,13 +1540,14 @@ mod tests {
         let root = make_repo("path-keys");
         let cwd_text = root.to_string_lossy().to_string();
         let ctx = test_record_context(&cwd_text);
+        let project_id = project_id_for_root(root.to_string_lossy().as_ref()).expect("project id");
 
         for key in FILE_ATTENTION_PATH_KEYS {
             let input = json!({ key: "src/lib.rs" }).to_string();
             let row = build_tool_row(
                 &ctx, "e1", "call-1", "", "Edit", "request", 0, &input, "", "",
             );
-            assert_eq!(row["project_id"], "team", "key {key}");
+            assert_eq!(row["project_id"], project_id, "key {key}");
             assert_eq!(row["repo_rel_path"], "src/lib.rs", "key {key}");
         }
 
@@ -1525,7 +1563,7 @@ mod tests {
             "",
             "",
         );
-        assert_eq!(nested["project_id"], "team");
+        assert_eq!(nested["project_id"], project_id);
         assert_eq!(nested["repo_rel_path"], "src/lib.rs");
         std::fs::remove_dir_all(root).ok();
     }
@@ -1583,6 +1621,48 @@ mod tests {
         assert_eq!(response["project_id"], "");
         assert_eq!(response["repo_rel_path"], "");
         assert_eq!(response["worktree_root"], "");
+        std::fs::remove_dir_all(root).ok();
+    }
+    #[test]
+    fn tool_rows_leave_compound_and_multi_path_inputs_unnormalized() {
+        let root = make_repo("compound-paths");
+        let cwd_text = root.to_string_lossy().to_string();
+        let ctx = test_record_context(&cwd_text);
+        let absolute = root.join("src/lib.rs").to_string_lossy().to_string();
+
+        for delimiter in ["\0", "\n", "\r", ";", "|", "&", "`"] {
+            let compound = build_tool_row(
+                &ctx,
+                "e1",
+                "call-1",
+                "",
+                "Bash",
+                "request",
+                0,
+                &json!({"path": format!("{absolute}{delimiter}src/other.rs")}).to_string(),
+                "",
+                "",
+            );
+            assert_eq!(compound["project_id"], "", "delimiter {delimiter:?}");
+            assert_eq!(compound["repo_rel_path"], "", "delimiter {delimiter:?}");
+            assert_eq!(compound["worktree_root"], "", "delimiter {delimiter:?}");
+        }
+
+        let multiple = build_tool_row(
+            &ctx,
+            "e2",
+            "call-2",
+            "",
+            "MultiEdit",
+            "request",
+            0,
+            r#"{"path":["src/lib.rs","src/other.rs"]}"#,
+            "",
+            "",
+        );
+        assert_eq!(multiple["project_id"], "");
+        assert_eq!(multiple["repo_rel_path"], "");
+        assert_eq!(multiple["worktree_root"], "");
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/moraine-mcp-core/src/contract.rs
+++ b/crates/moraine-mcp-core/src/contract.rs
@@ -735,10 +735,10 @@ pub struct CanonicalOpenV1Args {
 
 /// How far `file_attention` widens its search.
 ///
-/// `Project` (default) keeps the answer focused on the launch project by
-/// honoring the server's configured origin scope (`--project-only`). `All` is
-/// the deliberate widen for unscoped servers: it drops request-level origin
-/// narrowing so a touch in any worktree the backend holds can be returned. A
+/// `Project` (default) keeps the answer focused on the normalized identity of
+/// the launch project, independently of `--project-only`. `All` is the
+/// deliberate widen for unscoped servers: it drops request-level project
+/// narrowing so a touch in any project the backend holds can be returned. A
 /// configured server scope remains a hard floor, so `scope` never exposes IDs
 /// that `open` would reject.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]

--- a/crates/moraine-mcp-core/src/file_attention_v1.rs
+++ b/crates/moraine-mcp-core/src/file_attention_v1.rs
@@ -35,12 +35,6 @@ use tracing::warn;
 /// per-file touch count, but bounds memory on a pathological tail.
 const FILE_ATTENTION_SCAN_CAP: usize = 2_000;
 
-/// Marker files that identify a repo (worktree) root when stripping an absolute
-/// query path to its repo-relative tail. `.moraine.toml` is the committed,
-/// per-project moraine backend reference; `.git` (a dir in the main checkout, a
-/// file in a worktree) is the universal fallback.
-const REPO_ROOT_MARKERS: [&str; 2] = [".moraine.toml", ".git"];
-
 impl AppState {
     pub(crate) async fn file_attention_v1(&self, arguments: Value) -> Result<Value> {
         let perf = Performance::builder(FILE_ATTENTION_DEFAULT_SLA_TARGET_MS);
@@ -58,7 +52,7 @@ impl AppState {
         let perf = perf.with_sla_target(FILE_ATTENTION_BROAD_SLA_TARGET_MS);
 
         let mut warnings: Vec<String> = Vec::new();
-        let tail = resolve_tail(&args.path);
+        let tail = resolve_tail_from(&args.path, self.launch_dir.as_deref());
         if tail.normalized {
             warnings.push(format!(
                 "normalized {:?} to {:?} before matching.",
@@ -84,11 +78,15 @@ impl AppState {
                 tail.rel
             ));
         }
-        if args.scope == FileAttentionScope::Project && self.repo.config().session_scope.is_none() {
-            // The default scope honors `--project-only`; without it the server
-            // sees the whole backend, so "project" cannot narrow further.
+        if args.scope == FileAttentionScope::Project && tail.project_id.is_none() {
             warnings.push(
-                "scope=\"project\" but this server is not project-scoped (not launched with --project-only); results may span every project in the backend. The surfaced roots show the spread."
+                "scope=\"project\" could not establish the launch project's normalized identity; the repository query remains closed rather than widening across projects."
+                    .to_string(),
+            );
+        }
+        if args.scope == FileAttentionScope::Project {
+            warnings.push(
+                "pre-digest worktree roots pruned before durable project mapping was installed cannot be attributed safely and remain excluded; currently registered roots are migrated and future normalized roots remain durable."
                     .to_string(),
             );
         }
@@ -106,8 +104,12 @@ impl AppState {
             cancellation_token: query_id.clone(),
             rel: tail.rel.clone(),
             normalized_project_id: tail.project_id.clone(),
-            derive_worktree_roots: tail.derive_worktree_roots,
-            apply_project_scope: args.scope == FileAttentionScope::Project || project_scoped_server,
+            normalized_project_roots: tail
+                .root
+                .as_deref()
+                .and_then(moraine_config::worktree_roots_for_repo_root)
+                .unwrap_or_default(),
+            apply_project_scope: args.scope == FileAttentionScope::Project,
             start_unix_ms: args.start_unix_ms,
             end_unix_ms: args.end_unix_ms,
             tool: args.tool.clone(),
@@ -217,32 +219,46 @@ struct TailResolution {
 
 /// Reduce a query `path` to the repo-relative tail used for suffix matching.
 ///
-/// - A relative path is the tail as given.
-/// - An absolute path is stripped of its worktree root, found by walking up to
-///   a `.moraine.toml` / `.git` marker. When no marker is found (e.g. the file
-///   was deleted, or lives in a foreign root), the absolute path is matched
-///   literally and `tail_is_absolute` is set so the caller can warn.
+/// Relative paths are resolved lexically against the launch directory, so a
+/// deleted or not-yet-created file still carries the launch project's identity.
+/// Absolute paths are stripped against their marker root. Compound shell text
+/// is never interpreted as a path or repository root.
+#[cfg(test)]
 fn resolve_tail(path: &str) -> TailResolution {
+    resolve_tail_from(path, std::env::current_dir().ok().as_deref())
+}
+
+fn resolve_tail_from(path: &str, launch_dir: Option<&Path>) -> TailResolution {
     let cleaned = path.strip_prefix("./").unwrap_or(path);
+    let raw_is_single_path = is_single_path_candidate(cleaned);
     let normalized = normalize_path_text(cleaned);
     let normalized_changed = normalized != cleaned;
+    let normalized_is_single_path = is_single_path_candidate(&normalized);
+    let launch_project = launch_dir.and_then(|cwd| {
+        let scope_probe = cwd.join(".moraine-project-scope");
+        let root = find_project_root(&scope_probe)?;
+        let project_id = project_id_for_root(&root)?;
+        Some((root, project_id))
+    });
+
     if !normalized.starts_with('/') {
-        if let Ok(cwd) = std::env::current_dir() {
-            let candidate = cwd.join(&normalized);
-            if candidate.exists() {
-                let candidate_str = candidate.to_string_lossy().to_string();
-                if let Some(root) = find_project_root(&candidate) {
-                    if let Some(rel) = strip_root(&candidate_str, &root) {
-                        if !rel.is_empty() {
-                            return TailResolution {
-                                rel,
-                                project_id: project_id_for_root(&root),
-                                root: Some(root),
-                                tail_is_absolute: false,
-                                normalized: normalized_changed,
-                                derive_worktree_roots: true,
-                            };
-                        }
+        if raw_is_single_path && normalized_is_single_path {
+            if let (Some(cwd), Some((root, project_id))) = (launch_dir, launch_project) {
+                let absolute = normalize_path_text(&format!(
+                    "{}/{}",
+                    cwd.to_string_lossy().trim_end_matches('/'),
+                    normalized
+                ));
+                if let Some(rel) = strip_root(&absolute, &root) {
+                    if !rel.is_empty() {
+                        return TailResolution {
+                            rel,
+                            project_id: Some(project_id),
+                            root: Some(root),
+                            tail_is_absolute: false,
+                            normalized: normalized_changed,
+                            derive_worktree_roots: true,
+                        };
                     }
                 }
             }
@@ -257,17 +273,29 @@ fn resolve_tail(path: &str) -> TailResolution {
         };
     }
 
-    if let Some(root) = find_project_root(Path::new(&normalized)) {
-        if let Some(rel) = strip_root(&normalized, &root) {
-            if !rel.is_empty() {
-                return TailResolution {
-                    rel,
-                    project_id: project_id_for_root(&root),
-                    root: Some(root),
-                    tail_is_absolute: false,
-                    normalized: normalized_changed,
-                    derive_worktree_roots: true,
-                };
+    if raw_is_single_path && normalized_is_single_path {
+        if let Some(root) = find_project_root(Path::new(&normalized)) {
+            if let Some(rel) = strip_root(&normalized, &root) {
+                if !rel.is_empty() {
+                    let target_project_id = project_id_for_root(&root);
+                    let project_id = match (launch_dir, launch_project, target_project_id) {
+                        (None, _, target_project_id) => target_project_id,
+                        (Some(_), Some((_, launch_id)), Some(target_id))
+                            if launch_id == target_id =>
+                        {
+                            Some(launch_id)
+                        }
+                        _ => None,
+                    };
+                    return TailResolution {
+                        rel,
+                        project_id,
+                        root: Some(root),
+                        tail_is_absolute: false,
+                        normalized: normalized_changed,
+                        derive_worktree_roots: true,
+                    };
+                }
             }
         }
     }
@@ -280,6 +308,14 @@ fn resolve_tail(path: &str) -> TailResolution {
         normalized: normalized_changed,
         derive_worktree_roots: false,
     }
+}
+
+fn is_single_path_candidate(path: &str) -> bool {
+    !path.is_empty()
+        && !path.contains('\0')
+        && !path
+            .chars()
+            .any(|character| matches!(character, '\n' | '\r' | ';' | '|' | '&' | '`'))
 }
 
 fn normalize_path_text(path: &str) -> String {
@@ -326,15 +362,15 @@ fn strip_root(path: &str, root: &str) -> Option<String> {
         .map(|tail| tail.to_string())
 }
 
-/// Walk up from a file path's parent directory looking for a repo-root marker,
-/// bounded at `$HOME` or the filesystem root. Returns the marker directory.
+/// Walk up from a file path's parent directory looking for the nearest
+/// repository boundary, bounded at `$HOME` or the filesystem root. A linked
+/// worktree may inherit its `.moraine.toml` route from an enclosing checkout,
+/// but its own `.git` marker still defines the root reported to callers.
 fn find_project_root(file_path: &Path) -> Option<String> {
     let home = std::env::var_os("HOME").map(PathBuf::from);
     let mut dir = file_path.parent();
     while let Some(current) = dir {
-        if REPO_ROOT_MARKERS
-            .iter()
-            .any(|marker| current.join(marker).exists())
+        if current.join(moraine_config::REPO_BACKEND_FILE).exists() || current.join(".git").exists()
         {
             return Some(current.to_string_lossy().to_string());
         }
@@ -347,11 +383,7 @@ fn find_project_root(file_path: &Path) -> Option<String> {
 }
 
 fn project_id_for_root(root: &str) -> Option<String> {
-    let root = Path::new(root);
-    if root.join(moraine_config::REPO_BACKEND_FILE).is_file() {
-        return moraine_config::find_repo_backend_ref(root);
-    }
-    None
+    moraine_config::project_id_for_repo_root(root)
 }
 
 /// Count non-empty, slash-separated segments of a tail. `mod.rs` is depth 1;
@@ -934,14 +966,78 @@ mod tests {
     }
 
     #[test]
-    fn resolve_tail_passes_relative_paths_through() {
-        let resolved = resolve_tail("crates/foo/tee.rs");
+    fn resolve_tail_passes_unscoped_relative_paths_through() {
+        let resolved = resolve_tail_from("crates/foo/tee.rs", None);
         assert_eq!(resolved.rel, "crates/foo/tee.rs");
         assert!(!resolved.tail_is_absolute);
         assert!(resolved.root.is_none());
 
-        let dotted = resolve_tail("./crates/foo/tee.rs");
+        let dotted = resolve_tail_from("./crates/foo/tee.rs", None);
         assert_eq!(dotted.rel, "crates/foo/tee.rs");
+    }
+
+    #[test]
+    fn resolve_tail_carries_launch_project_identity_for_missing_relative_file() {
+        let dir = std::env::temp_dir().join(format!("moraine-fa-relative-{}", std::process::id()));
+        let root = dir.join("repo");
+        std::fs::create_dir_all(&root).expect("mkdir root");
+        std::fs::create_dir_all(root.join(".git")).expect("mkdir git dir");
+        std::fs::write(root.join(".moraine.toml"), "backend = \"x\"\n").expect("write marker");
+
+        let resolved = resolve_tail_from("crates/new/file.rs", Some(&root));
+        assert_eq!(resolved.rel, "crates/new/file.rs");
+        assert_eq!(resolved.root.as_deref(), root.to_str());
+        assert_eq!(
+            resolved.project_id,
+            moraine_config::project_id_for_repo_root(&root)
+        );
+        assert!(resolved.derive_worktree_roots);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resolve_tail_makes_nested_launch_paths_repository_relative() {
+        let dir =
+            std::env::temp_dir().join(format!("moraine-fa-nested-launch-{}", std::process::id()));
+        let root = dir.join("repo");
+        let launch = root.join("crates/foo");
+        std::fs::create_dir_all(root.join(".git")).expect("mkdir git dir");
+        std::fs::create_dir_all(&launch).expect("mkdir launch dir");
+        std::fs::write(root.join(".moraine.toml"), "backend = \"x\"\n").expect("write marker");
+
+        let nested = resolve_tail_from("src/lib.rs", Some(&launch));
+        assert_eq!(nested.rel, "crates/foo/src/lib.rs");
+        assert_eq!(nested.root.as_deref(), root.to_str());
+
+        let parent = resolve_tail_from("../shared.rs", Some(&launch));
+        assert_eq!(parent.rel, "crates/shared.rs");
+        assert_eq!(parent.root.as_deref(), root.to_str());
+
+        let outside = resolve_tail_from("../../../outside.rs", Some(&launch));
+        assert!(outside.project_id.is_none());
+        assert!(!outside.derive_worktree_roots);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resolve_tail_never_derives_provenance_from_compound_input() {
+        let dir = std::env::temp_dir().join(format!("moraine-fa-compound-{}", std::process::id()));
+        let root = dir.join("repo");
+        std::fs::create_dir_all(&root).expect("mkdir root");
+        std::fs::create_dir_all(root.join(".git")).expect("mkdir git dir");
+        std::fs::write(root.join(".moraine.toml"), "backend = \"x\"\n").expect("write marker");
+
+        for delimiter in ["\0", "\n", "\r", ";", "|", "&", "`"] {
+            let path = format!("bad{delimiter}command/../src/lib.rs");
+            let resolved = resolve_tail_from(&path, Some(&root));
+            assert!(resolved.root.is_none(), "delimiter {delimiter:?}");
+            assert!(resolved.project_id.is_none(), "delimiter {delimiter:?}");
+            assert!(!resolved.derive_worktree_roots, "delimiter {delimiter:?}");
+        }
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
@@ -950,15 +1046,69 @@ mod tests {
         let root = dir.join("repo");
         let nested = root.join("crates/foo");
         std::fs::create_dir_all(&nested).expect("mkdir nested");
+        std::fs::create_dir_all(root.join(".git")).expect("mkdir git dir");
         std::fs::write(root.join(".moraine.toml"), "backend = \"x\"\n").expect("write marker");
         let file = nested.join("tee.rs");
         std::fs::write(&file, "// test").expect("write file");
 
-        let resolved = resolve_tail(file.to_str().expect("utf8 path"));
+        let resolved = resolve_tail_from(file.to_str().expect("utf8 path"), None);
         assert_eq!(resolved.rel, "crates/foo/tee.rs");
         assert!(!resolved.tail_is_absolute);
         assert_eq!(resolved.root.as_deref(), root.to_str());
-        assert_eq!(resolved.project_id.as_deref(), Some("x"));
+        assert_eq!(
+            resolved.project_id,
+            moraine_config::project_id_for_repo_root(&root)
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resolve_tail_closes_project_scope_for_absolute_path_in_another_project() {
+        let dir =
+            std::env::temp_dir().join(format!("moraine-fa-cross-project-{}", std::process::id()));
+        let launch = dir.join("launch");
+        let other = dir.join("other");
+        for root in [&launch, &other] {
+            std::fs::create_dir_all(root.join(".git")).expect("mkdir git dir");
+            std::fs::write(root.join(".moraine.toml"), "backend = \"shared\"\n")
+                .expect("write marker");
+        }
+        let file = other.join("src/lib.rs");
+        std::fs::create_dir_all(file.parent().expect("file parent")).expect("mkdir file parent");
+        std::fs::write(&file, "// test").expect("write file");
+
+        let resolved = resolve_tail_from(file.to_str().expect("utf8 path"), Some(&launch));
+        assert_eq!(resolved.rel, "src/lib.rs");
+        assert_eq!(resolved.root.as_deref(), other.to_str());
+        assert!(resolved.project_id.is_none());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resolve_tail_keeps_linked_worktree_root_with_enclosing_project_marker() {
+        let dir =
+            std::env::temp_dir().join(format!("moraine-fa-linked-worktree-{}", std::process::id()));
+        let root = dir.join("repo");
+        let linked = root.join("worktrees/linked");
+        let linked_git_dir = root.join(".git/worktrees/linked");
+        std::fs::create_dir_all(&linked_git_dir).expect("mkdir linked git dir");
+        std::fs::create_dir_all(&linked).expect("mkdir linked worktree");
+        std::fs::write(linked_git_dir.join("commondir"), "../..\n").expect("write commondir");
+        std::fs::write(
+            linked.join(".git"),
+            format!("gitdir: {}\n", linked_git_dir.to_string_lossy()),
+        )
+        .expect("write linked git marker");
+        std::fs::write(root.join(".moraine.toml"), "backend = \"shared\"\n").expect("write marker");
+
+        let resolved = resolve_tail_from("src/lib.rs", Some(&linked));
+        assert_eq!(resolved.root.as_deref(), linked.to_str());
+        assert_eq!(
+            resolved.project_id,
+            moraine_config::project_id_for_repo_root(&root)
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -1289,13 +1439,16 @@ mod tests {
 
     #[test]
     fn resolve_tail_normalizes_dotdot_and_repeated_slashes() {
-        assert_eq!(resolve_tail("crates/foo/../foo.rs").rel, "crates/foo.rs");
         assert_eq!(
-            resolve_tail("crates//foo///bar.rs").rel,
+            resolve_tail_from("crates/foo/../foo.rs", None).rel,
+            "crates/foo.rs"
+        );
+        assert_eq!(
+            resolve_tail_from("crates//foo///bar.rs", None).rel,
             "crates/foo/bar.rs"
         );
         assert_eq!(
-            resolve_tail("crates/foo dir/x.rs").rel,
+            resolve_tail_from("crates/foo dir/x.rs", None).rel,
             "crates/foo dir/x.rs"
         );
     }

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -47,6 +47,7 @@ struct ToolCallParams {
 struct AppState {
     cfg: Arc<AppConfig>,
     repo: Arc<dyn ConversationRepository>,
+    launch_dir: Option<PathBuf>,
     prewarm_started: Arc<AtomicBool>,
 }
 
@@ -302,7 +303,7 @@ impl AppState {
                                     { "type": "null" }
                                 ],
                                 "default": "project",
-                                "description": "project (default) keeps the answer to the launch project by honoring --project-only; all drops that origin narrowing to include every worktree the backend holds."
+                                "description": "project (default) restricts results to the normalized launch-project identity even without --project-only; all is the deliberate widening path on an unscoped server. A configured --project-only origin boundary remains enforced."
                             },
                             "granularity": {
                                 "anyOf": [
@@ -453,16 +454,23 @@ impl AppState {
         cfg: Arc<AppConfig>,
         repo: Arc<dyn ConversationRepository>,
         prewarm_started: Arc<AtomicBool>,
+        launch_dir: Option<PathBuf>,
     ) -> Arc<AppState> {
         Arc::new(AppState {
             cfg,
             repo,
+            launch_dir,
             prewarm_started,
         })
     }
 
     fn embedded(cfg: AppConfig, repo: Arc<dyn ConversationRepository>) -> Arc<AppState> {
-        Self::with_repository(cfg.into(), repo, Arc::new(AtomicBool::new(false)))
+        Self::with_repository(
+            cfg.into(),
+            repo,
+            Arc::new(AtomicBool::new(false)),
+            std::env::current_dir().ok(),
+        )
     }
 }
 
@@ -882,11 +890,16 @@ async fn serve_socket_connection(state: SocketState, stream: tokio::net::UnixStr
         return Ok(());
     };
 
-    let (backend, replay_first_line, negotiated) =
+    let (backend, replay_first_line, negotiated, launch_dir) =
         match private_proxy::classify_server_first_line(&first_line) {
             ServerFirstLine::Route { cwd } => {
                 match state.router.repository_for_project_dir(Some(&cwd)).await {
-                    Ok(backend) => (backend, None, true),
+                    Ok(backend) => (
+                        backend,
+                        None,
+                        true,
+                        (!cwd.is_empty()).then(|| PathBuf::from(cwd)),
+                    ),
                     Err(error) => {
                         let message = format!("{error:#}");
                         private_proxy::write_route_error(&mut write_half, &message).await?;
@@ -900,7 +913,12 @@ async fn serve_socket_connection(state: SocketState, stream: tokio::net::UnixStr
             }
             ServerFirstLine::Raw => {
                 let backend = state.router.default_repository().await?;
-                (backend, Some(first_line), false)
+                (
+                    backend,
+                    Some(first_line),
+                    false,
+                    std::env::current_dir().ok(),
+                )
             }
         };
 
@@ -912,8 +930,12 @@ async fn serve_socket_connection(state: SocketState, stream: tokio::net::UnixStr
         }
         Err(error) => return Err(error),
     };
-    let app_state =
-        AppState::with_repository(state.cfg, backend.repository().clone(), prewarm_started);
+    let app_state = AppState::with_repository(
+        state.cfg,
+        backend.repository().clone(),
+        prewarm_started,
+        launch_dir,
+    );
     if negotiated {
         private_proxy::write_ack(&mut write_half).await?;
     }
@@ -1859,6 +1881,85 @@ mod tests {
             .await
             .expect("route server task")
             .expect("route server shutdown");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn negotiated_socket_keeps_client_launch_project_for_file_attention() {
+        let root = std::env::temp_dir().join(format!(
+            "moraine-mcp-route-project-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time after unix epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(root.join(".git")).expect("create test git directory");
+        std::fs::write(root.join(".moraine.toml"), "backend = \"default\"\n")
+            .expect("write repository backend marker");
+        let expected_project_id =
+            moraine_config::project_id_for_repo_root(&root).expect("canonical project id");
+
+        let cfg = Arc::new(AppConfig::default());
+        let repository = Arc::new(InMemoryConversationRepository::default());
+        let router = BackendRepositoryRouter::from_preloaded_for_testing(
+            cfg.clone(),
+            [(
+                "default".to_string(),
+                repository.clone() as Arc<dyn ConversationRepository>,
+            )],
+        )
+        .expect("preloaded default router");
+        let (sock, shutdown_tx, server) =
+            spawn_test_socket("route-project", cfg, Arc::new(router)).await;
+
+        let root_text = root.to_string_lossy().to_string();
+        let connection = accepted_test_connection(&sock, &root_text).await;
+        let output = proxy_test_requests(
+            connection,
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"file_attention\",\"arguments\":{\"path\":\"src/lib.rs\",\"scope\":\"project\"}}}\n".to_vec(),
+        )
+        .await;
+        let response: Value = serde_json::from_slice(&output).expect("file_attention response");
+        assert_eq!(response["id"], json!(1));
+        assert!(
+            response["result"]["isError"] == json!(false),
+            "file_attention should succeed: {response}"
+        );
+        assert!(
+            response["result"]["structuredContent"]["warnings"]
+                .as_array()
+                .expect("file_attention warnings")
+                .iter()
+                .any(|warning| warning.as_str().is_some_and(
+                    |warning| warning.contains("pruned before durable project mapping")
+                )),
+            "project scope must disclose the one-time unmappable-history exclusion: {response}"
+        );
+
+        let calls = repository.calls();
+        assert_eq!(calls.file_attention.len(), 1);
+        let query = &calls.file_attention[0];
+        assert_eq!(query.rel, "src/lib.rs");
+        assert_eq!(
+            query.normalized_project_id.as_deref(),
+            Some(expected_project_id.as_str())
+        );
+        assert!(
+            query
+                .normalized_project_roots
+                .iter()
+                .any(|root| root == &root_text),
+            "launch root must be present in registered project roots"
+        );
+        assert!(query.apply_project_scope);
+
+        shutdown_tx.send(()).expect("shutdown route server");
+        server
+            .await
+            .expect("route server task")
+            .expect("route server shutdown");
+        std::fs::remove_dir_all(root).ok();
     }
 
     #[cfg(unix)]

--- a/docs/agent-mcp-search/interface.md
+++ b/docs/agent-mcp-search/interface.md
@@ -202,16 +202,25 @@ Input:
 ```
 
 `path` is required. Absolute paths are reduced to a repo-relative tail by walking
-up to a `.moraine.toml` / `.git` marker; a repo-relative path is used as the tail
-directly and gives the best cross-worktree coverage. Existing relative paths are
-resolved from the server's working directory first, so nested worktree prefixes
-strip to the nested worktree root. Boundary whitespace, `file://` URIs, and
-directory-style trailing slashes are rejected rather than silently mapped to a
-different file. `scope` is `project`
-(default, honoring `--project-only`) or `all` (drop request-level origin
-narrowing on unscoped servers to include every worktree the backend holds).
-When the server was launched with `--project-only`, that configured project
-scope remains a hard floor so returned IDs stay openable. `granularity` is
+up to a `.moraine.toml` / `.git` marker. Relative paths are resolved from the
+client's launch directory, including when the client is routed through the
+central MCP server, so deleted or not-yet-created files retain launch-project
+provenance. Boundary whitespace, `file://` URIs, and directory-style trailing
+slashes are rejected rather than silently mapped to a different file. Compound
+shell text and multi-path captures are never interpreted as one path or root;
+unprovable roots remain `unknown`.
+
+`scope` is `project` (default) or `all`. `project` restricts both normalized and
+legacy fallback lookup to the launch repository's canonical Git-common-directory
+identity independently of `--project-only`, and fails closed when that identity
+cannot be established. `all` deliberately drops that request-level project
+narrowing. A configured `--project-only` server scope remains a hard floor so
+returned IDs stay openable. Registered pre-digest roots are migrated to a
+durable project mapping, and future normalized roots populate that mapping
+automatically. A root pruned before this mapping was installed has no stored Git
+identity and cannot be attributed safely; project scope excludes it rather than
+widening across projects, and the response warns about this one-time upgrade
+limitation. `granularity` is
 `sessions` (default, one rollup per session) or `events` (the flat
 touch-by-touch timeline). `tool` filters by tool name and `mutations_only`
 excludes common pure-read tools. The default limit is `min(50, mcp.max_results)`

--- a/docs/mcp-search-interface-spec.md
+++ b/docs/mcp-search-interface-spec.md
@@ -848,13 +848,22 @@ Rules:
 - `path` is required and must name a file path string. Leading/trailing
   whitespace, `file://` URIs, and directory-style trailing slashes are invalid.
 - Absolute paths are reduced to a repo-relative tail by walking up to
-  `.moraine.toml` or `.git`. Existing relative paths are resolved from the MCP
-  server working directory first, so nested worktree prefixes strip to the
-  nested worktree root.
-- `scope` is `project` or `all`. `project` honors `--project-only`; `all`
-  deliberately drops request-level origin narrowing on unscoped servers. A
-  configured server scope remains a hard floor, so returned IDs must remain
-  accepted by `open`.
+  `.moraine.toml` or `.git`. Relative paths are resolved from the client's MCP
+  launch directory, including through a central-server route, so missing files
+  still retain launch-project provenance. Compound shell text and multi-path
+  captures are not interpreted as one path or root; unprovable roots remain
+  `unknown`.
+- `scope` is `project` or `all`. `project` independently restricts normalized
+  and legacy fallback lookup to the launch repository's canonical
+  Git-common-directory identity and fails closed if that identity cannot be
+  established. `all` deliberately drops request-level project narrowing. A
+  configured `--project-only` server scope remains a hard floor, so returned IDs
+  remain accepted by `open`.
+- Registered pre-digest roots are migrated into a durable project mapping, and
+  future normalized roots populate it automatically. A root pruned before that
+  mapping was installed lacks stored Git identity and cannot be attributed
+  safely; `project` excludes it rather than widening and emits an upgrade
+  limitation warning.
 - `granularity` is `sessions` or `events`.
 - Datetime bounds are optional, inclusive at `start_datetime` and exclusive at
   `end_datetime`. Bounds must be RFC 3339 strings with explicit timezone and at

--- a/sql/021_file_attention_normalization.sql
+++ b/sql/021_file_attention_normalization.sql
@@ -1,8 +1,9 @@
 -- Forward-only normalization columns for file_attention Phase 1.
 --
 -- Existing rows read these as defaults. New ingest rows fill them only when a
--- repo/worktree root and project backend marker can be proven; Tier 0 suffix
--- matching remains the permanent fallback for legacy and unnormalizable rows.
+-- repo/worktree root, Git common-directory identity, and project backend marker
+-- can be proven; Tier 0 suffix matching remains the permanent fallback for
+-- legacy and unnormalizable rows.
 
 ALTER TABLE moraine.events
   ADD COLUMN IF NOT EXISTS project_id LowCardinality(String) DEFAULT '';

--- a/sql/026_file_attention_project_roots.sql
+++ b/sql/026_file_attention_project_roots.sql
@@ -1,0 +1,40 @@
+-- Durable canonical project mapping for worktree roots.
+--
+-- The mapping lets project-scoped file_attention attribute pre-digest rows
+-- after a linked worktree is deleted or pruned. New normalized event/tool rows
+-- populate it automatically; existing digest rows are backfilled once.
+
+CREATE TABLE IF NOT EXISTS moraine.file_attention_project_roots (
+  project_id LowCardinality(String),
+  worktree_root String,
+  observed_version UInt64
+)
+ENGINE = ReplacingMergeTree(observed_version)
+ORDER BY (project_id, worktree_root);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS moraine.mv_file_attention_project_roots_from_events
+TO moraine.file_attention_project_roots
+AS
+SELECT project_id, worktree_root, event_version AS observed_version
+FROM moraine.events
+WHERE startsWith(project_id, 'git:') AND worktree_root != '';
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS moraine.mv_file_attention_project_roots_from_tool_io
+TO moraine.file_attention_project_roots
+AS
+SELECT project_id, worktree_root, event_version AS observed_version
+FROM moraine.tool_io
+WHERE startsWith(project_id, 'git:') AND worktree_root != '';
+
+INSERT INTO moraine.file_attention_project_roots (project_id, worktree_root, observed_version)
+SELECT project_id, worktree_root, max(event_version)
+FROM (
+  SELECT project_id, worktree_root, event_version
+  FROM moraine.events FINAL
+  WHERE startsWith(project_id, 'git:') AND worktree_root != ''
+  UNION ALL
+  SELECT project_id, worktree_root, event_version
+  FROM moraine.tool_io FINAL
+  WHERE startsWith(project_id, 'git:') AND worktree_root != ''
+)
+GROUP BY project_id, worktree_root;


### PR DESCRIPTION
## Description

**What.** Gives `file_attention` canonical Git-project provenance, fail-closed request-level project scoping, safe compound-path handling, and durable root mappings across worktree pruning.

**Why.** Compound tool inputs could be reported as concatenated roots, and `scope: "project"` could widen across every project in an unscoped backend.

The change hashes each canonical Git common directory for project identity, preserves the MCP client's negotiated launch directory through the central server, and applies the same project boundary to normalized exact lookup and Tier-0 suffix fallback. Ingest now leaves compound and multi-path captures unnormalized instead of selecting an arbitrary path. Migration 026 records canonical project/root mappings from normalized events and tool rows, backfills existing digest rows, and migrates currently registered pre-digest worktree roots so later pruning does not erase attribution.

Already-pruned roots from before this upgrade carry only the old shared backend name and a deleted path; no Git identity remains to distinguish repositories sharing that backend. Project scope deliberately excludes those unmappable rows rather than widening, and every project-scoped response discloses this one-time upgrade limitation.

Closes #478.
Closes #479.

## Usage

Existing calls keep the same shape:

```json
{"path":"crates/moraine-mcp-core/src/file_attention_v1.rs","scope":"project"}
```

`project` now enforces the launch repository independently of `--project-only`. Use `scope: "all"` for deliberate backend-wide search; an existing `--project-only` boundary remains a hard floor.

## Bug Evidence

Before this change, semicolon-delimited tool inputs could become one reported root, and `scope: "project"` on an unscoped server could return roots from unrelated projects. The root cause was first-candidate normalization plus request scope being delegated to the server launch configuration.

The ingest path now accepts exactly one proven structured path, root SQL rejects compound delimiters, the routed client launch directory supplies canonical provenance, and both exact and fallback queries enforce the same digest boundary. Focused tests cover registered linked-worktree migration, durable mapping SQL, fail-closed exclusion for an unmappable pre-upgrade pruned root, central-server launch provenance, and the warning contract.

## Changelog

- Normalizes file-attention provenance with a canonical Git common-directory project identity.
- Enforces `scope: "project"` without requiring `--project-only`.
- Prevents compound and multi-path captures from being reported as roots.
- Preserves attributable pre-digest history through durable project/root mappings.

## Validation

Ran `cargo fmt --all -- --check` successfully. Ran `cargo test -p moraine-config project_id_` (2 passed), `cargo test -p moraine-ingest-core tool_rows_` (4 passed), `cargo test -p moraine-ingest-core event_rows_` (4 passed), `cargo test -p moraine-mcp-core file_attention` (26 passed), `cargo test -p moraine-conversations --test repository_integration file_attention` (8 passed), and `cargo test -p moraine-clickhouse schema_skew_probe` (2 passed). The commit hook also passed repository formatting and the strict clippy baseline.