### PR TITLE
perf(search): accelerate MCP cached-posting ranking

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -13,6 +13,13 @@ pub(super) struct SearchScoreAccum<'a> {
     pub(super) matched_mask: u64,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(super) struct RankedPosting<'a> {
+    pub(super) row: &'a CachedPostingRow,
+    pub(super) score: f64,
+    pub(super) matched_terms: u64,
+}
+
 impl ClickHouseConversationRepository {
     pub async fn search_session_metadata(
         &self,
@@ -735,6 +742,93 @@ FORMAT JSONEachRow",
         idf.max(0.0)
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn rank_cached_postings<'a>(
+        terms: &[String],
+        postings_by_term: &'a HashMap<String, Arc<[CachedPostingRow]>>,
+        df_by_term: &HashMap<String, u64>,
+        docs: u64,
+        avgdl: f64,
+        k1: f64,
+        b: f64,
+        min_should_match: u16,
+        min_score: f64,
+    ) -> Vec<RankedPosting<'a>> {
+        let posting_count = terms
+            .iter()
+            .take(64)
+            .filter_map(|term| postings_by_term.get(term))
+            .map(|rows| rows.len())
+            .sum::<usize>();
+        let initial_capacity = usize::try_from(docs)
+            .unwrap_or(usize::MAX)
+            .min(posting_count)
+            .min(TERM_POSTINGS_CACHE_MAX_ROWS_TOTAL);
+        let mut index_by_uid = HashMap::<&str, u32>::with_capacity(initial_capacity);
+        let mut accum_by_uid = Vec::<SearchScoreAccum<'a>>::with_capacity(initial_capacity);
+        let bm25_base = k1 * (1.0 - b);
+        let bm25_length_scale = k1 * b / avgdl.max(1.0);
+        for (idx, term) in terms.iter().take(64).enumerate() {
+            let df = *df_by_term.get(term).unwrap_or(&0);
+            let idf = Self::bm25_idf(docs, df);
+            if idf <= 0.0 {
+                continue;
+            }
+
+            if let Some(rows) = postings_by_term.get(term) {
+                for row in rows.iter() {
+                    let entry_index =
+                        *index_by_uid
+                            .entry(row.event_uid.as_str())
+                            .or_insert_with(|| {
+                                let index = u32::try_from(accum_by_uid.len())
+                                    .expect("posting candidate count exceeds u32");
+                                accum_by_uid.push(SearchScoreAccum {
+                                    row,
+                                    score: 0.0,
+                                    matched_mask: 0,
+                                });
+                                index
+                            }) as usize;
+                    let entry = &mut accum_by_uid[entry_index];
+                    let tf = f64::from(row.tf);
+                    let norm = tf + bm25_base + bm25_length_scale * f64::from(row.doc_len);
+                    entry.score += idf * tf * (k1 + 1.0) / norm;
+                    entry.matched_mask |= 1u64 << idx;
+                }
+            }
+        }
+
+        let mut candidates = Vec::<RankedPosting<'a>>::with_capacity(accum_by_uid.len());
+        for acc in &accum_by_uid {
+            let matched_terms = acc.matched_mask.count_ones() as u64;
+            if matched_terms < min_should_match as u64 || acc.score < min_score {
+                continue;
+            }
+            candidates.push(RankedPosting {
+                row: acc.row,
+                score: acc.score,
+                matched_terms,
+            });
+        }
+        Self::order_ranked_posting_prefix(&mut candidates, 256);
+        candidates
+    }
+
+    fn compare_ranked_postings(a: &RankedPosting<'_>, b: &RankedPosting<'_>) -> std::cmp::Ordering {
+        b.score
+            .total_cmp(&a.score)
+            .then_with(|| a.row.event_uid.cmp(&b.row.event_uid))
+    }
+
+    fn order_ranked_posting_prefix(candidates: &mut [RankedPosting<'_>], prefix_len: usize) {
+        let prefix_len = prefix_len.min(candidates.len());
+        if prefix_len < candidates.len() {
+            candidates.select_nth_unstable_by(prefix_len, Self::compare_ranked_postings);
+        }
+        candidates[..prefix_len].sort_unstable_by(Self::compare_ranked_postings);
+    }
+
     pub(super) fn has_broad_fast_path_term(
         terms: &[String],
         df_by_term: &HashMap<String, u64>,
@@ -1136,13 +1230,6 @@ FORMAT JSONEachRow",
         min_score: f64,
         limit: u16,
     ) -> RepoResult<Vec<SearchMcpEventRow>> {
-        #[derive(Clone, Copy)]
-        struct CandidateRef<'a> {
-            row: &'a CachedPostingRow,
-            score: f64,
-            matched_terms: u64,
-        }
-
         let df_map = self.df_map(terms).await?;
         if Self::has_broad_fast_path_term(terms, &df_map, docs) {
             return Ok(Vec::new());
@@ -1150,62 +1237,17 @@ FORMAT JSONEachRow",
 
         let postings_by_term = self.load_term_postings_for_terms(terms).await?;
         let use_document_codex_flag = self.search_documents_has_codex_flag().await?;
-        let k1 = self.cfg.bm25_k1.max(0.01);
-        let b = self.cfg.bm25_b.clamp(0.0, 1.0);
-        let mut idf_by_term = HashMap::<&str, f64>::new();
-        for term in terms {
-            let df = *df_map.get(term).unwrap_or(&0);
-            idf_by_term.insert(term.as_str(), Self::bm25_idf(docs, df));
-        }
-
-        let mut accum_by_uid = HashMap::<&str, SearchScoreAccum<'_>>::new();
-        for (idx, term) in terms.iter().enumerate() {
-            if idx >= 64 {
-                break;
-            }
-            let idf = *idf_by_term.get(term.as_str()).unwrap_or(&0.0);
-            if idf <= 0.0 {
-                continue;
-            }
-
-            if let Some(rows) = postings_by_term.get(term) {
-                for row in rows.iter() {
-                    let entry = accum_by_uid
-                        .entry(row.event_uid.as_str())
-                        .or_insert_with(|| SearchScoreAccum {
-                            row,
-                            score: 0.0,
-                            matched_mask: 0,
-                        });
-
-                    entry.score += idf * Self::bm25_term_score(row.tf, row.doc_len, avgdl, k1, b);
-                    entry.matched_mask |= 1u64 << idx;
-                }
-            }
-        }
-
-        let mut candidates = Vec::<CandidateRef<'_>>::new();
-        for acc in accum_by_uid.values() {
-            let matched_terms = acc.matched_mask.count_ones() as u64;
-            if matched_terms < min_should_match as u64 || acc.score < min_score {
-                continue;
-            }
-            candidates.push(CandidateRef {
-                row: acc.row,
-                score: acc.score,
-                matched_terms,
-            });
-        }
-
-        if candidates.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        candidates.sort_by(|a, b| {
-            b.score
-                .total_cmp(&a.score)
-                .then_with(|| a.row.event_uid.cmp(&b.row.event_uid))
-        });
+        let mut candidates = Self::rank_cached_postings(
+            terms,
+            &postings_by_term,
+            &df_map,
+            docs,
+            avgdl,
+            self.cfg.bm25_k1.max(0.01),
+            self.cfg.bm25_b.clamp(0.0, 1.0),
+            min_should_match,
+            min_score,
+        );
 
         let mut rows = Vec::<SearchMcpEventRow>::new();
         let target_rows = (limit as usize)
@@ -1214,7 +1256,12 @@ FORMAT JSONEachRow",
             .min(256);
         let hydrate_chunk_size = target_rows.max(128);
         let mut offset = 0usize;
+        let mut remaining_candidates_sorted = false;
         while offset < candidates.len() && rows.len() < target_rows {
+            if offset > 0 && !remaining_candidates_sorted {
+                candidates[offset..].sort_unstable_by(Self::compare_ranked_postings);
+                remaining_candidates_sorted = true;
+            }
             let end = (offset + hydrate_chunk_size).min(candidates.len());
             let event_uids: Vec<String> = candidates[offset..end]
                 .iter()

--- a/crates/moraine-conversations/src/clickhouse_repo/tests.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/tests.rs
@@ -1,4 +1,5 @@
 use super::file_attention::merge_file_attention_touches;
+use super::search::{RankedPosting, SearchScoreAccum};
 use super::*;
 
 fn sample_search_doc() -> SearchDocExtraCacheEntry {
@@ -533,4 +534,130 @@ fn open_context_filter_clause_respects_include_system_events_flag() {
     assert!(filtered_clause.contains("progress"));
     assert!(filtered_clause.contains("file_history_snapshot"));
     assert!(filtered_clause.contains("lowerUTF8(actor_role) = 'system'"));
+}
+
+#[test]
+fn cached_posting_ranker_matches_full_sort_reference() {
+    let posting = |event_uid: &str, doc_len: u32, tf: u16| CachedPostingRow {
+        event_uid: event_uid.to_string(),
+        doc_len,
+        tf,
+    };
+    let terms = ["alpha", "beta", "gamma"]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let mut alpha_rows = vec![
+        posting("u1", 100, 2),
+        posting("u2", 120, 1),
+        posting("tie-a", 100, 1),
+    ];
+    let mut beta_rows = vec![
+        posting("u1", 100, 1),
+        posting("u3", 80, 4),
+        posting("tie-b", 100, 1),
+    ];
+    for doc in 0..300 {
+        let event_uid = format!("bulk-{doc:03}");
+        alpha_rows.push(posting(&event_uid, 100, 1));
+        beta_rows.push(posting(&event_uid, 100, 1));
+    }
+    let postings_by_term = HashMap::<String, Arc<[CachedPostingRow]>>::from([
+        (
+            "alpha".to_string(),
+            Arc::from(alpha_rows.into_boxed_slice()),
+        ),
+        ("beta".to_string(), Arc::from(beta_rows.into_boxed_slice())),
+        (
+            "gamma".to_string(),
+            Arc::from(
+                vec![
+                    posting("u2", 120, 3),
+                    posting("u3", 80, 1),
+                    posting("tie-a", 100, 1),
+                    posting("tie-b", 100, 1),
+                ]
+                .into_boxed_slice(),
+            ),
+        ),
+    ]);
+    let df_by_term = postings_by_term
+        .iter()
+        .map(|(term, rows)| (term.clone(), rows.len() as u64))
+        .collect::<HashMap<_, _>>();
+    let docs = 100_u64;
+    let avgdl = 100.0;
+    let k1 = 1.2;
+    let b = 0.75;
+    let min_should_match = 2;
+
+    let actual = ClickHouseConversationRepository::rank_cached_postings(
+        &terms,
+        &postings_by_term,
+        &df_by_term,
+        docs,
+        avgdl,
+        k1,
+        b,
+        min_should_match,
+        0.0,
+    );
+
+    let mut reference_by_uid = HashMap::<&str, SearchScoreAccum<'_>>::new();
+    for (idx, term) in terms.iter().enumerate() {
+        let idf = ClickHouseConversationRepository::bm25_idf(docs, df_by_term[term]);
+        for row in postings_by_term[term].iter() {
+            let entry =
+                reference_by_uid
+                    .entry(row.event_uid.as_str())
+                    .or_insert(SearchScoreAccum {
+                        row,
+                        score: 0.0,
+                        matched_mask: 0,
+                    });
+            entry.score += idf
+                * ClickHouseConversationRepository::bm25_term_score(
+                    row.tf,
+                    row.doc_len,
+                    avgdl,
+                    k1,
+                    b,
+                );
+            entry.matched_mask |= 1_u64 << idx;
+        }
+    }
+    let mut expected = reference_by_uid
+        .into_values()
+        .filter_map(|acc| {
+            let matched_terms = u64::from(acc.matched_mask.count_ones());
+            (matched_terms >= u64::from(min_should_match)).then_some(RankedPosting {
+                row: acc.row,
+                score: acc.score,
+                matched_terms,
+            })
+        })
+        .collect::<Vec<_>>();
+    expected.sort_unstable_by(|a, b| {
+        b.score
+            .total_cmp(&a.score)
+            .then_with(|| a.row.event_uid.cmp(&b.row.event_uid))
+    });
+
+    assert_eq!(actual.len(), expected.len());
+    assert!(actual.len() > 256, "fixture must exercise partial ordering");
+    assert_eq!(
+        expected[255].score, expected[256].score,
+        "fixture must place a score tie across the partial-order boundary"
+    );
+    for (actual, expected) in actual.iter().zip(&expected).take(256) {
+        assert_eq!(actual.row.event_uid, expected.row.event_uid);
+        assert_eq!(actual.matched_terms, expected.matched_terms);
+        assert!(
+            (actual.score - expected.score).abs() < 1e-12,
+            "score mismatch for {}: {} != {}",
+            actual.row.event_uid,
+            actual.score,
+            expected.score
+        );
+    }
 }


### PR DESCRIPTION
## Description

**What.** Speeds up the MCP event cached-posting ranking path by reducing ordering work, moving score accumulation into contiguous storage, and hoisting invariant BM25 arithmetic.

**Why.** The fast path spent most of its CPU fully sorting candidates and repeatedly paying hash-table/allocation costs before it could hydrate the small prefix needed by MCP search.

The production change has three parts:

1. **Order only the first hydration prefix.** `select_nth_unstable_by` partitions the best 256 candidates, then only that prefix is sorted. If filters exhaust it, the remaining suffix is sorted exactly once. This keeps the common path cheap while bounding rejection-heavy work at $O(N \log N)$.
2. **Make the scoring loop cheaper.** Candidate storage is reserved once, and query-invariant BM25 length-normalization terms are computed before walking postings.
3. **Separate lookup from accumulation.** The hash map stores only `event_uid → u32 index`; scores, matched-term masks, and row references live in a contiguous vector. Initial reservation is capped by the document count, posting count, and the existing 262,144-row cache budget, preventing overlapping term lists from amplifying eager allocation.

A non-timing regression test compares more than 256 optimized candidates against a straightforward full-sort reference, including BM25 scores, matched-term counts, UID tie-breaking, filtering, and a score tie across the partial-order boundary.

![Optimization research progress](https://gist.githubusercontent.com/eric-tramel/6f9e3062b9aa903dfce59fd16953a26c/raw/autoresearch-retrieval-progress.svg)

## Performance

### Production MCP boundary

The repository's full `concurrent_mcp_retrieval.py` benchmark compared release binaries from `main` and this PR against the same owned 100,000-document ClickHouse corpus. The `1,2,4,8,16,32` caller sweep used six fresh-service repetitions per concurrency with order reversed between passes.

Across the sweep, geometric-mean deltas were:

- **p50 latency: −5.7%**
- **p95 latency: −10.5%**
- **successful throughput: +7.7%**

Individual points were mixed: concurrency 4 regressed, while concurrency 8 and 32 improved materially. All 24 artifacts passed `benchmark_protocol.py validate`; every semantic oracle passed; admission behavior, errors, deadlines, and timeouts were identical between builds.

### Linux resource boundary

The full central MCP resource benchmark ran release `aarch64-unknown-linux-gnu` binaries at `N=1,10,50,100`, three repetitions each:

- Central-server RSS was flat to **1.3% lower**.
- Total RSS was **1.3–2.0% lower**.
- Marginal RSS per client was **1.8–3.7% lower**.
- Both artifacts and their independent result-fingerprint oracles passed.

Full commands, per-concurrency tables, caveats, and artifact semantics are recorded in the [benchmark comparison](https://github.com/eric-tramel/moraine/pull/525#issuecomment-4958859047) and [final validation summary](https://github.com/eric-tramel/moraine/pull/525#issuecomment-4958891641).

The built-in comparator reports `timing.status=not_evaluated` / `reason=missing_comparison_policy`, as required by repository policy. These measurements are diagnostic, not merge-gating assertions.

## Usage

No user or operator action is required. Search APIs, ranking semantics, configuration, and schemas are unchanged. Broad terms continue to bypass the cached-posting fast path through the existing guard.

## Changelog

- Speeds up MCP cached-posting BM25 ranking with partial prefix ordering and compact contiguous accumulators.
- Bounds eager ranking allocation and rejection-heavy suffix ordering.
- No configuration, schema, API, or operational migration change.

## Validation

`cargo test -p moraine-conversations --lib --locked` passes the full library suite, including the full-sort ranking oracle. `cargo test -p moraine-conversations --test repository_integration --locked` passes all 80 repository integration tests.

`cargo fmt --all -- --check` and `cargo clippy -p moraine-conversations --lib --locked -- -D warnings` pass.

The full built-in benchmark validation is linked above. All temporary benchmark worktrees, sandboxes, ClickHouse data, and owned volumes were removed after artifact collection.
