### PR TITLE
fix(mcp): report negative limit ranges

### DIFF
--- a/crates/moraine-mcp-core/src/contract.rs
+++ b/crates/moraine-mcp-core/src/contract.rs
@@ -516,7 +516,7 @@ pub struct SearchSessionsArgs {
     #[serde(default)]
     pub event_types: Option<Vec<String>>,
     #[serde(default)]
-    pub n_hits: Option<u16>,
+    pub n_hits: Option<i64>,
 }
 
 impl SearchSessionsArgs {
@@ -551,13 +551,18 @@ impl SearchSessionsArgs {
             None => default_search_event_types(),
         };
 
-        let n_hits = self.n_hits.unwrap_or(SEARCH_SESSIONS_DEFAULT_N_HITS);
-        if !(SEARCH_SESSIONS_MIN_N_HITS..=SEARCH_SESSIONS_MAX_N_HITS).contains(&n_hits) {
+        let n_hits = self
+            .n_hits
+            .unwrap_or(i64::from(SEARCH_SESSIONS_DEFAULT_N_HITS));
+        if !(i64::from(SEARCH_SESSIONS_MIN_N_HITS)..=i64::from(SEARCH_SESSIONS_MAX_N_HITS))
+            .contains(&n_hits)
+        {
             return Err(invalid_request_with_field(
                 "n_hits",
                 "n_hits must be between 1 and 50",
             ));
         }
+        let n_hits = n_hits as u16;
 
         Ok(CanonicalSearchSessionsArgs {
             query,
@@ -633,7 +638,7 @@ pub struct ListSessionsArgs {
     #[serde(default)]
     pub end_datetime: Option<String>,
     #[serde(default)]
-    pub limit: Option<u16>,
+    pub limit: Option<i64>,
     #[serde(default)]
     pub cursor: Option<String>,
     #[serde(default)]
@@ -647,13 +652,14 @@ impl ListSessionsArgs {
         let max_limit = max_results.max(LIST_SESSIONS_MIN_LIMIT);
         let limit = self
             .limit
-            .unwrap_or(LIST_SESSIONS_DEFAULT_LIMIT.min(max_limit));
-        if !(LIST_SESSIONS_MIN_LIMIT..=max_limit).contains(&limit) {
+            .unwrap_or(i64::from(LIST_SESSIONS_DEFAULT_LIMIT.min(max_limit)));
+        if !(i64::from(LIST_SESSIONS_MIN_LIMIT)..=i64::from(max_limit)).contains(&limit) {
             return Err(invalid_request_with_field(
                 "limit",
                 format!("limit must be between 1 and {max_limit}"),
             ));
         }
+        let limit = limit as u16;
 
         let Some(start_datetime) = self.start_datetime else {
             return Err(list_sessions_datetime_required_error());
@@ -809,7 +815,7 @@ pub struct FileAttentionArgs {
     #[serde(default)]
     pub mutations_only: Option<bool>,
     #[serde(default)]
-    pub limit: Option<u16>,
+    pub limit: Option<i64>,
 }
 
 impl FileAttentionArgs {
@@ -845,13 +851,14 @@ impl FileAttentionArgs {
         let max_limit = max_results.max(FILE_ATTENTION_MIN_LIMIT);
         let limit = self
             .limit
-            .unwrap_or(FILE_ATTENTION_DEFAULT_LIMIT.min(max_limit));
-        if !(FILE_ATTENTION_MIN_LIMIT..=max_limit).contains(&limit) {
+            .unwrap_or(i64::from(FILE_ATTENTION_DEFAULT_LIMIT.min(max_limit)));
+        if !(i64::from(FILE_ATTENTION_MIN_LIMIT)..=i64::from(max_limit)).contains(&limit) {
             return Err(invalid_request_with_field(
                 "limit",
                 format!("limit must be between 1 and {max_limit}"),
             ));
         }
+        let limit = limit as u16;
 
         // Both bounds are optional and independent, but if both are supplied
         // the window must be non-empty — same contract as list_sessions.

--- a/crates/moraine-mcp-core/src/file_attention_v1.rs
+++ b/crates/moraine-mcp-core/src/file_attention_v1.rs
@@ -910,6 +910,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn rejects_negative_limit_with_field_specific_message() {
+        let error = parse_file_attention_args(
+            json!({
+                "path": "crates/moraine-mcp-core/src/contract.rs",
+                "limit": -1
+            }),
+            25,
+        )
+        .expect_err("negative limit rejected");
+
+        assert_eq!(error.code(), ToolErrorCode::InvalidRequest);
+        assert_eq!(error.message(), "limit must be between 1 and 25");
+    }
+
     fn touch(
         session: &str,
         event: &str,

--- a/crates/moraine-mcp-core/src/list_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/list_sessions_v1.rs
@@ -417,6 +417,22 @@ mod tests {
         assert_eq!(limit.code(), ToolErrorCode::InvalidRequest);
     }
 
+    #[test]
+    fn rejects_negative_limit_with_field_specific_message() {
+        let error = parse_list_sessions_args(
+            json!({
+                "start_datetime": "2026-04-30T09:00:00-04:00",
+                "end_datetime": "2026-04-30T13:00:00-04:00",
+                "limit": -1
+            }),
+            25,
+        )
+        .expect_err("negative limit rejected");
+
+        assert_eq!(error.code(), ToolErrorCode::InvalidRequest);
+        assert_eq!(error.message(), "limit must be between 1 and 25");
+    }
+
     #[tokio::test]
     async fn shapes_session_metadata_only_with_open_handle() {
         let page = Page {

--- a/crates/moraine-mcp-core/src/search_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/search_sessions_v1.rs
@@ -678,6 +678,18 @@ mod tests {
     }
 
     #[test]
+    fn rejects_negative_n_hits_with_field_specific_message() {
+        let error = parse_search_sessions_args(json!({
+            "query": "migration",
+            "n_hits": -1
+        }))
+        .expect_err("negative n_hits rejected");
+
+        assert_eq!(error.code(), ToolErrorCode::InvalidRequest);
+        assert_eq!(error.message(), "n_hits must be between 1 and 50");
+    }
+
+    #[test]
     fn contract_validation_rejects_blank_query() {
         let error = SearchSessionsArgs {
             query: "   ".to_string(),


### PR DESCRIPTION
## Description

**What.** Reports field-specific range errors when MCP limit arguments are negative.

**Why.** Negative integers were rejected during `u16` deserialization, so callers received misleading request-shape messages instead of the documented numeric range.

The raw `list_sessions.limit`, `search_sessions.n_hits`, and `file_attention.limit` fields now deserialize as signed integers. Existing validation rejects out-of-range values before narrowing them to the canonical `u16` types used downstream.

## Usage

Negative limits now return the same actionable messages as zero:

```text
list_sessions(limit=-1)  -> limit must be between 1 and 25
search_sessions(n_hits=-1) -> n_hits must be between 1 and 50
file_attention(limit=-1) -> limit must be between 1 and 25
```

No configuration or operator action is required.

## Bug Evidence

Before this change, valid requests with `-1` in these fields returned generic messages such as `list_sessions expects a JSON object with start_datetime and end_datetime`; structured details only exposed `invalid value: integer -1, expected u16`.

The request-boundary type caused deserialization to fail before field validation. Focused regression tests now pass negative values through each parser and assert `invalid_request` plus the exact documented range message.

Closes #520.

## Changelog

- Returns actionable field-specific range errors for negative MCP session and file-attention limits.
- No schema, configuration, storage, or service lifecycle changes.

## Validation

Ran `cargo test -p moraine-mcp-core --lib --locked`: 97 tests passed. Ran `cargo clippy -p moraine-mcp-core --all-targets --locked -- -D warnings`: passed. Ran `cargo fmt --all -- --check`: passed. A seven-persona review wave (elegance, idiom, correctness, completeness, security, YAGNI, and scope) found no actionable issues.