### PR TITLE
fix(clickhouse): tolerate clean output EOF

### DIFF
--- a/apps/moraine/src/managed_clickhouse.rs
+++ b/apps/moraine/src/managed_clickhouse.rs
@@ -725,14 +725,16 @@ impl OutputStream {
     }
 }
 
-async fn stop_after_output_forwarder(
-    child: &mut Child,
-    forwarders: &mut OutputForwarders,
-    stream: OutputStream,
-    outcome: std::result::Result<Result<()>, tokio::task::JoinError>,
-    grace: Duration,
-    log: &SupervisorLog,
-) -> Result<GenerationOutcome> {
+async fn wait_output_forwarder(
+    task: &mut Option<JoinHandle<Result<()>>>,
+) -> std::result::Result<Result<()>, tokio::task::JoinError> {
+    match task {
+        Some(task) => task.await,
+        None => std::future::pending().await,
+    }
+}
+
+fn mark_output_closed(forwarders: &mut OutputForwarders, stream: OutputStream) {
     match stream {
         OutputStream::Stdout => {
             forwarders.stdout.take();
@@ -741,9 +743,20 @@ async fn stop_after_output_forwarder(
             forwarders.stderr.take();
         }
     }
+}
+
+async fn stop_after_output_forwarder(
+    child: &mut Child,
+    forwarders: &mut OutputForwarders,
+    stream: OutputStream,
+    outcome: std::result::Result<Result<()>, tokio::task::JoinError>,
+    grace: Duration,
+    log: &SupervisorLog,
+) -> Result<GenerationOutcome> {
+    mark_output_closed(forwarders, stream);
     let stream_name = stream.name();
     let failure = match outcome {
-        Ok(Ok(())) => anyhow!("ClickHouse {stream_name} closed while the child was still running"),
+        Ok(Ok(())) => unreachable!("normal output closure is handled without stopping the child"),
         Ok(Err(err)) => err.context(format!("ClickHouse {stream_name} forwarding failed")),
         Err(err) => anyhow!(err).context(format!("ClickHouse {stream_name} forwarder task failed")),
     };
@@ -1038,65 +1051,76 @@ async fn run_generation(
 
     let readiness = wait_for_clickhouse(cfg);
     tokio::pin!(readiness);
-    let startup_outcome = tokio::select! {
-        biased;
-        _ = signals.recv() => {
-            let status =
-                terminate_and_reap(&mut child, policy.child_shutdown_grace, None).await?;
-            let _ = log
-                .line(format!(
-                    "clickhouse supervisor: generation={generation} state=stopped reason={}",
-                    describe_exit(status)
-                ))
-                .await;
-            Some(GenerationOutcome::Stopped)
-        }
-        status = child.wait() => {
-            let status = status.context("failed waiting for ClickHouse startup exit")?;
-            Some(GenerationOutcome::Failed {
-                reason: format!("exited before readiness ({})", describe_exit(status)),
-                ready_uptime: None,
-            })
-        }
-        ready = &mut readiness => {
-            match ready {
-                Ok(()) => None,
-                Err(err) => {
-                    let status =
-                        terminate_and_reap(&mut child, policy.child_shutdown_grace, None)
-                            .await?;
-                    Some(GenerationOutcome::Failed {
-                        reason: format!(
-                            "readiness failed ({err:#}); stopped child ({})",
-                            describe_exit(status)
-                        ),
-                        ready_uptime: None,
-                    })
+    let startup_outcome = loop {
+        let outcome = tokio::select! {
+            biased;
+            _ = signals.recv() => {
+                let status =
+                    terminate_and_reap(&mut child, policy.child_shutdown_grace, None).await?;
+                let _ = log
+                    .line(format!(
+                        "clickhouse supervisor: generation={generation} state=stopped reason={}",
+                        describe_exit(status)
+                    ))
+                    .await;
+                Some(GenerationOutcome::Stopped)
+            }
+            status = child.wait() => {
+                let status = status.context("failed waiting for ClickHouse startup exit")?;
+                Some(GenerationOutcome::Failed {
+                    reason: format!("exited before readiness ({})", describe_exit(status)),
+                    ready_uptime: None,
+                })
+            }
+            ready = &mut readiness => {
+                match ready {
+                    Ok(()) => None,
+                    Err(err) => {
+                        let status =
+                            terminate_and_reap(&mut child, policy.child_shutdown_grace, None)
+                                .await?;
+                        Some(GenerationOutcome::Failed {
+                            reason: format!(
+                                "readiness failed ({err:#}); stopped child ({})",
+                                describe_exit(status)
+                            ),
+                            ready_uptime: None,
+                        })
+                    }
                 }
             }
-        }
-        stdout = forwarders.stdout.as_mut().expect("stdout forwarder is active") => {
-            return stop_after_output_forwarder(
-                &mut child,
-                &mut forwarders,
-                OutputStream::Stdout,
-                stdout,
-                policy.child_shutdown_grace,
-                log,
-            )
-            .await;
-        }
-        stderr = forwarders.stderr.as_mut().expect("stderr forwarder is active") => {
-            return stop_after_output_forwarder(
-                &mut child,
-                &mut forwarders,
-                OutputStream::Stderr,
-                stderr,
-                policy.child_shutdown_grace,
-                log,
-            )
-            .await;
-        }
+            stdout = wait_output_forwarder(&mut forwarders.stdout) => {
+                if matches!(stdout, Ok(Ok(()))) {
+                    mark_output_closed(&mut forwarders, OutputStream::Stdout);
+                    continue;
+                }
+                return stop_after_output_forwarder(
+                    &mut child,
+                    &mut forwarders,
+                    OutputStream::Stdout,
+                    stdout,
+                    policy.child_shutdown_grace,
+                    log,
+                )
+                .await;
+            }
+            stderr = wait_output_forwarder(&mut forwarders.stderr) => {
+                if matches!(stderr, Ok(Ok(()))) {
+                    mark_output_closed(&mut forwarders, OutputStream::Stderr);
+                    continue;
+                }
+                return stop_after_output_forwarder(
+                    &mut child,
+                    &mut forwarders,
+                    OutputStream::Stderr,
+                    stderr,
+                    policy.child_shutdown_grace,
+                    log,
+                )
+                .await;
+            }
+        };
+        break outcome;
     };
     if let Some(outcome) = startup_outcome {
         finish_output_forwarders(&mut forwarders, log).await?;
@@ -1126,48 +1150,59 @@ async fn run_generation(
         ),
     )
     .await?;
-    let outcome = tokio::select! {
-        biased;
-        _ = signals.recv() => {
-            let status =
-                terminate_and_reap(&mut child, policy.child_shutdown_grace, None).await?;
-            let _ = log
-                .line(format!(
-                    "clickhouse supervisor: generation={generation} state=stopped reason={}",
-                    describe_exit(status)
-                ))
-                .await;
-            GenerationOutcome::Stopped
-        }
-        status = child.wait() => {
-            let status = status.context("failed waiting for ClickHouse exit")?;
-            GenerationOutcome::Failed {
-                reason: describe_exit(status),
-                ready_uptime: Some(ready_since.elapsed()),
+    let outcome = loop {
+        let outcome = tokio::select! {
+            biased;
+            _ = signals.recv() => {
+                let status =
+                    terminate_and_reap(&mut child, policy.child_shutdown_grace, None).await?;
+                let _ = log
+                    .line(format!(
+                        "clickhouse supervisor: generation={generation} state=stopped reason={}",
+                        describe_exit(status)
+                    ))
+                    .await;
+                GenerationOutcome::Stopped
             }
-        }
-        stdout = forwarders.stdout.as_mut().expect("stdout forwarder is active") => {
-            return stop_after_output_forwarder(
-                &mut child,
-                &mut forwarders,
-                OutputStream::Stdout,
-                stdout,
-                policy.child_shutdown_grace,
-                log,
-            )
-            .await;
-        }
-        stderr = forwarders.stderr.as_mut().expect("stderr forwarder is active") => {
-            return stop_after_output_forwarder(
-                &mut child,
-                &mut forwarders,
-                OutputStream::Stderr,
-                stderr,
-                policy.child_shutdown_grace,
-                log,
-            )
-            .await;
-        }
+            status = child.wait() => {
+                let status = status.context("failed waiting for ClickHouse exit")?;
+                GenerationOutcome::Failed {
+                    reason: describe_exit(status),
+                    ready_uptime: Some(ready_since.elapsed()),
+                }
+            }
+            stdout = wait_output_forwarder(&mut forwarders.stdout) => {
+                if matches!(stdout, Ok(Ok(()))) {
+                    mark_output_closed(&mut forwarders, OutputStream::Stdout);
+                    continue;
+                }
+                return stop_after_output_forwarder(
+                    &mut child,
+                    &mut forwarders,
+                    OutputStream::Stdout,
+                    stdout,
+                    policy.child_shutdown_grace,
+                    log,
+                )
+                .await;
+            }
+            stderr = wait_output_forwarder(&mut forwarders.stderr) => {
+                if matches!(stderr, Ok(Ok(()))) {
+                    mark_output_closed(&mut forwarders, OutputStream::Stderr);
+                    continue;
+                }
+                return stop_after_output_forwarder(
+                    &mut child,
+                    &mut forwarders,
+                    OutputStream::Stderr,
+                    stderr,
+                    policy.child_shutdown_grace,
+                    log,
+                )
+                .await;
+            }
+        };
+        break outcome;
     };
     finish_output_forwarders(&mut forwarders, log).await?;
     Ok(outcome)
@@ -1909,6 +1944,66 @@ mod tests {
             fs::read_to_string(&observed).expect("watchdog environment"),
             "0|0"
         );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    async fn run_closed_output_generation(root: &Path, body: &str) -> GenerationOutcome {
+        let server_bin = root.join("clickhouse-server");
+        fs::write(&server_bin, format!("#!/bin/sh\n{body}\n")).expect("write fake server");
+        fs::set_permissions(&server_bin, fs::Permissions::from_mode(0o755))
+            .expect("make fake server executable");
+        let config_path = root.join("config.xml");
+        fs::write(&config_path, "<clickhouse/>").expect("fake config");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve unused port");
+        let port = listener.local_addr().expect("unused port").port();
+        drop(listener);
+        let cfg = test_config(root, format!("http://127.0.0.1:{port}"));
+        let mut signals = ShutdownSignals::install().expect("shutdown signals");
+        let log = test_supervisor_log(root);
+        let outcome = run_generation(
+            &cfg,
+            &server_bin,
+            &config_path,
+            1,
+            test_policy(),
+            &mut signals,
+            &log,
+        )
+        .await
+        .expect("clean output EOF must not fail supervision");
+        drop(log);
+        outcome
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn generation_tolerates_one_stream_closing_while_child_remains_live() {
+        let root = temp_dir("one-stream-clean-eof");
+        let started = Instant::now();
+        let outcome = run_closed_output_generation(&root, "exec 2>&-\nsleep 0.2\nexit 42").await;
+
+        assert!(
+            started.elapsed() >= Duration::from_millis(150),
+            "clean stderr EOF ended supervision before the child exited"
+        );
+        assert!(matches!(
+            outcome,
+            GenerationOutcome::Failed { reason, .. } if reason.contains("exit code 42")
+        ));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn generation_tolerates_immediate_exit_after_both_streams_close() {
+        let root = temp_dir("both-streams-clean-eof");
+        let outcome = run_closed_output_generation(&root, "exec 1>&-\nexec 2>&-\nexit 42").await;
+
+        assert!(matches!(
+            outcome,
+            GenerationOutcome::Failed { reason, .. } if reason.contains("exit code 42")
+        ));
         let _ = fs::remove_dir_all(root);
     }
 

--- a/apps/moraine/tests/clickhouse_supervision.rs
+++ b/apps/moraine/tests/clickhouse_supervision.rs
@@ -23,12 +23,10 @@ fn temp_dir(name: &str) -> PathBuf {
     path
 }
 
-fn unused_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .expect("reserve port")
-        .local_addr()
-        .expect("reserved port address")
-        .port()
+fn reserve_unhealthy_endpoint() -> TcpListener {
+    (20_000..60_000)
+        .find_map(|port| TcpListener::bind(("127.0.0.1", port)).ok())
+        .expect("reserve safe ClickHouse test endpoint")
 }
 
 fn write_executable(path: &Path, contents: &str) {
@@ -103,10 +101,9 @@ fn wait_for_file(path: &Path, timeout: Duration) -> String {
     }
 }
 
-fn wait_for_retained_log(supervisor: &mut Child, path: &Path, needle: &str, timeout: Duration) {
-    let deadline = Instant::now() + timeout;
-    loop {
-        let found = (0..=3).any(|generation| {
+fn retained_log_contents(path: &Path) -> Vec<(PathBuf, String)> {
+    (0..=3)
+        .filter_map(|generation| {
             let retained_path = if generation == 0 {
                 path.to_path_buf()
             } else {
@@ -114,17 +111,28 @@ fn wait_for_retained_log(supervisor: &mut Child, path: &Path, needle: &str, time
                 name.push(format!(".{generation}"));
                 path.with_file_name(name)
             };
-            fs::read_to_string(retained_path)
-                .map(|contents| contents.contains(needle))
-                .unwrap_or(false)
-        });
+            fs::read_to_string(&retained_path)
+                .ok()
+                .map(|contents| (retained_path, contents))
+        })
+        .collect()
+}
+
+fn wait_for_retained_log(supervisor: &mut Child, path: &Path, needle: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let retained = retained_log_contents(path);
+        let found = retained
+            .iter()
+            .any(|(_, contents)| contents.contains(needle));
         if found {
             return;
         }
-        assert!(
-            supervisor.try_wait().expect("inspect supervisor").is_none(),
-            "supervisor exited before logging `{needle}`"
-        );
+        if let Some(status) = supervisor.try_wait().expect("inspect supervisor") {
+            panic!(
+                "supervisor exited with {status} before logging `{needle}`; retained logs: {retained:#?}"
+            );
+        }
         assert!(
             Instant::now() < deadline,
             "timed out waiting for `{needle}` in retained segments for {}",
@@ -157,7 +165,14 @@ fn failed_initial_readiness_rolls_back_supervisor_child_and_pid() {
             raw_pid_path.display()
         ),
     );
-    let config = write_config(&root, unused_port());
+    let endpoint_guard = reserve_unhealthy_endpoint();
+    let config = write_config(
+        &root,
+        endpoint_guard
+            .local_addr()
+            .expect("reserved endpoint address")
+            .port(),
+    );
 
     let output = Command::new(env!("CARGO_BIN_EXE_moraine"))
         .arg("--config")
@@ -200,7 +215,14 @@ fn sigterm_during_backoff_exits_without_replacement() {
             count_path.display()
         ),
     );
-    let config = write_config(&root, unused_port());
+    let endpoint_guard = reserve_unhealthy_endpoint();
+    let config = write_config(
+        &root,
+        endpoint_guard
+            .local_addr()
+            .expect("reserved endpoint address")
+            .port(),
+    );
     let supervisor_log_path = root.join("runtime/logs/clickhouse-supervisor.log");
     let mut supervisor = Command::new(env!("CARGO_BIN_EXE_moraine"))
         .arg("--config")


### PR DESCRIPTION
## Description

**What.** Treats clean ClickHouse stdout/stderr EOF as stream completion rather than a live-child failure, and makes the supervision integration harness reserve held derivation-safe endpoints.

**Why.** Repeated parallel runs exposed two causal failures after #516. First, an OS-assigned HTTP port of 64657 overflowed ClickHouse's derived `+886` interserver port. After endpoint isolation fixed that, CI diagnostics showed the production race: a fast-exiting child closed stderr before `child.wait()` was observed, and the supervisor incorrectly returned fatal `ClickHouse stderr closed while the child was still running` instead of applying its restart/backoff policy.

`run_generation` now removes a cleanly completed stream from the active select and continues supervising the child, readiness, signals, and remaining stream. An inactive stream waits forever without polling, so there is no busy loop. Only reader I/O errors and JoinErrors remain fatal; after child exit, the existing bounded drain still joins or aborts remaining readers.

The integration tests also hold a loopback listener from the safe 20000–59999 range for their full scope. Parallel tests cannot reuse the endpoint, all derived ClickHouse ports fit in `u16`, and a listener that never returns HTTP remains deterministically unhealthy. Early supervisor exits include status and retained rolling logs.

## Usage

No user-facing usage change. Managed ClickHouse now tolerates children that intentionally close one or both output streams while remaining under supervision.

## Changelog

- Fixes managed ClickHouse treating normal stdout/stderr closure as a supervisor-fatal output failure.
- Makes supervision integration endpoints isolated and safe for derived ClickHouse ports.

## Validation

The default-parallel integration target first reproduced the port-overflow failure at attempt 87. Safe held endpoint reservation then passed 100/100 plus 30/30 repeated runs. After the clean-EOF production fix, `cargo test -p moraine --test clickhouse_supervision -- --nocapture` passed another 50/50 default-parallel runs.

Two deterministic regressions cover a long-lived child that closes one stream 200 ms before exit and an immediate child exit after both streams close. `cargo test -p moraine managed_clickhouse::tests -- --nocapture` passed 23 tests, including forwarder-error and descendant-held-pipe draining behavior.

`cargo clippy -p moraine --all-targets -- -D warnings` and `cargo fmt --all -- --check` passed. Focused correctness review found no race, busy loop, lost forwarder error, or behavior weakening.

Follow-up to #518 and #516.