### PR TITLE
fix(clickhouse): bound supervisor log retention

### DIFF
--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -6,7 +6,7 @@ description = "Unified runtime control plane for Moraine services"
 
 [dependencies]
 anyhow = "1.0"
-tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "time", "process", "signal"] }
+tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "time", "process", "signal", "io-util"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }

--- a/apps/moraine/src/commands/logs.rs
+++ b/apps/moraine/src/commands/logs.rs
@@ -4,7 +4,9 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use crate::paths::RuntimePaths;
-use crate::process::{clickhouse_supervisor_log_path, log_path};
+use crate::process::{
+    clickhouse_supervisor_log_path, log_path, RollingLog, CLICKHOUSE_SUPERVISOR_LOG_ROTATIONS,
+};
 use crate::render::{LogsSnapshot, ServiceLogSection};
 use crate::service::Service;
 
@@ -56,8 +58,7 @@ fn tail_lines(path: &Path, lines: usize) -> Result<Vec<String>> {
     } else {
         0
     };
-    let content = std::str::from_utf8(&bytes[start..])
-        .with_context(|| format!("failed to decode log file {} as utf-8", path.display()))?;
+    let content = String::from_utf8_lossy(&bytes[start..]);
     let mut collected = content
         .lines()
         .rev()
@@ -69,18 +70,31 @@ fn tail_lines(path: &Path, lines: usize) -> Result<Vec<String>> {
 }
 
 fn service_log_paths(paths: &RuntimePaths, service: Service) -> Vec<PathBuf> {
-    if service == Service::ClickHouse {
-        vec![
-            clickhouse_supervisor_log_path(paths),
-            log_path(paths, service),
-        ]
-    } else {
-        vec![log_path(paths, service)]
+    if service != Service::ClickHouse {
+        return vec![log_path(paths, service)];
     }
+
+    let supervisor = clickhouse_supervisor_log_path(paths);
+    let mut log_paths = (1..=CLICKHOUSE_SUPERVISOR_LOG_ROTATIONS)
+        .rev()
+        .map(|generation| RollingLog::rotation_path(&supervisor, generation))
+        .filter(|path| path.exists())
+        .collect::<Vec<_>>();
+    log_paths.push(supervisor);
+    log_paths.push(log_path(paths, service));
+    log_paths
 }
 
 fn default_log_services() -> [Service; 3] {
     [Service::ClickHouse, Service::Ingest, Service::Backend]
+}
+
+fn is_not_found(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|error| error.kind() == std::io::ErrorKind::NotFound)
+    })
 }
 
 pub(super) fn collect_logs(
@@ -106,11 +120,24 @@ pub(super) fn collect_logs(
                 });
                 continue;
             }
+            let retained_lines = match tail_lines(&path, lines) {
+                Ok(lines) => lines,
+                Err(err) if is_not_found(&err) => {
+                    sections.push(ServiceLogSection {
+                        service: svc,
+                        path: path_string,
+                        exists: false,
+                        lines: Vec::new(),
+                    });
+                    continue;
+                }
+                Err(err) => return Err(err),
+            };
             sections.push(ServiceLogSection {
                 service: svc,
                 path: path_string,
                 exists: true,
-                lines: tail_lines(&path, lines)?,
+                lines: retained_lines,
             });
         }
     }
@@ -168,6 +195,26 @@ mod tests {
     }
 
     #[test]
+    fn missing_log_error_is_detected_through_context() {
+        let root = temp_dir("tail-lines-missing");
+        let err = tail_lines(&root.join("vanished.log"), 1).expect_err("missing log");
+        assert!(is_not_found(&err), "{err:#}");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn tail_lines_remains_readable_when_rotation_splits_utf8() {
+        let root = temp_dir("tail-lines-split-utf8");
+        let path = root.join("test.log");
+        fs::write(&path, [0xa9, b'\n', b't', b'a', b'i', b'l', b'\n'])
+            .expect("write split utf8 log");
+
+        let lines = tail_lines(&path, 2).expect("decode split log");
+        assert_eq!(lines, vec!["�".to_string(), "tail".to_string()]);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn clickhouse_logs_include_supervisor_and_server_sections() {
         let root = temp_dir("clickhouse-log-sections");
         let mut cfg = AppConfig::default();
@@ -189,6 +236,40 @@ mod tests {
         assert_eq!(snapshot.sections[0].lines, ["state=exhausted"]);
         assert_eq!(snapshot.sections[1].path, server.display().to_string());
         assert_eq!(snapshot.sections[1].lines, ["server line"]);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn clickhouse_logs_include_retained_supervisor_rotations() {
+        let root = temp_dir("clickhouse-rotated-log-sections");
+        let mut cfg = AppConfig::default();
+        cfg.runtime.root_dir = root.join("runtime").display().to_string();
+        cfg.runtime.logs_dir = root.join("logs").display().to_string();
+        let paths = crate::paths::runtime_paths(&cfg);
+        fs::create_dir_all(&paths.logs_dir).expect("logs dir");
+        fs::create_dir_all(paths.clickhouse_root.join("log")).expect("clickhouse log dir");
+        let supervisor = clickhouse_supervisor_log_path(&paths);
+        fs::write(
+            RollingLog::rotation_path(&supervisor, 2),
+            "oldest retained\n",
+        )
+        .expect("oldest supervisor rotation");
+        fs::write(
+            RollingLog::rotation_path(&supervisor, 1),
+            "newer retained\n",
+        )
+        .expect("newer supervisor rotation");
+        fs::write(&supervisor, "current supervisor\n").expect("current supervisor");
+        fs::write(log_path(&paths, Service::ClickHouse), "server line\n").expect("server log");
+
+        let snapshot =
+            collect_logs(&paths, Some(Service::ClickHouse), 10).expect("collect retained logs");
+
+        assert_eq!(snapshot.sections.len(), 4);
+        assert_eq!(snapshot.sections[0].lines, ["oldest retained"]);
+        assert_eq!(snapshot.sections[1].lines, ["newer retained"]);
+        assert_eq!(snapshot.sections[2].lines, ["current supervisor"]);
+        assert_eq!(snapshot.sections[3].lines, ["server line"]);
         let _ = fs::remove_dir_all(root);
     }
 

--- a/apps/moraine/src/managed_clickhouse.rs
+++ b/apps/moraine/src/managed_clickhouse.rs
@@ -3,12 +3,15 @@ use moraine_clickhouse::ClickHouseClient;
 use moraine_config::AppConfig;
 use reqwest::{Client, Url};
 use sha2::{Digest, Sha256};
-use std::fs::{self, OpenOptions};
+use std::fs;
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, ExitStatus, Stdio};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::{Child, Command as TokioCommand};
+use tokio::task::JoinHandle;
 use tokio::time::{sleep, timeout, Instant};
 
 #[cfg(unix)]
@@ -20,7 +23,8 @@ use std::os::unix::{
 use crate::paths::{ensure_runtime_dirs, RuntimePaths};
 use crate::process::{
     cleanup_legacy_clickhouse_pipe_log, clickhouse_supervisor_log_path, pid_path,
-    remove_pid_if_matches, service_running, write_pid, StartOutcome, StartState,
+    remove_pid_if_matches, service_running, write_pid, RollingLog, RollingLogPolicy, StartOutcome,
+    StartState,
 };
 use crate::render::ClickhouseStatusSnapshot;
 use crate::service::Service;
@@ -573,6 +577,11 @@ const RESTART_DELAYS: [Duration; 5] = [
 const STABILITY_WINDOW: Duration = Duration::from_secs(5 * 60);
 const CHILD_SHUTDOWN_GRACE: Duration = Duration::from_secs(4);
 const SUPERVISOR_SHUTDOWN_GRACE: Duration = Duration::from_secs(8);
+const OUTPUT_DRAIN_GRACE: Duration = Duration::from_secs(1);
+const OUTPUT_RECORD_BYTES: usize = 64 * 1024;
+const OUTPUT_FRAGMENT_BYTES: usize = OUTPUT_RECORD_BYTES - 64;
+const OUTPUT_CONTINUATION_MARKER: &[u8] = b" [moraine: output continues]\n";
+const OUTPUT_UNTERMINATED_MARKER: &[u8] = b" [moraine: stream ended without newline]\n";
 
 #[derive(Clone, Copy)]
 struct SupervisorPolicy {
@@ -587,6 +596,234 @@ impl SupervisorPolicy {
             restart_delays: RESTART_DELAYS,
             stability_window: STABILITY_WINDOW,
             child_shutdown_grace: CHILD_SHUTDOWN_GRACE,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct SupervisorLog {
+    inner: Arc<Mutex<RollingLog>>,
+}
+
+impl SupervisorLog {
+    fn open(path: PathBuf, policy: RollingLogPolicy) -> Result<Self> {
+        Ok(Self {
+            inner: Arc::new(Mutex::new(RollingLog::open(path, policy)?)),
+        })
+    }
+
+    async fn write_record(&self, bytes: Vec<u8>) -> Result<Vec<u8>> {
+        let inner = Arc::clone(&self.inner);
+        let (bytes, result) = tokio::task::spawn_blocking(move || {
+            let result = inner
+                .lock()
+                .map_err(|_| anyhow!("ClickHouse supervisor log lock is poisoned"))
+                .and_then(|mut log| log.write_all(&bytes));
+            (bytes, result)
+        })
+        .await
+        .context("ClickHouse supervisor log writer task failed")?;
+        result?;
+        Ok(bytes)
+    }
+
+    async fn line(&self, message: impl AsRef<str>) -> Result<()> {
+        let message = message.as_ref();
+        let mut bytes = Vec::with_capacity(message.len() + 1);
+        bytes.extend_from_slice(message.as_bytes());
+        bytes.push(b'\n');
+        self.write_record(bytes).await.map(|_| ())
+    }
+
+    async fn flush(&self) -> Result<()> {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            inner
+                .lock()
+                .map_err(|_| anyhow!("ClickHouse supervisor log lock is poisoned"))?
+                .flush()
+        })
+        .await
+        .context("ClickHouse supervisor log flush task failed")?
+    }
+
+    #[cfg(test)]
+    fn writer_count(&self) -> usize {
+        Arc::strong_count(&self.inner)
+    }
+}
+
+struct OutputForwarders {
+    stdout: Option<JoinHandle<Result<()>>>,
+    stderr: Option<JoinHandle<Result<()>>>,
+}
+
+impl OutputForwarders {
+    async fn finish(&mut self) -> Result<bool> {
+        let stdout = self.stdout.take();
+        let stderr = self.stderr.take();
+        let stdout_abort = stdout.as_ref().map(JoinHandle::abort_handle);
+        let stderr_abort = stderr.as_ref().map(JoinHandle::abort_handle);
+        let drain = async move {
+            let (stdout, stderr) = tokio::join!(
+                join_output_forwarder(stdout, "stdout"),
+                join_output_forwarder(stderr, "stderr")
+            );
+            stdout?;
+            stderr?;
+            Ok(())
+        };
+        match timeout(OUTPUT_DRAIN_GRACE, drain).await {
+            Ok(result) => result.map(|()| true),
+            Err(_) => {
+                if let Some(abort) = stdout_abort {
+                    abort.abort();
+                }
+                if let Some(abort) = stderr_abort {
+                    abort.abort();
+                }
+                Ok(false)
+            }
+        }
+    }
+}
+
+async fn finish_output_forwarders(
+    forwarders: &mut OutputForwarders,
+    log: &SupervisorLog,
+) -> Result<()> {
+    if !forwarders.finish().await? {
+        log.line(format!(
+            "clickhouse supervisor: output-drain=aborted timeout_seconds={}",
+            OUTPUT_DRAIN_GRACE.as_secs_f64()
+        ))
+        .await?;
+    }
+    Ok(())
+}
+
+async fn join_output_forwarder(task: Option<JoinHandle<Result<()>>>, stream: &str) -> Result<()> {
+    if let Some(task) = task {
+        task.await
+            .with_context(|| format!("ClickHouse {stream} forwarder task failed"))??;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum OutputStream {
+    Stdout,
+    Stderr,
+}
+
+impl OutputStream {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        }
+    }
+}
+
+async fn stop_after_output_forwarder(
+    child: &mut Child,
+    forwarders: &mut OutputForwarders,
+    stream: OutputStream,
+    outcome: std::result::Result<Result<()>, tokio::task::JoinError>,
+    grace: Duration,
+    log: &SupervisorLog,
+) -> Result<GenerationOutcome> {
+    match stream {
+        OutputStream::Stdout => {
+            forwarders.stdout.take();
+        }
+        OutputStream::Stderr => {
+            forwarders.stderr.take();
+        }
+    }
+    let stream_name = stream.name();
+    let failure = match outcome {
+        Ok(Ok(())) => anyhow!("ClickHouse {stream_name} closed while the child was still running"),
+        Ok(Err(err)) => err.context(format!("ClickHouse {stream_name} forwarding failed")),
+        Err(err) => anyhow!(err).context(format!("ClickHouse {stream_name} forwarder task failed")),
+    };
+    let stopped = terminate_and_reap(child, grace, None).await;
+    let drained = finish_output_forwarders(forwarders, log).await;
+    if let Err(err) = stopped {
+        return Err(failure.context(format!(
+            "also failed to stop child after output forwarding failure: {err:#}"
+        )));
+    }
+    if let Err(err) = drained {
+        return Err(failure.context(format!(
+            "also failed to drain remaining child output: {err:#}"
+        )));
+    }
+    Err(failure)
+}
+
+async fn log_while_child_live(
+    child: &mut Child,
+    forwarders: &mut OutputForwarders,
+    grace: Duration,
+    log: &SupervisorLog,
+    message: String,
+) -> Result<()> {
+    let Err(log_err) = log.line(message).await else {
+        return Ok(());
+    };
+    let stopped = terminate_and_reap(child, grace, None).await;
+    let drained = forwarders.finish().await;
+    if let Err(err) = stopped {
+        return Err(log_err.context(format!(
+            "also failed to stop child after supervisor log failure: {err:#}"
+        )));
+    }
+    if let Err(err) = drained {
+        return Err(log_err.context(format!(
+            "also failed to drain child after supervisor log failure: {err:#}"
+        )));
+    }
+    Err(log_err)
+}
+
+async fn forward_clickhouse_output<R>(mut reader: R, log: SupervisorLog) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut input = [0_u8; 8 * 1024];
+    let mut record = Vec::with_capacity(OUTPUT_RECORD_BYTES);
+    loop {
+        let read = reader
+            .read(&mut input)
+            .await
+            .context("failed to read ClickHouse output")?;
+        if read == 0 {
+            if !record.is_empty() {
+                record.extend_from_slice(OUTPUT_UNTERMINATED_MARKER);
+                log.write_record(record).await?;
+            }
+            return Ok(());
+        }
+
+        let mut offset = 0;
+        while offset < read {
+            let available = OUTPUT_FRAGMENT_BYTES - record.len();
+            let input_end = read.min(offset + available);
+            let newline = input[offset..input_end]
+                .iter()
+                .position(|byte| *byte == b'\n');
+            let take = newline.map_or(input_end - offset, |index| index + 1);
+            record.extend_from_slice(&input[offset..offset + take]);
+            offset += take;
+            if newline.is_some() {
+                record = log.write_record(record).await?;
+                record.clear();
+            } else if record.len() == OUTPUT_FRAGMENT_BYTES {
+                record.extend_from_slice(OUTPUT_CONTINUATION_MARKER);
+                record = log.write_record(record).await?;
+                record.clear();
+            }
         }
     }
 }
@@ -680,7 +917,11 @@ async fn send_terminate(pid: u32) -> Result<()> {
     }
 }
 
-async fn terminate_and_reap(child: &mut Child, grace: Duration) -> Result<ExitStatus> {
+async fn terminate_and_reap(
+    child: &mut Child,
+    grace: Duration,
+    log: Option<&SupervisorLog>,
+) -> Result<ExitStatus> {
     if let Some(status) = child.try_wait().context("failed to inspect child status")? {
         return Ok(status);
     }
@@ -694,7 +935,14 @@ async fn terminate_and_reap(child: &mut Child, grace: Duration) -> Result<ExitSt
             {
                 return Ok(status);
             }
-            eprintln!("clickhouse supervisor: {err:#}; forcing child shutdown");
+            if let Some(log) = log {
+                log.line(format!(
+                    "clickhouse supervisor: {err:#}; forcing child shutdown"
+                ))
+                .await?;
+            } else {
+                eprintln!("clickhouse supervisor: {err:#}; forcing child shutdown");
+            }
         }
 
         #[cfg(not(unix))]
@@ -720,7 +968,11 @@ async fn terminate_and_reap(child: &mut Child, grace: Duration) -> Result<ExitSt
     }
 }
 
-fn spawn_clickhouse_generation(server_bin: &Path, config_path: &Path) -> Result<Child> {
+fn spawn_clickhouse_generation(
+    server_bin: &Path,
+    config_path: &Path,
+    log: &SupervisorLog,
+) -> Result<(Child, OutputForwarders)> {
     let mut command = TokioCommand::new(server_bin);
     command
         .arg("--config-file")
@@ -731,10 +983,25 @@ fn spawn_clickhouse_generation(server_bin: &Path, config_path: &Path) -> Result<
         .env("CLICKHOUSE_WATCHDOG_ENABLE", "0")
         .env("CLICKHOUSE_WATCHDOG_RESTART", "0")
         .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .kill_on_drop(true);
-    command
+    let mut child = command
         .spawn()
-        .with_context(|| format!("failed to start {}", server_bin.display()))
+        .with_context(|| format!("failed to start {}", server_bin.display()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("ClickHouse stdout pipe was not created"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("ClickHouse stderr pipe was not created"))?;
+    let forwarders = OutputForwarders {
+        stdout: Some(tokio::spawn(forward_clickhouse_output(stdout, log.clone()))),
+        stderr: Some(tokio::spawn(forward_clickhouse_output(stderr, log.clone()))),
+    };
+    Ok((child, forwarders))
 }
 
 async fn run_generation(
@@ -744,56 +1011,103 @@ async fn run_generation(
     generation: u64,
     policy: SupervisorPolicy,
     signals: &mut ShutdownSignals,
+    log: &SupervisorLog,
 ) -> Result<GenerationOutcome> {
-    let mut child = match spawn_clickhouse_generation(server_bin, config_path) {
-        Ok(child) => child,
-        Err(err) => {
-            return Ok(GenerationOutcome::Failed {
-                reason: format!("{err:#}"),
-                ready_uptime: None,
-            });
-        }
-    };
-    let pid = child.id();
-    eprintln!(
-        "clickhouse supervisor: generation={generation} pid={} state=starting",
-        pid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
-    );
-
-    let readiness = wait_for_clickhouse(cfg);
-    tokio::pin!(readiness);
-    tokio::select! {
-        biased;
-        _ = signals.recv() => {
-            let status = terminate_and_reap(&mut child, policy.child_shutdown_grace).await?;
-            eprintln!(
-                "clickhouse supervisor: generation={generation} state=stopped reason={}",
-                describe_exit(status)
-            );
-            return Ok(GenerationOutcome::Stopped);
-        }
-        status = child.wait() => {
-            let status = status.context("failed waiting for ClickHouse startup exit")?;
-            return Ok(GenerationOutcome::Failed {
-                reason: format!("exited before readiness ({})", describe_exit(status)),
-                ready_uptime: None,
-            });
-        }
-        ready = &mut readiness => {
-            if let Err(err) = ready {
-                let status = terminate_and_reap(&mut child, policy.child_shutdown_grace).await?;
+    let (mut child, mut forwarders) =
+        match spawn_clickhouse_generation(server_bin, config_path, log) {
+            Ok(generation) => generation,
+            Err(err) => {
                 return Ok(GenerationOutcome::Failed {
-                    reason: format!("readiness failed ({err:#}); stopped child ({})", describe_exit(status)),
+                    reason: format!("{err:#}"),
                     ready_uptime: None,
                 });
             }
+        };
+    let pid = child.id();
+    log_while_child_live(
+        &mut child,
+        &mut forwarders,
+        policy.child_shutdown_grace,
+        log,
+        format!(
+            "clickhouse supervisor: generation={generation} pid={} state=starting",
+            pid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
+        ),
+    )
+    .await?;
+
+    let readiness = wait_for_clickhouse(cfg);
+    tokio::pin!(readiness);
+    let startup_outcome = tokio::select! {
+        biased;
+        _ = signals.recv() => {
+            let status =
+                terminate_and_reap(&mut child, policy.child_shutdown_grace, None).await?;
+            let _ = log
+                .line(format!(
+                    "clickhouse supervisor: generation={generation} state=stopped reason={}",
+                    describe_exit(status)
+                ))
+                .await;
+            Some(GenerationOutcome::Stopped)
         }
+        status = child.wait() => {
+            let status = status.context("failed waiting for ClickHouse startup exit")?;
+            Some(GenerationOutcome::Failed {
+                reason: format!("exited before readiness ({})", describe_exit(status)),
+                ready_uptime: None,
+            })
+        }
+        ready = &mut readiness => {
+            match ready {
+                Ok(()) => None,
+                Err(err) => {
+                    let status =
+                        terminate_and_reap(&mut child, policy.child_shutdown_grace, None)
+                            .await?;
+                    Some(GenerationOutcome::Failed {
+                        reason: format!(
+                            "readiness failed ({err:#}); stopped child ({})",
+                            describe_exit(status)
+                        ),
+                        ready_uptime: None,
+                    })
+                }
+            }
+        }
+        stdout = forwarders.stdout.as_mut().expect("stdout forwarder is active") => {
+            return stop_after_output_forwarder(
+                &mut child,
+                &mut forwarders,
+                OutputStream::Stdout,
+                stdout,
+                policy.child_shutdown_grace,
+                log,
+            )
+            .await;
+        }
+        stderr = forwarders.stderr.as_mut().expect("stderr forwarder is active") => {
+            return stop_after_output_forwarder(
+                &mut child,
+                &mut forwarders,
+                OutputStream::Stderr,
+                stderr,
+                policy.child_shutdown_grace,
+                log,
+            )
+            .await;
+        }
+    };
+    if let Some(outcome) = startup_outcome {
+        finish_output_forwarders(&mut forwarders, log).await?;
+        return Ok(outcome);
     }
 
     if let Some(status) = child
         .try_wait()
         .context("failed to inspect ClickHouse after readiness")?
     {
+        finish_output_forwarders(&mut forwarders, log).await?;
         return Ok(GenerationOutcome::Failed {
             reason: format!("exited at readiness boundary ({})", describe_exit(status)),
             ready_uptime: None,
@@ -801,28 +1115,62 @@ async fn run_generation(
     }
 
     let ready_since = Instant::now();
-    eprintln!(
-        "clickhouse supervisor: generation={generation} pid={} state=ready",
-        pid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
-    );
-    tokio::select! {
+    log_while_child_live(
+        &mut child,
+        &mut forwarders,
+        policy.child_shutdown_grace,
+        log,
+        format!(
+            "clickhouse supervisor: generation={generation} pid={} state=ready",
+            pid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
+        ),
+    )
+    .await?;
+    let outcome = tokio::select! {
         biased;
         _ = signals.recv() => {
-            let status = terminate_and_reap(&mut child, policy.child_shutdown_grace).await?;
-            eprintln!(
-                "clickhouse supervisor: generation={generation} state=stopped reason={}",
-                describe_exit(status)
-            );
-            Ok(GenerationOutcome::Stopped)
+            let status =
+                terminate_and_reap(&mut child, policy.child_shutdown_grace, None).await?;
+            let _ = log
+                .line(format!(
+                    "clickhouse supervisor: generation={generation} state=stopped reason={}",
+                    describe_exit(status)
+                ))
+                .await;
+            GenerationOutcome::Stopped
         }
         status = child.wait() => {
             let status = status.context("failed waiting for ClickHouse exit")?;
-            Ok(GenerationOutcome::Failed {
+            GenerationOutcome::Failed {
                 reason: describe_exit(status),
                 ready_uptime: Some(ready_since.elapsed()),
-            })
+            }
         }
-    }
+        stdout = forwarders.stdout.as_mut().expect("stdout forwarder is active") => {
+            return stop_after_output_forwarder(
+                &mut child,
+                &mut forwarders,
+                OutputStream::Stdout,
+                stdout,
+                policy.child_shutdown_grace,
+                log,
+            )
+            .await;
+        }
+        stderr = forwarders.stderr.as_mut().expect("stderr forwarder is active") => {
+            return stop_after_output_forwarder(
+                &mut child,
+                &mut forwarders,
+                OutputStream::Stderr,
+                stderr,
+                policy.child_shutdown_grace,
+                log,
+            )
+            .await;
+        }
+    };
+    finish_output_forwarders(&mut forwarders, log).await?;
+    Ok(outcome)
 }
 
 fn next_failure_count(
@@ -839,6 +1187,7 @@ async fn supervise_clickhouse(
     server_bin: &Path,
     config_path: &Path,
     policy: SupervisorPolicy,
+    log: &SupervisorLog,
 ) -> Result<ExitCode> {
     let mut signals = ShutdownSignals::install()?;
     let mut consecutive_failures = 0usize;
@@ -849,15 +1198,19 @@ async fn supervise_clickhouse(
             let Some(delay) = policy.restart_delays.get(consecutive_failures - 1).copied() else {
                 unreachable!("restart budget checked after every failed generation");
             };
-            eprintln!(
+            log.line(format!(
                 "clickhouse supervisor: replacement={} delay_seconds={} state=backoff",
                 consecutive_failures,
                 delay.as_secs_f64()
-            );
+            ))
+            .await?;
             tokio::select! {
                 biased;
                 _ = signals.recv() => {
-                    eprintln!("clickhouse supervisor: state=stopped reason=intentional shutdown during backoff");
+                    log.line(
+                        "clickhouse supervisor: state=stopped reason=intentional shutdown during backoff"
+                    )
+                    .await?;
                     return Ok(ExitCode::SUCCESS);
                 }
                 _ = sleep(delay) => {}
@@ -871,6 +1224,7 @@ async fn supervise_clickhouse(
             generation,
             policy,
             &mut signals,
+            log,
         )
         .await?;
         match outcome {
@@ -882,19 +1236,22 @@ async fn supervise_clickhouse(
                 let (next_count, reset) =
                     next_failure_count(consecutive_failures, ready_uptime, policy.stability_window);
                 if reset {
-                    eprintln!(
+                    log.line(format!(
                         "clickhouse supervisor: generation={generation} state=stable-budget-reset"
-                    );
+                    ))
+                    .await?;
                 }
                 consecutive_failures = next_count;
-                eprintln!(
+                log.line(format!(
                     "clickhouse supervisor: generation={generation} state=failed reason={reason}"
-                );
+                ))
+                .await?;
                 if consecutive_failures > policy.restart_delays.len() {
-                    eprintln!(
+                    log.line(format!(
                         "clickhouse supervisor: state=exhausted replacements={} final_reason={reason}",
                         policy.restart_delays.len()
-                    );
+                    ))
+                    .await?;
                     return Ok(ExitCode::from(1));
                 }
                 generation += 1;
@@ -904,7 +1261,7 @@ async fn supervise_clickhouse(
 }
 
 async fn stop_new_supervisor(child: &mut Child, pid_file: &Path, pid: u32) -> Result<()> {
-    terminate_and_reap(child, SUPERVISOR_SHUTDOWN_GRACE).await?;
+    terminate_and_reap(child, SUPERVISOR_SHUTDOWN_GRACE, None).await?;
     remove_pid_if_matches(pid_file, pid);
     Ok(())
 }
@@ -980,14 +1337,13 @@ pub(crate) async fn start_clickhouse(
     resolve_clickhouse_server_command(cfg, paths).await?;
     materialize_clickhouse_config(cfg, paths)?;
 
-    let logfile = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&supervisor_log)
-        .with_context(|| format!("failed to open {}", supervisor_log.display()))?;
-    let logfile_err = logfile
-        .try_clone()
-        .with_context(|| format!("failed to clone {}", supervisor_log.display()))?;
+    // Validate the sink before detaching. The supervisor reopens it as the
+    // sole writer, so neither it nor ClickHouse inherits a rotatable file
+    // descriptor from this short-lived launcher.
+    drop(RollingLog::open(
+        supervisor_log.clone(),
+        RollingLogPolicy::clickhouse_supervisor(),
+    )?);
     let launcher = std::env::current_exe().context("failed to resolve current moraine binary")?;
     let mut supervisor = TokioCommand::new(&launcher)
         .arg("--config")
@@ -995,8 +1351,8 @@ pub(crate) async fn start_clickhouse(
         .arg("clickhouse")
         .arg("supervise")
         .stdin(Stdio::null())
-        .stdout(Stdio::from(logfile))
-        .stderr(Stdio::from(logfile_err))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .with_context(|| {
             format!(
@@ -1061,18 +1417,39 @@ pub(crate) async fn run_supervised_clickhouse(
     paths: &RuntimePaths,
 ) -> Result<ExitCode> {
     ensure_runtime_dirs(paths)?;
-    let server_bin = resolve_clickhouse_server_command(cfg, paths).await?;
-    materialize_clickhouse_config(cfg, paths)?;
-
-    let result = supervise_clickhouse(
-        cfg,
-        &server_bin,
-        &paths.clickhouse_config,
-        SupervisorPolicy::production(),
-    )
+    let log = SupervisorLog::open(
+        clickhouse_supervisor_log_path(paths),
+        RollingLogPolicy::clickhouse_supervisor(),
+    )?;
+    let result = async {
+        let server_bin = resolve_clickhouse_server_command(cfg, paths).await?;
+        materialize_clickhouse_config(cfg, paths)?;
+        supervise_clickhouse(
+            cfg,
+            &server_bin,
+            &paths.clickhouse_config,
+            SupervisorPolicy::production(),
+            &log,
+        )
+        .await
+    }
     .await;
+
+    if let Err(err) = &result {
+        let _ = log
+            .line(format!("clickhouse supervisor: state=fatal reason={err:#}"))
+            .await;
+    }
+    let flush = log.flush().await;
     remove_pid_if_matches(&pid_path(paths, Service::ClickHouse), std::process::id());
-    result
+    match (result, flush) {
+        (Ok(code), Ok(())) => Ok(code),
+        (Ok(_), Err(err)) => Err(err),
+        (Err(err), Ok(())) => Err(err),
+        (Err(err), Err(flush_err)) => Err(err.context(format!(
+            "also failed to flush supervisor log: {flush_err:#}"
+        ))),
+    }
 }
 
 pub(crate) fn managed_clickhouse_version(paths: &RuntimePaths) -> Option<String> {
@@ -1413,6 +1790,17 @@ mod tests {
         }
     }
 
+    fn test_supervisor_log(root: &Path) -> SupervisorLog {
+        SupervisorLog::open(
+            root.join("clickhouse-supervisor.log"),
+            RollingLogPolicy {
+                segment_bytes: 1024,
+                rotations: 2,
+            },
+        )
+        .expect("open test supervisor log")
+    }
+
     #[test]
     fn fake_clickhouse_process() {
         let Ok(mode) = std::env::var("MORAINE_TEST_CLICKHOUSE_MODE") else {
@@ -1429,6 +1817,7 @@ mod tests {
             + 1;
         fs::write(&count_file, format!("{count}\n")).expect("record generation");
         fs::write(&pid_file, format!("{}\n", std::process::id())).expect("record child pid");
+        eprintln!("fake ClickHouse generation={count} mode={mode}");
 
         match mode.as_str() {
             "exit" => thread::sleep(Duration::from_millis(120)),
@@ -1468,7 +1857,7 @@ mod tests {
     }
 
     #[test]
-    fn materialized_config_caps_only_idle_global_threads() {
+    fn materialized_config_applies_managed_runtime_limits() {
         let root = temp_dir("thread-pool-config");
         let cfg = test_config(&root, "http://127.0.0.1:18123".to_string());
         let paths = crate::paths::runtime_paths(&cfg);
@@ -1482,6 +1871,7 @@ mod tests {
                 .count(),
             1
         );
+        assert_eq!(rendered.matches("<console>false</console>").count(), 1);
         assert!(!rendered.contains("<max_thread_pool_size>"));
         let _ = fs::remove_dir_all(root);
     }
@@ -1506,9 +1896,13 @@ mod tests {
         let config_path = root.join("config.xml");
         fs::write(&config_path, "<clickhouse/>").expect("fake config");
 
-        let mut child =
-            spawn_clickhouse_generation(&script, &config_path).expect("spawn fake generation");
+        let log = test_supervisor_log(&root);
+        let (mut child, mut forwarders) = spawn_clickhouse_generation(&script, &config_path, &log)
+            .expect("spawn fake generation");
         let status = child.wait().await.expect("wait fake generation");
+        finish_output_forwarders(&mut forwarders, &log)
+            .await
+            .expect("drain fake output");
 
         assert!(status.success());
         assert_eq!(
@@ -1516,6 +1910,151 @@ mod tests {
             "0|0"
         );
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn output_drain_aborts_reader_when_descendant_keeps_pipe_open() {
+        let root = temp_dir("output-drain-timeout");
+        let script = root.join("pipe-holder");
+        let descendant_pid = root.join("descendant.pid");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nsleep 60 &\necho $! > {}\nexit 0\n",
+                shell_quote(&descendant_pid)
+            ),
+        )
+        .expect("write pipe-holder script");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755))
+            .expect("make pipe-holder executable");
+        let config_path = root.join("config.xml");
+        fs::write(&config_path, "<clickhouse/>").expect("fake config");
+        let log = test_supervisor_log(&root);
+        let (mut child, mut forwarders) = spawn_clickhouse_generation(&script, &config_path, &log)
+            .expect("spawn pipe-holder generation");
+        assert!(child.wait().await.expect("wait direct child").success());
+
+        let started = Instant::now();
+        let drained = forwarders.finish().await.expect("bounded drain result");
+        assert!(!drained, "descendant-held pipe unexpectedly drained");
+        assert!(started.elapsed() < Duration::from_secs(2));
+
+        let descendant = fs::read_to_string(&descendant_pid)
+            .expect("descendant pid")
+            .trim()
+            .to_string();
+        let _ = Command::new("kill").args(["-TERM", &descendant]).status();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while log.writer_count() != 1 {
+            assert!(
+                Instant::now() < deadline,
+                "aborted output tasks retained log handles"
+            );
+            sleep(Duration::from_millis(5)).await;
+        }
+        drop(log);
+        fs::remove_dir_all(root).expect("remove drain test root");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn high_volume_child_output_rotates_while_child_remains_live() {
+        let root = temp_dir("live-output-rotation");
+        let script = root.join("synthetic-clickhouse");
+        let ready = root.join("writer-ready");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\n\
+                 i=0\n\
+                 while [ \"$i\" -lt 10000 ]; do\n\
+                   printf 'stdout-%08d-abcdefghijklmnopqrstuvwxyz\\n' \"$i\"\n\
+                   printf 'stderr-%08d-abcdefghijklmnopqrstuvwxyz\\n' \"$i\" >&2\n\
+                   i=$((i + 1))\n\
+                 done\n\
+                 touch {}\n\
+                 exec sleep 60\n",
+                shell_quote(&ready)
+            ),
+        )
+        .expect("write synthetic writer");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755))
+            .expect("make synthetic writer executable");
+        let config_path = root.join("config.xml");
+        fs::write(&config_path, "<clickhouse/>").expect("fake config");
+        let log_path = root.join("clickhouse-supervisor.log");
+        let log = test_supervisor_log(&root);
+
+        let (mut child, mut forwarders) = spawn_clickhouse_generation(&script, &config_path, &log)
+            .expect("spawn synthetic writer");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !ready.exists() || !crate::process::RollingLog::rotation_path(&log_path, 2).exists() {
+            assert!(
+                Instant::now() < deadline,
+                "synthetic writer did not fill retained segments"
+            );
+            sleep(Duration::from_millis(5)).await;
+        }
+
+        assert!(
+            child.try_wait().expect("inspect live writer").is_none(),
+            "writer exited before live rotation was observed"
+        );
+        let retained_while_live: u64 = (0..=2)
+            .filter_map(|generation| {
+                let path = if generation == 0 {
+                    log_path.clone()
+                } else {
+                    crate::process::RollingLog::rotation_path(&log_path, generation)
+                };
+                fs::metadata(path).ok()
+            })
+            .map(|metadata| {
+                assert!(metadata.len() <= 1024, "live segment exceeded size cap");
+                metadata.len()
+            })
+            .sum();
+        assert!(retained_while_live <= 3 * 1024);
+        eprintln!(
+            "synthetic child emitted 860000 bytes; live retained bytes={retained_while_live}"
+        );
+
+        terminate_and_reap(&mut child, Duration::from_millis(200), Some(&log))
+            .await
+            .expect("stop synthetic writer");
+        finish_output_forwarders(&mut forwarders, &log)
+            .await
+            .expect("drain synthetic output");
+        assert_eq!(log.writer_count(), 1, "output tasks retained log handles");
+        log.line("shutdown-marker")
+            .await
+            .expect("write shutdown marker");
+        log.flush().await.expect("flush shutdown marker");
+        assert!(fs::read(&log_path)
+            .expect("read current retained log")
+            .ends_with(b"shutdown-marker\n"));
+        let retained = [
+            crate::process::RollingLog::rotation_path(&log_path, 2),
+            crate::process::RollingLog::rotation_path(&log_path, 1),
+            log_path.clone(),
+        ]
+        .into_iter()
+        .filter_map(|path| fs::read(path).ok())
+        .flatten()
+        .collect::<Vec<_>>();
+        let retained = String::from_utf8(retained).expect("synthetic output is utf8");
+        for line in retained.lines().skip(1) {
+            assert!(
+                line == "shutdown-marker"
+                    || ((line.starts_with("stdout-") || line.starts_with("stderr-"))
+                        && line.ends_with("-abcdefghijklmnopqrstuvwxyz")),
+                "stdout/stderr record was interleaved: {line:?}"
+            );
+        }
+
+        drop(log);
+        fs::remove_dir_all(root).expect("remove logs after shutdown");
     }
 
     #[cfg(unix)]
@@ -1547,7 +2086,7 @@ mod tests {
             sleep(Duration::from_millis(5)).await;
         }
 
-        let status = terminate_and_reap(&mut child, Duration::from_millis(50))
+        let status = terminate_and_reap(&mut child, Duration::from_millis(50), None)
             .await
             .expect("terminate child");
 
@@ -1594,7 +2133,8 @@ mod tests {
         let config_path = root.join("config.xml");
         fs::write(&config_path, "<clickhouse/>").expect("fake config");
 
-        let exit = supervise_clickhouse(&cfg, &server_bin, &config_path, test_policy())
+        let log = test_supervisor_log(&root);
+        let exit = supervise_clickhouse(&cfg, &server_bin, &config_path, test_policy(), &log)
             .await
             .expect("supervisor result");
 
@@ -1605,6 +2145,19 @@ mod tests {
                 .trim(),
             "6"
         );
+        log.flush().await.expect("flush restarted generations");
+        assert_eq!(log.writer_count(), 1, "generation output tasks leaked");
+        let log_path = root.join("clickhouse-supervisor.log");
+        let retained = [
+            crate::process::RollingLog::rotation_path(&log_path, 2),
+            crate::process::RollingLog::rotation_path(&log_path, 1),
+            log_path,
+        ]
+        .into_iter()
+        .filter_map(|path| fs::read_to_string(path).ok())
+        .collect::<String>();
+        assert!(retained.contains("fake ClickHouse generation=6 mode=exit"));
+        assert!(retained.contains("state=exhausted"));
         let _ = fs::remove_dir_all(root);
     }
 
@@ -1620,6 +2173,7 @@ mod tests {
         let config_path = root.join("config.xml");
         fs::write(&config_path, "<clickhouse/>").expect("fake config");
         let mut signals = ShutdownSignals::install().expect("shutdown signals");
+        let log = test_supervisor_log(&root);
 
         let outcome = run_generation(
             &cfg,
@@ -1628,6 +2182,7 @@ mod tests {
             1,
             test_policy(),
             &mut signals,
+            &log,
         )
         .await
         .expect("generation outcome");

--- a/apps/moraine/src/process.rs
+++ b/apps/moraine/src/process.rs
@@ -1,10 +1,11 @@
 use anyhow::{bail, Context, Result};
 use moraine_config::AppConfig;
-use std::fs::{self, OpenOptions};
-use std::io::{Read, Write};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use crate::paths::RuntimePaths;
@@ -40,6 +41,294 @@ pub(crate) fn pid_path(paths: &RuntimePaths, service: Service) -> PathBuf {
 
 pub(crate) fn clickhouse_supervisor_log_path(paths: &RuntimePaths) -> PathBuf {
     paths.logs_dir.join("clickhouse-supervisor.log")
+}
+
+/// The current supervisor stream plus three rotations retain at most 32 MiB.
+/// If the current path is externally unlinked, at most one 8 MiB segment can
+/// remain detached until the next write reopens the path or the process exits.
+pub(crate) const CLICKHOUSE_SUPERVISOR_LOG_SEGMENT_BYTES: u64 = 8 * 1024 * 1024;
+pub(crate) const CLICKHOUSE_SUPERVISOR_LOG_ROTATIONS: usize = 3;
+
+#[derive(Clone, Copy)]
+pub(crate) struct RollingLogPolicy {
+    pub(crate) segment_bytes: u64,
+    pub(crate) rotations: usize,
+}
+
+impl RollingLogPolicy {
+    pub(crate) const fn clickhouse_supervisor() -> Self {
+        Self {
+            segment_bytes: CLICKHOUSE_SUPERVISOR_LOG_SEGMENT_BYTES,
+            rotations: CLICKHOUSE_SUPERVISOR_LOG_ROTATIONS,
+        }
+    }
+}
+
+pub(crate) struct RollingLog {
+    path: PathBuf,
+    policy: RollingLogPolicy,
+    file: Option<File>,
+    len: u64,
+}
+
+impl RollingLog {
+    pub(crate) fn open(path: PathBuf, policy: RollingLogPolicy) -> Result<Self> {
+        if policy.segment_bytes == 0 {
+            bail!("rolling log segment size must be greater than zero");
+        }
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create log directory {}", parent.display()))?;
+        }
+
+        Self::bound_existing_file(&path, policy.segment_bytes)?;
+        for generation in 1..=policy.rotations {
+            Self::bound_existing_file(
+                &Self::rotation_path(&path, generation),
+                policy.segment_bytes,
+            )?;
+        }
+
+        let file = Self::open_append(&path)?;
+        let len = file
+            .metadata()
+            .with_context(|| format!("failed to inspect {}", path.display()))?
+            .len();
+        Ok(Self {
+            path,
+            policy,
+            file: Some(file),
+            len,
+        })
+    }
+
+    pub(crate) fn write_all(&mut self, mut bytes: &[u8]) -> Result<()> {
+        self.reopen_if_replaced()?;
+        while !bytes.is_empty() {
+            if self.len >= self.policy.segment_bytes {
+                self.rotate()?;
+            }
+            let available = self.policy.segment_bytes - self.len;
+            let write_len = usize::try_from(available.min(bytes.len() as u64))
+                .expect("write length is bounded by the input slice");
+            self.file
+                .as_mut()
+                .context("rolling log file is unavailable")?
+                .write_all(&bytes[..write_len])
+                .with_context(|| format!("failed to write {}", self.path.display()))?;
+            self.len += write_len as u64;
+            bytes = &bytes[write_len..];
+        }
+        Ok(())
+    }
+
+    pub(crate) fn flush(&mut self) -> Result<()> {
+        self.file
+            .as_mut()
+            .context("rolling log file is unavailable")?
+            .flush()
+            .with_context(|| format!("failed to flush {}", self.path.display()))
+    }
+
+    fn open_append(path: &Path) -> Result<File> {
+        if fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+            bail!("refusing symlinked log path {}", path.display());
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .with_context(|| format!("failed to open {}", path.display()))?;
+        Self::verify_opened_path(&file, path)?;
+        Ok(file)
+    }
+
+    pub(crate) fn rotation_path(path: &Path, generation: usize) -> PathBuf {
+        let mut name = path
+            .file_name()
+            .expect("rolling log path has a file name")
+            .to_os_string();
+        name.push(format!(".{generation}"));
+        path.with_file_name(name)
+    }
+
+    fn bound_existing_file(path: &Path, max_bytes: u64) -> Result<()> {
+        let metadata = match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_file() => metadata,
+            Ok(_) => bail!("log path is not a regular file: {}", path.display()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => {
+                return Err(err).with_context(|| format!("failed to inspect {}", path.display()));
+            }
+        };
+        let len = metadata.len();
+        if len <= max_bytes {
+            return Ok(());
+        }
+
+        let mut source = File::open(path)
+            .with_context(|| format!("failed to open oversized log {}", path.display()))?;
+        Self::verify_opened_path(&source, path)?;
+        source
+            .seek(SeekFrom::Start(len - max_bytes))
+            .with_context(|| format!("failed to seek oversized log {}", path.display()))?;
+        let tail_len = usize::try_from(max_bytes)
+            .context("rolling log segment size does not fit in memory")?;
+        let mut tail = vec![0; tail_len];
+        source
+            .read_exact(&mut tail)
+            .with_context(|| format!("failed to read oversized log {}", path.display()))?;
+        drop(source);
+
+        static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+        let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let mut temp_name = path
+            .file_name()
+            .context("rolling log path has no file name")?
+            .to_os_string();
+        temp_name.push(format!(".tmp-{}-{sequence}", std::process::id()));
+        let temp_path = path.with_file_name(temp_name);
+        let replacement = (|| -> Result<()> {
+            let mut temp = OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(&temp_path)
+                .with_context(|| format!("failed to create {}", temp_path.display()))?;
+            temp.write_all(&tail)
+                .with_context(|| format!("failed to write {}", temp_path.display()))?;
+            temp.flush()
+                .with_context(|| format!("failed to flush {}", temp_path.display()))?;
+            temp.set_permissions(metadata.permissions())
+                .with_context(|| format!("failed to set permissions on {}", temp_path.display()))?;
+            Self::verify_opened_path(&temp, &temp_path)?;
+            #[cfg(windows)]
+            fs::remove_file(path)
+                .with_context(|| format!("failed to replace {}", path.display()))?;
+            fs::rename(&temp_path, path).with_context(|| {
+                format!(
+                    "failed to replace oversized log {} with retained tail",
+                    path.display()
+                )
+            })
+        })();
+        if replacement.is_err() {
+            let _ = fs::remove_file(&temp_path);
+        }
+        replacement
+    }
+
+    fn verify_opened_path(file: &File, path: &Path) -> Result<()> {
+        let opened = file
+            .metadata()
+            .with_context(|| format!("failed to inspect opened log {}", path.display()))?;
+        let current = fs::symlink_metadata(path)
+            .with_context(|| format!("failed to inspect log path {}", path.display()))?;
+        if !opened.file_type().is_file()
+            || !current.file_type().is_file()
+            || !same_file(&opened, &current)
+        {
+            bail!("log path changed while opening {}", path.display());
+        }
+        Ok(())
+    }
+
+    fn reopen_if_replaced(&mut self) -> Result<()> {
+        let needs_reopen = match (&self.file, fs::symlink_metadata(&self.path)) {
+            (_, Err(err)) if err.kind() == std::io::ErrorKind::NotFound => true,
+            (_, Err(err)) => {
+                return Err(err)
+                    .with_context(|| format!("failed to inspect {}", self.path.display()));
+            }
+            (None, Ok(_)) => true,
+            (Some(file), Ok(path_metadata)) => {
+                let file_metadata = file
+                    .metadata()
+                    .with_context(|| format!("failed to inspect {}", self.path.display()))?;
+                !path_metadata.file_type().is_file() || !same_file(&file_metadata, &path_metadata)
+            }
+        };
+        if needs_reopen {
+            Self::bound_existing_file(&self.path, self.policy.segment_bytes)?;
+            let file = Self::open_append(&self.path)?;
+            self.len = file
+                .metadata()
+                .with_context(|| format!("failed to inspect {}", self.path.display()))?
+                .len();
+            self.file = Some(file);
+        }
+        Ok(())
+    }
+
+    fn rotate(&mut self) -> Result<()> {
+        self.file.take();
+        let rotation = self.rotate_files();
+        let reopened = Self::open_append(&self.path);
+        match reopened {
+            Ok(file) => {
+                self.len = file
+                    .metadata()
+                    .with_context(|| format!("failed to inspect {}", self.path.display()))?
+                    .len();
+                self.file = Some(file);
+            }
+            Err(reopen_err) => {
+                return match rotation {
+                    Ok(()) => Err(reopen_err),
+                    Err(rotation_err) => Err(rotation_err
+                        .context(format!("also failed to reopen rolling log: {reopen_err:#}"))),
+                };
+            }
+        }
+        rotation
+    }
+
+    fn rotate_files(&self) -> Result<()> {
+        if self.policy.rotations > 0 {
+            let oldest = Self::rotation_path(&self.path, self.policy.rotations);
+            if oldest.exists() {
+                fs::remove_file(&oldest)
+                    .with_context(|| format!("failed to remove {}", oldest.display()))?;
+            }
+            for generation in (1..self.policy.rotations).rev() {
+                let source = Self::rotation_path(&self.path, generation);
+                if source.exists() {
+                    let destination = Self::rotation_path(&self.path, generation + 1);
+                    fs::rename(&source, &destination).with_context(|| {
+                        format!(
+                            "failed to rotate {} to {}",
+                            source.display(),
+                            destination.display()
+                        )
+                    })?;
+                }
+            }
+            if self.path.exists() {
+                let first = Self::rotation_path(&self.path, 1);
+                fs::rename(&self.path, &first).with_context(|| {
+                    format!(
+                        "failed to rotate {} to {}",
+                        self.path.display(),
+                        first.display()
+                    )
+                })?;
+            }
+        } else if self.path.exists() {
+            fs::remove_file(&self.path)
+                .with_context(|| format!("failed to reset {}", self.path.display()))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn same_file(left: &fs::Metadata, right: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+#[cfg(not(unix))]
+fn same_file(left: &fs::Metadata, right: &fs::Metadata) -> bool {
+    left.len() == right.len() && left.modified().ok() == right.modified().ok()
 }
 
 fn clickhouse_internal_log_path(paths: &RuntimePaths) -> PathBuf {
@@ -646,6 +935,197 @@ mod tests {
             logs_dir.join("ingest.log")
         );
 
+        let _ = fs::remove_dir_all(root);
+    }
+
+    fn tiny_log_policy() -> RollingLogPolicy {
+        RollingLogPolicy {
+            segment_bytes: 64,
+            rotations: 2,
+        }
+    }
+
+    fn retained_log_paths(path: &Path) -> [PathBuf; 3] {
+        [
+            path.to_path_buf(),
+            RollingLog::rotation_path(path, 1),
+            RollingLog::rotation_path(path, 2),
+        ]
+    }
+    #[test]
+    fn clickhouse_supervisor_log_policy_is_32_mib() {
+        let policy = RollingLogPolicy::clickhouse_supervisor();
+        assert_eq!(policy.segment_bytes, 8 * 1024 * 1024);
+        assert_eq!(policy.rotations, 3);
+        assert_eq!(
+            policy.segment_bytes * (policy.rotations as u64 + 1),
+            32 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn rolling_log_bounds_repeated_output_and_preserves_recent_bytes() {
+        let root = temp_dir("rolling-log-bound");
+        let path = root.join("supervisor.log");
+        let mut log = RollingLog::open(path.clone(), tiny_log_policy()).expect("open rolling log");
+
+        log.write_all(&vec![b'x'; 64 * 20 + 17])
+            .expect("write repeated output");
+        log.write_all(b"recent-marker\n")
+            .expect("write recent marker");
+        log.flush().expect("flush rolling log");
+
+        let paths = retained_log_paths(&path);
+        let retained_bytes: u64 = paths
+            .iter()
+            .filter_map(|path| fs::metadata(path).ok())
+            .map(|metadata| {
+                assert!(metadata.len() <= 64, "segment exceeded configured cap");
+                metadata.len()
+            })
+            .sum();
+        assert!(retained_bytes <= 64 * 3);
+        assert!(
+            fs::read(&path)
+                .expect("read current log")
+                .ends_with(b"recent-marker\n"),
+            "newest diagnostics were not retained"
+        );
+        drop(log);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rolling_log_reopens_replaced_path_without_writing_unlinked_inode() {
+        let root = temp_dir("rolling-log-reopen");
+        let path = root.join("supervisor.log");
+        let mut log = RollingLog::open(path.clone(), tiny_log_policy()).expect("open rolling log");
+        log.write_all(b"old inode\n").expect("write old inode");
+        fs::remove_file(&path).expect("unlink live log");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            assert_eq!(
+                log.file
+                    .as_ref()
+                    .expect("open old inode")
+                    .metadata()
+                    .expect("old inode metadata")
+                    .nlink(),
+                0
+            );
+        }
+
+        log.write_all(b"new inode\n").expect("reopen after unlink");
+        log.flush().expect("flush replacement log");
+        assert_eq!(fs::read(&path).expect("read replacement"), b"new inode\n");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            assert_eq!(
+                log.file
+                    .as_ref()
+                    .expect("open replacement inode")
+                    .metadata()
+                    .expect("replacement metadata")
+                    .nlink(),
+                1
+            );
+        }
+        drop(log);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rolling_log_restart_keeps_bound_and_appends_to_current_segment() {
+        let root = temp_dir("rolling-log-restart");
+        let path = root.join("supervisor.log");
+        {
+            let mut log =
+                RollingLog::open(path.clone(), tiny_log_policy()).expect("open first writer");
+            log.write_all(&[b'a'; 150]).expect("write first run");
+            log.flush().expect("flush first run");
+        }
+        {
+            let mut log =
+                RollingLog::open(path.clone(), tiny_log_policy()).expect("reopen second writer");
+            log.write_all(b"restart-marker\n")
+                .expect("write restart marker");
+            log.flush().expect("flush second run");
+        }
+
+        let retained_bytes: u64 = retained_log_paths(&path)
+            .iter()
+            .filter_map(|path| fs::metadata(path).ok())
+            .map(|metadata| metadata.len())
+            .sum();
+        assert!(retained_bytes <= 64 * 3);
+        assert!(fs::read(&path)
+            .expect("read restarted log")
+            .ends_with(b"restart-marker\n"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rolling_log_startup_reduces_oversized_file_to_recent_tail() {
+        let root = temp_dir("rolling-log-oversized-startup");
+        let path = root.join("supervisor.log");
+        let mut old = vec![b'o'; 256];
+        old.extend_from_slice(b"recent-tail");
+        fs::write(&path, &old).expect("write oversized old log");
+
+        let log = RollingLog::open(path.clone(), tiny_log_policy()).expect("bound old log");
+
+        let retained = fs::read(&path).expect("read bounded old log");
+        assert_eq!(retained.len(), 64);
+        assert!(retained.ends_with(b"recent-tail"));
+        drop(log);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rolling_log_recovers_after_rotation_error() {
+        let root = temp_dir("rolling-log-rotation-error");
+        let path = root.join("supervisor.log");
+        let mut log = RollingLog::open(path.clone(), tiny_log_policy()).expect("open rolling log");
+        log.write_all(&[b'x'; 64]).expect("fill current segment");
+        let blocked_oldest = RollingLog::rotation_path(&path, 2);
+        fs::create_dir(&blocked_oldest).expect("block oldest rotation");
+
+        let err = log
+            .write_all(b"first retry")
+            .expect_err("rotation should fail on directory");
+        assert!(err.to_string().contains("failed to remove"), "{err:#}");
+        fs::remove_dir(&blocked_oldest).expect("unblock rotation");
+        log.write_all(b"recovered\n")
+            .expect("writer should remain usable after error");
+        log.flush().expect("flush recovered writer");
+        assert!(fs::read(&path)
+            .expect("read recovered segment")
+            .ends_with(b"recovered\n"));
+        drop(log);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rolling_log_rejects_symlinked_oversized_segment_without_changing_target() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_dir("rolling-log-symlink");
+        let target = root.join("target");
+        let path = root.join("supervisor.log");
+        let original = vec![b's'; 256];
+        fs::write(&target, &original).expect("write symlink target");
+        symlink(&target, &path).expect("create log symlink");
+
+        let Err(err) = RollingLog::open(path, tiny_log_policy()) else {
+            panic!("symlink should be rejected");
+        };
+
+        assert!(err.to_string().contains("not a regular file"), "{err:#}");
+        assert_eq!(fs::read(&target).expect("read target"), original);
         let _ = fs::remove_dir_all(root);
     }
 

--- a/apps/moraine/tests/clickhouse_supervision.rs
+++ b/apps/moraine/tests/clickhouse_supervision.rs
@@ -101,18 +101,27 @@ fn wait_for_file(path: &Path, timeout: Duration) -> String {
     }
 }
 
-fn wait_for_log(path: &Path, needle: &str, timeout: Duration) {
+fn wait_for_retained_log(path: &Path, needle: &str, timeout: Duration) {
     let deadline = Instant::now() + timeout;
     loop {
-        if fs::read_to_string(path)
-            .map(|contents| contents.contains(needle))
-            .unwrap_or(false)
-        {
+        let found = (0..=3).any(|generation| {
+            let retained_path = if generation == 0 {
+                path.to_path_buf()
+            } else {
+                let mut name = path.file_name().expect("log file name").to_os_string();
+                name.push(format!(".{generation}"));
+                path.with_file_name(name)
+            };
+            fs::read_to_string(retained_path)
+                .map(|contents| contents.contains(needle))
+                .unwrap_or(false)
+        });
+        if found {
             return;
         }
         assert!(
             Instant::now() < deadline,
-            "timed out waiting for `{needle}` in {}",
+            "timed out waiting for `{needle}` in retained segments for {}",
             path.display()
         );
         thread::sleep(Duration::from_millis(20));
@@ -186,19 +195,17 @@ fn sigterm_during_backoff_exits_without_replacement() {
         ),
     );
     let config = write_config(&root, unused_port());
-    let supervisor_log_path = root.join("supervisor.stderr");
-    let supervisor_log = fs::File::create(&supervisor_log_path).expect("create supervisor log");
-    let supervisor_log_err = supervisor_log.try_clone().expect("clone supervisor log");
+    let supervisor_log_path = root.join("runtime/logs/clickhouse-supervisor.log");
     let mut supervisor = Command::new(env!("CARGO_BIN_EXE_moraine"))
         .arg("--config")
         .arg(&config)
         .args(["clickhouse", "supervise"])
-        .stdout(Stdio::from(supervisor_log))
-        .stderr(Stdio::from(supervisor_log_err))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .expect("start supervisor");
 
-    wait_for_log(
+    wait_for_retained_log(
         &supervisor_log_path,
         "state=backoff",
         Duration::from_secs(3),

--- a/config/clickhouse.xml
+++ b/config/clickhouse.xml
@@ -1,6 +1,7 @@
 <clickhouse>
   <logger>
     <level>information</level>
+    <console>false</console>
     <log>__MORAINE_HOME__/clickhouse/log/clickhouse-server.log</log>
     <errorlog>__MORAINE_HOME__/clickhouse/log/clickhouse-server.err.log</errorlog>
     <size>1000M</size>


### PR DESCRIPTION
## Description

**What.** Routes managed ClickHouse stdout and stderr through a bounded rolling sink instead of inherited append-only file descriptors.

**Why.** A foreground ClickHouse console stream grew `clickhouse-supervisor.log` to 147.8 GB, exhausted the host disk, and remained allocated after unlink because the live supervisor and server still held the inode.

The supervisor now owns both child pipes and forwards complete bounded records through a blocking filesystem worker with backpressure. The sink keeps the current 8 MiB segment plus three rotations, reopens after unlink or replacement, atomically reduces oversized preexisting files to their recent 8 MiB tail, rejects symlinked log paths, and bounds pipe draining during shutdown. ClickHouse console duplication is explicitly disabled while its existing internal rotating file log remains available. `moraine logs clickhouse` includes retained supervisor rotations and tolerates a segment disappearing during live rollover.

## Bug Evidence

Before the fix, `lsof +L1` showed supervisor PID 75711 and ClickHouse PID 75712 holding stdout and stderr descriptors to the unlinked supervisor log. The largest observed descriptor size was 147,840,291,161 bytes. Stopping both processes raised free space from about 1.8 GiB to 20 GiB.

Moraine launches ClickHouse in foreground mode, and the rendered logger config did not set `<console>`. ClickHouse documents that console logging defaults on outside daemon mode, while `<size>` and `<count>` rotate only the configured file channel. The incident file was already unlinked, so the exact repeated message is unavailable.

A live synthetic child emitted 860,000 bytes across stdout and stderr while remaining alive. The test observed 2,493 retained bytes under a three-segment 1 KiB policy, below its exact 3,072-byte cap, then terminated the child, drained both pipes, and read the shutdown marker. The production policy applies the same path at 32 MiB total visible retention (four 8 MiB segments). An externally unlinked current inode is at most 8 MiB and is closed before the next write; shutdown also releases it.

## Usage

No configuration change is required. `moraine up` applies bounded retention automatically. Recent supervisor rotations and the ClickHouse internal server log remain readable with:

```bash
moraine logs clickhouse --lines 200
```

## Changelog

- Bounds managed ClickHouse supervisor and child process output to 32 MiB of visible retained segments.
- Prevents live writers from retaining unbounded deleted supervisor logs.
- Preserves recent rotated diagnostics in `moraine logs clickhouse` and disables duplicate ClickHouse console logging.

## Validation

Ran `cargo test -p moraine process::tests::rolling_log -- --nocapture` (6 passed), `cargo test -p moraine commands::logs::tests -- --nocapture` (7 passed), and `cargo test -p moraine managed_clickhouse::tests -- --nocapture` (21 passed). The managed suite covers high-volume live rotation, six-generation restart exhaustion, readiness cleanup, bounded descendant-held pipe draining, watchdog disablement, and rendered console configuration.

Ran `cargo test -p moraine --test clickhouse_supervision -- --nocapture` (2 passed). The integration test launches the supervisor with production-style null stdio, observes `state=backoff` through the rolling production path and retained segments, sends SIGTERM, and proves no replacement generation starts.

Ran `cargo clippy -p moraine --all-targets -- -D warnings`, focused integration clippy, and `cargo fmt --all -- --check` successfully.

A seven-persona delegated review covered elegance, idiom, correctness, completeness, security, YAGNI, and scope. Accepted findings hardened rollover-time log reads, record boundaries, Tokio blocking behavior, live forwarder failure cleanup, symlink handling, writer recovery after filesystem errors, and pipe-drain timeouts. Follow-up review found no remaining findings. The CI integration repair received an additional correctness review and preserved the original backoff/shutdown contract.

Closes #512