### PR TITLE
docs(mcp): clarify search phrase semantics

### DIFF
--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -168,7 +168,7 @@ impl AppState {
                         "properties": {
                             "query": {
                                 "type": "string",
-                                "description": "Natural-language search query."
+                                "description": "Keyword (BM25) search query. Matching is bag-of-words: quotes and punctuation are ignored, and a quoted phrase is matched as independent terms subject to the configured minimum-match threshold, not as an exact phrase."
                             },
                             "within_id": {
                                 "type": ["string", "null"],
@@ -1732,6 +1732,10 @@ mod tests {
             .iter()
             .find(|tool| tool["name"].as_str() == Some("search_sessions"))
             .expect("search_sessions exists");
+        assert_eq!(
+            search["inputSchema"]["properties"]["query"]["description"],
+            json!("Keyword (BM25) search query. Matching is bag-of-words: quotes and punctuation are ignored, and a quoted phrase is matched as independent terms subject to the configured minimum-match threshold, not as an exact phrase.")
+        );
         assert_eq!(
             search["inputSchema"]["properties"]["event_types"]["description"],
             json!("Optional normalized event type filter. Defaults to user_input, assistant_response, and tool_response.")


### PR DESCRIPTION
## Description

**What.** Clarifies the public `search_sessions.query` schema description to document keyword/BM25 bag-of-words behavior.

**Why.** Quoted phrases currently lose their quotes during tokenization and are matched as independent terms, but the MCP tool surface previously described the input only as a natural-language query.

The description now states that quotes and punctuation are ignored, quoted phrases are not exact-phrase constraints, and independent terms remain subject to the configured minimum-match threshold. The existing tools/list contract test pins that published behavior.

## Usage

MCP clients inspecting `tools/list` now see the phrase-search limitation directly on the `search_sessions.query` parameter. Search execution and ranking are unchanged.

## Changelog

- Documents `search_sessions` keyword and quoted-phrase matching semantics.
- No runtime, configuration, migration, or operational behavior change.

## Bug Evidence

Before this change, `tools/list` described the parameter only as `Natural-language search query.`, so callers could reasonably expect `"connection refused"` to require an exact phrase even though tokenization discards quotes and positional information.

The schema now explicitly describes the existing bag-of-words behavior, and `tools_list_publishes_mcp_search_surface_with_output_schemas` asserts the exact public description.

Closes #394.

## Validation

Ran `cargo test -p moraine-mcp-core tools_list_publishes_mcp_search_surface_with_output_schemas --locked` successfully after the final wording update. Ran `cargo test -p moraine-mcp-core --lib --locked` in dev sandbox `sb-4ffda8`; all 94 tests passed, then tore the sandbox down. `cargo fmt --all -- --check` passed. A seven-persona delegated review completed; one correctness finding about configurable `min_should_match` was accepted, the wording was qualified, and the correctness reviewer confirmed the concern resolved.