### PR TITLE
fix(mcp): optimize retrieval query plans

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo/helpers.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/helpers.rs
@@ -5,11 +5,12 @@ pub(super) const MCP_INTERNAL_TOOL_NAMES_SQL: &str =
 
 impl ClickHouseConversationRepository {
     pub(super) fn mode_subquery(&self) -> String {
-        let events_source = canonical_events_source(&self.table_ref("events"));
+        self.mode_subquery_for_sessions(None)
+    }
+
+    pub(super) fn mode_aggregate_sql() -> String {
         format!(
-            "SELECT
-  session_id,
-  multiIf(
+            "multiIf(
     countIf(
       payload_type = 'web_search_call'
       OR payload_type = 'search_results_received'
@@ -21,9 +22,22 @@ impl ClickHouseConversationRepository {
     countIf(event_kind IN ('tool_call', 'tool_result') OR payload_type = 'tool_use') > 0,
     'tool_calling',
     'chat'
-  ) AS mode
+  )"
+        )
+    }
+
+    pub(super) fn mode_subquery_for_sessions(&self, session_ids_sql: Option<&str>) -> String {
+        let events_source = canonical_events_source(&self.table_ref("events"));
+        let mode_aggregate = Self::mode_aggregate_sql();
+        let session_filter = session_ids_sql
+            .map(|session_ids_sql| format!("WHERE session_id IN ({session_ids_sql})\n"))
+            .unwrap_or_default();
+        format!(
+            "SELECT
+  session_id,
+  {mode_aggregate} AS mode
 FROM {events_source}
-GROUP BY session_id"
+{session_filter}GROUP BY session_id"
         )
     }
 

--- a/crates/moraine-conversations/src/clickhouse_repo/list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/list.rs
@@ -178,7 +178,6 @@ FORMAT JSONEachRow",
 
         let session_summary = self.table_ref("v_session_summary");
         let events_source = canonical_events_source(&self.table_ref("events"));
-        let mode_subquery = self.mode_subquery();
 
         let mut where_clauses = vec![
             // A blank session_id is never a real session (e.g. the orphan
@@ -197,9 +196,6 @@ FORMAT JSONEachRow",
                 filter.end_unix_ms
             ),
         ];
-        if let Some(mode_clause) = Self::mode_filter_clause(filter.mode) {
-            where_clauses.push(mode_clause);
-        }
         if let Some(scope_clause) = self.session_scope_clause("s.session_id") {
             where_clauses.push(scope_clause);
         }
@@ -222,88 +218,149 @@ FORMAT JSONEachRow",
             ConversationListSort::Desc => "DESC",
             ConversationListSort::Asc => "ASC",
         };
+        let limit_plus = (limit as usize) + 1;
+        let window_limit_sql = if filter.mode.is_none() {
+            format!(
+                "  ORDER BY s.last_event_time {order_dir}, s.session_id {order_dir}\n  LIMIT {limit_plus}\n"
+            )
+        } else {
+            String::new()
+        };
+        let mode_filter_sql = filter
+            .mode
+            .map(|mode| {
+                format!(
+                    "WHERE ifNull(r.mode, 'chat') = {}\n",
+                    sql_quote(mode.as_str())
+                )
+            })
+            .unwrap_or_default();
+        let mode_aggregate = Self::mode_aggregate_sql();
 
+        // Resolve the time/scope window first, applying the keyset LIMIT before
+        // event aggregation whenever no mode predicate depends on that
+        // aggregation. Then compute every event-backed field in one grouped pass
+        // over only the candidate sessions. The previous query independently
+        // aggregated mode, completion state, and metadata across the entire
+        // events table before applying the window and LIMIT.
         let query = format!(
-            "SELECT
-  s.session_id AS session_id,
-  toString(s.first_event_time) AS first_event_time,
-  toInt64(toUnixTimestamp64Milli(s.first_event_time)) AS first_event_unix_ms,
-  toString(s.last_event_time) AS last_event_time,
-  toInt64(toUnixTimestamp64Milli(s.last_event_time)) AS last_event_unix_ms,
-  toUInt32(s.total_turns) AS total_turns,
-  toUInt64(s.total_events) AS total_events,
-  ifNull(m.mode, 'chat') AS mode,
-  toUInt8(
-    ifNull(status.latest_terminal_turn_seq, toUInt32(0)) = toUInt32(s.total_turns)
-    AND ifNull(status.latest_terminal_payload_type, '') = 'task_complete'
-  ) AS completed,
-  ifNull(meta.title, '') AS title,
-  ifNull(meta.source, '') AS source,
-  ifNull(meta.session_slug, '') AS session_slug,
-  ifNull(meta.session_summary, '') AS session_summary
-FROM {session_summary} AS s
-LEFT JOIN ({mode_subquery}) AS m ON m.session_id = s.session_id
-LEFT JOIN (
+            "WITH
+window_sessions AS (
+  SELECT
+    s.session_id AS session_id,
+    toString(s.first_event_time) AS first_event_time,
+    toInt64(toUnixTimestamp64Milli(s.first_event_time)) AS first_event_unix_ms,
+    toString(s.last_event_time) AS last_event_time,
+    toInt64(toUnixTimestamp64Milli(s.last_event_time)) AS last_event_unix_ms,
+    toUInt32(s.total_turns) AS total_turns,
+    toUInt64(s.total_events) AS total_events
+  FROM {session_summary} AS s
+  WHERE {where_sql}
+{window_limit_sql}),
+event_rollups AS (
   SELECT
     session_id,
+    {mode_aggregate} AS mode,
     maxIf(toUInt32(turn_index), payload_type IN ('task_complete', 'turn_aborted')) AS latest_terminal_turn_seq,
     ifNull(
       argMaxIf(payload_type, tuple(event_ts, event_uid), payload_type IN ('task_complete', 'turn_aborted')),
       ''
-    ) AS latest_terminal_payload_type
-  FROM {events_source}
-  GROUP BY session_id
-) AS status ON status.session_id = s.session_id
-LEFT JOIN (
-  SELECT
-    session_id,
+    ) AS latest_terminal_payload_type,
     ifNull(
-      argMax(
+      argMaxIf(
         coalesce(
           nullIf(JSONExtractString(payload_json, 'title'), ''),
           nullIf(JSONExtractString(payload_json, 'name'), ''),
           nullIf(JSONExtractString(payload_json, 'summary'), '')
         ),
-        tuple(event_ts, event_uid)
+        tuple(event_ts, event_uid),
+        event_kind = 'session_meta'
       ),
       ''
     ) AS title,
     ifNull(
-      argMax(
+      argMaxIf(
         coalesce(
           nullIf(JSONExtractString(payload_json, 'source'), ''),
           nullIf(source_name, '')
         ),
-        tuple(event_ts, event_uid)
+        tuple(event_ts, event_uid),
+        event_kind = 'session_meta'
       ),
       ''
     ) AS source,
-    ifNull(argMax(nullIf(JSONExtractString(payload_json, 'slug'), ''), tuple(event_ts, event_uid)), '') AS session_slug,
     ifNull(
-      argMax(
+      argMaxIf(
+        nullIf(JSONExtractString(payload_json, 'slug'), ''),
+        tuple(event_ts, event_uid),
+        event_kind = 'session_meta'
+      ),
+      ''
+    ) AS session_slug,
+    ifNull(
+      argMaxIf(
         coalesce(
           nullIf(JSONExtractString(payload_json, 'summary'), ''),
           nullIf(JSONExtractString(payload_json, 'title'), ''),
           nullIf(JSONExtractString(payload_json, 'name'), '')
         ),
-        tuple(event_ts, event_uid)
+        tuple(event_ts, event_uid),
+        event_kind = 'session_meta'
       ),
       ''
     ) AS session_summary
   FROM {events_source}
-  WHERE event_kind = 'session_meta'
+  WHERE session_id IN (SELECT session_id FROM window_sessions)
   GROUP BY session_id
-) AS meta ON meta.session_id = s.session_id
-WHERE {where_sql}
-ORDER BY s.last_event_time {order_dir}, s.session_id {order_dir}
-LIMIT {limit_plus}
+),
+candidate_sessions AS (
+  SELECT
+    w.session_id AS session_id,
+    w.first_event_time AS first_event_time,
+    w.last_event_time AS last_event_time,
+    w.first_event_unix_ms AS first_event_unix_ms,
+    w.last_event_unix_ms AS last_event_unix_ms,
+    w.total_turns AS total_turns,
+    w.total_events AS total_events,
+    ifNull(r.mode, 'chat') AS mode,
+    toUInt8(
+      ifNull(r.latest_terminal_turn_seq, toUInt32(0)) = w.total_turns
+      AND ifNull(r.latest_terminal_payload_type, '') = 'task_complete'
+    ) AS completed,
+    ifNull(r.title, '') AS title,
+    ifNull(r.source, '') AS source,
+    ifNull(r.session_slug, '') AS session_slug,
+    ifNull(r.session_summary, '') AS session_summary
+  FROM window_sessions AS w
+  LEFT JOIN event_rollups AS r ON r.session_id = w.session_id
+  {mode_filter_sql}ORDER BY w.last_event_unix_ms {order_dir}, w.session_id {order_dir}
+  LIMIT {limit_plus}
+)
+SELECT
+  session_id,
+  first_event_time,
+  first_event_unix_ms,
+  last_event_time,
+  last_event_unix_ms,
+  total_turns,
+  total_events,
+  mode,
+  completed,
+  title,
+  source,
+  session_slug,
+  session_summary
+FROM candidate_sessions
+ORDER BY last_event_unix_ms {order_dir}, session_id {order_dir}
 FORMAT JSONEachRow",
             session_summary = session_summary,
             events_source = events_source,
-            mode_subquery = mode_subquery,
             where_sql = where_sql,
+            mode_aggregate = mode_aggregate,
+            window_limit_sql = window_limit_sql,
+            mode_filter_sql = mode_filter_sql,
             order_dir = order_dir,
-            limit_plus = (limit as usize) + 1,
+            limit_plus = limit_plus,
         );
 
         let rows: Vec<McpSessionListRow> = self.map_backend(self.query_rows(&query, None).await)?;

--- a/crates/moraine-conversations/src/clickhouse_repo/open.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/open.rs
@@ -70,8 +70,10 @@ FORMAT JSONEachRow",
         session_id: &str,
     ) -> RepoResult<Option<SessionMetadata>> {
         let session_summary = self.table_ref("v_session_summary");
-        let mode_subquery = self.mode_subquery();
         let trace_table = self.table_ref("v_conversation_trace");
+        let session_id_sql = sql_quote(session_id);
+        let single_session_sql = format!("SELECT {session_id_sql}");
+        let mode_subquery = self.mode_subquery_for_sessions(Some(&single_session_sql));
         let query = format!(
             "SELECT
   s.session_id AS session_id,
@@ -107,7 +109,7 @@ FORMAT JSONEachRow",
             session_summary = session_summary,
             mode_subquery = mode_subquery,
             trace_table = trace_table,
-            session_id_sql = sql_quote(session_id),
+            session_id_sql = session_id_sql,
         );
 
         let rows: Vec<SessionMetadataRow> =
@@ -115,41 +117,86 @@ FORMAT JSONEachRow",
         Ok(rows.into_iter().next().map(Self::map_session_metadata_row))
     }
 
-    pub(super) async fn load_mcp_session_info(
+    pub(super) async fn load_mcp_session_header(
         &self,
         session_id: &str,
-    ) -> RepoResult<McpSessionInfoRow> {
+    ) -> RepoResult<Option<(SessionMetadata, McpSessionInfoRow)>> {
+        let session_summary = self.table_ref("v_session_summary");
+        let trace_table = self.table_ref("v_conversation_trace");
         let events_source = canonical_events_source(&self.table_ref("events"));
+        let session_id_sql = sql_quote(session_id);
+        let mode_aggregate = Self::mode_aggregate_sql();
         let query = format!(
             "SELECT
-  ifNull(
-    argMaxIf(nullIf(JSONExtractString(payload_json, 'title'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'),
-    ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'name'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'), '')
-  ) AS title,
-  ifNull(
-    argMaxIf(nullIf(JSONExtractString(payload_json, 'source'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'),
-    ifNull(argMax(nullIf(source_name, ''), tuple(event_ts, event_uid)), '')
-  ) AS source,
-  ifNull(argMax(nullIf(harness, ''), tuple(event_ts, event_uid)), '') AS harness,
-  ifNull(argMax(nullIf(inference_provider, ''), tuple(event_ts, event_uid)), '') AS inference_provider,
-  ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'slug'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'), '') AS session_slug,
-  ifNull(
-    argMaxIf(nullIf(JSONExtractString(payload_json, 'summary'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'),
+  s.session_id AS session_id,
+  toString(s.first_event_time) AS first_event_time,
+  toInt64(toUnixTimestamp64Milli(s.first_event_time)) AS first_event_unix_ms,
+  toString(s.last_event_time) AS last_event_time,
+  toInt64(toUnixTimestamp64Milli(s.last_event_time)) AS last_event_unix_ms,
+  toUInt32(s.total_turns) AS total_turns,
+  toUInt64(s.total_events) AS total_events,
+  toUInt64(s.user_messages) AS user_messages,
+  toUInt64(s.assistant_messages) AS assistant_messages,
+  toUInt64(s.tool_calls) AS tool_calls,
+  toUInt64(s.tool_results) AS tool_results,
+  ifNull(i.mode, 'chat') AS mode,
+  ifNull(e.first_event_uid, '') AS first_event_uid,
+  ifNull(e.last_event_uid, '') AS last_event_uid,
+  ifNull(e.last_actor_role, '') AS last_actor_role,
+  ifNull(i.title, '') AS title,
+  ifNull(i.source, '') AS source,
+  ifNull(i.harness, '') AS harness,
+  ifNull(i.inference_provider, '') AS inference_provider,
+  ifNull(i.session_slug, '') AS session_slug,
+  ifNull(i.session_summary, '') AS session_summary
+FROM {session_summary} AS s
+LEFT JOIN (
+  SELECT
+    session_id,
+    argMin(event_uid, tuple(event_time, event_order, event_uid)) AS first_event_uid,
+    argMax(event_uid, tuple(event_time, event_order, event_uid)) AS last_event_uid,
+    argMax(actor_role, tuple(event_time, event_order, event_uid)) AS last_actor_role
+  FROM {trace_table}
+  WHERE session_id = {session_id_sql}
+  GROUP BY session_id
+) AS e ON e.session_id = s.session_id
+LEFT JOIN (
+  SELECT
+    {mode_aggregate} AS mode,
+    session_id,
     ifNull(
       argMaxIf(nullIf(JSONExtractString(payload_json, 'title'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'),
       ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'name'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'), '')
-    )
-  ) AS session_summary
-FROM {events_source}
-WHERE session_id = {}
-GROUP BY session_id
+    ) AS title,
+    ifNull(
+      argMaxIf(nullIf(JSONExtractString(payload_json, 'source'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'),
+      ifNull(argMax(nullIf(source_name, ''), tuple(event_ts, event_uid)), '')
+    ) AS source,
+    ifNull(argMax(nullIf(harness, ''), tuple(event_ts, event_uid)), '') AS harness,
+    ifNull(argMax(nullIf(inference_provider, ''), tuple(event_ts, event_uid)), '') AS inference_provider,
+    ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'slug'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'), '') AS session_slug,
+    ifNull(
+      argMaxIf(nullIf(JSONExtractString(payload_json, 'summary'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'),
+      ifNull(
+        argMaxIf(nullIf(JSONExtractString(payload_json, 'title'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'),
+        ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'name'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'), '')
+      )
+    ) AS session_summary
+  FROM {events_source}
+  WHERE session_id = {session_id_sql}
+  GROUP BY session_id
+) AS i ON i.session_id = s.session_id
+WHERE s.session_id = {session_id_sql}
 LIMIT 1
-FORMAT JSONEachRow",
-            sql_quote(session_id),
+FORMAT JSONEachRow"
         );
 
-        let rows: Vec<McpSessionInfoRow> = self.map_backend(self.query_rows(&query, None).await)?;
-        Ok(rows.into_iter().next().unwrap_or_default())
+        let rows: Vec<McpSessionHeaderRow> =
+            self.map_backend(self.query_rows(&query, None).await)?;
+        Ok(rows
+            .into_iter()
+            .next()
+            .map(|row| (Self::map_session_metadata_row(row.metadata), row.info)))
     }
 
     pub(super) async fn load_turn_summary(
@@ -578,12 +625,21 @@ FORMAT JSONEachRow",
             return Ok(None);
         }
 
-        let Some(metadata) = self.load_session_metadata(session_id).await? else {
+        let load_started = Instant::now();
+        let (header, events, turn_summaries) = tokio::join!(
+            self.load_mcp_session_header(session_id),
+            self.load_mcp_session_events(session_id, None, None),
+            self.load_turns_for_session(session_id),
+        );
+        tracing::debug!(
+            elapsed_ms = load_started.elapsed().as_millis() as u64,
+            "mcp_open_session_load"
+        );
+        let Some((metadata, session_info)) = header? else {
             return Ok(None);
         };
-        let events = self.load_mcp_session_events(session_id, None, None).await?;
-        let session_info = self.load_mcp_session_info(session_id).await?;
-        let turn_summaries = self.load_turns_for_session(session_id).await?;
+        let events = events?;
+        let turn_summaries = turn_summaries?;
         let mut events_by_turn = BTreeMap::<u32, Vec<TraceEvent>>::new();
         for event in events {
             events_by_turn
@@ -646,7 +702,16 @@ FORMAT JSONEachRow",
             return Ok(None);
         }
 
-        let turn_summaries = self.load_turns_for_session(session_id).await?;
+        let load_started = Instant::now();
+        let (turn_summaries, events) = tokio::join!(
+            self.load_turns_for_session(session_id),
+            self.load_mcp_session_events(session_id, Some(turn_seq), None),
+        );
+        tracing::debug!(
+            elapsed_ms = load_started.elapsed().as_millis() as u64,
+            "mcp_open_turn_load"
+        );
+        let turn_summaries = turn_summaries?;
         let Some(summary) = turn_summaries
             .iter()
             .find(|summary| summary.turn_seq == turn_seq)
@@ -654,6 +719,7 @@ FORMAT JSONEachRow",
         else {
             return Ok(None);
         };
+        let events = events?;
         let previous_turn = turn_summaries
             .iter()
             .rev()
@@ -663,9 +729,6 @@ FORMAT JSONEachRow",
             .iter()
             .find(|summary| summary.turn_seq > turn_seq)
             .map(Self::mcp_turn_ref_from_summary);
-        let events = self
-            .load_mcp_session_events(session_id, Some(turn_seq), None)
-            .await?;
 
         Ok(Some(self.mcp_turn_open(
             summary,
@@ -897,19 +960,26 @@ FORMAT JSONEachRow",
             return Ok(None);
         }
 
-        let events = self
-            .load_mcp_session_events(&session_id, None, Some(event_uid))
-            .await?;
+        let load_started = Instant::now();
+        let (events, header, turn_summaries) = tokio::join!(
+            self.load_mcp_session_events(&session_id, None, Some(event_uid)),
+            self.load_mcp_session_header(&session_id),
+            self.load_turns_for_session(&session_id),
+        );
+        tracing::debug!(
+            elapsed_ms = load_started.elapsed().as_millis() as u64,
+            "mcp_open_event_load"
+        );
+        let events = events?;
         let Some(target_index) = events.iter().position(|event| event.event_uid == event_uid)
         else {
             return Ok(None);
         };
         let event = events[target_index].clone();
-        let Some(parent_session) = self.load_session_metadata(&session_id).await? else {
+        let Some((parent_session, parent_session_info)) = header? else {
             return Ok(None);
         };
-        let parent_session_info = self.load_mcp_session_info(&session_id).await?;
-        let turn_summaries = self.load_turns_for_session(&session_id).await?;
+        let turn_summaries = turn_summaries?;
         let Some(parent_turn) = turn_summaries
             .iter()
             .find(|summary| summary.turn_seq == event.turn_seq)

--- a/crates/moraine-conversations/src/clickhouse_repo/rows.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/rows.rs
@@ -42,6 +42,14 @@ pub(super) struct SessionMetadataRow {
     pub(super) last_actor_role: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub(super) struct McpSessionHeaderRow {
+    #[serde(flatten)]
+    pub(super) metadata: SessionMetadataRow,
+    #[serde(flatten)]
+    pub(super) info: McpSessionInfoRow,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub(super) struct McpSessionListRow {
     pub(super) session_id: String,

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -2311,11 +2311,11 @@ FORMAT JSONEachRow",
             .iter()
             .map(|row| row.session_id.clone())
             .collect::<Vec<_>>();
-        let session_time_bounds = self.load_session_time_bounds(&session_ids).await?;
-        let session_metadata_by_session_id = self
-            .fetch_conversation_session_metadata(&session_ids)
-            .await?;
-        let event_enrichment_by_uid = self.load_mcp_event_enrichment(&rows).await?;
+        let (session_time_bounds, session_metadata_by_session_id, event_enrichment_by_uid) = tokio::try_join!(
+            self.load_session_time_bounds(&session_ids),
+            self.fetch_conversation_session_metadata(&session_ids),
+            self.load_mcp_event_enrichment(&rows),
+        )?;
         let max_raw_score = rows.iter().map(|row| row.raw_score).fold(0.0_f64, f64::max);
 
         Ok(rows

--- a/crates/moraine-conversations/tests/repository_integration/search.rs
+++ b/crates/moraine-conversations/tests/repository_integration/search.rs
@@ -522,6 +522,74 @@ async fn search_mcp_events_supports_global_search_with_enriched_hits() {
     assert_eq!(result.hits[0].model.as_deref(), Some("gpt-5.3-codex"));
 }
 #[tokio::test(flavor = "multi_thread")]
+async fn search_mcp_events_does_not_serialize_independent_enrichment_queries() {
+    let reached = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let (repo, state) = build_repo_with_options(
+        100,
+        MockOptions {
+            query_barrier: Some(QueryBarrier {
+                required: vec!["FROM `moraine`.`v_session_summary`", "WHERE session_id IN"],
+                reached: reached.clone(),
+                release: release.clone(),
+            }),
+            ..MockOptions::default()
+        },
+    )
+    .await;
+    let repo = Arc::new(repo);
+    let search = {
+        let repo = Arc::clone(&repo);
+        tokio::spawn(async move {
+            repo.search_mcp_events(SearchMcpEventsQuery {
+                query: "hello world".to_string(),
+                n_hits: Some(10),
+                event_types: Some(vec![
+                    McpEventType::ToolResponse,
+                    McpEventType::UserInput,
+                    McpEventType::AssistantResponse,
+                ]),
+                min_score: Some(0.0),
+                min_should_match: Some(1),
+                ..SearchMcpEventsQuery::default()
+            })
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(2), reached.notified())
+        .await
+        .expect("session-time enrichment query reached the wire barrier");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let (metadata_started, event_enrichment_started) = {
+                let queries = state.queries.lock().expect("queries lock");
+                (
+                    queries
+                        .iter()
+                        .any(|query| query.contains("event_kind = 'session_meta'")),
+                    queries
+                        .iter()
+                        .any(|query| query.contains("AS event_ordinal")),
+                )
+            };
+            if metadata_started && event_enrichment_started {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("metadata and event enrichment reached ClickHouse concurrently");
+
+    release.notify_one();
+    let result = search
+        .await
+        .expect("search task joins")
+        .expect("parallel enrichment succeeds");
+    assert_eq!(result.hits.len(), 2);
+}
+#[tokio::test(flavor = "multi_thread")]
 async fn search_mcp_events_supports_session_scoped_search() {
     let (repo, state) = build_repo().await;
 

--- a/crates/moraine-conversations/tests/repository_integration/sessions.rs
+++ b/crates/moraine-conversations/tests/repository_integration/sessions.rs
@@ -216,12 +216,21 @@ async fn list_mcp_sessions_uses_overlap_filter_and_cursor_pagination() {
 
     assert!(list_query.contains("toUnixTimestamp64Milli(s.last_event_time) >= 1767261600000"));
     assert!(list_query.contains("toUnixTimestamp64Milli(s.first_event_time) < 1767500000000"));
-    assert!(list_query.contains("ifNull(m.mode, 'chat') = 'web_search'"));
-    assert!(list_query.contains("ORDER BY s.last_event_time DESC, s.session_id DESC"));
+    assert!(list_query.contains("ifNull(r.mode, 'chat') = 'web_search'"));
+    assert!(list_query.contains("ORDER BY w.last_event_unix_ms DESC, w.session_id DESC"));
     assert!(list_query.contains("payload_type IN ('task_complete', 'turn_aborted')"));
     // Blank session_id rows are filtered at the source so they never consume a
     // LIMIT slot or anchor the keyset cursor (#386).
     assert!(list_query.contains("notEmpty(trimBoth(s.session_id))"));
+    assert!(list_query.contains("window_sessions AS ("));
+    assert!(list_query.contains("candidate_sessions AS ("));
+    assert_eq!(
+        list_query
+            .matches("session_id IN (SELECT session_id FROM window_sessions)")
+            .count(),
+        1,
+        "all event-backed fields must share one window-bounded aggregate"
+    );
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn list_mcp_sessions_rejects_cursor_filter_mismatch() {
@@ -295,6 +304,12 @@ async fn list_mcp_sessions_applies_session_origin_scope() {
     assert!(list_query.contains("WHERE cwd != ''"));
     assert!(list_query.contains("origin_cwd = '/work/project'"));
     assert!(list_query.contains("startsWith(origin_cwd, '/work/project/')"));
+    let window_sessions = list_query
+        .split_once("event_rollups AS (")
+        .map(|(window, _)| window)
+        .expect("list query must define event rollups after the session window");
+    assert!(window_sessions.contains("ORDER BY s.last_event_time DESC, s.session_id DESC"));
+    assert!(window_sessions.contains("LIMIT 6"));
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn list_mcp_sessions_rejects_cursor_from_differently_scoped_server() {
@@ -593,6 +608,120 @@ async fn get_mcp_session_includes_turn_summaries_and_latest_completion() {
     for query in turn_summary_queries {
         assert_typed_turn_timestamp_projection(query);
     }
+    assert!(queries.iter().any(|query| {
+        query.contains("FROM `moraine`.`v_session_summary` AS s")
+            && query.contains("AS inference_provider")
+            && query.contains("AS session_summary")
+    }));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_mcp_session_does_not_serialize_independent_clickhouse_queries() {
+    let reached = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let header = ScriptedResponse::rows(
+        &[
+            "FROM `moraine`.`v_session_summary` AS s",
+            "AS session_summary",
+        ],
+        json!([{
+            "session_id": "sess-parallel",
+            "first_event_time": "2026-02-01 10:00:00",
+            "first_event_unix_ms": 1769940000000_i64,
+            "last_event_time": "2026-02-01 10:00:01",
+            "last_event_unix_ms": 1769940001000_i64,
+            "total_turns": 1_u32,
+            "total_events": 1_u64,
+            "user_messages": 1_u64,
+            "assistant_messages": 0_u64,
+            "tool_calls": 0_u64,
+            "tool_results": 0_u64,
+            "mode": "chat",
+            "first_event_uid": "evt-parallel",
+            "last_event_uid": "evt-parallel",
+            "last_actor_role": "user",
+            "title": "",
+            "source": "fixture",
+            "harness": "codex",
+            "inference_provider": "openai",
+            "session_slug": "",
+            "session_summary": ""
+        }]),
+    )
+    .blocked(reached.clone(), release.clone());
+    let events = ScriptedResponse::rows(
+        &["ORDER BY event_order ASC, event_uid ASC"],
+        json!([trace_event_row(
+            "sess-parallel",
+            "evt-parallel",
+            1,
+            1,
+            "user",
+            "message",
+            "message",
+            "parallel lookup",
+            "{}",
+            "",
+            "",
+        )]),
+    );
+    let turns = ScriptedResponse::rows(
+        &["FROM `moraine`.`v_turn_summary`"],
+        json!([turn_summary_row("sess-parallel", 1, 1, 1, 0, 0, 0, 0,)]),
+    );
+    let (repo, state) = build_unordered_scripted_repo(vec![header, events, turns]).await;
+    let repo = Arc::new(repo);
+    let open = {
+        let repo = Arc::clone(&repo);
+        tokio::spawn(async move { repo.get_mcp_session("sess-parallel").await })
+    };
+
+    tokio::time::timeout(Duration::from_secs(2), reached.notified())
+        .await
+        .expect("header query reached the wire barrier");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if state.queries.lock().expect("queries lock").len() >= 2 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("a second query reached ClickHouse while the header query was blocked");
+
+    release.notify_one();
+    let session = open
+        .await
+        .expect("open task joins")
+        .expect("parallel session queries succeed")
+        .expect("session exists");
+    assert_eq!(session.metadata.session_id, "sess-parallel");
+    assert_eq!(state.queries.lock().expect("queries lock").len(), 3);
+}
+#[tokio::test(flavor = "multi_thread")]
+async fn get_mcp_session_missing_header_ignores_concurrent_sibling_failures() {
+    let header = ScriptedResponse::rows(
+        &[
+            "FROM `moraine`.`v_session_summary` AS s",
+            "AS session_summary",
+        ],
+        json!([]),
+    );
+    let events = ScriptedResponse::failure(
+        &["ORDER BY event_order ASC, event_uid ASC"],
+        "events unavailable",
+    );
+    let turns =
+        ScriptedResponse::failure(&["FROM `moraine`.`v_turn_summary`"], "turns unavailable");
+    let (repo, state) = build_unordered_scripted_repo(vec![header, events, turns]).await;
+
+    let session = repo
+        .get_mcp_session("sess-missing-parallel")
+        .await
+        .expect("missing authoritative header takes precedence over sibling failures");
+    assert!(session.is_none());
+    assert_eq!(state.queries.lock().expect("queries lock").len(), 3);
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn get_mcp_turn_returns_compact_events_and_incomplete_state() {
@@ -647,7 +776,7 @@ async fn get_mcp_turn_returns_compact_events_and_incomplete_state() {
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn get_mcp_event_returns_full_content_and_navigation_refs() {
-    let (repo, _state) = build_repo().await;
+    let (repo, state) = build_repo().await;
 
     let event = repo
         .get_mcp_event("evt-open-full")
@@ -685,6 +814,13 @@ async fn get_mcp_event_returns_full_content_and_navigation_refs() {
     );
     assert!(event.previous_turn.is_none());
     assert_eq!(event.next_turn.as_ref().map(|turn| turn.turn_seq), Some(2));
+
+    let queries = state.queries.lock().expect("queries lock").clone();
+    assert_eq!(
+        queries.len(),
+        4,
+        "event open should issue one identity query plus three parallel parent queries"
+    );
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn list_session_events_supports_forward_cursor_pagination() {

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -22,6 +22,13 @@ pub(crate) struct ScriptedBarrier {
 }
 
 #[derive(Clone)]
+pub(crate) struct QueryBarrier {
+    pub(crate) required: Vec<&'static str>,
+    pub(crate) reached: Arc<Notify>,
+    pub(crate) release: Arc<Notify>,
+}
+
+#[derive(Clone)]
 pub(crate) struct ScriptedResponse {
     pub(crate) required: Vec<&'static str>,
     pub(crate) forbidden: Vec<&'static str>,
@@ -76,6 +83,8 @@ impl ScriptedResponse {
 pub(crate) struct MockOptions {
     pub(crate) omit_second_snippet_row: bool,
     pub(crate) scripted_responses: Vec<ScriptedResponse>,
+    pub(crate) unordered_scripted_responses: bool,
+    pub(crate) query_barrier: Option<QueryBarrier>,
 }
 
 #[derive(Default)]
@@ -117,12 +126,41 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
             .expect("query lock")
             .push(query.clone());
 
+        if let Some(barrier) = state.options.query_barrier.clone() {
+            if barrier
+                .required
+                .iter()
+                .all(|required| query.contains(*required))
+            {
+                barrier.reached.notify_one();
+                barrier.release.notified().await;
+            }
+        }
+
         let scripted_response = {
             let mut scripted = state
                 .scripted_responses
                 .lock()
                 .expect("scripted response lock");
-            scripted.as_mut().map(|responses| responses.pop_front())
+            scripted.as_mut().map(|responses| {
+                if state.options.unordered_scripted_responses {
+                    responses
+                        .iter()
+                        .position(|response| {
+                            response
+                                .required
+                                .iter()
+                                .all(|required| query.contains(*required))
+                                && response
+                                    .forbidden
+                                    .iter()
+                                    .all(|forbidden| !query.contains(*forbidden))
+                        })
+                        .and_then(|position| responses.remove(position))
+                } else {
+                    responses.pop_front()
+                }
+            })
         };
         if let Some(scripted_response) = scripted_response {
             let Some(response) = scripted_response else {
@@ -476,7 +514,13 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                             "mode": "tool_calling",
                             "first_event_uid": "evt-open-1",
                             "last_event_uid": "evt-open-8",
-                            "last_actor_role": "system"
+                            "last_actor_role": "system",
+                            "title": "Open model session",
+                            "source": "codex-source",
+                            "harness": "codex",
+                            "inference_provider": "openai",
+                            "session_slug": "open-model-session",
+                            "session_summary": "Session summary from metadata"
                         }
                     ])),
                 );
@@ -1808,6 +1852,20 @@ pub(crate) async fn build_scripted_repo(
         100,
         MockOptions {
             scripted_responses,
+            ..MockOptions::default()
+        },
+    )
+    .await
+}
+
+pub(crate) async fn build_unordered_scripted_repo(
+    scripted_responses: Vec<ScriptedResponse>,
+) -> (ClickHouseConversationRepository, Arc<MockState>) {
+    build_repo_with_options(
+        100,
+        MockOptions {
+            scripted_responses,
+            unordered_scripted_responses: true,
             ..MockOptions::default()
         },
     )


### PR DESCRIPTION
## Description

**What.** Bounds and coalesces MCP retrieval queries, and runs independent ClickHouse loads concurrently for `search_sessions`, `list_sessions`, and `open`.

**Why.** Warm retrieval calls were repeatedly missing their published SLA targets, with event/session opens taking several seconds.

- Restricts mode and metadata aggregation to candidate sessions, applying keyset limits before event rollups when no mode predicate requires a wider scan.
- Coalesces session metadata and MCP header fields into one query.
- Preserves not-found/error precedence while overlapping independent session, turn, event, and search-enrichment reads.
- Centralizes the conversation-mode aggregate so list/open/general repository paths cannot drift.
- Adds deterministic concurrency, query-count, plan-shape, and failure-precedence coverage.

Closes #480.

## Usage

No user-facing invocation changes. Existing `search_sessions`, `list_sessions`, and `open` calls use the optimized plans automatically, with unchanged response schemas and SLA targets.

## Performance

Environment: Docker Desktop on Apple Silicon, Linux arm64 container (10 CPUs, 7.65 GiB), ClickHouse 25.12.5.44, debug Rust build. The paired base/branch runs used the same full-profile workload ID, oracle fingerprint, and dataset fingerprint (`sha256:357e3014555d8c7e5351882e3047edd1f41e9fc79e350a1064e31c8088368daf`). Corpus: 100,120 events, 10,020 sessions, 100,040 turns, 200,000 canonical search documents (200,003 physical rows including replacement versions), and 1,000,001 postings.

The warm run used one warmup and 20 measured sequential repetitions per tool (`n_hits=3`, all open handle kinds, list limit 20). All 100 oracle checks passed on both revisions; the branch had zero SLA misses.

| Tool | SLA | Base p50 / p95 | PR p50 / p95 | p50 delta | p95 delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `search_sessions` (result-cache hit) | 750 ms | 0.67 / 0.70 ms | 0.73 / 0.77 ms | +10.3% | +9.7% |
| `list_sessions` | 300 ms | 35.09 / 35.64 ms | 33.97 / 35.75 ms | -3.2% | +0.3% |
| `open(event)` | 500 ms | 91.63 / 97.72 ms | 51.86 / 54.41 ms | -43.4% | -44.3% |
| `open(turn)` | 750 ms | 53.62 / 58.42 ms | 40.37 / 44.05 ms | -24.7% | -24.6% |
| `open(session)` | 1,000 ms | 89.19 / 91.52 ms | 49.16 / 52.45 ms | -44.9% | -42.7% |

To exercise the search plan rather than the 15-second result cache, a second same-corpus run used ten distinct oracle-backed search keys against warm ClickHouse (one sample each). Search improved from 52.07 / 61.18 ms p50/p95 to 45.67 / 54.76 ms, with zero SLA misses and all 20 paired oracle checks passing.

Across the paired warm plus distinct-key workloads:

| Metric | Base | PR | Delta |
| --- | ---: | ---: | ---: |
| Aggregate request throughput | 18.40 req/s | 28.14 req/s | +52.9% |
| ClickHouse SELECT count | 327 | 285 | -12.8% |
| Rows read | 47,798,133 | 43,617,997 | -8.7% |
| Bytes read | 12,841,168,808 | 12,644,504,447 | -1.5% |
| Peak query memory | 208,369,899 B | 197,980,092 B | -5.0% |

The small cache-hit search and list p95 differences are benchmark noise, not claimed improvements; both remain far below their unchanged targets. The uncached-key search run isolates the changed enrichment path.

## Changelog

- Improves MCP search, list, and open query latency without changing public schemas or SLA targets.

## Validation

Ran the full focused `moraine-conversations` repository integration target in the sandbox after implementation: 70 tests passed. After rebasing onto current `main` (including #511 and #513), reran the conflict-affected `get_mcp_session_includes_turn_summaries_and_latest_completion` test successfully. The commit hook also passed repository formatting and strict Clippy.

The final reviewed-query smoke run against the 200k-document sandbox passed all five tool/oracle checks with zero SLA misses: 0.73 ms search, 38.68 ms list, 51.68 ms event open, 39.50 ms turn open, and 50.85 ms session open.

Seven delegated review personas completed. Elegance requested centralizing the duplicated mode aggregate; correctness requested preserving not-found precedence under sibling query failures. Both fixes were applied, revalidated, and accepted in targeted follow-up. Idiom, completeness, security, YAGNI, and scope reported no findings.