### PR TITLE
fix(mcp): preserve logical project aliases

### DIFF
--- a/apps/moraine-mcp/src/rpc.rs
+++ b/apps/moraine-mcp/src/rpc.rs
@@ -137,8 +137,23 @@ fn backend_router(
     )?))
 }
 
+fn prefer_logical_pwd(cwd: PathBuf, pwd: Option<&std::ffi::OsStr>) -> PathBuf {
+    let Some(pwd) = pwd.map(PathBuf::from).filter(|pwd| pwd.is_absolute()) else {
+        return cwd;
+    };
+    match (cwd.canonicalize(), pwd.canonicalize()) {
+        (Ok(canonical_cwd), Ok(canonical_pwd)) if canonical_cwd == canonical_pwd => pwd,
+        _ => cwd,
+    }
+}
+
+fn launch_dir_for_route() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    Some(prefer_logical_pwd(cwd, std::env::var_os("PWD").as_deref()))
+}
+
 async fn run_stdio_entry(cfg: AppConfig, session_scope: Option<SessionOriginScope>) -> Result<()> {
-    let cwd = std::env::current_dir()
+    let cwd = launch_dir_for_route()
         .map(|dir| dir.to_string_lossy().into_owned())
         .unwrap_or_default();
 
@@ -349,6 +364,29 @@ mod tests {
             "/tmp/moraine-mcp-{}-{stamp}.sock",
             std::process::id()
         ))
+    }
+
+    #[test]
+    fn route_prefers_same_directory_logical_pwd() {
+        let base = temp_path("logical-route");
+        let physical = base.join("physical");
+        let logical = base.join("logical");
+        std::fs::create_dir_all(physical.join("nested")).expect("create physical route directory");
+        std::os::unix::fs::symlink(&physical, &logical).expect("create logical route alias");
+
+        let logical_nested = logical.join("nested");
+        assert_eq!(
+            prefer_logical_pwd(physical.join("nested"), Some(logical_nested.as_os_str())),
+            logical_nested
+        );
+        assert_eq!(
+            prefer_logical_pwd(
+                physical.join("nested"),
+                Some(base.join("missing").as_os_str())
+            ),
+            physical.join("nested")
+        );
+        std::fs::remove_dir_all(base).ok();
     }
 
     #[test]

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -1431,7 +1431,14 @@ fn project_id_for_common_dir(common_dir: &Path) -> String {
 /// Git common directory. These roots support a safe transition for normalized
 /// rows written before `project_id` became the common-directory digest.
 pub fn worktree_roots_for_repo_root(root: impl AsRef<Path>) -> Option<Vec<String>> {
-    let root = root.as_ref();
+    let pwd = std::env::var_os("PWD").map(PathBuf::from);
+    worktree_roots_for_repo_root_with_pwd(root.as_ref(), pwd.as_deref())
+}
+
+fn worktree_roots_for_repo_root_with_pwd(
+    root: &Path,
+    logical_cwd: Option<&Path>,
+) -> Option<Vec<String>> {
     find_repo_backend_ref(root)?;
     let common_dir = git_common_dir(root)?;
     let mut roots = vec![root.to_path_buf()];
@@ -1456,6 +1463,20 @@ pub fn worktree_roots_for_repo_root(root: impl AsRef<Path>) -> Option<Vec<String
             };
             if let Some(worktree_root) = git_marker.parent() {
                 roots.push(worktree_root.to_path_buf());
+            }
+        }
+    }
+
+    let canonical_root = root.canonicalize().ok();
+    if let (Some(canonical_root), Some(logical_cwd)) = (&canonical_root, logical_cwd) {
+        if let Ok(canonical_cwd) = logical_cwd.canonicalize() {
+            if let Ok(relative_cwd) = canonical_cwd.strip_prefix(canonical_root) {
+                let depth = relative_cwd.components().count();
+                if let Some(logical_root) = logical_cwd.ancestors().nth(depth) {
+                    if logical_root.canonicalize().ok().as_ref() == Some(canonical_root) {
+                        roots.push(logical_root.to_path_buf());
+                    }
+                }
             }
         }
     }
@@ -1579,6 +1600,46 @@ mod tests {
             assert!(roots.contains(&canonical_linked.to_string_lossy().to_string()));
         }
 
+        std::fs::remove_dir_all(base).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn worktree_roots_include_logical_launch_alias() {
+        let base = std::env::temp_dir().join(format!(
+            "moraine-project-root-alias-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time after unix epoch")
+                .as_nanos()
+        ));
+        let physical_root = base.join("physical/repo");
+        let logical_root = base.join("logical-repo");
+        std::fs::create_dir_all(physical_root.join(".git")).expect("create physical repository");
+        std::fs::create_dir_all(physical_root.join("nested")).expect("create nested launch dir");
+        std::fs::write(
+            physical_root.join(REPO_BACKEND_FILE),
+            "backend = \"shared\"\n",
+        )
+        .expect("write repo backend marker");
+        std::os::unix::fs::symlink(&physical_root, &logical_root)
+            .expect("create logical repository alias");
+
+        let roots = worktree_roots_for_repo_root_with_pwd(
+            &physical_root,
+            Some(&logical_root.join("nested")),
+        )
+        .expect("registered worktree roots");
+
+        assert!(roots.contains(&logical_root.to_string_lossy().to_string()));
+        assert!(roots.contains(
+            &physical_root
+                .canonicalize()
+                .expect("canonical physical root")
+                .to_string_lossy()
+                .to_string()
+        ));
         std::fs::remove_dir_all(base).ok();
     }
 


### PR DESCRIPTION
## Description

**What.** Preserves validated logical project-root aliases when the MCP proxy routes a client and when `file_attention` builds the current repository's compatible root set.

**Why.** Historical normalized rows can contain the logical `$PWD` spelling of a symlinked checkout. If a current client reports only the physical path, exact root-membership checks can exclude valid pre-digest history from the same repository.

This focused follow-up:

- makes the stdio proxy prefer `$PWD` only when it is absolute and canonicalizes to the process's actual current directory;
- derives the repository-level logical alias when the logical launch directory is nested below the root;
- retains the physical and canonical root spellings alongside the logical alias;
- adds Unix symlink regressions for proxy-route selection and root registration.

The canonical file-attention scope work from #513 remains unchanged; this PR only covers the two-file logical-alias compatibility delta.

## Usage

No user action is required. Launching Moraine from a symlinked checkout now preserves that validated logical checkout spelling through central MCP routing and project-root compatibility matching.

## Changelog

- Preserves logical symlink aliases for project-scoped `file_attention` compatibility with historical normalized rows.

## Validation

After merging current `main`, ran `cargo fmt --all -- --check` successfully. The focused regressions passed with `cargo test -p moraine-config worktree_roots_include_logical_launch_alias -- --exact` and `cargo test -p moraine-mcp route_prefers_same_directory_logical_pwd -- --exact`. Also reran the affected behavior suites: `cargo test -p moraine-mcp-core file_attention_v1::tests` (23 passed), `cargo test -p moraine-conversations --test repository_integration file_attention` (8 passed), `cargo test -p moraine-ingest-core tool_rows_` (4 passed), and `cargo test -p moraine-ingest-core event_rows_` (4 passed).