### PR TITLE
fix(mcp): bound concurrent retrieval dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,6 +1260,7 @@ name = "moraine-mcp-core"
 version = "0.6.4"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "libc",
  "moraine-config",

--- a/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
@@ -483,7 +483,12 @@ SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
         if query_id.is_empty() {
             return Ok(());
         }
-        let sql = format!("KILL QUERY WHERE query_id = {} SYNC", sql_quote(query_id));
+        let child_prefix = format!("{query_id}-");
+        let sql = format!(
+            "KILL QUERY WHERE query_id = {} OR startsWith(query_id, {}) SYNC",
+            sql_quote(query_id),
+            sql_quote(&child_prefix)
+        );
         self.map_backend(self.ch.request_text(&sql, None, None, false, None).await)
             .map(|_| ())
     }

--- a/crates/moraine-conversations/src/clickhouse_repo/mod.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -16,6 +17,16 @@ use uuid::Uuid;
 
 const REPOSITORY_READ_SETTINGS: [(&str, &str); 1] =
     [("do_not_merge_across_partitions_select_final", "0")];
+
+tokio::task_local! {
+    static ACTIVE_MCP_QUERY_ID: String;
+}
+pub async fn with_repository_query_id<F>(query_id: String, future: F) -> F::Output
+where
+    F: Future,
+{
+    ACTIVE_MCP_QUERY_ID.scope(query_id, future).await
+}
 
 use crate::cursor::{
     decode_cursor, encode_cursor, ConversationCursor, McpSessionListCursor, SessionEventCursor,
@@ -111,9 +122,16 @@ impl ClickHouseConversationRepository {
         query: &str,
         database: Option<&str>,
     ) -> AnyResult<Vec<T>> {
-        self.ch
-            .query_rows_with_params(query, database, &REPOSITORY_READ_SETTINGS)
-            .await
+        if let Ok(query_id) = ACTIVE_MCP_QUERY_ID.try_with(Clone::clone) {
+            let params = [("query_id", query_id.as_str()), REPOSITORY_READ_SETTINGS[0]];
+            self.ch
+                .query_rows_with_params(query, database, &params)
+                .await
+        } else {
+            self.ch
+                .query_rows_with_params(query, database, &REPOSITORY_READ_SETTINGS)
+                .await
+        }
     }
 
     pub(super) async fn query_rows_with_params<T: DeserializeOwned>(
@@ -122,8 +140,17 @@ impl ClickHouseConversationRepository {
         database: Option<&str>,
         params: &[(&str, &str)],
     ) -> AnyResult<Vec<T>> {
-        let mut request_params = Vec::with_capacity(params.len() + REPOSITORY_READ_SETTINGS.len());
+        let query_id = ACTIVE_MCP_QUERY_ID.try_with(Clone::clone).ok();
+        let has_query_id = params.iter().any(|(name, _)| *name == "query_id");
+        let mut request_params = Vec::with_capacity(
+            params.len() + REPOSITORY_READ_SETTINGS.len() + usize::from(!has_query_id),
+        );
         request_params.extend_from_slice(params);
+        if !has_query_id {
+            if let Some(query_id) = query_id.as_deref() {
+                request_params.push(("query_id", query_id));
+            }
+        }
         request_params.extend_from_slice(&REPOSITORY_READ_SETTINGS);
         self.ch
             .query_rows_with_params(query, database, &request_params)

--- a/crates/moraine-conversations/src/clickhouse_repo/mod.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/mod.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 use std::future::Future;
-use std::sync::{Arc, OnceLock};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, OnceLock,
+};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use ahash::AHashMap as HashMap;
@@ -18,14 +21,37 @@ use uuid::Uuid;
 const REPOSITORY_READ_SETTINGS: [(&str, &str); 1] =
     [("do_not_merge_across_partitions_select_final", "0")];
 
-tokio::task_local! {
-    static ACTIVE_MCP_QUERY_ID: String;
+#[derive(Clone)]
+struct ActiveMcpQueryId {
+    base: Arc<str>,
+    sequence: Arc<AtomicU64>,
 }
+
+impl ActiveMcpQueryId {
+    fn new(base: String) -> Self {
+        Self {
+            base: base.into(),
+            sequence: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    fn next(&self) -> String {
+        let sequence = self.sequence.fetch_add(1, Ordering::Relaxed);
+        format!("{}-{sequence}", self.base)
+    }
+}
+
+tokio::task_local! {
+    static ACTIVE_MCP_QUERY_ID: ActiveMcpQueryId;
+}
+
 pub async fn with_repository_query_id<F>(query_id: String, future: F) -> F::Output
 where
     F: Future,
 {
-    ACTIVE_MCP_QUERY_ID.scope(query_id, future).await
+    ACTIVE_MCP_QUERY_ID
+        .scope(ActiveMcpQueryId::new(query_id), future)
+        .await
 }
 
 use crate::cursor::{
@@ -122,7 +148,7 @@ impl ClickHouseConversationRepository {
         query: &str,
         database: Option<&str>,
     ) -> AnyResult<Vec<T>> {
-        if let Ok(query_id) = ACTIVE_MCP_QUERY_ID.try_with(Clone::clone) {
+        if let Ok(query_id) = ACTIVE_MCP_QUERY_ID.try_with(ActiveMcpQueryId::next) {
             let params = [("query_id", query_id.as_str()), REPOSITORY_READ_SETTINGS[0]];
             self.ch
                 .query_rows_with_params(query, database, &params)
@@ -140,7 +166,7 @@ impl ClickHouseConversationRepository {
         database: Option<&str>,
         params: &[(&str, &str)],
     ) -> AnyResult<Vec<T>> {
-        let query_id = ACTIVE_MCP_QUERY_ID.try_with(Clone::clone).ok();
+        let query_id = ACTIVE_MCP_QUERY_ID.try_with(ActiveMcpQueryId::next).ok();
         let has_query_id = params.iter().any(|(name, _)| *name == "query_id");
         let mut request_params = Vec::with_capacity(
             params.len() + REPOSITORY_READ_SETTINGS.len() + usize::from(!has_query_id),

--- a/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
@@ -126,7 +126,13 @@ impl ConversationRepository for ClickHouseConversationRepository {
         &self,
         query: SearchMcpEventsQuery,
     ) -> RepoResult<SearchMcpEventsResult> {
-        self.search_mcp_events_impl(query).await
+        if let Some(query_id) = query.cancellation_token.clone() {
+            ACTIVE_MCP_QUERY_ID
+                .scope(query_id, self.search_mcp_events_impl(query))
+                .await
+        } else {
+            self.search_mcp_events_impl(query).await
+        }
     }
 
     async fn search_conversations(

--- a/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
@@ -127,9 +127,7 @@ impl ConversationRepository for ClickHouseConversationRepository {
         query: SearchMcpEventsQuery,
     ) -> RepoResult<SearchMcpEventsResult> {
         if let Some(query_id) = query.cancellation_token.clone() {
-            ACTIVE_MCP_QUERY_ID
-                .scope(query_id, self.search_mcp_events_impl(query))
-                .await
+            with_repository_query_id(query_id, self.search_mcp_events_impl(query)).await
         } else {
             self.search_mcp_events_impl(query).await
         }

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -2786,7 +2786,10 @@ FORMAT JSONEachRow",
             }
         }
 
-        let query_id = Uuid::new_v4().to_string();
+        let query_id = query
+            .cancellation_token
+            .clone()
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
         let started = Instant::now();
 
         let terms_with_qf = tokenize_query(query_text, self.cfg.bm25_max_query_terms);

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -701,6 +701,8 @@ pub struct SearchEventsResult {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SearchMcpEventsQuery {
     pub query: String,
+    #[serde(skip)]
+    pub cancellation_token: Option<String>,
     #[serde(default)]
     pub n_hits: Option<u16>,
     #[serde(default)]

--- a/crates/moraine-conversations/src/in_memory_repo.rs
+++ b/crates/moraine-conversations/src/in_memory_repo.rs
@@ -140,7 +140,10 @@ impl InMemoryConversationRepository {
     fn empty_search_mcp_events(&self, query: &SearchMcpEventsQuery) -> SearchMcpEventsResult {
         let requested_n_hits = query.n_hits.unwrap_or(self.config.max_results).max(1);
         SearchMcpEventsResult {
-            query_id: "in-memory".to_string(),
+            query_id: query
+                .cancellation_token
+                .clone()
+                .unwrap_or_else(|| "in-memory".to_string()),
             query: query.query.clone(),
             terms: Vec::new(),
             event_types: query

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -7,7 +7,7 @@ mod in_memory_repo;
 mod repo;
 
 pub use backend_router::{BackendRepository, BackendRepositoryRouter};
-pub use clickhouse_repo::ClickHouseConversationRepository;
+pub use clickhouse_repo::{with_repository_query_id, ClickHouseConversationRepository};
 pub use domain::{
     is_user_facing_content_event, Conversation, ConversationDetailOptions, ConversationListFilter,
     ConversationListSort, ConversationMode, ConversationSearchHit, ConversationSearchQuery,

--- a/crates/moraine-conversations/tests/repository_integration/file_attention.rs
+++ b/crates/moraine-conversations/tests/repository_integration/file_attention.rs
@@ -355,3 +355,20 @@ async fn file_attention_project_scope_without_identity_stays_closed() {
         "an unknown request project must stay closed without issuing a backend query"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cancel_query_kills_base_and_fanout_child_query_ids() {
+    let (repo, state) = build_repo().await;
+
+    repo.cancel_query("mcp-request-123")
+        .await
+        .expect("cancel query family");
+
+    let queries = state.queries.lock().expect("queries lock");
+    let kill = queries
+        .iter()
+        .find(|query| query.starts_with("KILL QUERY"))
+        .expect("kill query captured");
+    assert!(kill.contains("query_id = 'mcp-request-123'"));
+    assert!(kill.contains("startsWith(query_id, 'mcp-request-123-')"));
+}

--- a/crates/moraine-conversations/tests/repository_integration/main.rs
+++ b/crates/moraine-conversations/tests/repository_integration/main.rs
@@ -5,9 +5,9 @@ use std::time::Duration;
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use moraine_conversations::{
-    AnalyticsRange, ConversationListFilter, ConversationListSort, ConversationMode,
-    ConversationRepository, ConversationSearchQuery, FileAttentionQuery, McpEventType,
-    McpSessionListFilter, PageRequest, RepoError, SearchEventKind, SearchEventsQuery,
+    with_repository_query_id, AnalyticsRange, ConversationListFilter, ConversationListSort,
+    ConversationMode, ConversationRepository, ConversationSearchQuery, FileAttentionQuery,
+    McpEventType, McpSessionListFilter, PageRequest, RepoError, SearchEventKind, SearchEventsQuery,
     SearchMcpEventsQuery, SessionAnalyticsQuery, SessionEventsDirection, SessionEventsQuery,
     SessionLookback, SessionMetadataSearchQuery, SessionStep, StoreProbe, TablePreviewQuery,
     TurnListFilter,

--- a/crates/moraine-conversations/tests/repository_integration/search.rs
+++ b/crates/moraine-conversations/tests/repository_integration/search.rs
@@ -546,9 +546,22 @@ async fn search_mcp_events_attaches_cancellation_token_to_clickhouse_reads() {
     assert_eq!(result.query_id, cancellation_token);
     let query_ids = state.query_ids.lock().expect("query id lock").clone();
     assert!(!query_ids.is_empty());
-    assert!(query_ids
+    let child_prefix = format!("{cancellation_token}-");
+    let observed = query_ids
         .iter()
-        .all(|query_id| query_id.as_deref() == Some(cancellation_token)));
+        .map(|query_id| query_id.as_deref().expect("query id"))
+        .collect::<Vec<_>>();
+    assert!(observed
+        .iter()
+        .all(|query_id| query_id.starts_with(&child_prefix)));
+    assert_eq!(
+        observed
+            .iter()
+            .copied()
+            .collect::<std::collections::HashSet<_>>()
+            .len(),
+        observed.len()
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -575,9 +588,22 @@ async fn repository_query_context_attaches_id_without_query_model_token() {
 
     let query_ids = state.query_ids.lock().expect("query id lock").clone();
     assert!(!query_ids.is_empty());
-    assert!(query_ids
+    let child_prefix = format!("{query_id}-");
+    let observed = query_ids
         .iter()
-        .all(|observed| observed.as_deref() == Some(query_id)));
+        .map(|observed| observed.as_deref().expect("query id"))
+        .collect::<Vec<_>>();
+    assert!(observed
+        .iter()
+        .all(|observed| observed.starts_with(&child_prefix)));
+    assert_eq!(
+        observed
+            .iter()
+            .copied()
+            .collect::<std::collections::HashSet<_>>()
+            .len(),
+        observed.len()
+    );
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn search_mcp_events_does_not_serialize_independent_enrichment_queries() {

--- a/crates/moraine-conversations/tests/repository_integration/search.rs
+++ b/crates/moraine-conversations/tests/repository_integration/search.rs
@@ -521,6 +521,64 @@ async fn search_mcp_events_supports_global_search_with_enriched_hits() {
     assert_eq!(result.hits[0].raw_score, 12.5);
     assert_eq!(result.hits[0].model.as_deref(), Some("gpt-5.3-codex"));
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_mcp_events_attaches_cancellation_token_to_clickhouse_reads() {
+    let (repo, state) = build_repo().await;
+    let cancellation_token = "mcp-search-cancel-test";
+
+    let result = repo
+        .search_mcp_events(SearchMcpEventsQuery {
+            query: "hello world".to_string(),
+            cancellation_token: Some(cancellation_token.to_string()),
+            n_hits: Some(2),
+            event_types: Some(vec![
+                McpEventType::UserInput,
+                McpEventType::AssistantResponse,
+            ]),
+            min_score: Some(0.0),
+            min_should_match: Some(1),
+            ..SearchMcpEventsQuery::default()
+        })
+        .await
+        .expect("cancellable mcp event search");
+
+    assert_eq!(result.query_id, cancellation_token);
+    let query_ids = state.query_ids.lock().expect("query id lock").clone();
+    assert!(!query_ids.is_empty());
+    assert!(query_ids
+        .iter()
+        .all(|query_id| query_id.as_deref() == Some(cancellation_token)));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn repository_query_context_attaches_id_without_query_model_token() {
+    let (repo, state) = build_repo().await;
+    let query_id = "mcp-request-context-test";
+
+    with_repository_query_id(
+        query_id.to_string(),
+        repo.search_mcp_events(SearchMcpEventsQuery {
+            query: "hello world".to_string(),
+            n_hits: Some(2),
+            event_types: Some(vec![
+                McpEventType::UserInput,
+                McpEventType::AssistantResponse,
+            ]),
+            min_score: Some(0.0),
+            min_should_match: Some(1),
+            ..SearchMcpEventsQuery::default()
+        }),
+    )
+    .await
+    .expect("query scoped by request context");
+
+    let query_ids = state.query_ids.lock().expect("query id lock").clone();
+    assert!(!query_ids.is_empty());
+    assert!(query_ids
+        .iter()
+        .all(|observed| observed.as_deref() == Some(query_id)));
+}
 #[tokio::test(flavor = "multi_thread")]
 async fn search_mcp_events_does_not_serialize_independent_enrichment_queries() {
     let reached = Arc::new(Notify::new());
@@ -624,6 +682,7 @@ async fn search_mcp_events_supports_turn_scoped_search() {
     let result = repo
         .search_mcp_events(SearchMcpEventsQuery {
             query: "cargo failure".to_string(),
+            cancellation_token: None,
             n_hits: Some(5),
             session_id: Some("sess_c".to_string()),
             turn_seq: Some(2),

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -90,6 +90,7 @@ pub(crate) struct MockOptions {
 #[derive(Default)]
 pub(crate) struct MockState {
     pub(crate) queries: Mutex<Vec<String>>,
+    pub(crate) query_ids: Mutex<Vec<Option<String>>>,
     pub(crate) options: MockOptions,
     pub(crate) scripted_responses: Mutex<Option<VecDeque<ScriptedResponse>>>,
 }
@@ -125,6 +126,11 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
             .lock()
             .expect("query lock")
             .push(query.clone());
+        state
+            .query_ids
+            .lock()
+            .expect("query id lock")
+            .push(params.get("query_id").cloned());
 
         if let Some(barrier) = state.options.query_barrier.clone() {
             if barrier
@@ -1801,6 +1807,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
         .then(|| options.scripted_responses.iter().cloned().collect());
     let state = Arc::new(MockState {
         queries: Mutex::default(),
+        query_ids: Mutex::default(),
         options,
         scripted_responses: Mutex::new(scripted_responses),
     });

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -31,3 +31,4 @@ libc = "0.2"
 # which would break `cargo test -p moraine-mcp-core` if that crate ever
 # dropped "macros".
 tokio = { version = "1.40", features = ["macros"] }
+async-trait = "0.1"

--- a/crates/moraine-mcp-core/src/concurrency_tests.rs
+++ b/crates/moraine-mcp-core/src/concurrency_tests.rs
@@ -582,27 +582,38 @@ async fn request_cancellation_propagates_unique_clickhouse_query_ids() {
 }
 
 #[tokio::test]
-async fn disconnect_write_failure_cancels_blocked_repository_work() {
-    let repository = Arc::new(BlockingRepository::new(BLOCK_SEARCH));
-    let (reader, mut writer, server) = start_connection(repository.clone());
+async fn full_socket_disconnect_cancels_blocked_repository_work() {
+    use std::os::fd::AsRawFd;
 
-    writer
+    let repository = Arc::new(BlockingRepository::new(BLOCK_SEARCH));
+    let state = AppState::embedded(AppConfig::default(), repository.clone());
+    let (server_stream, client_stream) =
+        tokio::net::UnixStream::pair().expect("create socket pair");
+    let peer_fd = server_stream.as_raw_fd();
+    let (server_read, server_write) = server_stream.into_split();
+    let (client_read, mut client_write) = client_stream.into_split();
+    let server = tokio::spawn(serve_connection_with_lifecycle(
+        state,
+        BufReader::new(server_read),
+        server_write,
+        None,
+        pending(),
+        wait_for_socket_hangup(peer_fd),
+    ));
+
+    client_write
         .write_all(search_request(1).as_bytes())
         .await
         .expect("send blocked request");
     repository.wait_for_started(1).await;
-    drop(reader);
-    writer
-        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":\"probe\",\"method\":\"ping\"}\n")
-        .await
-        .expect("send response probe after closing read half");
-    drop(writer);
+    drop(client_read);
+    drop(client_write);
 
     tokio::time::timeout(std::time::Duration::from_secs(1), server)
         .await
         .expect("disconnect cleanup deadline")
         .expect("connection task joined")
-        .expect_err("closed response half must fail the connection");
+        .expect("connection succeeded");
     repository.wait_for_dropped(1).await;
     repository.wait_for_cancelled(1).await;
     assert!(repository.cancelled_queries.lock().await[0].starts_with("moraine-search-sessions-"));

--- a/crates/moraine-mcp-core/src/concurrency_tests.rs
+++ b/crates/moraine-mcp-core/src/concurrency_tests.rs
@@ -598,7 +598,7 @@ async fn full_socket_disconnect_cancels_blocked_repository_work() {
         server_write,
         None,
         pending(),
-        wait_for_socket_hangup(peer_fd),
+        wait_for_socket_disconnect(peer_fd),
     ));
 
     client_write

--- a/crates/moraine-mcp-core/src/concurrency_tests.rs
+++ b/crates/moraine-mcp-core/src/concurrency_tests.rs
@@ -1,0 +1,754 @@
+use super::*;
+use moraine_conversations::{
+    AnalyticsRange, AnalyticsSnapshot, Conversation, ConversationDetailOptions,
+    ConversationListFilter, ConversationSearchQuery, ConversationSearchResults, FileAttentionQuery,
+    FileAttentionTouch, InMemoryConversationRepository, IngestHeartbeatRead, McpEventOpen,
+    McpSessionListFilter, McpSessionListItem, McpSessionOpen, McpTurnOpen, OpenContext,
+    OpenEventRequest, Page, PageRequest, RepoConfig, RepoResult, SearchEventsQuery,
+    SearchEventsResult, SearchMcpEventsQuery, SearchMcpEventsResult, SessionAnalytics,
+    SessionAnalyticsQuery, SessionEventsQuery, SessionMetadata, SessionMetadataSearchQuery,
+    SessionMetadataSearchResults, StoreDiagnostics, StoreHealth, TablePreview, TablePreviewQuery,
+    TableSummaries, TraceEvent, Turn, TurnListFilter, TurnSummary, WebSearchEvent,
+};
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+use tokio::io::{AsyncWriteExt, ReadHalf, WriteHalf};
+use tokio::sync::{Mutex, Notify};
+
+const BLOCK_SEARCH: u8 = 1;
+const BLOCK_FILE_ATTENTION: u8 = 2;
+const DELAY_SEARCH: u8 = 3;
+const PANIC_SEARCH: u8 = 4;
+const BLOCK_SCOPE: u8 = 5;
+const BLOCK_LIST: u8 = 6;
+const BLOCK_OPEN: u8 = 7;
+
+struct BlockingRepository {
+    inner: InMemoryConversationRepository,
+    mode: AtomicU8,
+    started: AtomicUsize,
+    dropped: AtomicUsize,
+    state_changed: Notify,
+    release_search: Notify,
+    cancelled_queries: Mutex<Vec<String>>,
+}
+
+impl BlockingRepository {
+    fn new(mode: u8) -> Self {
+        Self {
+            inner: InMemoryConversationRepository::default(),
+            mode: AtomicU8::new(mode),
+            started: AtomicUsize::new(0),
+            dropped: AtomicUsize::new(0),
+            state_changed: Notify::new(),
+            release_search: Notify::new(),
+            cancelled_queries: Mutex::new(Vec::new()),
+        }
+    }
+
+    async fn wait_for_started(&self, count: usize) {
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while self.started.load(Ordering::Acquire) < count {
+                self.state_changed.notified().await;
+            }
+        })
+        .await
+        .expect("blocked repository requests started");
+    }
+
+    async fn wait_for_dropped(&self, count: usize) {
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while self.dropped.load(Ordering::Acquire) < count {
+                self.state_changed.notified().await;
+            }
+        })
+        .await
+        .expect("blocked repository requests were cancelled");
+    }
+
+    async fn block_forever(&self) -> ! {
+        struct DropSignal<'a> {
+            dropped: &'a AtomicUsize,
+            state_changed: &'a Notify,
+        }
+
+        impl Drop for DropSignal<'_> {
+            fn drop(&mut self) {
+                self.dropped.fetch_add(1, Ordering::AcqRel);
+                self.state_changed.notify_one();
+            }
+        }
+
+        self.started.fetch_add(1, Ordering::AcqRel);
+        self.state_changed.notify_one();
+        let _drop_signal = DropSignal {
+            dropped: &self.dropped,
+            state_changed: &self.state_changed,
+        };
+        std::future::pending().await
+    }
+
+    async fn delay_until_released(&self) {
+        self.started.fetch_add(1, Ordering::AcqRel);
+        self.state_changed.notify_one();
+        self.release_search.notified().await;
+    }
+
+    async fn wait_for_cancelled(&self, count: usize) {
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if self.cancelled_queries.lock().await.len() >= count {
+                    break;
+                }
+                self.state_changed.notified().await;
+            }
+        })
+        .await
+        .expect("backend queries were explicitly cancelled");
+    }
+}
+
+#[async_trait::async_trait]
+impl ConversationRepository for BlockingRepository {
+    fn config(&self) -> &RepoConfig {
+        self.inner.config()
+    }
+
+    async fn prewarm_mcp_search_state(&self) -> RepoResult<()> {
+        self.inner.prewarm_mcp_search_state().await
+    }
+
+    async fn list_session_analytics(
+        &self,
+        query: SessionAnalyticsQuery,
+    ) -> RepoResult<Vec<SessionAnalytics>> {
+        self.inner.list_session_analytics(query).await
+    }
+
+    async fn analytics_series(&self, range: AnalyticsRange) -> RepoResult<AnalyticsSnapshot> {
+        self.inner.analytics_series(range).await
+    }
+
+    async fn list_web_searches(&self, limit: u16) -> RepoResult<Vec<WebSearchEvent>> {
+        self.inner.list_web_searches(limit).await
+    }
+
+    async fn latest_ingest_heartbeat(&self) -> RepoResult<IngestHeartbeatRead> {
+        self.inner.latest_ingest_heartbeat().await
+    }
+
+    async fn list_table_summaries(&self) -> RepoResult<TableSummaries> {
+        self.inner.list_table_summaries().await
+    }
+
+    async fn preview_table(&self, query: TablePreviewQuery) -> RepoResult<TablePreview> {
+        self.inner.preview_table(query).await
+    }
+
+    async fn read_store_health(&self) -> RepoResult<StoreHealth> {
+        self.inner.read_store_health().await
+    }
+
+    async fn read_store_diagnostics(&self) -> RepoResult<StoreDiagnostics> {
+        self.inner.read_store_diagnostics().await
+    }
+
+    async fn list_conversations(
+        &self,
+        filter: ConversationListFilter,
+        page: PageRequest,
+    ) -> RepoResult<Page<moraine_conversations::ConversationSummary>> {
+        self.inner.list_conversations(filter, page).await
+    }
+
+    async fn get_conversation(
+        &self,
+        session_id: &str,
+        opts: ConversationDetailOptions,
+    ) -> RepoResult<Option<Conversation>> {
+        self.inner.get_conversation(session_id, opts).await
+    }
+
+    async fn get_session_metadata(&self, session_id: &str) -> RepoResult<Option<SessionMetadata>> {
+        if self.mode.load(Ordering::Acquire) == BLOCK_SCOPE {
+            self.block_forever().await
+        }
+        self.inner.get_session_metadata(session_id).await
+    }
+
+    async fn get_mcp_session(&self, session_id: &str) -> RepoResult<Option<McpSessionOpen>> {
+        if self.mode.load(Ordering::Acquire) == BLOCK_OPEN {
+            self.block_forever().await
+        }
+        self.inner.get_mcp_session(session_id).await
+    }
+
+    async fn list_mcp_sessions(
+        &self,
+        filter: McpSessionListFilter,
+        page: PageRequest,
+    ) -> RepoResult<Page<McpSessionListItem>> {
+        if self.mode.load(Ordering::Acquire) == BLOCK_LIST {
+            self.block_forever().await
+        }
+        self.inner.list_mcp_sessions(filter, page).await
+    }
+
+    async fn list_turns(
+        &self,
+        session_id: &str,
+        filter: TurnListFilter,
+        page: PageRequest,
+    ) -> RepoResult<Page<TurnSummary>> {
+        self.inner.list_turns(session_id, filter, page).await
+    }
+
+    async fn get_turn(&self, session_id: &str, turn_seq: u32) -> RepoResult<Option<Turn>> {
+        self.inner.get_turn(session_id, turn_seq).await
+    }
+
+    async fn get_mcp_turn(
+        &self,
+        session_id: &str,
+        turn_seq: u32,
+    ) -> RepoResult<Option<McpTurnOpen>> {
+        self.inner.get_mcp_turn(session_id, turn_seq).await
+    }
+
+    async fn open_event(&self, request: OpenEventRequest) -> RepoResult<OpenContext> {
+        self.inner.open_event(request).await
+    }
+
+    async fn get_mcp_event(&self, event_uid: &str) -> RepoResult<Option<McpEventOpen>> {
+        self.inner.get_mcp_event(event_uid).await
+    }
+
+    async fn list_session_events(
+        &self,
+        query: SessionEventsQuery,
+        page: PageRequest,
+    ) -> RepoResult<Page<TraceEvent>> {
+        self.inner.list_session_events(query, page).await
+    }
+
+    async fn search_events(&self, query: SearchEventsQuery) -> RepoResult<SearchEventsResult> {
+        self.inner.search_events(query).await
+    }
+
+    async fn search_mcp_events(
+        &self,
+        query: SearchMcpEventsQuery,
+    ) -> RepoResult<SearchMcpEventsResult> {
+        match self.mode.load(Ordering::Acquire) {
+            BLOCK_SEARCH => self.block_forever().await,
+            DELAY_SEARCH if query.query == "slow" => self.delay_until_released().await,
+            PANIC_SEARCH => panic!("simulated repository panic"),
+            _ => {}
+        }
+        self.inner.search_mcp_events(query).await
+    }
+
+    async fn search_conversations(
+        &self,
+        query: ConversationSearchQuery,
+    ) -> RepoResult<ConversationSearchResults> {
+        self.inner.search_conversations(query).await
+    }
+
+    async fn search_session_metadata(
+        &self,
+        query: SessionMetadataSearchQuery,
+    ) -> RepoResult<SessionMetadataSearchResults> {
+        self.inner.search_session_metadata(query).await
+    }
+
+    async fn file_attention(
+        &self,
+        query: FileAttentionQuery,
+    ) -> RepoResult<Vec<FileAttentionTouch>> {
+        if self.mode.load(Ordering::Acquire) == BLOCK_FILE_ATTENTION {
+            self.block_forever().await
+        }
+        self.inner.file_attention(query).await
+    }
+
+    async fn cancel_query(&self, query_id: &str) -> RepoResult<()> {
+        self.cancelled_queries
+            .lock()
+            .await
+            .push(query_id.to_string());
+        self.state_changed.notify_one();
+        Ok(())
+    }
+}
+
+type ClientReader = BufReader<ReadHalf<tokio::io::DuplexStream>>;
+type ClientWriter = WriteHalf<tokio::io::DuplexStream>;
+
+fn start_connection(
+    repository: Arc<BlockingRepository>,
+) -> (
+    ClientReader,
+    ClientWriter,
+    tokio::task::JoinHandle<Result<()>>,
+) {
+    let state = AppState::embedded(AppConfig::default(), repository);
+    let (client, server) = tokio::io::duplex(64 * 1024);
+    let (client_read, client_write) = tokio::io::split(client);
+    let (server_read, server_write) = tokio::io::split(server);
+    let task = tokio::spawn(serve_connection(
+        state,
+        BufReader::new(server_read),
+        server_write,
+    ));
+    (BufReader::new(client_read), client_write, task)
+}
+
+fn start_connection_with_shutdown(
+    repository: Arc<BlockingRepository>,
+) -> (
+    ClientReader,
+    ClientWriter,
+    oneshot::Sender<()>,
+    tokio::task::JoinHandle<Result<()>>,
+) {
+    let state = AppState::embedded(AppConfig::default(), repository);
+    let (client, server) = tokio::io::duplex(64 * 1024);
+    let (client_read, client_write) = tokio::io::split(client);
+    let (server_read, server_write) = tokio::io::split(server);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let task = tokio::spawn(serve_connection_with_shutdown(
+        state,
+        BufReader::new(server_read),
+        server_write,
+        None,
+        async move {
+            let _ = shutdown_rx.await;
+        },
+    ));
+    (BufReader::new(client_read), client_write, shutdown_tx, task)
+}
+
+fn search_request_with_query(id: Value, query: &str) -> String {
+    let mut request = serde_json::to_string(&json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {
+            "name": "search_sessions",
+            "arguments": { "query": query },
+        },
+    }))
+    .expect("serialize search request");
+    request.push('\n');
+    request
+}
+
+fn search_request(id: usize) -> String {
+    search_request_with_query(json!(id), "latency")
+}
+fn tool_request(id: &str, name: &str, arguments: Value) -> String {
+    let mut request = serde_json::to_string(&json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {
+            "name": name,
+            "arguments": arguments,
+        },
+    }))
+    .expect("serialize tool request");
+    request.push('\n');
+    request
+}
+
+async fn read_response(reader: &mut ClientReader) -> Value {
+    let mut line = String::new();
+    tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        reader.read_line(&mut line),
+    )
+    .await
+    .expect("response deadline")
+    .expect("read response");
+    serde_json::from_str(line.trim()).expect("one complete JSON response frame")
+}
+
+#[tokio::test]
+async fn blocked_burst_preserves_fast_validation_backpressure_and_recovery() {
+    let repository = Arc::new(BlockingRepository::new(BLOCK_SEARCH));
+    let (mut reader, mut writer, server) = start_connection(repository.clone());
+
+    let burst = (1..=MAX_IN_FLIGHT_REQUESTS)
+        .map(search_request)
+        .collect::<String>();
+    writer
+        .write_all(burst.as_bytes())
+        .await
+        .expect("send burst");
+    repository.wait_for_started(MAX_IN_FLIGHT_REQUESTS).await;
+
+    writer
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":\"invalid\",\"method\":\"tools/call\",\"params\":{\"name\":\"open\",\"arguments\":{\"id\":\"unknown:123\"}}}\n",
+        )
+        .await
+        .expect("send invalid request");
+    writer
+        .write_all(search_request(9).as_bytes())
+        .await
+        .expect("send over-capacity request");
+
+    let first = read_response(&mut reader).await;
+    let second = read_response(&mut reader).await;
+    let responses = [first, second];
+    let invalid = responses
+        .iter()
+        .find(|response| response["id"] == json!("invalid"))
+        .expect("invalid request bypassed blocked retrievals");
+    assert_eq!(
+        invalid["result"]["structuredContent"]["error"]["code"],
+        json!("invalid_id")
+    );
+    let rejected = responses
+        .iter()
+        .find(|response| response["id"] == json!(9))
+        .expect("bounded burst was rejected promptly");
+    assert_eq!(rejected["error"]["code"], json!(-32000));
+
+    for id in 1..=MAX_IN_FLIGHT_REQUESTS {
+        writer
+            .write_all(
+                format!(
+                    "{{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\",\"params\":{{\"requestId\":{id},\"reason\":\"test\"}}}}\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .expect("cancel request");
+    }
+    repository.wait_for_dropped(MAX_IN_FLIGHT_REQUESTS).await;
+    repository.wait_for_cancelled(MAX_IN_FLIGHT_REQUESTS).await;
+    let mut cancelled_searches = repository.cancelled_queries.lock().await.clone();
+    cancelled_searches.sort();
+    cancelled_searches.dedup();
+    assert_eq!(cancelled_searches.len(), MAX_IN_FLIGHT_REQUESTS);
+    assert!(cancelled_searches
+        .iter()
+        .all(|query_id| query_id.starts_with("moraine-search-sessions-")));
+    repository.mode.store(0, Ordering::Release);
+
+    writer
+        .write_all(search_request(10).as_bytes())
+        .await
+        .expect("send recovery request");
+    let recovered = read_response(&mut reader).await;
+    assert_eq!(recovered["id"], json!(10));
+    assert!(recovered.get("result").is_some());
+
+    writer.shutdown().await.expect("half-close request stream");
+    drop(writer);
+    tokio::time::timeout(std::time::Duration::from_secs(1), server)
+        .await
+        .expect("connection drained")
+        .expect("connection task joined")
+        .expect("connection succeeded");
+}
+
+#[tokio::test]
+async fn cancellation_is_registered_before_each_tool_first_repository_read() {
+    let repository = Arc::new(BlockingRepository::new(BLOCK_SCOPE));
+    let (_reader, mut writer, server) = start_connection(repository.clone());
+    let session_id = crate::contract::McpSessionId::from_raw_session_id("blocked-session")
+        .expect("valid session id")
+        .to_string();
+    let requests = [
+        (
+            BLOCK_SCOPE,
+            "scope",
+            tool_request(
+                "scope",
+                "search_sessions",
+                json!({ "query": "latency", "within_id": session_id }),
+            ),
+        ),
+        (
+            BLOCK_LIST,
+            "list",
+            tool_request(
+                "list",
+                "list_sessions",
+                json!({
+                    "start_datetime": "2026-01-01T00:00:00Z",
+                    "end_datetime": "2026-01-02T00:00:00Z",
+                    "limit": 1,
+                }),
+            ),
+        ),
+        (
+            BLOCK_OPEN,
+            "open",
+            tool_request("open", "open", json!({ "id": session_id })),
+        ),
+    ];
+
+    for (index, (mode, id, request)) in requests.into_iter().enumerate() {
+        repository.mode.store(mode, Ordering::Release);
+        writer
+            .write_all(request.as_bytes())
+            .await
+            .expect("send blocked tool request");
+        repository.wait_for_started(index + 1).await;
+        writer
+            .write_all(
+                format!(
+                    "{{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\",\"params\":{{\"requestId\":\"{id}\"}}}}\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .expect("cancel blocked tool request");
+        repository.wait_for_dropped(index + 1).await;
+        repository.wait_for_cancelled(index + 1).await;
+    }
+
+    assert!(repository
+        .cancelled_queries
+        .lock()
+        .await
+        .iter()
+        .all(|query_id| query_id.starts_with("moraine-request-")));
+
+    writer.shutdown().await.expect("half-close request stream");
+    drop(writer);
+    tokio::time::timeout(std::time::Duration::from_secs(1), server)
+        .await
+        .expect("connection drained")
+        .expect("connection task joined")
+        .expect("connection succeeded");
+}
+
+#[tokio::test]
+async fn request_cancellation_propagates_unique_clickhouse_query_ids() {
+    let repository = Arc::new(BlockingRepository::new(BLOCK_FILE_ATTENTION));
+    let (mut reader, mut writer, server) = start_connection(repository.clone());
+
+    for id in ["file-a", "file-b"] {
+        writer
+            .write_all(
+                format!(
+                    "{{\"jsonrpc\":\"2.0\",\"id\":\"{id}\",\"method\":\"tools/call\",\"params\":{{\"name\":\"file_attention\",\"arguments\":{{\"path\":\"src/lib.rs\"}}}}}}\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .expect("send file request");
+    }
+    repository.wait_for_started(2).await;
+
+    for id in ["file-a", "file-b"] {
+        writer
+            .write_all(
+                format!(
+                    "{{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\",\"params\":{{\"requestId\":\"{id}\"}}}}\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .expect("cancel file request");
+    }
+    repository.wait_for_dropped(2).await;
+
+    repository.wait_for_cancelled(2).await;
+    let cancelled = repository.cancelled_queries.lock().await.clone();
+    assert_ne!(cancelled[0], cancelled[1]);
+    assert!(cancelled
+        .iter()
+        .all(|query_id| query_id.starts_with("moraine-file-attention-")));
+
+    writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":\"ping\",\"method\":\"ping\"}\n")
+        .await
+        .expect("send ping after cancellation");
+    let ping = read_response(&mut reader).await;
+    assert_eq!(ping["id"], json!("ping"));
+
+    writer.shutdown().await.expect("half-close request stream");
+    drop(writer);
+    tokio::time::timeout(std::time::Duration::from_secs(1), server)
+        .await
+        .expect("connection drained")
+        .expect("connection task joined")
+        .expect("connection succeeded");
+}
+
+#[tokio::test]
+async fn disconnect_write_failure_cancels_blocked_repository_work() {
+    let repository = Arc::new(BlockingRepository::new(BLOCK_SEARCH));
+    let (reader, mut writer, server) = start_connection(repository.clone());
+
+    writer
+        .write_all(search_request(1).as_bytes())
+        .await
+        .expect("send blocked request");
+    repository.wait_for_started(1).await;
+    drop(reader);
+    writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":\"probe\",\"method\":\"ping\"}\n")
+        .await
+        .expect("send response probe after closing read half");
+    drop(writer);
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), server)
+        .await
+        .expect("disconnect cleanup deadline")
+        .expect("connection task joined")
+        .expect_err("closed response half must fail the connection");
+    repository.wait_for_dropped(1).await;
+    repository.wait_for_cancelled(1).await;
+    assert!(repository.cancelled_queries.lock().await[0].starts_with("moraine-search-sessions-"));
+}
+
+#[tokio::test]
+async fn clean_read_half_close_preserves_slow_admitted_response() {
+    let repository = Arc::new(BlockingRepository::new(DELAY_SEARCH));
+    let (mut reader, mut writer, server) = start_connection(repository.clone());
+
+    writer
+        .write_all(search_request_with_query(json!("slow-half-close"), "slow").as_bytes())
+        .await
+        .expect("send slow request");
+    repository.wait_for_started(1).await;
+    writer.shutdown().await.expect("half-close request stream");
+    drop(writer);
+
+    tokio::time::sleep(std::time::Duration::from_millis(350)).await;
+    repository.release_search.notify_one();
+    let response = read_response(&mut reader).await;
+    assert_eq!(response["id"], json!("slow-half-close"));
+    assert!(response.get("result").is_some());
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), server)
+        .await
+        .expect("half-closed connection drained")
+        .expect("connection task joined")
+        .expect("connection succeeded");
+}
+
+#[tokio::test]
+async fn failed_request_task_releases_id_permit_and_backend_query() {
+    let repository = Arc::new(BlockingRepository::new(PANIC_SEARCH));
+    let (mut reader, mut writer, server) = start_connection(repository.clone());
+
+    writer
+        .write_all(search_request_with_query(json!("reused"), "panic").as_bytes())
+        .await
+        .expect("send panicking request");
+    let failed = read_response(&mut reader).await;
+    assert_eq!(failed["id"], json!("reused"));
+    assert_eq!(failed["error"]["code"], json!(-32603));
+    repository.wait_for_cancelled(1).await;
+
+    repository.mode.store(0, Ordering::Release);
+    writer
+        .write_all(search_request_with_query(json!("reused"), "recovered").as_bytes())
+        .await
+        .expect("reuse request id after task failure");
+    let recovered = read_response(&mut reader).await;
+    assert_eq!(recovered["id"], json!("reused"));
+    assert!(recovered.get("result").is_some());
+
+    writer.shutdown().await.expect("half-close request stream");
+    drop(writer);
+    tokio::time::timeout(std::time::Duration::from_secs(1), server)
+        .await
+        .expect("connection drained")
+        .expect("connection task joined")
+        .expect("connection succeeded");
+}
+
+#[tokio::test]
+async fn responses_are_framed_and_keep_ids_when_completion_is_out_of_order() {
+    let repository = Arc::new(BlockingRepository::new(DELAY_SEARCH));
+    let (mut reader, mut writer, server) = start_connection(repository.clone());
+
+    writer
+        .write_all(search_request_with_query(json!("slow-id"), "slow").as_bytes())
+        .await
+        .expect("send slow request");
+    repository.wait_for_started(1).await;
+    writer
+        .write_all(search_request_with_query(json!(42), "fast").as_bytes())
+        .await
+        .expect("send fast request");
+
+    let fast = read_response(&mut reader).await;
+    assert_eq!(fast["id"], json!(42));
+    assert!(fast.get("result").is_some());
+
+    repository.release_search.notify_one();
+    let slow = read_response(&mut reader).await;
+    assert_eq!(slow["id"], json!("slow-id"));
+    assert!(slow.get("result").is_some());
+
+    writer.shutdown().await.expect("half-close request stream");
+    drop(writer);
+    tokio::time::timeout(std::time::Duration::from_secs(1), server)
+        .await
+        .expect("connection drained")
+        .expect("connection task joined")
+        .expect("connection succeeded");
+}
+
+#[tokio::test]
+async fn service_shutdown_cancels_in_flight_backend_query() {
+    let repository = Arc::new(BlockingRepository::new(BLOCK_FILE_ATTENTION));
+    let (_reader, mut writer, shutdown, server) =
+        start_connection_with_shutdown(repository.clone());
+
+    writer
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":\"shutdown\",\"method\":\"tools/call\",\"params\":{\"name\":\"file_attention\",\"arguments\":{\"path\":\"src/lib.rs\"}}}\n",
+        )
+        .await
+        .expect("send blocked request");
+    repository.wait_for_started(1).await;
+    shutdown.send(()).expect("request service shutdown");
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), server)
+        .await
+        .expect("service shutdown deadline")
+        .expect("connection task joined")
+        .expect("connection succeeded");
+    repository.wait_for_dropped(1).await;
+    repository.wait_for_cancelled(1).await;
+    assert!(repository.cancelled_queries.lock().await[0].starts_with("moraine-file-attention-"));
+}
+
+#[tokio::test]
+async fn malformed_transport_still_cancels_in_flight_backend_query() {
+    let repository = Arc::new(BlockingRepository::new(BLOCK_FILE_ATTENTION));
+    let (_reader, mut writer, server) = start_connection(repository.clone());
+
+    writer
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":\"malformed\",\"method\":\"tools/call\",\"params\":{\"name\":\"file_attention\",\"arguments\":{\"path\":\"src/lib.rs\"}}}\n",
+        )
+        .await
+        .expect("send blocked request");
+    repository.wait_for_started(1).await;
+    writer
+        .write_all(&[0xff, b'\n'])
+        .await
+        .expect("send malformed UTF-8 frame");
+
+    let error = tokio::time::timeout(std::time::Duration::from_secs(2), server)
+        .await
+        .expect("transport cleanup deadline")
+        .expect("connection task joined")
+        .expect_err("invalid UTF-8 must fail the connection");
+    assert!(error
+        .to_string()
+        .contains("stream did not contain valid UTF-8"));
+    repository.wait_for_dropped(1).await;
+    repository.wait_for_cancelled(1).await;
+}

--- a/crates/moraine-mcp-core/src/file_attention_v1.rs
+++ b/crates/moraine-mcp-core/src/file_attention_v1.rs
@@ -10,8 +10,8 @@
 //! it never reinvents inspection.
 
 use super::{
-    handled_tool_error_result, internal_id_error, repo_error_to_contract_error,
-    tool_success_result, AppState,
+    backend_query_id, handled_tool_error_result, internal_id_error, repo_error_to_contract_error,
+    tool_success_result, AppState, QueryCancellationGuard,
 };
 use crate::contract::{
     format_rfc3339_utc_millis, CanonicalFileAttentionArgs, ContractError, FileAttentionArgs,
@@ -25,7 +25,6 @@ use moraine_conversations::{FileAttentionQuery, FileAttentionTouch};
 use serde_json::{json, Value};
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::time::{timeout, Duration};
 use tracing::warn;
 
@@ -99,7 +98,7 @@ impl AppState {
             );
         }
 
-        let query_id = file_attention_query_id();
+        let query_id = backend_query_id("file-attention");
         let repo_query = FileAttentionQuery {
             cancellation_token: query_id.clone(),
             rel: tail.rel.clone(),
@@ -118,19 +117,25 @@ impl AppState {
             execution_budget_secs: FILE_ATTENTION_DEADLINE_MS.div_ceil(1_000),
         };
 
-        let touches = match timeout(
+        let mut cancellation = QueryCancellationGuard::new(query_id.clone());
+        let repo_result = timeout(
             Duration::from_millis(FILE_ATTENTION_DEADLINE_MS),
             self.repo.file_attention(repo_query),
         )
-        .await
-        {
-            Ok(Ok(touches)) => touches,
+        .await;
+
+        let touches = match repo_result {
+            Ok(Ok(touches)) => {
+                cancellation.disarm();
+                touches
+            }
             Ok(Err(error)) => {
+                cancellation.disarm();
                 return encode_error(
                     canonical_request,
                     repo_error_to_contract_error(error),
                     perf.finish(),
-                )
+                );
             }
             Err(_) => {
                 if let Err(error) = self.repo.cancel_query(&query_id).await {
@@ -140,6 +145,7 @@ impl AppState {
                         "file_attention: failed to cancel timed-out ClickHouse query"
                     );
                 }
+                cancellation.disarm();
                 return encode_error(
                     canonical_request,
                     ContractError::new(
@@ -162,14 +168,6 @@ impl AppState {
         .context("failed to encode file_attention response envelope")?;
         Ok(tool_success_result(format_text(&payload), payload))
     }
-}
-
-fn file_attention_query_id() -> String {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    format!("moraine-file-attention-{}-{nanos}", std::process::id())
 }
 
 fn parse_file_attention_args(

--- a/crates/moraine-mcp-core/src/file_attention_v1.rs
+++ b/crates/moraine-mcp-core/src/file_attention_v1.rs
@@ -10,8 +10,8 @@
 //! it never reinvents inspection.
 
 use super::{
-    backend_query_id, handled_tool_error_result, internal_id_error, repo_error_to_contract_error,
-    tool_success_result, AppState, QueryCancellationGuard,
+    backend_query_id, cancel_query_with_deadline, handled_tool_error_result, internal_id_error,
+    repo_error_to_contract_error, tool_success_result, AppState, QueryCancellationGuard,
 };
 use crate::contract::{
     format_rfc3339_utc_millis, CanonicalFileAttentionArgs, ContractError, FileAttentionArgs,
@@ -138,13 +138,7 @@ impl AppState {
                 );
             }
             Err(_) => {
-                if let Err(error) = self.repo.cancel_query(&query_id).await {
-                    warn!(
-                        query_id = %query_id,
-                        error = %error,
-                        "file_attention: failed to cancel timed-out ClickHouse query"
-                    );
-                }
+                cancel_query_with_deadline(self, &query_id).await;
                 cancellation.disarm();
                 return encode_error(
                     canonical_request,

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -555,7 +555,7 @@ where
 async fn serve_connection_with_shutdown<R, W, S>(
     state: Arc<AppState>,
     reader: R,
-    mut writer: W,
+    writer: W,
     first_line: Option<Vec<u8>>,
     shutdown: S,
 ) -> Result<()>
@@ -564,11 +564,29 @@ where
     W: AsyncWrite + Unpin,
     S: Future<Output = ()>,
 {
+    serve_connection_with_lifecycle(state, reader, writer, first_line, shutdown, pending()).await
+}
+
+async fn serve_connection_with_lifecycle<R, W, S, D>(
+    state: Arc<AppState>,
+    reader: R,
+    mut writer: W,
+    first_line: Option<Vec<u8>>,
+    shutdown: S,
+    peer_disconnected: D,
+) -> Result<()>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+    S: Future<Output = ()>,
+    D: Future<Output = ()>,
+{
     let mut requests = JoinSet::new();
     let mut active = HashMap::new();
     let mut shutdown_requested = false;
     let mut connection_error = None;
     tokio::pin!(shutdown);
+    tokio::pin!(peer_disconnected);
 
     if let Some(first_line) = first_line {
         let first_line =
@@ -631,12 +649,14 @@ where
     // EOF only closes the request half of a stream. A client may continue
     // reading responses after it has sent every frame, so admitted work keeps
     // its normal lifecycle and every completed response is serialized before
-    // this connection closes. Service shutdown and write failures still move
-    // directly to cancellation below.
+    // this connection closes. Socket transports separately report a full peer
+    // hangup, while service shutdown and write failures move directly to
+    // cancellation below.
     if !shutdown_requested && connection_error.is_none() {
         while !requests.is_empty() {
             let completed = tokio::select! {
                 _ = &mut shutdown => break,
+                _ = &mut peer_disconnected => break,
                 completed = requests.join_next() => completed,
             };
             if let Some(response) = finish_request(&state, completed, &mut active).await {
@@ -1252,10 +1272,32 @@ fn rename_socket_noreplace(_from: &std::path::Path, _to: &std::path::Path) -> st
 }
 
 #[cfg(unix)]
+fn socket_peer_hung_up(fd: std::os::fd::RawFd) -> bool {
+    let mut descriptor = libc::pollfd {
+        fd,
+        events: libc::POLLHUP,
+        revents: 0,
+    };
+    // SAFETY: `descriptor` points to one initialized pollfd for the duration
+    // of this non-blocking call. The owning socket halves outlive the monitor.
+    let ready = unsafe { libc::poll(&mut descriptor, 1, 0) };
+    ready > 0 && descriptor.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL) != 0
+}
+
+#[cfg(unix)]
+async fn wait_for_socket_hangup(fd: std::os::fd::RawFd) {
+    while !socket_peer_hung_up(fd) {
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+#[cfg(unix)]
 async fn serve_socket_connection(state: SocketState, stream: tokio::net::UnixStream) -> Result<()> {
     use private_proxy::ServerFirstLine;
+    use std::os::fd::AsRawFd;
 
     let mut shutdown = state.shutdown.clone();
+    let peer_fd = stream.as_raw_fd();
 
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
@@ -1313,7 +1355,7 @@ async fn serve_socket_connection(state: SocketState, stream: tokio::net::UnixStr
     if negotiated {
         private_proxy::write_ack(&mut write_half).await?;
     }
-    serve_connection_with_shutdown(
+    serve_connection_with_lifecycle(
         app_state,
         reader,
         write_half,
@@ -1323,6 +1365,7 @@ async fn serve_socket_connection(state: SocketState, stream: tokio::net::UnixStr
                 let _ = shutdown.changed().await;
             }
         },
+        wait_for_socket_hangup(peer_fd),
     )
     .await
 }

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -1281,21 +1281,35 @@ fn rename_socket_noreplace(_from: &std::path::Path, _to: &std::path::Path) -> st
 }
 
 #[cfg(unix)]
-fn socket_peer_hung_up(fd: std::os::fd::RawFd) -> bool {
-    let mut descriptor = libc::pollfd {
-        fd,
-        events: libc::POLLHUP,
-        revents: 0,
+fn socket_peer_disconnected(fd: std::os::fd::RawFd) -> bool {
+    // A zero-length send emits no protocol bytes, but still checks whether the
+    // peer retains its read half. Unlike POLLHUP, this distinguishes a client
+    // write-half shutdown from a full disconnect on supported Unix sockets.
+    // SAFETY: a null buffer is valid for a zero-length send, and the owning
+    // socket halves outlive this monitor.
+    let sent = unsafe {
+        libc::send(
+            fd,
+            std::ptr::null(),
+            0,
+            libc::MSG_DONTWAIT | libc::MSG_NOSIGNAL,
+        )
     };
-    // SAFETY: `descriptor` points to one initialized pollfd for the duration
-    // of this non-blocking call. The owning socket halves outlive the monitor.
-    let ready = unsafe { libc::poll(&mut descriptor, 1, 0) };
-    ready > 0 && descriptor.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL) != 0
+    if sent == 0 {
+        return false;
+    }
+
+    let errno = std::io::Error::last_os_error().raw_os_error();
+    !matches!(
+        errno,
+        Some(code)
+            if code == libc::EINTR || code == libc::EAGAIN || code == libc::EWOULDBLOCK
+    )
 }
 
 #[cfg(unix)]
-async fn wait_for_socket_hangup(fd: std::os::fd::RawFd) {
-    while !socket_peer_hung_up(fd) {
+async fn wait_for_socket_disconnect(fd: std::os::fd::RawFd) {
+    while !socket_peer_disconnected(fd) {
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
 }
@@ -1374,7 +1388,7 @@ async fn serve_socket_connection(state: SocketState, stream: tokio::net::UnixStr
                 let _ = shutdown.changed().await;
             }
         },
-        wait_for_socket_hangup(peer_fd),
+        wait_for_socket_disconnect(peer_fd),
     )
     .await
 }

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -16,16 +16,38 @@ pub use private_proxy::private_route_deadline;
 pub use private_proxy::{negotiate_private_route, PrivateProxyConnection, PrivateRouteNegotiation};
 use serde::Deserialize;
 use serde_json::{json, Value};
-#[cfg(all(test, unix))]
-use std::future::pending;
-use std::future::Future;
+use std::collections::HashMap;
+use std::future::{pending, Future};
 use std::path::PathBuf;
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc, Mutex as StdMutex,
 };
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::sync::{oneshot, watch, Semaphore};
+use tokio::task::JoinSet;
 use tracing::{debug, warn};
+
+const MAX_IN_FLIGHT_REQUESTS: usize = 8;
+const QUERY_CANCELLATION_DEADLINE: std::time::Duration = std::time::Duration::from_millis(1_000);
+const SERVICE_DRAIN_GRACE: std::time::Duration = std::time::Duration::from_millis(1_250);
+
+type QueryCancellationSlot = Arc<StdMutex<Option<String>>>;
+
+tokio::task_local! {
+    static REQUEST_QUERY_CANCELLATION: QueryCancellationSlot;
+}
+
+pub(crate) fn backend_query_id(kind: &str) -> String {
+    static QUERY_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let sequence = QUERY_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("moraine-{kind}-{}-{nanos}-{sequence}", std::process::id())
+}
 
 #[derive(Debug, Deserialize)]
 struct RpcRequest {
@@ -43,12 +65,19 @@ struct ToolCallParams {
     arguments: Value,
 }
 
+#[derive(Debug, Deserialize)]
+struct CancelledParams {
+    #[serde(rename = "requestId")]
+    request_id: Value,
+}
+
 #[derive(Clone)]
 struct AppState {
     cfg: Arc<AppConfig>,
     repo: Arc<dyn ConversationRepository>,
     launch_dir: Option<PathBuf>,
     prewarm_started: Arc<AtomicBool>,
+    request_permits: Arc<Semaphore>,
 }
 
 impl AppState {
@@ -455,12 +484,14 @@ impl AppState {
         repo: Arc<dyn ConversationRepository>,
         prewarm_started: Arc<AtomicBool>,
         launch_dir: Option<PathBuf>,
+        request_permits: Arc<Semaphore>,
     ) -> Arc<AppState> {
         Arc::new(AppState {
             cfg,
             repo,
             launch_dir,
             prewarm_started,
+            request_permits,
         })
     }
 
@@ -470,43 +501,183 @@ impl AppState {
             repo,
             Arc::new(AtomicBool::new(false)),
             std::env::current_dir().ok(),
+            Arc::new(Semaphore::new(MAX_IN_FLIGHT_REQUESTS)),
         )
+    }
+}
+
+pub(crate) struct QueryCancellationGuard {
+    query_id: String,
+    slot: Option<QueryCancellationSlot>,
+}
+
+impl QueryCancellationGuard {
+    pub(crate) fn new(query_id: String) -> Self {
+        let slot = REQUEST_QUERY_CANCELLATION
+            .try_with(|slot| slot.clone())
+            .ok();
+        if let Some(slot) = &slot {
+            *slot.lock().expect("query cancellation slot poisoned") = Some(query_id.clone());
+        }
+        Self { query_id, slot }
+    }
+
+    pub(crate) fn disarm(&mut self) {
+        let Some(slot) = &self.slot else {
+            return;
+        };
+        let mut registered = slot.lock().expect("query cancellation slot poisoned");
+        if registered.as_ref() == Some(&self.query_id) {
+            *registered = None;
+        }
     }
 }
 
 /// Drive a single newline-delimited JSON-RPC connection to completion.
 ///
-/// This is the one source of truth for the public MCP wire framing: one JSON
-/// object per line in, one JSON object plus `\n` per response out, with blank
-/// lines skipped. Socket connections may provide a first line that was already
-/// read while discriminating the daemon-private route request; that line is
-/// replayed here exactly once for compatibility with older raw clients.
+/// Slow repository requests execute concurrently and may complete out of order.
+/// Response encoding and writes stay on this connection task so JSON frames can
+/// never interleave. Admission is shared across socket connections and rejects
+/// excess work immediately instead of building an unbounded queue.
 async fn serve_connection_with_first_line<R, W>(
     state: Arc<AppState>,
-    mut reader: R,
-    mut writer: W,
+    reader: R,
+    writer: W,
     first_line: Option<Vec<u8>>,
 ) -> Result<()>
 where
     R: AsyncBufRead + Unpin,
     W: AsyncWrite + Unpin,
 {
+    serve_connection_with_shutdown(state, reader, writer, first_line, pending()).await
+}
+
+async fn serve_connection_with_shutdown<R, W, S>(
+    state: Arc<AppState>,
+    reader: R,
+    mut writer: W,
+    first_line: Option<Vec<u8>>,
+    shutdown: S,
+) -> Result<()>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+    S: Future<Output = ()>,
+{
+    let mut requests = JoinSet::new();
+    let mut active = HashMap::new();
+    let mut shutdown_requested = false;
+    let mut connection_error = None;
+    tokio::pin!(shutdown);
+
     if let Some(first_line) = first_line {
         let first_line =
             std::str::from_utf8(&first_line).context("incoming RPC line is not valid UTF-8")?;
-        serve_rpc_line(&state, first_line, &mut writer).await?;
-    }
-
-    let mut line = String::new();
-    loop {
-        line.clear();
-        if reader.read_line(&mut line).await? == 0 {
-            break;
+        if let Some(response) =
+            dispatch_rpc_line(&state, first_line, &mut requests, &mut active).await?
+        {
+            tokio::select! {
+                result = write_rpc_response(&mut writer, &response) => result?,
+                _ = &mut shutdown => shutdown_requested = true,
+            }
         }
-        serve_rpc_line(&state, &line, &mut writer).await?;
     }
 
-    Ok(())
+    let mut lines = reader.lines();
+    while !shutdown_requested && connection_error.is_none() {
+        tokio::select! {
+            _ = &mut shutdown => {
+                shutdown_requested = true;
+            }
+            completed = requests.join_next(), if !requests.is_empty() => {
+                if let Some(response) = finish_request(&state, completed, &mut active).await {
+                    tokio::select! {
+                        result = write_rpc_response(&mut writer, &response) => {
+                            if let Err(error) = result {
+                                connection_error = Some(error);
+                            }
+                        }
+                        _ = &mut shutdown => shutdown_requested = true,
+                    }
+                }
+            }
+            next_line = lines.next_line() => {
+                let line = match next_line {
+                    Ok(Some(line)) => line,
+                    Ok(None) => break,
+                    Err(error) => {
+                        connection_error = Some(error.into());
+                        continue;
+                    }
+                };
+                match dispatch_rpc_line(&state, &line, &mut requests, &mut active).await {
+                    Ok(Some(response)) => {
+                        tokio::select! {
+                            result = write_rpc_response(&mut writer, &response) => {
+                                if let Err(error) = result {
+                                    connection_error = Some(error);
+                                }
+                            }
+                            _ = &mut shutdown => shutdown_requested = true,
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(error) => connection_error = Some(error),
+                }
+            }
+        }
+    }
+
+    // EOF only closes the request half of a stream. A client may continue
+    // reading responses after it has sent every frame, so admitted work keeps
+    // its normal lifecycle and every completed response is serialized before
+    // this connection closes. Service shutdown and write failures still move
+    // directly to cancellation below.
+    if !shutdown_requested && connection_error.is_none() {
+        while !requests.is_empty() {
+            let completed = tokio::select! {
+                _ = &mut shutdown => break,
+                completed = requests.join_next() => completed,
+            };
+            if let Some(response) = finish_request(&state, completed, &mut active).await {
+                tokio::select! {
+                    result = write_rpc_response(&mut writer, &response) => {
+                        if let Err(error) = result {
+                            connection_error = Some(error);
+                            break;
+                        }
+                    }
+                    _ = &mut shutdown => break,
+                }
+            }
+        }
+    }
+
+    for request in active.values_mut() {
+        if let Some(cancellation) = request.cancellation.take() {
+            let _ = cancellation.send(());
+        }
+    }
+
+    // Request tasks own backend cancellation and must be given time to finish
+    // it before the connection or service reports itself drained.
+    let cancellation_deadline = tokio::time::Instant::now() + QUERY_CANCELLATION_DEADLINE;
+    while !requests.is_empty() {
+        match tokio::time::timeout_at(cancellation_deadline, requests.join_next()).await {
+            Ok(completed) => {
+                let _ = finish_request(&state, completed, &mut active).await;
+            }
+            Err(_) => break,
+        }
+    }
+    requests.abort_all();
+    while requests.join_next().await.is_some() {}
+
+    if let Some(error) = connection_error {
+        Err(error)
+    } else {
+        Ok(())
+    }
 }
 
 async fn serve_connection<R, W>(state: Arc<AppState>, reader: R, writer: W) -> Result<()>
@@ -517,13 +688,24 @@ where
     serve_connection_with_first_line(state, reader, writer, None).await
 }
 
-async fn serve_rpc_line<W>(state: &Arc<AppState>, line: &str, writer: &mut W) -> Result<()>
-where
-    W: AsyncWrite + Unpin,
-{
+struct ActiveRequest {
+    id: Value,
+    task_id: tokio::task::Id,
+    query_cancellation: QueryCancellationSlot,
+    cancellation: Option<oneshot::Sender<()>>,
+}
+
+type RequestResult = (String, Option<Value>);
+
+async fn dispatch_rpc_line(
+    state: &Arc<AppState>,
+    line: &str,
+    requests: &mut JoinSet<RequestResult>,
+    active: &mut HashMap<String, ActiveRequest>,
+) -> Result<Option<Value>> {
     let line = line.trim();
     if line.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
 
     debug!("incoming rpc line: {}", line);
@@ -531,16 +713,191 @@ where
         Ok(req) => req,
         Err(err) => {
             warn!("failed to parse rpc request: {}", err);
-            return Ok(());
+            return Ok(None);
         }
     };
 
-    if let Some(resp) = state.handle_request(req).await {
-        let payload = serde_json::to_vec(&resp)?;
-        writer.write_all(&payload).await?;
-        writer.write_all(b"\n").await?;
-        writer.flush().await?;
+    if req.method == "notifications/cancelled" {
+        if let Ok(params) = serde_json::from_value::<CancelledParams>(req.params) {
+            if let Some(request) = active.get_mut(&request_key(&params.request_id)?) {
+                if let Some(cancellation) = request.cancellation.take() {
+                    let _ = cancellation.send(());
+                }
+            }
+        }
+        return Ok(None);
     }
+
+    if !request_requires_admission(&req, state.cfg.mcp.max_results) {
+        return Ok(state.handle_request(req).await);
+    }
+
+    let id = req
+        .id
+        .clone()
+        .expect("admitted repository requests always carry an id");
+    let key = request_key(&id)?;
+    if active.contains_key(&key) {
+        return Ok(Some(rpc_err(
+            id,
+            -32600,
+            "duplicate request id is already in flight",
+        )));
+    }
+
+    let permit = match state.request_permits.clone().try_acquire_owned() {
+        Ok(permit) => permit,
+        Err(_) => {
+            return Ok(Some(rpc_err(
+                id,
+                -32000,
+                "server busy: concurrent request limit reached",
+            )))
+        }
+    };
+
+    let (cancel_tx, mut cancel_rx) = oneshot::channel();
+    let request_query_id = backend_query_id("request");
+    let query_cancellation = Arc::new(StdMutex::new(Some(request_query_id.clone())));
+    let task_query_cancellation = query_cancellation.clone();
+    let request_state = state.clone();
+    let task_key = key.clone();
+    let task = requests.spawn(async move {
+        let _permit = permit;
+        let query_cancellation = task_query_cancellation;
+        enum Outcome {
+            Completed(Option<Value>),
+            Cancelled,
+        }
+        let outcome = {
+            let request = REQUEST_QUERY_CANCELLATION.scope(
+                query_cancellation.clone(),
+                moraine_conversations::with_repository_query_id(
+                    request_query_id,
+                    request_state.handle_request(req),
+                ),
+            );
+            tokio::pin!(request);
+            tokio::select! {
+                biased;
+                _ = &mut cancel_rx => Outcome::Cancelled,
+                response = &mut request => Outcome::Completed(response),
+            }
+        };
+        let response = match outcome {
+            Outcome::Completed(response) => response,
+            Outcome::Cancelled => {
+                cancel_registered_query(&request_state, &query_cancellation).await;
+                None
+            }
+        };
+        (task_key, response)
+    });
+    active.insert(
+        key,
+        ActiveRequest {
+            id,
+            task_id: task.id(),
+            query_cancellation,
+            cancellation: Some(cancel_tx),
+        },
+    );
+    Ok(None)
+}
+
+async fn cancel_registered_query(state: &AppState, slot: &QueryCancellationSlot) {
+    let query_id = slot
+        .lock()
+        .expect("query cancellation slot poisoned")
+        .take();
+    let Some(query_id) = query_id else {
+        return;
+    };
+    match tokio::time::timeout(
+        QUERY_CANCELLATION_DEADLINE,
+        state.repo.cancel_query(&query_id),
+    )
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => warn!(
+            query_id = %query_id,
+            error = %error,
+            "failed to cancel abandoned MCP ClickHouse query"
+        ),
+        Err(_) => warn!(
+            query_id = %query_id,
+            "timed out cancelling abandoned MCP ClickHouse query"
+        ),
+    }
+}
+
+fn request_requires_admission(req: &RpcRequest, max_results: u16) -> bool {
+    if req.id.is_none() || req.method != "tools/call" {
+        return false;
+    }
+    let Ok(params) = serde_json::from_value::<ToolCallParams>(req.params.clone()) else {
+        return false;
+    };
+
+    match params.name.as_str() {
+        contract::SEARCH_SESSIONS_TOOL => {
+            serde_json::from_value::<contract::SearchSessionsArgs>(params.arguments)
+                .is_ok_and(|args| args.validate().is_ok())
+        }
+        contract::LIST_SESSIONS_TOOL => {
+            serde_json::from_value::<contract::ListSessionsArgs>(params.arguments)
+                .is_ok_and(|args| args.validate(max_results).is_ok())
+        }
+        contract::OPEN_TOOL => serde_json::from_value::<contract::OpenV1Args>(params.arguments)
+            .is_ok_and(|args| args.validate().is_ok()),
+        contract::FILE_ATTENTION_TOOL => {
+            serde_json::from_value::<contract::FileAttentionArgs>(params.arguments)
+                .is_ok_and(|args| args.validate(max_results).is_ok())
+        }
+        _ => false,
+    }
+}
+
+fn request_key(id: &Value) -> Result<String> {
+    serde_json::to_string(id).context("failed to encode JSON-RPC request id")
+}
+
+async fn finish_request(
+    state: &AppState,
+    completed: Option<Result<RequestResult, tokio::task::JoinError>>,
+    active: &mut HashMap<String, ActiveRequest>,
+) -> Option<Value> {
+    match completed {
+        Some(Ok((key, response))) => {
+            active.remove(&key);
+            response
+        }
+        Some(Err(error)) => {
+            let failed = active
+                .iter()
+                .find_map(|(key, request)| (request.task_id == error.id()).then(|| key.clone()))
+                .and_then(|key| active.remove(&key));
+            debug!("mcp request task ended unexpectedly: {error}");
+            if let Some(request) = failed {
+                cancel_registered_query(state, &request.query_cancellation).await;
+                Some(rpc_err(request.id, -32603, "request failed"))
+            } else {
+                None
+            }
+        }
+        None => None,
+    }
+}
+
+async fn write_rpc_response<W>(writer: &mut W, response: &Value) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let payload = serde_json::to_vec(response)?;
+    writer.write_all(&payload).await?;
+    writer.write_all(b"\n").await?;
+    writer.flush().await?;
     Ok(())
 }
 
@@ -596,6 +953,8 @@ struct SocketState {
     cfg: Arc<AppConfig>,
     router: Arc<BackendRepositoryRouter>,
     prewarm_gates: BackendPrewarmGates,
+    request_permits: Arc<Semaphore>,
+    shutdown: watch::Receiver<bool>,
 }
 
 /// Run the shared MCP server on a Unix domain socket using the daemon-owned
@@ -605,8 +964,8 @@ struct SocketState {
 /// never installs signal handlers or terminates the process. Each accepted
 /// connection negotiates and pins one repository handle, while connections to
 /// the same backend share both its repository and its MCP prewarm gate. When
-/// shutdown resolves, accepting stops, connection tasks are cancelled, and the
-/// public socket path is unlinked before this future returns.
+/// shutdown resolves, accepting stops, connection and request cancellation is
+/// drained within a fixed bound, and the public socket path is unlinked.
 #[cfg(unix)]
 pub async fn run_socket_with_router<S>(
     cfg: Arc<AppConfig>,
@@ -620,8 +979,11 @@ where
     use tokio::net::{UnixListener, UnixStream};
     use tokio::task::JoinSet;
 
+    let (connection_shutdown_tx, connection_shutdown_rx) = watch::channel(false);
     let state = SocketState {
         prewarm_gates: BackendPrewarmGates::new(&cfg),
+        request_permits: Arc::new(Semaphore::new(MAX_IN_FLIGHT_REQUESTS)),
+        shutdown: connection_shutdown_rx,
         cfg,
         router,
     };
@@ -773,6 +1135,15 @@ where
         }
     }
 
+    let _ = connection_shutdown_tx.send(true);
+    let drain_deadline = tokio::time::Instant::now() + SERVICE_DRAIN_GRACE;
+    while !connections.is_empty() {
+        match tokio::time::timeout_at(drain_deadline, connections.join_next()).await {
+            Ok(Some(_)) => {}
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
     connections.abort_all();
     while connections.join_next().await.is_some() {}
     Ok(())
@@ -884,6 +1255,8 @@ fn rename_socket_noreplace(_from: &std::path::Path, _to: &std::path::Path) -> st
 async fn serve_socket_connection(state: SocketState, stream: tokio::net::UnixStream) -> Result<()> {
     use private_proxy::ServerFirstLine;
 
+    let mut shutdown = state.shutdown.clone();
+
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
     let Some(first_line) = private_proxy::read_server_first_line(&mut reader).await? else {
@@ -935,11 +1308,23 @@ async fn serve_socket_connection(state: SocketState, stream: tokio::net::UnixStr
         backend.repository().clone(),
         prewarm_started,
         launch_dir,
+        state.request_permits,
     );
     if negotiated {
         private_proxy::write_ack(&mut write_half).await?;
     }
-    serve_connection_with_first_line(app_state, reader, write_half, replay_first_line).await
+    serve_connection_with_shutdown(
+        app_state,
+        reader,
+        write_half,
+        replay_first_line,
+        async move {
+            if !*shutdown.borrow() {
+                let _ = shutdown.changed().await;
+            }
+        },
+    )
+    .await
 }
 
 /// Run the stdio byte pumps after a private route negotiation was accepted.
@@ -1064,6 +1449,9 @@ where
 {
     anyhow::bail!("the central MCP socket server is only supported on Unix platforms")
 }
+
+#[cfg(test)]
+mod concurrency_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -28,7 +28,12 @@ use tokio::sync::{oneshot, watch, Semaphore};
 use tokio::task::JoinSet;
 use tracing::{debug, warn};
 
-const MAX_IN_FLIGHT_REQUESTS: usize = 8;
+// The widest retrieval stage runs three independent ClickHouse reads.
+// Eight admitted requests therefore cap MCP-owned backend reads at 24 while
+// retaining that per-request fan-out.
+const MAX_REPOSITORY_READ_FAN_OUT: usize = 3;
+const MAX_IN_FLIGHT_BACKEND_READS: usize = 24;
+const MAX_IN_FLIGHT_REQUESTS: usize = MAX_IN_FLIGHT_BACKEND_READS / MAX_REPOSITORY_READ_FAN_OUT;
 const QUERY_CANCELLATION_DEADLINE: std::time::Duration = std::time::Duration::from_millis(1_000);
 const SERVICE_DRAIN_GRACE: std::time::Duration = std::time::Duration::from_millis(1_250);
 
@@ -833,20 +838,24 @@ async fn cancel_registered_query(state: &AppState, slot: &QueryCancellationSlot)
     let Some(query_id) = query_id else {
         return;
     };
+    cancel_query_with_deadline(state, &query_id).await;
+}
+
+pub(crate) async fn cancel_query_with_deadline(state: &AppState, query_id: &str) {
     match tokio::time::timeout(
         QUERY_CANCELLATION_DEADLINE,
-        state.repo.cancel_query(&query_id),
+        state.repo.cancel_query(query_id),
     )
     .await
     {
         Ok(Ok(())) => {}
         Ok(Err(error)) => warn!(
-            query_id = %query_id,
+            query_id,
             error = %error,
             "failed to cancel abandoned MCP ClickHouse query"
         ),
         Err(_) => warn!(
-            query_id = %query_id,
+            query_id,
             "timed out cancelling abandoned MCP ClickHouse query"
         ),
     }

--- a/crates/moraine-mcp-core/src/search_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/search_sessions_v1.rs
@@ -1,6 +1,6 @@
 use super::{
-    handled_tool_error_result, internal_id_error, repo_error_to_contract_error,
-    tool_success_result, AppState,
+    backend_query_id, handled_tool_error_result, internal_id_error, repo_error_to_contract_error,
+    tool_success_result, AppState, QueryCancellationGuard,
 };
 use crate::contract::{
     format_rfc3339_utc_millis, CanonicalSearchSessionsArgs, ContractError, McpEventId, McpId,
@@ -39,8 +39,10 @@ impl AppState {
             return Ok(scope_error);
         }
 
+        let query_id = backend_query_id("search-sessions");
         let repo_query = SearchMcpEventsQuery {
             query: args.query.clone(),
+            cancellation_token: Some(query_id.clone()),
             n_hits: Some(args.n_hits),
             session_id: scoped_session_id(&args).map(ToOwned::to_owned),
             turn_seq: scoped_turn_seq(&args),
@@ -55,9 +57,14 @@ impl AppState {
             min_should_match: None,
         };
 
+        let mut cancellation = QueryCancellationGuard::new(query_id);
         let search_result = match self.repo.search_mcp_events(repo_query).await {
-            Ok(result) => result,
+            Ok(result) => {
+                cancellation.disarm();
+                result
+            }
             Err(error) => {
+                cancellation.disarm();
                 return encode_search_sessions_error(
                     canonical_request,
                     repo_error_to_contract_error(error),


### PR DESCRIPTION
## Description

**What.** Makes MCP retrieval dispatch concurrent but bounded, with serialized response framing and request-family ClickHouse cancellation.

**Why.** One slow retrieval previously blocked every later frame on the same connection, while canceled bursts could leave backend work running and starve subsequent retrieval for minutes.

The connection reader now admits valid repository calls through one shared eight-request semaphore and executes admitted calls independently. Completed JSON-RPC responses are encoded and written only by the connection task, so out-of-order completion retains the original request ID without interleaving newline-delimited frames.

Each admitted call registers a cancellation family before its first repository read. Concurrent ClickHouse fan-out receives unique child query IDs, and cancellation kills the base ID plus every child. Client cancellation, task failure, full disconnect, service shutdown, and tool deadline paths all release admission and bound backend cleanup. A clean client write-half close remains distinct from a full socket disconnect and drains already-admitted responses.

## Usage

No MCP request or response schema changes. Up to eight valid repository calls execute concurrently across socket connections; additional valid calls receive a prompt JSON-RPC `server busy` error instead of joining an unbounded queue. Invalid arguments continue to return validation errors without waiting for repository admission.

## Bug Evidence

Before this change, `serve_connection_with_first_line` awaited each repository request before reading the next frame. The issue reproducer's blocked search burst therefore delayed even argument validation and small list calls. Dropping the client future also did not reliably issue `KILL QUERY` for the backend work.

Deterministic regressions now hold repository calls open and prove that validation bypasses them, the ninth valid call is rejected promptly, canceled permits recover, IDs survive out-of-order completion, frames remain atomic, and backend query families are canceled on client cancellation, task failure, full disconnect, malformed transport, and service shutdown. A separate regression half-closes the request stream for longer than the former 250 ms grace and still receives the admitted response.

The canonical stack smoke also caught and fixed an integration issue introduced by concurrent repository fan-out: sibling ClickHouse reads initially reused one query ID. They now receive unique child IDs under one cancelable request family.

## Changelog

- Removes per-connection retrieval head-of-line blocking with bounded concurrent dispatch.
- Rejects excess repository work promptly while keeping validation responsive.
- Cancels complete ClickHouse query families on cancellation, disconnect, timeout, task failure, and shutdown.
- Preserves pending responses for clients that half-close only their request stream.

## Validation

On the final branch rebased onto `main` through #516:

- `cargo test -p moraine-mcp-core concurrency_tests -- --nocapture` — 9 passed.
- `cargo test -p moraine-mcp-core --lib --tests` — 94 passed.
- `cargo test -p moraine-conversations --test repository_integration` — 80 passed.
- `cargo build --workspace --locked` — passed.
- `bash scripts/ci/e2e-stack.sh` — passed, including bounded ClickHouse query ownership, daemon and embedded MCP search/open/list smoke coverage, named routing, project-only scope, fallback, and stack cleanup.

Seven delegated review personas covered correctness, completeness, security, idiomatic Rust, elegance, YAGNI, and scope. Accepted findings moved query registration before every first repository read, repaired JoinError cleanup, distinguished half-close from full disconnect, bounded file-attention cancellation, and made fan-out query IDs unique. The remaining YAGNI suggestion to collapse request-level and search-family IDs was rejected because they cover different lifecycles: the request ID owns pre-search validation and cross-tool admission, while the search-family ID is returned in the repository result and prefixes concurrent child queries for cancellation.

Closes #483
