### PR TITLE
test(clickhouse): stabilize backoff synchronization

### DIFF
--- a/apps/moraine/tests/clickhouse_supervision.rs
+++ b/apps/moraine/tests/clickhouse_supervision.rs
@@ -8,6 +8,8 @@ use std::process::{Child, Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+const EVENT_TIMEOUT: Duration = Duration::from_secs(15);
+
 fn temp_dir(name: &str) -> PathBuf {
     let stamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -101,7 +103,7 @@ fn wait_for_file(path: &Path, timeout: Duration) -> String {
     }
 }
 
-fn wait_for_retained_log(path: &Path, needle: &str, timeout: Duration) {
+fn wait_for_retained_log(supervisor: &mut Child, path: &Path, needle: &str, timeout: Duration) {
     let deadline = Instant::now() + timeout;
     loop {
         let found = (0..=3).any(|generation| {
@@ -119,6 +121,10 @@ fn wait_for_retained_log(path: &Path, needle: &str, timeout: Duration) {
         if found {
             return;
         }
+        assert!(
+            supervisor.try_wait().expect("inspect supervisor").is_none(),
+            "supervisor exited before logging `{needle}`"
+        );
         assert!(
             Instant::now() < deadline,
             "timed out waiting for `{needle}` in retained segments for {}",
@@ -206,17 +212,17 @@ fn sigterm_during_backoff_exits_without_replacement() {
         .expect("start supervisor");
 
     wait_for_retained_log(
+        &mut supervisor,
         &supervisor_log_path,
         "state=backoff",
-        Duration::from_secs(3),
+        EVENT_TIMEOUT,
     );
     let status = Command::new("kill")
         .arg(supervisor.id().to_string())
         .status()
         .expect("signal supervisor");
     assert!(status.success());
-    assert!(wait_for_child(&mut supervisor, Duration::from_secs(3)).success());
-    thread::sleep(Duration::from_millis(1200));
+    assert!(wait_for_child(&mut supervisor, EVENT_TIMEOUT).success());
     assert_eq!(
         fs::read_to_string(&count_path)
             .expect("generation count")


### PR DESCRIPTION
## Description

**What.** Makes the managed ClickHouse supervision integration tests reserve isolated, derivation-safe endpoints and synchronize on observable process state.

**Why.** After #516 merged, the backoff test failed under parallel workspace execution. Causal diagnostics reproduced the failure locally: an OS-assigned HTTP port of 64657 overflowed the supervisor's derived `+886` interserver port, so the supervisor exited before entering backoff. The sibling test then timed out waiting for its fake child.

Each test now holds a loopback listener selected from the safe 20000–59999 range for its full lexical scope. Parallel tests cannot reuse the endpoint, every derived ClickHouse port fits in `u16`, and the bound-but-unaccepted listener stays deterministically unhealthy. The backoff wait also fails immediately with exit status and retained logs if the supervisor exits before the event; its 15-second deadline is only a stuck-test watchdog.

The test still requires `state=backoff` in the production rolling log before SIGTERM. After successful supervisor exit, it checks the generation count immediately; the prior 1.2-second sleep was redundant because an exited supervisor cannot launch a replacement.

## Usage

No runtime behavior changes.

## Changelog

None. Integration-test isolation and diagnostics only.

## Validation

The full default-parallel target, `cargo test -p moraine --test clickhouse_supervision -- --nocapture`, first reproduced the port-overflow failure at repeated attempt 87 with the new causal diagnostics. After reserving safe held endpoints, the full target passed 100/100 repeated runs. After replacing ephemeral retry with the portable explicit safe range, it passed another 30/30 runs.

`cargo clippy -p moraine --test clickhouse_supervision -- -D warnings` and `cargo fmt --all -- --check` passed. A focused correctness review found no isolation or false-pass issue: the listener is held for the test lifetime, derived offsets remain valid, and a listener that never produces an HTTP response cannot mimic healthy ClickHouse.

Follow-up to #516.