### PR TITLE
feat(bench): add concurrent MCP retrieval benchmark

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -300,7 +300,7 @@ and [Harness author workflow](harness-author-workflow.md#6-add-fixtures).
 
 ## Benchmark protocol and registry
 
-All five existing producers emit one `moraine-benchmark-v1` result object per output
+All six existing producers emit one `moraine-benchmark-v1` result object per output
 file. Rust owns cross-process analytics latency; `scripts/bench` owns process/database/
 system measurement. Setup, seeding, build, startup, and warmup stay outside timed
 samples. Smoke records latency but never gates on it.
@@ -320,16 +320,19 @@ The envelope records `schema_version`, benchmark/scenario IDs,
 `source.{git_commit,dirty}`, build profile/target, non-identifying OS/CPU runner class,
 workload/profile/measured boundary, applicable fingerprints, planned/attempted/
 successful/error counts, unit-suffixed successful raw measurements, semantic status,
-non-blocking timing status, safe diagnostics, and artifact references. Dataset-backed,
-cache-sensitive, concurrent, and request-producing scenarios conditionally require
-dataset digest/cardinality, cache state, concurrency, and request source.
+non-blocking timing status, safe diagnostics, and artifact references. Request-producing
+load scenarios may also retain redaction-safe per-case records and arbitrary-cardinality
+observation series. Dataset-backed, cache-sensitive, concurrent, and request-producing
+scenarios conditionally require dataset digest/cardinality, cache state, concurrency,
+and request source.
 
-Validation enforces `attempted = successful + errors`, `attempted <= planned`, and each
-raw series length equals `successful`; percentiles use successes while error rate stays
-explicit. Producers omit meaningless null/sentinel fields. Artifacts must not contain
-credentials, credentialized URLs, raw query/conversation/prompt/content, absolute home
-paths, or user/host identity. Large raw samples may be externalized only with count and
-checksum retained.
+Validation enforces `attempted = successful + errors`, `attempted <= planned`, each raw
+measurement series length equals `successful`, outcome totals equal `attempted`, and
+burst records agree with both. Percentiles use successes while error and rejection
+rates stay explicit. Producers omit meaningless null/sentinel fields. Artifacts must
+not contain credentials, credentialized URLs, raw query/conversation/prompt/content,
+absolute home paths, or user/host identity. Large raw samples may be externalized only
+with count and checksum retained.
 
 A comparison rejects different schema versions, workload/dataset, measured boundary,
 cache state, request source, concurrency, build profile, or any applicable fingerprint.
@@ -358,6 +361,62 @@ python3 -m unittest discover -s scripts/bench/tests \
 | `replay_mcp_latency` / persistent and cold-process | `python3 scripts/bench/replay_mcp_latency.py --config <moraine.toml> --oracle-manifest <seed-owned-oracle.json> --profile smoke --mode persistent --output-json target/bench/replay-mcp-persistent-smoke.json`; use `cold_process` for the distinct lifecycle boundary and `full` for full runs. Check: `python3 -m unittest scripts/bench/test_replay_mcp_latency.py`. The independent manifest is `{"schema_version":"moraine-replay-mcp-oracle-v1","provenance":"<seed/query-generator-reference>","cases":[{"query_id":"<telemetry-query-id>","variant_label":"<expanded-query-variant>","tool":"search","semantic_digest":"sha256:<64-lowercase-hex>","cardinality":<positive-result-count>,"marker":"<seed-owned-marker>"}]}` with one case for every selected query variant and tool. | Populated telemetry, production `bin/moraine`/`moraine-mcp`, exact git provenance, and complete seed/query expectations created without invoking the measured MCP path. Persistent owns one long-lived MCP child; cold owns one per sample. Per-RPC timeout and TERM/KILL cleanup are producer-owned. Manifest/case fingerprints and provenance are retained in workload identity. | T4; modes are fingerprint-distinct and never compared to one another. Missing/malformed/incomplete oracle fails before process spawn; repeatably wrong or one-sample smoke semantics, child/timeout/output failure is nonzero; timing non-blocking. |
 | `mcp_two_tool_sla` / MCP tool matrix | `python3 scripts/bench/mcp_two_tool_sla.py --config <owned-config> --oracle-json <seed-owned-oracle.json> --profile smoke --output-json target/bench/mcp-two-tool-sla.json` (or `--profile full`; full defaults warmup=1/repeats=5/min-docs=100000). Check: `python3 scripts/bench/test_mcp_two_tool_sla.py`. The independent oracle is `{"schema_version":"moraine-mcp-two-tool-oracle-v1","queries":[{"query":"<selected-query>","expected":{"result_count":<n>,"open_ids":{"event":"<seed-id>","turn":"<seed-id>","session":"<seed-id>"},"result_marker":{"<seed-field>":"<seed-value>"}}}],"list_sessions":{"result_count":<n>,"session_ids":["<seed-session-id>"],"result_marker":{"<seed-field>":"<seed-value>"}}}`. Each query needs at least one expectation; only requested open kinds require IDs. The root `list_sessions` object is required whenever that default boundary is measured and needs at least one count/ID/object-marker expectation. | Python 3, read-only ClickHouse corpus, production binaries, exact git provenance, and a complete oracle generated by the corpus owner without measured MCP responses. Search cardinality/IDs/object marker are checked against seed truth; open targets the oracle ID rather than a measured search result; every list result checks the exact count, presence of all seed IDs, and matching seed object marker. One owned stdio MCP child; 20s RPC timeout; close stdin, TERM/wait 5s, KILL/wait 5s. | T4. Missing/incomplete oracle or corpus/prerequisite, repeatable wrong search/open/list result, insufficient sample, validation/write failure is nonzero. No first measured response becomes expected truth. Historical SLA values are diagnostics; v1 timing stays `not_evaluated`. |
 | `central_mcp_resource` / embedded-versus-central | Smoke: `uv run --script scripts/bench/central_mcp_resource.py --moraine-mcp target/debug/moraine-mcp --arms embedded,central --ns 1 --reps 1 --profile smoke --settle-seconds 0 --batch 1 --startup-timeout-seconds 5 --request-timeout-seconds 20 --dataset-fingerprint sha256:<64-lowercase-hex> --dataset-cardinality <seeded-session-count> --json-out target/bench/central-mcp-resource-smoke.json`. Full substitutes the release binary, owned sandbox ClickHouse URL, `--ns 1,10,50,100 --reps 3 --profile full --settle-seconds 2 --batch 25 --startup-timeout-seconds 10`, and `...-full.json`. Check: `python3 scripts/bench/test_central_mcp_resource.py`. | Built MCP binary, deterministic seeded ClickHouse, and psutil or Linux `/proc`; Linux is authoritative. Each repetition owns temporary config/root/socket, central daemon, clients, loopback port, and static fixture; cleanup TERM/KILLs children and removes the root. macOS observations are directional. | T4. JSON output requires dataset fingerprint/cardinality. The configured arm×N matrix is one paired result. Startup/exit/timeout/semantic/sampling/cleanup/validation/atomic-output failure is nonzero; timing/resources remain `not_evaluated` and non-blocking. |
+| `concurrent_mcp_retrieval` / central persistent concurrent uncached `search_sessions` | Smoke: `python3 scripts/bench/concurrent_mcp_retrieval.py --moraine-mcp target/debug/moraine-mcp --clickhouse-url http://clickhouse:8123 --database moraine --oracle-json <seed-owned-oracle.json> --concurrency 1 --concurrency 4 --reps 1 --profile smoke --startup-timeout-seconds 10 --request-timeout-seconds 20 --run-timeout-seconds 120 --max-processes 16 --output-dir target/bench/concurrent-smoke`. Full uses a release binary, `--profile full --concurrency 1,2,4,8,16,32 --reps 3 --run-timeout-seconds 1800 --max-processes 64`; choose the sweep and high-stress value as caller workload inputs, never from the backend admission limit. A range such as `--concurrency 1:32:2` is inclusive. Smoke recovery is fixed at 0 and 1 seconds; full recovery is fixed at 0 and 10 seconds. Check: `python3 -m unittest scripts/bench/test_concurrent_mcp_retrieval.py`; validate every result with `for artifact in target/bench/concurrent-smoke/*.json; do python3 scripts/bench/benchmark_protocol.py validate "$artifact"; done`. The independent seed owner writes `{"schema_version":"moraine-concurrent-mcp-oracle-v1","provenance":"<stable-lowercase-slug>","dataset":{"fingerprint":"sha256:<64-lowercase-hex>","cardinality":<searchable-document-count>},"warmup":{"id":"warmup","query":"<startup-only-query>","result_count":<1..10>,"result_digest":"sha256:<digest-of-sorted-event-and-session-ids>"},"measured":[<same-shape-distinct-cases>],"recovery":[<same-shape-distinct-cases>]}`. Warmup, measured, and recovery query strings and IDs must all be distinct; the full manifest declares at least 100,000 searchable documents. | Linux owned dev sandbox, built MCP binary, deterministic seeded ClickHouse, and one oracle case per maximum requested concurrency plus two recovery probes. The timed boundary is each stdio `tools/call` write through its central-server response; client initialization, tool discovery, and one disjoint startup query are outside the burst. Every repetition owns a fresh central service, socket, clients, config, root, and temporary directory; the producer terminates/removes all of them while the sandbox owner owns ClickHouse corpus cleanup. `--max-processes` and startup/request/run timeouts protect the runner and do not state backend capacity or admission policy; request timeout is comparison-fingerprinted. | T4. Read-only seeded DB. One comparison-distinct schema-valid artifact per exact concurrency. Raw successful wall/server/SLA series, per-case outcome records, admission/error/timeout/deadline counts and rates, p50/p95/p99/max, throughput, maximum in-flight, hard-deadline violations, and largest-burst sequential recovery are retained. Timing is diagnostic `not_evaluated`; semantic-oracle and protocol failures remain correctness failures. |
+Prepare only an owned sandbox corpus. Both commands below truncate
+`moraine.search_documents`, `search_postings`, `search_query_log`, and
+`search_hit_log`; never point them at a host or shared database.
+
+```bash
+# Small live wiring/semantic smoke.
+python3 scripts/bench/seed_concurrent_mcp_benchmark.py seed \
+  --clickhouse-url http://clickhouse:8123 --database moraine \
+  --documents 200 --measured-cases 8 --recovery-cases 2 \
+  --oracle-json /tmp/concurrent-smoke-oracle.json
+
+# Full SLA-tier corpus and broad caller-selected sweep.
+python3 scripts/bench/seed_concurrent_mcp_benchmark.py seed \
+  --clickhouse-url http://clickhouse:8123 --database moraine \
+  --documents 100000 --measured-cases 64 --recovery-cases 2 \
+  --oracle-json /tmp/concurrent-full-oracle.json
+```
+
+The seeder writes the expected public event/session ID digest directly from its
+deterministic recipe; it never learns expectations from an MCP response. Cases
+alternate selective one-posting terms and distinct common terms, and reserve
+disjoint warmup/recovery terms. `seed ... --documents 100000` is the full-profile
+minimum. `clean` with the same ClickHouse/database arguments truncates the four
+tables explicitly; normally `moraine-sandbox down <id>` owns complete database,
+socket, child, config, temporary-directory, and volume cleanup.
+
+#### Current-main evidence (2026-07-12)
+
+An owned Linux sandbox run at `2ba068794554710708be8ca48ed88b8c73825c31`
+used the deterministic 100,000-document corpus, the sandbox workspace binary
+(`build.profile=unknown`), three fresh-service repetitions, and the caller-selected
+`1,2,4,8,16,32,64` sweep. Every artifact passed
+`benchmark_protocol.py validate`; every arm reported overlap and exact requested
+maximum in-flight. These are diagnostic observations, not a capacity contract:
+
+| Requested | Success / attempted | Rejected | p50 ms | p95 ms | p99 ms | max ms | mean success/s |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 3 / 3 | 0 | 43.7 | 123.3 | 130.4 | 132.2 | 19.1 |
+| 2 | 6 / 6 | 0 | 59.3 | 69.0 | 69.8 | 70.0 | 30.2 |
+| 4 | 12 / 12 | 0 | 91.0 | 149.0 | 149.9 | 150.1 | 38.6 |
+| 8 | 24 / 24 | 0 | 134.9 | 166.2 | 167.3 | 167.4 | 53.3 |
+| 16 | 24 / 48 | 24 | 120.1 | 143.5 | 147.7 | 148.9 | 61.2 |
+| 32 | 24 / 96 | 72 | 114.0 | 167.3 | 169.2 | 169.6 | 57.4 |
+| 64 | 24 / 192 | 168 | 184.1 | 243.9 | 247.9 | 248.8 | 38.4 |
+
+The observed curve rises through eight callers, then successful completions plateau
+at eight per repetition while admission rejections account for every additional
+attempt. That ordinal is an observation of this build, not an asserted product
+limit. All successful samples met their advertised SLA and none crossed the
+five-second hard deadline. At the largest arm, recovery wall latencies at fixed
+0/10-second offsets were `31.6/126.3`, `43.2/108.2`, and `34.7/103.1` ms across
+the three repetitions. Three repetitions show run-to-run spread but do not define
+the controlled runner, baseline, threshold, error, or variability policy; all
+artifacts therefore retain `timing.status=not_evaluated`.
+
 
 
 Every producer's deterministic checks cover arguments/profile/default/threshold

--- a/scripts/bench/benchmark_protocol.py
+++ b/scripts/bench/benchmark_protocol.py
@@ -318,6 +318,21 @@ def _validate_sample_invariants(artifact: Mapping[str, Any]) -> None:
         _fail("$.samples", "attempted must equal successful + errors")
     if attempted > samples["planned"]:
         _fail("$.samples", "attempted must not exceed planned")
+    outcomes = samples.get("outcomes")
+    if outcomes is not None and sum(outcomes.values()) != attempted:
+        _fail("$.samples.outcomes", "outcome counts must sum to samples.attempted")
+    records = samples.get("records")
+    if records is not None:
+        burst_records = [record for record in records if record["phase"] == "burst"]
+        if len(burst_records) != attempted:
+            _fail("$.samples.records", "burst record count must equal samples.attempted")
+        if outcomes is not None:
+            recorded_outcomes = {
+                name: sum(record["outcome"] == name for record in burst_records)
+                for name in outcomes
+            }
+            if recorded_outcomes != outcomes:
+                _fail("$.samples.records", "burst record outcomes must match samples.outcomes")
     measurements = samples.get("measurements")
     if measurements is not None:
         for name, series in measurements.items():

--- a/scripts/bench/concurrent_mcp_retrieval.py
+++ b/scripts/bench/concurrent_mcp_retrieval.py
@@ -1,0 +1,817 @@
+#!/usr/bin/env python3
+"""Concurrent, uncached search_sessions benchmark through the production MCP boundary.
+
+Each configured concurrency emits a separate moraine-benchmark-v1 artifact. Timing is
+always diagnostic. The runner owns a fresh central MCP service and client set for every
+independent repetition; it never reads the server's admission configuration.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional, Sequence
+
+import benchmark_protocol
+from central_mcp_resource import (
+    BenchmarkFailure,
+    McpClient,
+    _stop_server,
+    infer_build_profile,
+    raise_fd_limit,
+    resolve_moraine_mcp,
+    resolve_source,
+    spawn_client,
+    wait_for_socket,
+    write_config,
+)
+
+BENCHMARK_ID = "concurrent-mcp-retrieval"
+ORACLE_SCHEMA_VERSION = "moraine-concurrent-mcp-oracle-v1"
+MEASURED_BOUNDARY = "stdio-tools-call-write-to-response"
+REQUEST_SOURCE = "central-mcp-jsonrpc-stdio"
+HARD_DEADLINE_MS = 5_000.0
+PROFILE_RECOVERY_OFFSETS = {
+    "smoke": (0.0, 1.0),
+    "full": (0.0, 10.0),
+}
+OUTCOME_NAMES = (
+    "success",
+    "admission_rejection",
+    "mcp_error",
+    "jsonrpc_error",
+    "timeout",
+    "deadline_exceeded",
+    "semantic_error",
+    "client_error",
+)
+
+
+class ConfigurationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class OracleCase:
+    query_id: str
+    query: str
+    result_count: int
+    result_digest: str
+
+
+@dataclass(frozen=True)
+class OracleManifest:
+    provenance: str
+    dataset_fingerprint: str
+    dataset_cardinality: int
+    warmup: OracleCase
+    measured: tuple[OracleCase, ...]
+    recovery: tuple[OracleCase, ...]
+    query_set_fingerprint: str
+
+
+@dataclass
+class RequestSample:
+    query_id: str
+    outcome: str
+    wall_ms: float
+    started_ns: int
+    finished_ns: int
+    server_elapsed_ms: Optional[float] = None
+    sla_target_ms: Optional[float] = None
+    met_sla: Optional[bool] = None
+    exceeded_hard_deadline: bool = False
+    oracle_passed: bool = False
+
+
+@dataclass
+class BurstResult:
+    requested_concurrency: int
+    samples: list[RequestSample]
+    wall_ms: float
+    max_in_flight: int
+    overlap_proven: bool
+
+
+@dataclass
+class RepetitionResult:
+    burst: BurstResult
+    recovery: list[RequestSample]
+    cleanup_codes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ScenarioResult:
+    concurrency: int
+    repetitions: list[RepetitionResult]
+
+    @property
+    def burst_samples(self) -> list[RequestSample]:
+        return [sample for repetition in self.repetitions for sample in repetition.burst.samples]
+
+    @property
+    def successful(self) -> list[RequestSample]:
+        return [sample for sample in self.burst_samples if sample.outcome == "success"]
+
+    @property
+    def recovery_samples(self) -> list[RequestSample]:
+        return [sample for repetition in self.repetitions for sample in repetition.recovery]
+
+
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def positive_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive number") from exc
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive number")
+    return parsed
+
+
+
+
+def parse_concurrency(values: Sequence[str]) -> list[int]:
+    """Parse repeatable integers, comma lists, or inclusive START:STOP[:STEP] ranges."""
+    parsed: list[int] = []
+    for value in values:
+        for token in value.split(","):
+            token = token.strip()
+            if not token:
+                raise ConfigurationError("empty concurrency value")
+            if ":" not in token:
+                try:
+                    number = int(token)
+                except ValueError as exc:
+                    raise ConfigurationError(f"invalid concurrency value: {token}") from exc
+                if number <= 0:
+                    raise ConfigurationError("concurrency values must be positive")
+                parsed.append(number)
+                continue
+            parts = token.split(":")
+            if len(parts) not in (2, 3):
+                raise ConfigurationError(f"invalid concurrency range: {token}")
+            try:
+                start, stop = int(parts[0]), int(parts[1])
+                step = int(parts[2]) if len(parts) == 3 else 1
+            except ValueError as exc:
+                raise ConfigurationError(f"invalid concurrency range: {token}") from exc
+            if min(start, stop, step) <= 0 or stop < start:
+                raise ConfigurationError("concurrency ranges require 0 < start <= stop and step > 0")
+            parsed.extend(range(start, stop + 1, step))
+    if not parsed:
+        raise ConfigurationError("at least one concurrency value is required")
+    return list(dict.fromkeys(parsed))
+
+
+def sha256_json(value: Any, *, prefixed: bool = True) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    digest = hashlib.sha256(encoded).hexdigest()
+    return f"sha256:{digest}" if prefixed else digest
+
+
+def _validate_sha256(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.startswith("sha256:"):
+        raise ConfigurationError(f"{field} must be sha256:<64 lowercase hex>")
+    digest = value[7:]
+    if len(digest) != 64 or any(ch not in "0123456789abcdef" for ch in digest):
+        raise ConfigurationError(f"{field} must be sha256:<64 lowercase hex>")
+    return value
+
+
+def _load_case(value: Any, field: str) -> OracleCase:
+    if not isinstance(value, dict) or set(value) != {"id", "query", "result_count", "result_digest"}:
+        raise ConfigurationError(f"{field} has an invalid shape")
+    query_id, query, count = value["id"], value["query"], value["result_count"]
+    if not isinstance(query_id, str) or not query_id or any(ch not in "abcdefghijklmnopqrstuvwxyz0123456789._-" for ch in query_id):
+        raise ConfigurationError(f"{field}.id must be a lowercase slug")
+    if not isinstance(query, str) or not query.strip():
+        raise ConfigurationError(f"{field}.query must be non-empty")
+    if isinstance(count, bool) or not isinstance(count, int) or count <= 0 or count > 10:
+        raise ConfigurationError(f"{field}.result_count must be between 1 and 10")
+    return OracleCase(query_id, query, count, _validate_sha256(value["result_digest"], f"{field}.result_digest"))
+
+
+def load_oracle(path: Path, *, profile: str, needed_queries: int, recovery_count: int) -> OracleManifest:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigurationError("unable to read oracle manifest") from exc
+    required = {"schema_version", "provenance", "dataset", "warmup", "measured", "recovery"}
+    if not isinstance(raw, dict) or set(raw) != required or raw.get("schema_version") != ORACLE_SCHEMA_VERSION:
+        raise ConfigurationError("oracle manifest has an invalid shape or schema version")
+    provenance = raw["provenance"]
+    dataset = raw["dataset"]
+    if (
+        not isinstance(provenance, str)
+        or not provenance
+        or len(provenance) > 128
+        or any(ch not in "abcdefghijklmnopqrstuvwxyz0123456789._-" for ch in provenance)
+    ):
+        raise ConfigurationError("oracle provenance must be a lowercase stable slug")
+    if not isinstance(dataset, dict) or set(dataset) != {"fingerprint", "cardinality"}:
+        raise ConfigurationError("oracle dataset has an invalid shape")
+    cardinality = dataset["cardinality"]
+    if isinstance(cardinality, bool) or not isinstance(cardinality, int) or cardinality <= 0:
+        raise ConfigurationError("oracle dataset cardinality must be positive")
+    if profile == "full" and cardinality < 100_000:
+        raise ConfigurationError("full profile requires at least 100000 searchable documents")
+    warmup = _load_case(raw["warmup"], "warmup")
+    if not isinstance(raw["measured"], list) or not isinstance(raw["recovery"], list):
+        raise ConfigurationError("oracle measured and recovery entries must be arrays")
+    measured = tuple(_load_case(value, f"measured[{index}]") for index, value in enumerate(raw["measured"]))
+    recovery = tuple(_load_case(value, f"recovery[{index}]") for index, value in enumerate(raw["recovery"]))
+    if len(measured) < needed_queries:
+        raise ConfigurationError(f"oracle needs at least {needed_queries} measured queries")
+    if len(recovery) < recovery_count:
+        raise ConfigurationError(f"oracle needs at least {recovery_count} recovery queries")
+    all_cases = (warmup,) + measured + recovery
+    normalized = [" ".join(case.query.split()).casefold() for case in all_cases]
+    ids = [case.query_id for case in all_cases]
+    if len(normalized) != len(set(normalized)) or len(ids) != len(set(ids)):
+        raise ConfigurationError("warmup, measured, and recovery queries and ids must be distinct")
+    query_contract = [
+        {"id": case.query_id, "query_digest": sha256_json(" ".join(case.query.split()).casefold()),
+         "result_count": case.result_count, "result_digest": case.result_digest}
+        for case in measured[:needed_queries]
+    ]
+    return OracleManifest(
+        provenance=provenance,
+        dataset_fingerprint=_validate_sha256(dataset["fingerprint"], "dataset.fingerprint"),
+        dataset_cardinality=cardinality,
+        warmup=warmup,
+        measured=measured,
+        recovery=recovery,
+        query_set_fingerprint=sha256_json(query_contract),
+    )
+
+
+def result_digest(results: Sequence[Any]) -> str:
+    identities: list[dict[str, str]] = []
+    for hit in results:
+        if not isinstance(hit, dict):
+            raise BenchmarkFailure("semantic-oracle-failed")
+        event, session = hit.get("event"), hit.get("session")
+        if not isinstance(event, dict) or not isinstance(session, dict):
+            raise BenchmarkFailure("semantic-oracle-failed")
+        event_id, session_id = event.get("id"), session.get("id")
+        if not isinstance(event_id, str) or not isinstance(session_id, str):
+            raise BenchmarkFailure("semantic-oracle-failed")
+        identities.append({"event_id": event_id, "session_id": session_id})
+    identities.sort(key=lambda item: (item["session_id"], item["event_id"]))
+    return sha256_json(identities)
+
+
+def parse_performance(structured: Any) -> tuple[Optional[float], Optional[float], Optional[bool]]:
+    if not isinstance(structured, dict) or "performance" not in structured:
+        return None, None, None
+    performance = structured["performance"]
+    if not isinstance(performance, dict):
+        raise BenchmarkFailure("performance-contract-invalid")
+    elapsed, target, met = (
+        performance.get("elapsed_ms"),
+        performance.get("sla_target_ms"),
+        performance.get("met_sla"),
+    )
+    if isinstance(elapsed, bool) or not isinstance(elapsed, (int, float)) or elapsed < 0:
+        raise BenchmarkFailure("performance-contract-invalid")
+    if (
+        isinstance(target, bool)
+        or not isinstance(target, (int, float))
+        or target <= 0
+        or type(met) is not bool
+    ):
+        raise BenchmarkFailure("performance-contract-invalid")
+    if met != (elapsed <= target):
+        raise BenchmarkFailure("performance-contract-invalid")
+    return float(elapsed), float(target), met
+
+
+def validate_success(structured: Any, oracle: OracleCase) -> tuple[float, float, bool]:
+    if not isinstance(structured, dict) or structured.get("schema_version") != "moraine.mcp.search_sessions.v1":
+        raise BenchmarkFailure("semantic-oracle-failed")
+    if structured.get("tool") != "search_sessions" or "error" in structured:
+        raise BenchmarkFailure("semantic-oracle-failed")
+    data = structured.get("data")
+    if not isinstance(data, dict):
+        raise BenchmarkFailure("semantic-oracle-failed")
+    results = data.get("results")
+    if not isinstance(results, list) or data.get("result_count") != len(results) or len(results) != oracle.result_count:
+        raise BenchmarkFailure("semantic-oracle-failed")
+    if result_digest(results) != oracle.result_digest:
+        raise BenchmarkFailure("semantic-oracle-failed")
+    elapsed, target, met = parse_performance(structured)
+    if elapsed is None or target is None or met is None:
+        raise BenchmarkFailure("performance-contract-invalid")
+    return elapsed, target, met
+
+
+def initialize_client(client: McpClient, request_id: int) -> None:
+    client._rpc_result(request_id, "initialize", {})
+    tools = client._rpc_result(request_id + 1, "tools/list", {})
+    listed = tools.get("tools")
+    if not isinstance(listed, list) or not any(isinstance(tool, dict) and tool.get("name") == "search_sessions" for tool in listed):
+        raise BenchmarkFailure("semantic-oracle-failed")
+
+
+def send_with_gate(
+    client: McpClient, payload: dict[str, Any], sent_gate: threading.Barrier
+) -> dict[str, Any]:
+    if client.proc.stdin is None or client.proc.stdout is None:
+        raise BenchmarkFailure("client-pipe-unavailable")
+    if client.proc.poll() is not None:
+        raise BenchmarkFailure("client-exited")
+    try:
+        client.proc.stdin.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        client.proc.stdin.flush()
+    except (BrokenPipeError, OSError) as exc:
+        sent_gate.abort()
+        raise BenchmarkFailure("client-exited") from exc
+    sent_gate.wait()
+    response_line = client._read_response_line(time.monotonic() + client.request_timeout_s)
+    try:
+        response = json.loads(response_line)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise BenchmarkFailure("invalid-jsonrpc-response") from exc
+    if not isinstance(response, dict):
+        raise BenchmarkFailure("invalid-jsonrpc-response")
+    return response
+
+
+def invoke_search(
+    client: McpClient,
+    request_id: int,
+    oracle: OracleCase,
+    hard_deadline_ms: float,
+    sent_gate: Optional[threading.Barrier] = None,
+) -> RequestSample:
+    started_ns = time.perf_counter_ns()
+    outcome = "client_error"
+    server_elapsed = target = None
+    met_sla = None
+    oracle_passed = False
+    try:
+        payload = {
+            "jsonrpc": "2.0", "id": request_id, "method": "tools/call",
+            "params": {"name": "search_sessions", "arguments": {"query": oracle.query, "n_hits": 10}},
+        }
+        response = (
+            send_with_gate(client, payload, sent_gate)
+            if sent_gate is not None
+            else client._send(payload)
+        )
+        rpc_error = response.get("error")
+        if rpc_error is not None:
+            message = rpc_error.get("message", "") if isinstance(rpc_error, dict) else ""
+            outcome = "admission_rejection" if "concurrent request limit" in str(message).casefold() else "jsonrpc_error"
+        elif response.get("id") != request_id or not isinstance(response.get("result"), dict):
+            outcome = "jsonrpc_error"
+        else:
+            result = response["result"]
+            structured = result.get("structuredContent")
+            error = structured.get("error") if isinstance(structured, dict) else None
+            server_elapsed, target, met_sla = parse_performance(structured)
+            if isinstance(error, dict) and error.get("code") == "deadline_exceeded":
+                outcome = "deadline_exceeded"
+            elif bool(result.get("isError")) or isinstance(error, dict):
+                outcome = "mcp_error"
+            else:
+                server_elapsed, target, met_sla = validate_success(structured, oracle)
+                outcome = "success"
+                oracle_passed = True
+    except BenchmarkFailure as exc:
+        if exc.codes[0] == "request-timeout":
+            outcome = "timeout"
+        elif exc.codes[0] in ("semantic-oracle-failed", "performance-contract-invalid"):
+            outcome = "semantic_error"
+        else:
+            outcome = "client_error"
+    finished_ns = time.perf_counter_ns()
+    wall_ms = (finished_ns - started_ns) / 1_000_000.0
+    return RequestSample(
+        query_id=oracle.query_id, outcome=outcome, wall_ms=wall_ms,
+        started_ns=started_ns, finished_ns=finished_ns,
+        server_elapsed_ms=server_elapsed, sla_target_ms=target, met_sla=met_sla,
+        exceeded_hard_deadline=outcome == "success" and wall_ms > hard_deadline_ms,
+        oracle_passed=oracle_passed,
+    )
+
+
+def run_burst(
+    clients: Sequence[McpClient], cases: Sequence[OracleCase], *, hard_deadline_ms: float,
+    invoke: Callable[[McpClient, int, OracleCase, float], RequestSample] = invoke_search,
+) -> BurstResult:
+    concurrency = len(clients)
+    if concurrency <= 0 or len(cases) != concurrency:
+        raise BenchmarkFailure("invalid-burst-shape")
+    ready = threading.Barrier(concurrency + 1)
+    sent = threading.Barrier(concurrency)
+    lock = threading.Lock()
+    active = 0
+    max_active = 0
+    samples: list[Optional[RequestSample]] = [None] * concurrency
+    child_errors: list[BaseException] = []
+
+    def worker(index: int) -> None:
+        nonlocal active, max_active
+        try:
+            ready.wait()
+            with lock:
+                active += 1
+                max_active = max(max_active, active)
+            if invoke is invoke_search:
+                samples[index] = invoke_search(
+                    clients[index], 1000 + index, cases[index], hard_deadline_ms, sent
+                )
+            else:
+                samples[index] = invoke(
+                    clients[index], 1000 + index, cases[index], hard_deadline_ms
+                )
+        except BaseException as exc:
+            with lock:
+                child_errors.append(exc)
+            try:
+                sent.abort()
+            except threading.BrokenBarrierError:
+                pass
+        finally:
+            with lock:
+                if active:
+                    active -= 1
+
+    threads = [threading.Thread(target=worker, args=(index,), daemon=True) for index in range(concurrency)]
+    for thread in threads:
+        thread.start()
+    ready.wait()
+    burst_started_ns = time.perf_counter_ns()
+    for thread in threads:
+        thread.join()
+    burst_finished_ns = time.perf_counter_ns()
+    if child_errors or any(sample is None for sample in samples):
+        raise BenchmarkFailure("burst-child-failed") from (child_errors[0] if child_errors else None)
+    complete = [sample for sample in samples if sample is not None]
+    latest_start = max(sample.started_ns for sample in complete)
+    earliest_finish = min(sample.finished_ns for sample in complete)
+    overlap = latest_start <= earliest_finish
+    if max_active != concurrency or not overlap:
+        raise BenchmarkFailure("burst-overlap-not-proven")
+    return BurstResult(concurrency, complete, (burst_finished_ns - burst_started_ns) / 1_000_000.0, max_active, overlap)
+
+
+def _start_server(moraine_mcp: str, config: Path, root_dir: Path) -> subprocess.Popen:
+    static_dir = root_dir / "monitor-static"
+    static_dir.mkdir(parents=True)
+    (static_dir / "index.html").write_text("<!doctype html><title>Moraine benchmark</title>", encoding="utf-8")
+    try:
+        return subprocess.Popen(
+            [moraine_mcp, "--config", str(config), "--serve", "socket", "--host", "127.0.0.1", "--port", "0", "--static-dir", str(static_dir)],
+            stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    except OSError as exc:
+        raise BenchmarkFailure("central-startup-failed") from exc
+
+
+def run_repetition(
+    concurrency: int, *, moraine_mcp: str, clickhouse_url: str, database: str,
+    manifest: OracleManifest, recovery_count: int, recovery_offsets_s: Sequence[float],
+    startup_timeout_s: float, request_timeout_s: float, hard_deadline_ms: float,
+    run_deadline: Optional[float] = None,
+) -> RepetitionResult:
+    short_root = "/tmp" if Path("/tmp").is_dir() and os.access("/tmp", os.W_OK) else None
+    workdir = Path(tempfile.mkdtemp(prefix=f"mb-concurrent-{concurrency}-", dir=short_root))
+    clients: list[McpClient] = []
+    server: Optional[subprocess.Popen] = None
+    cleanup_codes: list[str] = []
+    primary: Optional[BaseException] = None
+    result: Optional[RepetitionResult] = None
+    def remaining_timeout(limit: float) -> float:
+        if run_deadline is None:
+            return limit
+        remaining = run_deadline - time.monotonic()
+        if remaining <= 0:
+            raise BenchmarkFailure("run-timeout")
+        return min(limit, remaining)
+
+    try:
+        root_dir = workdir / "root"
+        (root_dir / "run").mkdir(parents=True)
+        socket_path = root_dir / "run" / "mcp.sock"
+        config = workdir / "config.toml"
+        write_config(config, clickhouse_url=clickhouse_url, database=database, root_dir=root_dir,
+                     use_central_server=True, central_socket_path=socket_path)
+        server = _start_server(moraine_mcp, config, root_dir)
+        wait_for_socket(socket_path, server, remaining_timeout(startup_timeout_s))
+        warmup_client = spawn_client(moraine_mcp, config, remaining_timeout(request_timeout_s))
+        clients.append(warmup_client)
+        warmup_client.request_timeout_s = remaining_timeout(request_timeout_s)
+        initialize_client(warmup_client, 1)
+        warmup = invoke_search(warmup_client, 3, manifest.warmup, hard_deadline_ms)
+        if warmup.outcome != "success":
+            raise BenchmarkFailure("warmup-failed")
+        measured_clients: list[McpClient] = []
+        for _ in range(concurrency):
+            client = spawn_client(moraine_mcp, config, remaining_timeout(request_timeout_s))
+            measured_clients.append(client)
+            clients.append(client)
+        for index, client in enumerate(measured_clients):
+            client.request_timeout_s = remaining_timeout(request_timeout_s)
+            initialize_client(client, 10 + index * 2)
+        for client in measured_clients:
+            client.request_timeout_s = remaining_timeout(request_timeout_s)
+        burst = run_burst(measured_clients, manifest.measured[:concurrency], hard_deadline_ms=hard_deadline_ms)
+        recovery: list[RequestSample] = []
+        recovery_anchor = time.monotonic()
+        for index in range(recovery_count):
+            offset = recovery_offsets_s[index]
+            target_time = recovery_anchor + offset
+            if run_deadline is not None and target_time >= run_deadline:
+                raise BenchmarkFailure("run-timeout")
+            time.sleep(max(0.0, target_time - time.monotonic()))
+            warmup_client.request_timeout_s = remaining_timeout(request_timeout_s)
+            recovery.append(invoke_search(warmup_client, 20_000 + index, manifest.recovery[index], hard_deadline_ms))
+        result = RepetitionResult(burst, recovery)
+    except Exception as exc:
+        primary = exc
+    finally:
+        for client in clients:
+            cleanup_codes.extend(client.close())
+        if server is not None:
+            cleanup_codes.extend(_stop_server(server))
+        try:
+            shutil.rmtree(workdir)
+        except OSError:
+            cleanup_codes.append("workdir-cleanup-failed")
+    cleanup_codes = list(dict.fromkeys(cleanup_codes))
+    if primary is not None:
+        if isinstance(primary, BenchmarkFailure):
+            raise primary.add_codes(cleanup_codes)
+        raise BenchmarkFailure("repetition-failed", *cleanup_codes) from primary
+    if cleanup_codes:
+        raise BenchmarkFailure(*cleanup_codes)
+    if result is None:
+        raise BenchmarkFailure("repetition-failed")
+    return result
+
+
+def percentile(values: Sequence[float], q: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(float(value) for value in values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * q
+    low, high = math.floor(position), math.ceil(position)
+    return ordered[low] + (ordered[high] - ordered[low]) * (position - low)
+
+
+def runner_identity() -> dict[str, str]:
+    os_name = platform.system().lower() or "unknown"
+    machine = platform.machine().lower() or "unknown"
+    cpu = "apple-silicon" if os_name == "darwin" and machine == "arm64" else machine
+    return {"os": os_name.replace("_", "-"), "cpu_class": cpu.replace("_", "-")}
+
+
+def build_target() -> str:
+    return f"{(platform.machine().lower() or 'unknown').replace('_', '-')}-{(platform.system().lower() or 'unknown').replace('_', '-')}"
+
+
+def request_record(sample: RequestSample, repetition: int, phase: str) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "case_id": sample.query_id,
+        "repetition": repetition,
+        "phase": phase,
+        "outcome": sample.outcome,
+        "wall_latency_ms": sample.wall_ms,
+        "hard_deadline_violation": sample.exceeded_hard_deadline,
+        "oracle_passed": sample.oracle_passed,
+    }
+    if sample.server_elapsed_ms is not None:
+        record["server_elapsed_ms"] = sample.server_elapsed_ms
+    if sample.sla_target_ms is not None:
+        record["sla_target_ms"] = sample.sla_target_ms
+    if sample.met_sla is not None:
+        record["met_sla"] = sample.met_sla
+    return record
+
+
+def build_artifact(
+    result: ScenarioResult, *, manifest: OracleManifest, profile: str, source: dict[str, Any],
+    build_profile: str, recovery_offsets_s: Sequence[float], request_timeout_s: float,
+    run_timeout_s: float, hard_deadline_ms: float,
+) -> dict[str, Any]:
+    samples = result.burst_samples
+    successes = result.successful
+    attempted = len(samples)
+    outcomes = {name: sum(sample.outcome == name for sample in samples) for name in OUTCOME_NAMES}
+    errors = attempted - len(successes)
+    wall = [sample.wall_ms for sample in successes]
+    server = [sample.server_elapsed_ms for sample in successes]
+    targets = [sample.sla_target_ms for sample in successes]
+    met = [1.0 if sample.met_sla else 0.0 for sample in successes]
+    hard = [1.0 if sample.exceeded_hard_deadline else 0.0 for sample in successes]
+    burst_wall = [repetition.burst.wall_ms for repetition in result.repetitions]
+    throughput = [
+        (sum(sample.outcome == "success" for sample in repetition.burst.samples) / (repetition.burst.wall_ms / 1000.0))
+        if repetition.burst.wall_ms > 0 else 0.0 for repetition in result.repetitions
+    ]
+    recovery = result.recovery_samples
+    recovery_wall = [sample.wall_ms for sample in recovery]
+    recovery_success = [1.0 if sample.outcome == "success" else 0.0 for sample in recovery]
+    max_in_flight = max(repetition.burst.max_in_flight for repetition in result.repetitions)
+    records = [
+        request_record(sample, repetition_index, phase)
+        for repetition_index, repetition in enumerate(result.repetitions)
+        for phase, phase_samples in (
+            ("burst", repetition.burst.samples),
+            ("recovery", repetition.recovery),
+        )
+        for sample in phase_samples
+    ]
+    query_contract = [
+        {
+            "id": case.query_id,
+            "query_digest": sha256_json(" ".join(case.query.split()).casefold()),
+            "result_count": case.result_count,
+            "result_digest": case.result_digest,
+        }
+        for case in manifest.measured[: result.concurrency]
+    ]
+    all_probes = samples + recovery
+    semantic_failures = sum(sample.outcome == "semantic_error" for sample in all_probes)
+    semantic_pass = semantic_failures == 0
+    scenario_id = f"central-persistent-cold-concurrent-n{result.concurrency}-{profile}"
+    artifact: dict[str, Any] = {
+        "schema_version": benchmark_protocol.SCHEMA_VERSION,
+        "benchmark_id": BENCHMARK_ID,
+        "scenario_id": scenario_id,
+        "source": source,
+        "build": {"profile": build_profile, "target": build_target()},
+        "runner": runner_identity(),
+        "scenario": {
+            "profile": profile,
+            "workload_id": f"search-sessions-distinct-uncached-n{result.concurrency}",
+            "measured_boundary": MEASURED_BOUNDARY,
+            "dimensions": {"dataset_backed": True, "cache_sensitive": True, "concurrent": True, "request_producing": True},
+            "fingerprints": {
+                "dataset": {"fingerprint": manifest.dataset_fingerprint, "cardinality": manifest.dataset_cardinality},
+                "cache_state": "cold", "concurrency": result.concurrency, "request_source": REQUEST_SOURCE,
+                "request_schedule": "concurrent", "max_in_flight": max_in_flight,
+                "query_set": {"fingerprint": sha256_json(query_contract), "cardinality": result.concurrency},
+                "cache_isolation": "fresh-central-service-per-repetition", "lifecycle": "persistent",
+                "boundary": "central", "oracle_provenance": manifest.provenance,
+                "request_timeout_seconds": request_timeout_s,
+            },
+        },
+        "samples": {
+            "planned": len(result.repetitions) * result.concurrency,
+            "attempted": attempted, "successful": len(successes), "errors": errors,
+            "measurements": {
+                "wall_latency_ms": wall,
+                "server_elapsed_ms": [float(value) for value in server if value is not None],
+                "sla_target_ms": [float(value) for value in targets if value is not None],
+                "met_sla_ratio": met, "hard_deadline_violation_ratio": hard,
+            },
+            "outcomes": outcomes,
+            "observations": {
+                "burst_wall_ms": burst_wall, "successful_throughput_per_second": throughput,
+                "recovery_wall_latency_ms": recovery_wall,
+                "recovery_success_ratio": recovery_success,
+                "recovery_offset_seconds": list(recovery_offsets_s) * len(result.repetitions),
+            },
+            "records": records,
+        },
+        "semantic": {"status": "pass" if semantic_pass else "fail"},
+        "timing": {"status": "not_evaluated", "non_blocking": True},
+        "metrics": {
+            "quality": {
+                "oracle_status": "pass" if semantic_pass else "fail",
+                "passed_checks": sum(sample.oracle_passed for sample in all_probes),
+                "failed_checks": semantic_failures,
+                "expected_count": len(all_probes),
+                "observed_count": sum(sample.oracle_passed for sample in all_probes),
+                "success_rate": len(successes) / attempted if attempted else 0.0,
+                "error_rate": errors / attempted if attempted else 0.0,
+            },
+            "resources": {
+                "requested_concurrency_count": result.concurrency,
+                "maximum_in_flight_count": max_in_flight,
+                "overlap_proven_ratio": (
+                    sum(repetition.burst.overlap_proven for repetition in result.repetitions)
+                    / len(result.repetitions)
+                ),
+                "sla_met_rate_ratio": sum(met) / len(met) if met else 0.0,
+                "hard_deadline_violation_count": sum(hard),
+                "admission_rejection_count": outcomes["admission_rejection"],
+                "admission_rejection_rate_ratio": outcomes["admission_rejection"] / attempted if attempted else 0.0,
+                "error_rate_ratio": errors / attempted if attempted else 0.0,
+                "deadline_exceeded_count": outcomes["deadline_exceeded"],
+                "timeout_count": outcomes["timeout"],
+                "p50_latency_ms": percentile(wall, 0.50), "p95_latency_ms": percentile(wall, 0.95),
+                "p99_latency_ms": percentile(wall, 0.99), "max_latency_ms": max(wall, default=0.0),
+                "mean_throughput_per_second": sum(throughput) / len(throughput) if throughput else 0.0,
+                "request_timeout_seconds": request_timeout_s, "run_timeout_seconds": run_timeout_s,
+                "hard_deadline_ms": hard_deadline_ms,
+            },
+        },
+        "diagnostics": [], "artifacts": [],
+    }
+    benchmark_protocol.validate_artifact(artifact)
+    return artifact
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--moraine-mcp")
+    parser.add_argument("--clickhouse-url", default="http://127.0.0.1:8123")
+    parser.add_argument("--database", default="moraine")
+    parser.add_argument("--oracle-json", type=Path, required=True)
+    parser.add_argument("--concurrency", action="append", required=True, metavar="N|START:STOP[:STEP]")
+    parser.add_argument("--reps", type=positive_int, default=1)
+    parser.add_argument("--profile", choices=("smoke", "full"), default="smoke")
+    parser.add_argument("--startup-timeout-seconds", type=positive_float, default=10.0)
+    parser.add_argument("--request-timeout-seconds", type=positive_float, default=20.0)
+    parser.add_argument("--run-timeout-seconds", type=positive_float, default=600.0)
+    parser.add_argument("--max-processes", type=positive_int, default=256)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--git-commit")
+    parser.add_argument("--dirty", choices=("auto", "true", "false"), default="auto")
+    args = parser.parse_args(argv)
+    try:
+        args.concurrency = parse_concurrency(args.concurrency)
+    except ConfigurationError as exc:
+        parser.error(str(exc))
+    args.recovery_offsets = PROFILE_RECOVERY_OFFSETS[args.profile]
+    args.recovery_probes = len(args.recovery_offsets)
+    if max(args.concurrency) + 2 > args.max_processes:
+        parser.error("requested concurrency exceeds the operator-controlled --max-processes safety bound")
+    return args
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    started = time.monotonic()
+    run_deadline = started + args.run_timeout_seconds
+    try:
+        manifest = load_oracle(args.oracle_json, profile=args.profile, needed_queries=max(args.concurrency), recovery_count=args.recovery_probes)
+        moraine_mcp = resolve_moraine_mcp(args.moraine_mcp)
+        repo_root = Path(__file__).resolve().parents[2]
+        commit, dirty = resolve_source(repo_root, args.git_commit, args.dirty)
+        source = {"git_commit": commit, "dirty": dirty}
+        raise_fd_limit(max(8192, args.max_processes * 8))
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        semantic_failed = False
+        for concurrency in args.concurrency:
+            repetitions: list[RepetitionResult] = []
+            for _ in range(args.reps):
+                if time.monotonic() - started >= args.run_timeout_seconds:
+                    raise BenchmarkFailure("run-timeout")
+                repetitions.append(run_repetition(
+                    concurrency, moraine_mcp=moraine_mcp, clickhouse_url=args.clickhouse_url,
+                    database=args.database, manifest=manifest,
+                    recovery_count=args.recovery_probes if concurrency == max(args.concurrency) else 0,
+                    recovery_offsets_s=args.recovery_offsets if concurrency == max(args.concurrency) else (),
+                    startup_timeout_s=args.startup_timeout_seconds,
+                    request_timeout_s=args.request_timeout_seconds,
+                    hard_deadline_ms=HARD_DEADLINE_MS,
+                    run_deadline=run_deadline,
+                ))
+            result = ScenarioResult(concurrency, repetitions)
+            artifact = build_artifact(
+                result, manifest=manifest, profile=args.profile, source=source,
+                build_profile=infer_build_profile(moraine_mcp),
+                recovery_offsets_s=args.recovery_offsets if concurrency == max(args.concurrency) else (),
+                request_timeout_s=args.request_timeout_seconds, run_timeout_s=args.run_timeout_seconds,
+                hard_deadline_ms=HARD_DEADLINE_MS,
+            )
+            semantic_failed = semantic_failed or artifact["semantic"]["status"] == "fail"
+            path = args.output_dir / f"{BENCHMARK_ID}-n{concurrency}-{args.profile}.json"
+            benchmark_protocol.write_artifact(path, artifact)
+            print(f"n={concurrency} success={artifact['samples']['successful']}/{artifact['samples']['attempted']} output={path}")
+        return 2 if semantic_failed else 0
+    except (BenchmarkFailure, ConfigurationError, benchmark_protocol.ProtocolError, OSError) as exc:
+        code = exc.codes[0] if isinstance(exc, BenchmarkFailure) else type(exc).__name__.lower()
+        print(f"benchmark failed: {code}", file=os.sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/schema/moraine-benchmark-v1.schema.json
+++ b/scripts/bench/schema/moraine-benchmark-v1.schema.json
@@ -85,7 +85,23 @@
             },
             "cache_state": { "enum": ["cold", "warm", "mixed", "disabled"] },
             "concurrency": { "type": "integer", "minimum": 1 },
-            "request_source": { "$ref": "#/$defs/slug" }
+            "request_source": { "$ref": "#/$defs/slug" },
+            "request_schedule": { "enum": ["sequential", "concurrent"] },
+            "max_in_flight": { "type": "integer", "minimum": 1 },
+            "query_set": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["fingerprint", "cardinality"],
+              "properties": {
+                "fingerprint": { "$ref": "#/$defs/sha256Prefixed" },
+                "cardinality": { "type": "integer", "minimum": 1 }
+              }
+            },
+            "cache_isolation": { "$ref": "#/$defs/slug" },
+            "lifecycle": { "enum": ["persistent", "cold-process"] },
+            "boundary": { "enum": ["embedded", "central"] },
+            "oracle_provenance": { "$ref": "#/$defs/slug" },
+            "request_timeout_seconds": { "type": "number", "minimum": 0 }
           }
         }
       },
@@ -157,6 +173,25 @@
             "type": "array",
             "items": { "type": "number", "minimum": 0 }
           }
+        },
+        "outcomes": {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": { "$ref": "#/$defs/slug" },
+          "additionalProperties": { "type": "integer", "minimum": 0 }
+        },
+        "observations": {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": { "$ref": "#/$defs/measurementName" },
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "number", "minimum": 0 }
+          }
+        },
+        "records": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/requestRecord" }
         },
         "external_samples": {
           "type": "object",
@@ -253,23 +288,6 @@
           }
         }
       }
-    },
-    {
-      "if": {
-        "properties": {
-          "samples": {
-            "properties": { "successful": { "const": 0 } },
-            "required": ["successful"]
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "semantic": {
-            "properties": { "status": { "const": "fail" } }
-          }
-        }
-      }
     }
   ],
   "$defs": {
@@ -289,7 +307,7 @@
     },
     "measurementName": {
       "type": "string",
-      "pattern": "^[a-z][a-z0-9_]*(?:_ns|_us|_ms|_seconds|_bytes|_count|_ratio|_percent)$"
+      "pattern": "^[a-z][a-z0-9_]*(?:_ns|_us|_ms|_seconds|_per_second|_bytes|_count|_ratio|_percent)$"
     },
     "comparisonPolicy": {
       "type": "object",
@@ -354,6 +372,31 @@
         "input_tokens": { "type": "integer", "minimum": 0 },
         "output_tokens": { "type": "integer", "minimum": 0 },
         "total_tokens": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "requestRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "repetition",
+        "phase",
+        "outcome",
+        "wall_latency_ms",
+        "hard_deadline_violation",
+        "oracle_passed"
+      ],
+      "properties": {
+        "case_id": { "$ref": "#/$defs/slug" },
+        "repetition": { "type": "integer", "minimum": 0 },
+        "phase": { "enum": ["burst", "recovery"] },
+        "outcome": { "$ref": "#/$defs/slug" },
+        "wall_latency_ms": { "type": "number", "minimum": 0 },
+        "server_elapsed_ms": { "type": "number", "minimum": 0 },
+        "sla_target_ms": { "type": "number", "minimum": 0 },
+        "met_sla": { "type": "boolean" },
+        "hard_deadline_violation": { "type": "boolean" },
+        "oracle_passed": { "type": "boolean" }
       }
     },
     "diagnostic": {

--- a/scripts/bench/seed_concurrent_mcp_benchmark.py
+++ b/scripts/bench/seed_concurrent_mcp_benchmark.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Seed an owned ClickHouse sandbox and write an independent concurrent-search oracle."""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Optional, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+from urllib.request import Request, urlopen
+
+ORACLE_SCHEMA_VERSION = "moraine-concurrent-mcp-oracle-v1"
+IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class SeedFailure(RuntimeError):
+    pass
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def clickhouse_query(url: str, sql: str, timeout_s: float = 600.0) -> str:
+    parsed = urlparse(url)
+    query = parse_qsl(parsed.query, keep_blank_values=True)
+    query.append(("query", sql))
+    request_url = urlunparse(parsed._replace(query=urlencode(query)))
+    request = Request(request_url, method="POST")
+    try:
+        with urlopen(request, timeout=timeout_s) as response:
+            return response.read().decode("utf-8")
+    except (HTTPError, URLError, TimeoutError, OSError) as exc:
+        detail = ""
+        if isinstance(exc, HTTPError):
+            try:
+                detail = exc.read(1024).decode("utf-8", errors="replace")
+            except OSError:
+                pass
+        raise SeedFailure(f"ClickHouse query failed: {detail or type(exc).__name__}") from exc
+
+
+def public_id(prefix: str, raw: str) -> str:
+    encoded = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii").rstrip("=")
+    return f"{prefix}:{encoded}"
+
+
+def event_uid(number: int) -> str:
+    return f"bench-event-{number:08d}"
+
+
+def session_id(number: int) -> str:
+    return f"bench-session-{number:08d}"
+
+
+def result_digest(numbers: Sequence[int]) -> str:
+    identities = [
+        {"event_id": public_id("event", event_uid(number)), "session_id": public_id("session", session_id(number))}
+        for number in numbers
+    ]
+    identities.sort(key=lambda item: (item["session_id"], item["event_id"]))
+    encoded = json.dumps(identities, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def case(case_id: str, query: str, numbers: Sequence[int]) -> dict[str, Any]:
+    selected = list(numbers)[:10]
+    if not selected:
+        raise SeedFailure(f"oracle case {case_id} has no seeded result")
+    return {"id": case_id, "query": query, "result_count": len(selected), "result_digest": result_digest(selected)}
+
+
+def corpus_fingerprint(documents: int, measured_cases: int, recovery_cases: int) -> str:
+    recipe = {
+        "schema": "moraine-concurrent-search-corpus-v1",
+        "documents": documents,
+        "measured_cases": measured_cases,
+        "recovery_cases": recovery_cases,
+        "event_prefix": "bench-event",
+        "session_prefix": "bench-session",
+    }
+    encoded = json.dumps(recipe, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def build_oracle(documents: int, measured_cases: int, recovery_cases: int) -> dict[str, Any]:
+    warmup_number = documents - 1
+    measured: list[dict[str, Any]] = []
+    for index in range(measured_cases):
+        if index % 2 == 0:
+            measured.append(case(f"measured-{index:04d}", f"selective_{index:04d}", [index]))
+        else:
+            common_numbers = list(range(index, documents, measured_cases))
+            common_numbers.sort(
+                key=lambda number: (
+                    number < measured_cases
+                    or measured_cases <= number < measured_cases + recovery_cases
+                    or number == warmup_number,
+                    number,
+                )
+            )
+            measured.append(case(f"measured-{index:04d}", f"common_{index:04d}", common_numbers))
+    recovery = [
+        case(f"recovery-{index:04d}", f"recovery_{index:04d}", [measured_cases + index])
+        for index in range(recovery_cases)
+    ]
+    return {
+        "schema_version": ORACLE_SCHEMA_VERSION,
+        "provenance": "synthetic-search-corpus-v1",
+        "dataset": {
+            "fingerprint": corpus_fingerprint(documents, measured_cases, recovery_cases),
+            "cardinality": documents,
+        },
+        "warmup": case("warmup", "warmupterm", [warmup_number]),
+        "measured": measured,
+        "recovery": recovery,
+    }
+
+
+def seed_sql(database: str, documents: int, measured_cases: int, recovery_cases: int) -> str:
+    recovery_expr = "' '"
+    if recovery_cases:
+        recovery_expr = (
+            f"if(number >= {measured_cases} AND number < {measured_cases + recovery_cases}, "
+            f"concat('recovery_', leftPad(toString(number - {measured_cases}), 4, '0'), ' '), ' ')"
+        )
+    return f"""
+INSERT INTO {database}.search_documents
+(
+  doc_version, ingested_at, event_uid, compacted_parent_uid, session_id, session_date,
+  source_name, harness, inference_provider, endpoint_kind, source_file, source_generation,
+  source_line_no, source_offset, source_ref, record_ts, event_class, payload_type,
+  actor_role, name, phase, text_content, payload_json, token_usage_json
+)
+SELECT
+  1,
+  toDateTime64('2026-01-01 00:00:00', 3),
+  concat('bench-event-', leftPad(toString(number), 8, '0')),
+  '',
+  concat('bench-session-', leftPad(toString(number), 8, '0')),
+  toDate('2026-01-01'),
+  'benchmark',
+  'benchmark',
+  'benchmark',
+  'generation',
+  'synthetic/concurrent-search-v1.jsonl',
+  1,
+  number + 1,
+  number,
+  concat('synthetic:', toString(number)),
+  '2026-01-01T00:00:00.000Z',
+  'message',
+  'user',
+  'user',
+  '',
+  '',
+  concat(
+    'synthetic benchmark document ',
+    if(number < {measured_cases}, concat('selective_', leftPad(toString(number), 4, '0'), ' '), ' '),
+    concat('common_', leftPad(toString(number % {measured_cases}), 4, '0'), ' '),
+    {recovery_expr},
+    if(number = {documents - 1}, 'warmupterm', '')
+  ),
+  '{{}}',
+  '{{}}'
+FROM numbers({documents})
+""".strip()
+
+
+def truncate(database: str, url: str) -> None:
+    for table in ("search_hit_log", "search_query_log", "search_postings", "search_documents"):
+        clickhouse_query(url, f"TRUNCATE TABLE {database}.{table}")
+
+
+def atomic_write(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(value, indent=2, sort_keys=True) + "\n"
+    temporary: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(payload)
+            handle.flush()
+        temporary.replace(path)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("seed", "clean"))
+    parser.add_argument("--clickhouse-url", default="http://127.0.0.1:8123")
+    parser.add_argument("--database", default="moraine")
+    parser.add_argument("--documents", type=positive_int, default=100_000)
+    parser.add_argument("--measured-cases", type=positive_int, default=64)
+    parser.add_argument("--recovery-cases", type=positive_int, default=2)
+    parser.add_argument("--oracle-json", type=Path)
+    args = parser.parse_args(argv)
+    if not IDENTIFIER_RE.fullmatch(args.database):
+        parser.error("database must be a ClickHouse identifier")
+    if args.action == "seed" and args.oracle_json is None:
+        parser.error("seed requires --oracle-json")
+    if args.documents <= args.measured_cases + args.recovery_cases:
+        parser.error("documents must exceed measured plus recovery cases")
+    return args
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    try:
+        truncate(args.database, args.clickhouse_url)
+        if args.action == "clean":
+            return 0
+        clickhouse_query(args.clickhouse_url, seed_sql(args.database, args.documents, args.measured_cases, args.recovery_cases))
+        observed = clickhouse_query(
+            args.clickhouse_url,
+            f"SELECT count() FROM {args.database}.search_documents FINAL FORMAT TSVRaw",
+        ).strip()
+        if observed != str(args.documents):
+            raise SeedFailure(f"seed cardinality mismatch: expected {args.documents}, observed {observed}")
+        atomic_write(args.oracle_json, build_oracle(args.documents, args.measured_cases, args.recovery_cases))
+        print(f"seeded={observed} oracle={args.oracle_json}")
+        return 0
+    except (SeedFailure, OSError) as exc:
+        print(f"seed failed: {exc}", file=__import__("sys").stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/test_concurrent_mcp_retrieval.py
+++ b/scripts/bench/test_concurrent_mcp_retrieval.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Deterministic tests for concurrent_mcp_retrieval.py."""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import benchmark_protocol
+import concurrent_mcp_retrieval as bench
+
+DIGEST = "sha256:" + "a" * 64
+COMMIT = "b" * 40
+
+
+def oracle(case_id: str, query: str | None = None) -> bench.OracleCase:
+    return bench.OracleCase(case_id, query or f"term {case_id}", 1, DIGEST)
+
+
+def manifest(count: int = 4) -> bench.OracleManifest:
+    measured = tuple(oracle(f"measured-{index}") for index in range(count))
+    recovery = (oracle("recovery-0"), oracle("recovery-1"))
+    return bench.OracleManifest(
+        "seed-v1", DIGEST, 100_000, oracle("warmup"), measured, recovery,
+        bench.sha256_json([case.query_id for case in measured]),
+    )
+
+
+def sample(case_id: str, outcome: str = "success", wall_ms: float = 10.0, start: int = 1) -> bench.RequestSample:
+    successful = outcome == "success"
+    return bench.RequestSample(
+        case_id, outcome, wall_ms, start, start + max(1, int(wall_ms * 1_000_000)),
+        server_elapsed_ms=wall_ms - 1 if successful else None,
+        sla_target_ms=750.0 if successful else None,
+        met_sla=successful,
+        exceeded_hard_deadline=successful and wall_ms > 5_000,
+        oracle_passed=successful,
+    )
+
+
+class FakeResponseClient:
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+
+    def _send(self, payload):
+        if self.error:
+            raise self.error
+        return self.response
+
+
+class ConcurrencyParsingTests(unittest.TestCase):
+    def test_repeatable_values_and_inclusive_sweep_are_arbitrary_and_deduplicated(self):
+        self.assertEqual(bench.parse_concurrency(["1", "3,5", "8:12:2", "3"]), [1, 3, 5, 8, 10, 12])
+
+    def test_non_positive_or_reversed_values_are_rejected(self):
+        for value in ("0", "-1", "4:2", "1:5:0", ""):
+            with self.subTest(value=value), self.assertRaises(bench.ConfigurationError):
+                bench.parse_concurrency([value])
+
+    def test_process_budget_is_runner_protection_not_backend_policy(self):
+        with self.assertRaises(SystemExit):
+            bench.parse_args(["--oracle-json", "x", "--concurrency", "8", "--max-processes", "9", "--output-dir", "out"])
+        args = bench.parse_args(["--oracle-json", "x", "--concurrency", "8", "--max-processes", "10", "--output-dir", "out"])
+        self.assertEqual(args.concurrency, [8])
+        self.assertEqual(args.recovery_offsets, (0.0, 1.0))
+
+
+class OracleTests(unittest.TestCase):
+    def write_manifest(self, root: Path, *, duplicate=False, cardinality=100_000) -> Path:
+        def entry(case_id, query):
+            return {"id": case_id, "query": query, "result_count": 1, "result_digest": DIGEST}
+        raw = {
+            "schema_version": bench.ORACLE_SCHEMA_VERSION,
+            "provenance": "seed-v1",
+            "dataset": {"fingerprint": DIGEST, "cardinality": cardinality},
+            "warmup": entry("warmup", "startup-only"),
+            "measured": [entry("m0", "startup-only" if duplicate else "selective-a"), entry("m1", "common-b")],
+            "recovery": [entry("r0", "recovery-c")],
+        }
+        path = root / "oracle.json"
+        path.write_text(json.dumps(raw), encoding="utf-8")
+        return path
+
+    def test_distinct_query_allocation_and_query_set_digest(self):
+        with tempfile.TemporaryDirectory() as raw:
+            loaded = bench.load_oracle(self.write_manifest(Path(raw)), profile="full", needed_queries=2, recovery_count=1)
+        self.assertEqual([case.query_id for case in loaded.measured[:2]], ["m0", "m1"])
+        self.assertTrue(loaded.query_set_fingerprint.startswith("sha256:"))
+
+    def test_warmup_measured_and_recovery_queries_must_be_distinct(self):
+        with tempfile.TemporaryDirectory() as raw:
+            with self.assertRaisesRegex(bench.ConfigurationError, "must be distinct"):
+                bench.load_oracle(self.write_manifest(Path(raw), duplicate=True), profile="smoke", needed_queries=2, recovery_count=1)
+
+    def test_full_profile_requires_meaningful_corpus(self):
+        with tempfile.TemporaryDirectory() as raw:
+            with self.assertRaisesRegex(bench.ConfigurationError, "100000"):
+                bench.load_oracle(self.write_manifest(Path(raw), cardinality=99_999), profile="full", needed_queries=2, recovery_count=1)
+
+
+class BurstTests(unittest.TestCase):
+    def test_barrier_proves_overlap_and_retains_out_of_order_response_slots(self):
+        cases = [oracle(f"q{index}") for index in range(4)]
+
+        def delayed(_client, _request_id, case, _deadline):
+            delay = {"q0": 0.04, "q1": 0.01, "q2": 0.03, "q3": 0.02}[case.query_id]
+            started = time.perf_counter_ns()
+            time.sleep(delay)
+            return sample(case.query_id, wall_ms=delay * 1000, start=started)
+
+        result = bench.run_burst([object()] * 4, cases, hard_deadline_ms=5_000, invoke=delayed)
+        self.assertEqual(result.max_in_flight, 4)
+        self.assertTrue(result.overlap_proven)
+        self.assertEqual([item.query_id for item in result.samples], ["q0", "q1", "q2", "q3"])
+
+    def test_production_gate_writes_every_rpc_before_reading_any_response(self):
+        writes = []
+        clients = []
+        cases = []
+
+        for index in range(4):
+            results = [
+                {
+                    "event": {"id": f"event-{index}"},
+                    "session": {"id": f"session-{index}"},
+                }
+            ]
+            cases.append(
+                bench.OracleCase(
+                    f"q{index}", f"term-{index}", 1, bench.result_digest(results)
+                )
+            )
+
+            class Stdin:
+                def write(self, payload, index=index):
+                    writes.append((index, payload))
+
+                def flush(self):
+                    pass
+
+            rpc_result = {
+                "jsonrpc": "2.0",
+                "id": 1000 + index,
+                "result": {
+                    "isError": False,
+                    "structuredContent": {
+                        "schema_version": "moraine.mcp.search_sessions.v1",
+                        "tool": "search_sessions",
+                        "data": {"result_count": 1, "results": results},
+                        "performance": {
+                            "elapsed_ms": 1,
+                            "sla_target_ms": 750,
+                            "met_sla": True,
+                        },
+                    },
+                },
+            }
+            client = mock.Mock()
+            client.proc.stdin = Stdin()
+            client.proc.stdout = object()
+            client.proc.poll.return_value = None
+            client.request_timeout_s = 1
+
+            def read_response(_deadline, response=rpc_result):
+                self.assertEqual(len(writes), 4)
+                return json.dumps(response)
+
+            client._read_response_line.side_effect = read_response
+            clients.append(client)
+
+        result = bench.run_burst(clients, cases, hard_deadline_ms=5_000)
+        self.assertEqual(result.max_in_flight, 4)
+        self.assertTrue(result.overlap_proven)
+        self.assertEqual(len(writes), 4)
+
+    def test_child_failure_is_not_silently_converted_to_a_sample(self):
+        def fail(*_args):
+            raise RuntimeError("child died")
+
+        with self.assertRaisesRegex(bench.BenchmarkFailure, "burst-child-failed"):
+            bench.run_burst([object(), object()], [oracle("a"), oracle("b")], hard_deadline_ms=5_000, invoke=fail)
+
+
+class ClassificationTests(unittest.TestCase):
+    def rpc(self, result):
+        return {"jsonrpc": "2.0", "id": 7, "result": result}
+
+    def test_admission_jsonrpc_mcp_deadline_and_timeout_are_distinct(self):
+        variants = [
+            ({"error": {"message": "server busy: concurrent request limit reached"}}, None, "admission_rejection"),
+            ({"error": {"message": "other"}}, None, "jsonrpc_error"),
+            (self.rpc({"isError": True, "structuredContent": {"error": {"code": "bad_request"}}}), None, "mcp_error"),
+            (self.rpc({"isError": True, "structuredContent": {
+                "error": {"code": "deadline_exceeded"},
+                "performance": {"elapsed_ms": 5001, "sla_target_ms": 750, "met_sla": False},
+            }}), None, "deadline_exceeded"),
+            (None, bench.BenchmarkFailure("request-timeout"), "timeout"),
+        ]
+        for response, error, expected in variants:
+            with self.subTest(expected=expected):
+                observed = bench.invoke_search(FakeResponseClient(response, error), 7, oracle("q"), 5_000)
+                self.assertEqual(observed.outcome, expected)
+
+    def test_success_validates_server_performance_and_seed_owned_digest(self):
+        results = [{"event": {"id": "event-1"}, "session": {"id": "session-1"}}]
+        case = bench.OracleCase("q", "term", 1, bench.result_digest(results))
+        structured = {
+            "schema_version": "moraine.mcp.search_sessions.v1", "tool": "search_sessions",
+            "data": {"result_count": 1, "results": results},
+            "performance": {"elapsed_ms": 12, "sla_target_ms": 750, "met_sla": True},
+        }
+        observed = bench.invoke_search(FakeResponseClient(self.rpc({"isError": False, "structuredContent": structured})), 7, case, 5_000)
+        self.assertEqual(observed.outcome, "success")
+        self.assertTrue(observed.oracle_passed)
+        self.assertEqual(observed.server_elapsed_ms, 12)
+    def test_oracle_mismatch_is_a_semantic_error_not_a_timing_sample(self):
+        results = [{"event": {"id": "event-1"}, "session": {"id": "session-1"}}]
+        structured = {
+            "schema_version": "moraine.mcp.search_sessions.v1",
+            "tool": "search_sessions",
+            "data": {"result_count": 1, "results": results},
+            "performance": {"elapsed_ms": 12, "sla_target_ms": 750, "met_sla": True},
+        }
+        observed = bench.invoke_search(
+            FakeResponseClient(self.rpc({"isError": False, "structuredContent": structured})),
+            7,
+            oracle("q"),
+            5_000,
+        )
+        self.assertEqual(observed.outcome, "semantic_error")
+        self.assertFalse(observed.oracle_passed)
+
+
+
+class ArtifactTests(unittest.TestCase):
+    def scenario(self, concurrency=2, outcomes=("success", "admission_rejection")):
+        burst_samples = [sample(f"q{index}", outcome, 20 + index, start=index + 1) for index, outcome in enumerate(outcomes)]
+        burst = bench.BurstResult(concurrency, burst_samples, 50.0, concurrency, True)
+        recovery = [sample("r0", "success", 30.0, 10)] if concurrency == 2 else []
+        return bench.ScenarioResult(concurrency, [bench.RepetitionResult(burst, recovery)])
+
+    def build(self, scenario=None, request_timeout=20.0):
+        return bench.build_artifact(
+            scenario or self.scenario(), manifest=manifest(), profile="full",
+            source={"git_commit": COMMIT, "dirty": False}, build_profile="release",
+            recovery_offsets_s=[0.0] if (scenario or self.scenario()).concurrency == 2 else [],
+            request_timeout_s=request_timeout, run_timeout_s=600.0, hard_deadline_ms=5_000.0,
+        )
+
+    def test_schema_valid_artifact_exposes_raw_successes_outcomes_summary_and_recovery(self):
+        artifact = self.build()
+        benchmark_protocol.validate_artifact(artifact)
+        self.assertEqual(artifact["samples"]["measurements"]["wall_latency_ms"], [20.0])
+        self.assertEqual(artifact["samples"]["outcomes"]["admission_rejection"], 1)
+        self.assertEqual(artifact["samples"]["observations"]["recovery_wall_latency_ms"], [30.0])
+        self.assertEqual(artifact["samples"]["records"][0]["case_id"], "q0")
+        self.assertEqual(artifact["samples"]["records"][-1]["phase"], "recovery")
+        self.assertEqual(artifact["metrics"]["resources"]["maximum_in_flight_count"], 2)
+        self.assertEqual(artifact["metrics"]["resources"]["overlap_proven_ratio"], 1.0)
+        self.assertEqual(artifact["timing"]["status"], "not_evaluated")
+
+    def test_unlike_concurrency_is_comparison_incomparable(self):
+        left = self.build(self.scenario(1, ("success",)))
+        right = self.build(self.scenario(2, ("success", "success")))
+        with self.assertRaises(benchmark_protocol.IncomparableError):
+            benchmark_protocol.compare_artifacts(left, right)
+    def test_request_timeout_changes_comparison_identity(self):
+        left = self.build(request_timeout=1.0)
+        right = self.build(request_timeout=20.0)
+        with self.assertRaises(benchmark_protocol.IncomparableError):
+            benchmark_protocol.compare_artifacts(left, right)
+
+    def test_all_operational_failures_are_valid_observations_not_semantic_failures(self):
+        artifact = self.build(self.scenario(2, ("admission_rejection", "timeout")))
+        benchmark_protocol.validate_artifact(artifact)
+        self.assertEqual(artifact["samples"]["successful"], 0)
+        self.assertEqual(artifact["semantic"]["status"], "pass")
+
+    def test_recovery_oracle_failure_fails_semantics(self):
+        scenario = self.scenario()
+        scenario.repetitions[0].recovery = [sample("r0", "semantic_error")]
+        artifact = self.build(scenario)
+        self.assertEqual(artifact["semantic"]["status"], "fail")
+        self.assertEqual(artifact["metrics"]["quality"]["failed_checks"], 1)
+
+
+    def test_outcome_counts_must_cover_every_attempt(self):
+        artifact = self.build()
+        artifact["samples"]["outcomes"]["timeout"] += 1
+        with self.assertRaisesRegex(benchmark_protocol.ProtocolError, "outcome counts"):
+            benchmark_protocol.validate_artifact(artifact)
+
+    def test_percentiles_only_use_successful_samples_and_failures_remain_explicit(self):
+        scenario = self.scenario(4, ("success", "timeout", "success", "admission_rejection"))
+        scenario.repetitions[0].burst.samples[2].wall_ms = 100.0
+        artifact = self.build(scenario)
+        self.assertEqual(artifact["metrics"]["resources"]["p50_latency_ms"], 60.0)
+        self.assertEqual(artifact["samples"]["errors"], 2)
+        self.assertEqual(artifact["samples"]["outcomes"]["timeout"], 1)
+
+
+class CleanupTests(unittest.TestCase):
+    def test_repetition_closes_clients_stops_server_and_removes_workdir_after_failure(self):
+        fake_client = mock.Mock()
+        fake_client.close.return_value = []
+        fake_server = mock.Mock()
+        fake_server.poll.return_value = None
+        with tempfile.TemporaryDirectory() as root:
+            workdir = Path(root) / "owned"
+            workdir.mkdir()
+            with (
+                mock.patch.object(bench.tempfile, "mkdtemp", return_value=str(workdir)),
+                mock.patch.object(bench, "write_config"),
+                mock.patch.object(bench, "_start_server", return_value=fake_server),
+                mock.patch.object(bench, "wait_for_socket"),
+                mock.patch.object(bench, "spawn_client", return_value=fake_client),
+                mock.patch.object(bench, "initialize_client"),
+                mock.patch.object(bench, "invoke_search", return_value=sample("warmup")),
+                mock.patch.object(bench, "run_burst", side_effect=bench.BenchmarkFailure("burst-child-failed")),
+                mock.patch.object(bench, "_stop_server", return_value=[]) as stop_server,
+            ):
+                with self.assertRaisesRegex(bench.BenchmarkFailure, "burst-child-failed"):
+                    bench.run_repetition(
+                        2, moraine_mcp="mcp", clickhouse_url="http://clickhouse:8123", database="moraine",
+                        manifest=manifest(), recovery_count=0, recovery_offsets_s=(), startup_timeout_s=1,
+                        request_timeout_s=1, hard_deadline_ms=5_000,
+                    )
+            self.assertGreaterEqual(fake_client.close.call_count, 1)
+            stop_server.assert_called_once_with(fake_server)
+            self.assertFalse(workdir.exists())
+
+    def test_partial_measured_client_spawn_failure_closes_already_owned_children(self):
+        warmup_client, measured_client = mock.Mock(), mock.Mock()
+        for client in (warmup_client, measured_client):
+            client.close.return_value = []
+        server = mock.Mock()
+        with tempfile.TemporaryDirectory() as root:
+            workdir = Path(root) / "owned"
+            workdir.mkdir()
+            with (
+                mock.patch.object(bench.tempfile, "mkdtemp", return_value=str(workdir)),
+                mock.patch.object(bench, "write_config"),
+                mock.patch.object(bench, "_start_server", return_value=server),
+                mock.patch.object(bench, "wait_for_socket"),
+                mock.patch.object(
+                    bench,
+                    "spawn_client",
+                    side_effect=[
+                        warmup_client,
+                        measured_client,
+                        bench.BenchmarkFailure("client-startup-failed"),
+                    ],
+                ),
+                mock.patch.object(bench, "initialize_client"),
+                mock.patch.object(bench, "invoke_search", return_value=sample("warmup")),
+                mock.patch.object(bench, "_stop_server", return_value=[]),
+            ):
+                with self.assertRaisesRegex(bench.BenchmarkFailure, "client-startup-failed"):
+                    bench.run_repetition(
+                        2,
+                        moraine_mcp="mcp",
+                        clickhouse_url="http://clickhouse:8123",
+                        database="moraine",
+                        manifest=manifest(),
+                        recovery_count=0,
+                        recovery_offsets_s=(),
+                        startup_timeout_s=1,
+                        request_timeout_s=1,
+                        hard_deadline_ms=5_000,
+                    )
+            warmup_client.close.assert_called_once()
+            measured_client.close.assert_called_once()
+            self.assertFalse(workdir.exists())
+
+    def test_each_repetition_owns_fresh_service_config_clients_and_cache_state(self):
+        clients = [mock.Mock() for _ in range(4)]
+        for client in clients:
+            client.close.return_value = []
+        servers = [mock.Mock(), mock.Mock()]
+        burst = bench.BurstResult(1, [sample("measured-0")], 1.0, 1, True)
+        with tempfile.TemporaryDirectory() as root:
+            workdirs = [Path(root) / "rep-0", Path(root) / "rep-1"]
+            for workdir in workdirs:
+                workdir.mkdir()
+            with (
+                mock.patch.object(
+                    bench.tempfile, "mkdtemp", side_effect=[str(path) for path in workdirs]
+                ),
+                mock.patch.object(bench, "write_config") as write_config,
+                mock.patch.object(bench, "_start_server", side_effect=servers) as start_server,
+                mock.patch.object(bench, "wait_for_socket"),
+                mock.patch.object(bench, "spawn_client", side_effect=clients),
+                mock.patch.object(bench, "initialize_client"),
+                mock.patch.object(bench, "invoke_search", return_value=sample("warmup")),
+                mock.patch.object(bench, "run_burst", return_value=burst),
+                mock.patch.object(bench, "_stop_server", return_value=[]),
+            ):
+                for _ in range(2):
+                    bench.run_repetition(
+                        1,
+                        moraine_mcp="mcp",
+                        clickhouse_url="http://clickhouse:8123",
+                        database="moraine",
+                        manifest=manifest(),
+                        recovery_count=0,
+                        recovery_offsets_s=(),
+                        startup_timeout_s=1,
+                        request_timeout_s=1,
+                        hard_deadline_ms=5_000,
+                    )
+            self.assertEqual(start_server.call_count, 2)
+            config_paths = [call.args[0] for call in write_config.call_args_list]
+            self.assertEqual(len(config_paths), len(set(config_paths)))
+            self.assertTrue(all(not path.exists() for path in workdirs))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/bench/test_seed_concurrent_mcp_benchmark.py
+++ b/scripts/bench/test_seed_concurrent_mcp_benchmark.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Deterministic tests for seed_concurrent_mcp_benchmark.py."""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+from urllib.parse import parse_qs, urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import concurrent_mcp_retrieval as benchmark
+import seed_concurrent_mcp_benchmark as seed
+
+
+class SeedOracleTests(unittest.TestCase):
+    def test_oracle_is_seed_owned_distinct_and_loadable(self):
+        value = seed.build_oracle(100_000, 8, 2)
+        self.assertEqual(value["measured"][0]["result_count"], 1)
+        self.assertEqual(value["measured"][1]["result_count"], 10)
+        queries = [value["warmup"]["query"]] + [item["query"] for item in value["measured"] + value["recovery"]]
+        self.assertEqual(len(queries), len(set(queries)))
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "oracle.json"
+            path.write_text(json.dumps(value), encoding="utf-8")
+            loaded = benchmark.load_oracle(path, profile="full", needed_queries=8, recovery_count=2)
+        self.assertEqual(loaded.dataset_cardinality, 100_000)
+
+    def test_public_id_and_digest_match_benchmark_contract(self):
+        event = seed.public_id("event", seed.event_uid(1))
+        session = seed.public_id("session", seed.session_id(1))
+        expected = benchmark.sha256_json([{"event_id": event, "session_id": session}])
+        self.assertEqual(seed.result_digest([1]), expected)
+
+    def test_seed_sql_has_exact_cardinality_and_mixed_term_shapes(self):
+        sql = seed.seed_sql("moraine", 100_000, 64, 2)
+        self.assertIn("FROM numbers(100000)", sql)
+        self.assertIn("selective_", sql)
+        self.assertIn("common_", sql)
+        self.assertIn("recovery_", sql)
+        self.assertIn("warmupterm", sql)
+
+
+class SeedLifecycleTests(unittest.TestCase):
+    def test_seed_truncates_owned_tables_in_dependency_order_and_writes_oracle(self):
+        responses = ["", "", "", "", "", "200\n"]
+        with tempfile.TemporaryDirectory() as raw:
+            output = Path(raw) / "oracle.json"
+            with mock.patch.object(seed, "clickhouse_query", side_effect=responses) as query:
+                code = seed.main([
+                    "seed", "--documents", "200", "--measured-cases", "8",
+                    "--recovery-cases", "2", "--oracle-json", str(output),
+                ])
+            self.assertEqual(code, 0)
+            self.assertTrue(output.is_file())
+            statements = [call.args[1] for call in query.call_args_list]
+            self.assertEqual(
+                statements[:4],
+                [
+                    "TRUNCATE TABLE moraine.search_hit_log",
+                    "TRUNCATE TABLE moraine.search_query_log",
+                    "TRUNCATE TABLE moraine.search_postings",
+                    "TRUNCATE TABLE moraine.search_documents",
+                ],
+            )
+            self.assertIn("INSERT INTO moraine.search_documents", statements[4])
+
+    def test_clickhouse_query_preserves_existing_url_parameters(self):
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = b"ok"
+        with mock.patch.object(seed, "urlopen", return_value=response) as open_url:
+            self.assertEqual(
+                seed.clickhouse_query("http://clickhouse:8123/?database=moraine", "SELECT 1"),
+                "ok",
+            )
+        parsed = urlparse(open_url.call_args.args[0].full_url)
+        self.assertEqual(parse_qs(parsed.query), {"database": ["moraine"], "query": ["SELECT 1"]})
+
+    def test_clean_only_truncates_owned_tables(self):
+        with mock.patch.object(seed, "clickhouse_query", return_value="") as query:
+            code = seed.main(["clean", "--documents", "200", "--measured-cases", "8", "--recovery-cases", "2"])
+        self.assertEqual(code, 0)
+        self.assertEqual(query.call_count, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

**What.** Adds a reproducible concurrent, uncached `search_sessions` MCP benchmark with caller-selected parallelism and comparison-safe artifacts.

**Why.** Existing serial and cache-warm scenarios could report healthy results while overlapping production MCP requests degraded or crossed admission boundaries.

- Adds `concurrent_mcp_retrieval.py`, which emits one `moraine-benchmark-v1` artifact per exact concurrency value.
- Starts every repetition with a fresh central service, config, socket, and client set; every burst uses distinct seed-owned queries and a gated write/read boundary.
- Records per-request classifications, client/server latency, SLA fields, hard-deadline violations, throughput, overlap, maximum in-flight, and fixed-offset recovery probes.
- Adds a deterministic synthetic ClickHouse corpus/oracle seeder for smoke and >=100k-document full profiles.
- Extends the v1 benchmark schema with comparison fingerprints, outcome/observation records, and associated invariants without changing existing producer identities.
- Retains and explains a three-repetition 100k-document `1,2,4,8,16,32,64` evidence sweep in the testing guide.

Closes #523.

## Usage

Seed only an owned Linux dev sandbox:

```bash
python3 scripts/bench/seed_concurrent_mcp_benchmark.py seed \
  --clickhouse-url http://clickhouse:8123 --database moraine \
  --documents 100000 --measured-cases 64 --recovery-cases 2 \
  --oracle-json /tmp/concurrent-full-oracle.json
```

Run a caller-selected sweep:

```bash
python3 scripts/bench/concurrent_mcp_retrieval.py \
  --moraine-mcp /opt/moraine/bin/moraine-mcp \
  --clickhouse-url http://clickhouse:8123 --database moraine \
  --oracle-json /tmp/concurrent-full-oracle.json \
  --concurrency 1,2,4,8,16,32,64 --reps 3 --profile full \
  --request-timeout-seconds 20 --run-timeout-seconds 600 \
  --max-processes 70 --output-dir /tmp/concurrent-full
```

Concurrency is a workload input. The process cap and timeouts protect the runner; they do not define backend capacity. Recovery is fixed by profile, and the hard-deadline classification uses the documented five-second contract.

## Changelog

- Adds developer benchmark and deterministic seed tooling for concurrent uncached MCP retrieval.
- Extends benchmark-v1 artifact identity and per-request diagnostic records.
- No runtime configuration, schema migration, MCP contract, admission policy, SLA, or release behavior change.

## Benchmark Evidence

An owned Linux sandbox used 100,000 deterministic searchable documents and three fresh-service repetitions at each requested concurrency. All seven artifacts passed `benchmark_protocol.py validate`, and every arm reported overlap with `maximum_in_flight` equal to requested concurrency.

Successes plateaued at eight per repetition above concurrency 8: `3/3`, `6/6`, `12/12`, `24/24`, `24/48`, `24/96`, and `24/192`, with additional attempts classified as admission rejections. Successful p95 latency ranged from 69.0 ms to 243.9 ms; every successful response met its SLA and none crossed five seconds. The concurrency-64 recovery probes were 31.6/126.3, 43.2/108.2, and 34.7/103.1 ms at fixed 0/10-second offsets. These observations remain diagnostic with `timing.status=not_evaluated`.

## Operational Impact

Benchmark tooling only. The seeder truncates four search tables and is explicitly restricted to an owned sandbox. Each benchmark repetition cleans up its MCP children, socket, config, root, and temporary directory; sandbox teardown owns ClickHouse volumes.

## Validation

Ran `python3 -m unittest discover -s scripts/bench -p 'test_*.py' -v`: 122 tests passed, including every pre-existing serial/resource producer suite. Ran `python3 -m unittest discover -s scripts/bench/tests -p 'test_benchmark_protocol.py' -v`: 30 protocol tests passed.

Ran the live smoke and the full 100k-document Linux sandbox sweep through the production stdio-to-central MCP boundary. Validated every emitted smoke/full artifact with `python3 scripts/bench/benchmark_protocol.py validate`; all passed. Both owned sandboxes were torn down successfully.

A seven-persona review covered elegance, idiom, correctness, completeness, security, YAGNI, and scope. Accepted findings were fixed and the affected reviewers confirmed no remaining findings.