### PR TITLE
feat(mcp): filter retrieval by harness and source

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo/cache.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/cache.rs
@@ -267,6 +267,8 @@ impl ClickHouseConversationRepository {
         terms: &[String],
         event_types: &[McpEventType],
         session_id: Option<&str>,
+        harness: Option<&str>,
+        source_name: Option<&str>,
         turn_seq: Option<u32>,
         min_should_match: u16,
         min_score: f64,
@@ -277,15 +279,19 @@ impl ClickHouseConversationRepository {
         let event_type_sig = event_types
             .iter()
             .map(|event_type| event_type.as_str())
-            .collect::<Vec<_>>()
-            .join(",");
-        format!(
-            "event_types={event_type_sig};session={};turn_seq={};msm={min_should_match};min_score={:016x};limit={effective_n_hits};terms={}",
-            session_id.unwrap_or(""),
-            turn_seq.unwrap_or(0),
+            .collect::<Vec<_>>();
+        serde_json::to_string(&(
+            event_type_sig,
+            session_id,
+            turn_seq,
+            harness,
+            source_name,
+            min_should_match,
             min_score.to_bits(),
-            cache_terms.join(",")
-        )
+            effective_n_hits,
+            cache_terms,
+        ))
+        .expect("MCP search cache key contains only serializable primitives")
     }
 
     pub(super) async fn search_mcp_events_cache_get(

--- a/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
@@ -120,6 +120,9 @@ impl ClickHouseConversationRepository {
         if let Some(tool) = query.tool.as_deref() {
             inner_clauses.push(format!("lower(tool_name) = lower({})", sql_quote(tool)));
         }
+        if let Some(harness) = query.harness.as_deref() {
+            inner_clauses.push(format!("harness = {}", sql_quote(harness)));
+        }
         if query.mutations_only {
             inner_clauses.push(format!(
                 "lowerUTF8(tool_name) NOT IN ({FILE_ATTENTION_READ_TOOL_NAMES_SQL})"
@@ -136,6 +139,9 @@ impl ClickHouseConversationRepository {
         }
         if let Some(end) = query.end_unix_ms {
             outer_clauses.push(format!("toUnixTimestamp64Milli(tr.event_time) < {end}"));
+        }
+        if let Some(source_name) = query.source_name.as_deref() {
+            outer_clauses.push(format!("e.source_name = {}", sql_quote(source_name)));
         }
         let outer_where = if outer_clauses.is_empty() {
             "1".to_string()
@@ -164,6 +170,7 @@ impl ClickHouseConversationRepository {
     ti.event_uid AS event_uid,
     ti.tool_call_id AS tool_call_id,
     ti.harness AS harness,
+    ifNull(e.source_name, '') AS source_name,
     ti.tool_name AS tool_name,
     ti.tool_phase AS tool_phase,
     if({normalized_root_condition}, concat(ti.worktree_root, '/', ti.repo_rel_path), ti.repo_rel_path) AS matched_path,
@@ -182,7 +189,7 @@ impl ClickHouseConversationRepository {
     WHERE (session_id, event_uid) IN (SELECT session_id, event_uid FROM matched)
   ) AS tr ON tr.session_id = ti.session_id AND tr.event_uid = ti.event_uid
   ANY LEFT JOIN (
-    SELECT session_id, event_uid, any(cwd) AS cwd
+    SELECT session_id, event_uid, any(cwd) AS cwd, any(source_name) AS source_name
     FROM {events_source}
     WHERE (session_id, event_uid) IN (SELECT session_id, event_uid FROM matched)
     GROUP BY session_id, event_uid
@@ -308,6 +315,9 @@ SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
         if let Some(tool) = query.tool.as_deref() {
             inner_clauses.push(format!("lower(tool_name) = lower({})", sql_quote(tool)));
         }
+        if let Some(harness) = query.harness.as_deref() {
+            inner_clauses.push(format!("harness = {}", sql_quote(harness)));
+        }
         if query.mutations_only {
             inner_clauses.push(format!(
                 "lowerUTF8(tool_name) NOT IN ({FILE_ATTENTION_READ_TOOL_NAMES_SQL})"
@@ -364,6 +374,9 @@ SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
         }
         if let Some(end) = query.end_unix_ms {
             outer_clauses.push(format!("toUnixTimestamp64Milli(tr.event_time) < {end}"));
+        }
+        if let Some(source_name) = query.source_name.as_deref() {
+            outer_clauses.push(format!("e.source_name = {}", sql_quote(source_name)));
         }
         if query.apply_project_scope {
             let project_id = query
@@ -446,6 +459,7 @@ SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
     ti.event_uid AS event_uid,
     ti.tool_call_id AS tool_call_id,
     ti.harness AS harness,
+    ifNull(e.source_name, '') AS source_name,
     ti.tool_name AS tool_name,
     ti.tool_phase AS tool_phase,
     {matched_path_expr} AS matched_path,
@@ -464,7 +478,7 @@ SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
     WHERE (session_id, event_uid) IN (SELECT session_id, event_uid FROM matched)
   ) AS tr ON tr.session_id = ti.session_id AND tr.event_uid = ti.event_uid
   ANY LEFT JOIN (
-    SELECT session_id, event_uid, any(cwd) AS cwd{normalized_event_columns}
+    SELECT session_id, event_uid, any(cwd) AS cwd, any(source_name) AS source_name{normalized_event_columns}
     FROM {events_source}
     WHERE (session_id, event_uid) IN (SELECT session_id, event_uid FROM matched)
     GROUP BY session_id, event_uid

--- a/crates/moraine-conversations/src/clickhouse_repo/helpers.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/helpers.rs
@@ -74,23 +74,19 @@ FROM {events_source}
         // The session scope participates in the signature so a cursor minted
         // by an unscoped (or differently scoped) server is rejected instead
         // of silently resuming with different visibility.
-        let scope = self
-            .cfg
-            .session_scope
-            .as_ref()
-            .map(|scope| scope.roots.join(","))
-            .unwrap_or_else(|| "__none__".to_string());
-        format!(
-            "start={};end={};mode={};sort={};scope={}",
+        serde_json::to_string(&(
             filter.start_unix_ms,
             filter.end_unix_ms,
-            filter
-                .mode
-                .map(ConversationMode::as_str)
-                .unwrap_or("__none__"),
+            filter.mode.map(ConversationMode::as_str),
+            filter.harness.as_deref(),
+            filter.source_name.as_deref(),
             filter.sort.as_str(),
-            scope,
-        )
+            self.cfg
+                .session_scope
+                .as_ref()
+                .map(|scope| scope.roots.as_slice()),
+        ))
+        .expect("list_sessions cursor filter contains only serializable primitives")
     }
 
     pub(super) fn turn_filter_sig(session_id: &str, filter: &TurnListFilter) -> String {

--- a/crates/moraine-conversations/src/clickhouse_repo/list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/list.rs
@@ -219,22 +219,34 @@ FORMAT JSONEachRow",
             ConversationListSort::Asc => "ASC",
         };
         let limit_plus = (limit as usize) + 1;
-        let window_limit_sql = if filter.mode.is_none() {
+        let window_limit_sql = if filter.mode.is_none()
+            && filter.harness.is_none()
+            && filter.source_name.is_none()
+        {
             format!(
-                "  ORDER BY s.last_event_time {order_dir}, s.session_id {order_dir}\n  LIMIT {limit_plus}\n"
-            )
+                    "  ORDER BY s.last_event_time {order_dir}, s.session_id {order_dir}\n  LIMIT {limit_plus}\n"
+                )
         } else {
             String::new()
         };
-        let mode_filter_sql = filter
-            .mode
-            .map(|mode| {
-                format!(
-                    "WHERE ifNull(r.mode, 'chat') = {}\n",
-                    sql_quote(mode.as_str())
-                )
-            })
-            .unwrap_or_default();
+        let mut event_filter_clauses = Vec::new();
+        if let Some(mode) = filter.mode {
+            event_filter_clauses.push(format!(
+                "ifNull(r.mode, 'chat') = {}",
+                sql_quote(mode.as_str())
+            ));
+        }
+        if let Some(harness) = filter.harness.as_deref() {
+            event_filter_clauses.push(format!("r.latest_harness = {}", sql_quote(harness)));
+        }
+        if let Some(source_name) = filter.source_name.as_deref() {
+            event_filter_clauses.push(format!("r.latest_source_name = {}", sql_quote(source_name)));
+        }
+        let event_filter_sql = if event_filter_clauses.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}\n", event_filter_clauses.join("\n    AND "))
+        };
         let mode_aggregate = Self::mode_aggregate_sql();
 
         // Resolve the time/scope window first, applying the keyset LIMIT before
@@ -278,17 +290,8 @@ event_rollups AS (
       ),
       ''
     ) AS title,
-    ifNull(
-      argMaxIf(
-        coalesce(
-          nullIf(JSONExtractString(payload_json, 'source'), ''),
-          nullIf(source_name, '')
-        ),
-        tuple(event_ts, event_uid),
-        event_kind = 'session_meta'
-      ),
-      ''
-    ) AS source,
+    ifNull(argMax(nullIf(e.harness, ''), tuple(event_ts, event_uid)), '') AS latest_harness,
+    ifNull(argMax(nullIf(e.source_name, ''), tuple(event_ts, event_uid)), '') AS latest_source_name,
     ifNull(
       argMaxIf(
         nullIf(JSONExtractString(payload_json, 'slug'), ''),
@@ -309,7 +312,7 @@ event_rollups AS (
       ),
       ''
     ) AS session_summary
-  FROM {events_source}
+  FROM {events_source} AS e
   WHERE session_id IN (SELECT session_id FROM window_sessions)
   GROUP BY session_id
 ),
@@ -328,12 +331,13 @@ candidate_sessions AS (
       AND ifNull(r.latest_terminal_payload_type, '') = 'task_complete'
     ) AS completed,
     ifNull(r.title, '') AS title,
-    ifNull(r.source, '') AS source,
+    ifNull(r.latest_source_name, '') AS source,
+    ifNull(r.latest_harness, '') AS harness,
     ifNull(r.session_slug, '') AS session_slug,
     ifNull(r.session_summary, '') AS session_summary
   FROM window_sessions AS w
   LEFT JOIN event_rollups AS r ON r.session_id = w.session_id
-  {mode_filter_sql}ORDER BY w.last_event_unix_ms {order_dir}, w.session_id {order_dir}
+  {event_filter_sql}ORDER BY w.last_event_unix_ms {order_dir}, w.session_id {order_dir}
   LIMIT {limit_plus}
 )
 SELECT
@@ -348,6 +352,7 @@ SELECT
   completed,
   title,
   source,
+  harness,
   session_slug,
   session_summary
 FROM candidate_sessions
@@ -358,7 +363,7 @@ FORMAT JSONEachRow",
             where_sql = where_sql,
             mode_aggregate = mode_aggregate,
             window_limit_sql = window_limit_sql,
-            mode_filter_sql = mode_filter_sql,
+            event_filter_sql = event_filter_sql,
             order_dir = order_dir,
             limit_plus = limit_plus,
         );

--- a/crates/moraine-conversations/src/clickhouse_repo/rows.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/rows.rs
@@ -66,6 +66,8 @@ pub(super) struct McpSessionListRow {
     #[serde(default)]
     pub(super) source: String,
     #[serde(default)]
+    pub(super) harness: String,
+    #[serde(default)]
     pub(super) session_slug: String,
     #[serde(default)]
     pub(super) session_summary: String,
@@ -451,6 +453,7 @@ impl ClickHouseConversationRepository {
             completed: row.completed != 0,
             title: non_empty_string(row.title),
             source: non_empty_string(row.source),
+            harness: non_empty_string(row.harness),
             session_slug: non_empty_string(row.session_slug),
             session_summary: non_empty_string(row.session_summary),
         }

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -425,6 +425,8 @@ FORMAT JSONEachRow",
         event_types: &[McpEventType],
         session_id: Option<&str>,
         turn_seq: Option<u32>,
+        harness: Option<&str>,
+        source_name: Option<&str>,
         min_should_match: u16,
         min_score: f64,
         limit: u16,
@@ -484,6 +486,12 @@ GROUP BY t.event_uid)"
             ));
         } else if let Some(session_id) = session_id {
             where_clauses.push(format!("d.session_id = {}", sql_quote(session_id)));
+        }
+        if let Some(harness) = harness {
+            where_clauses.push(format!("d.harness = {}", sql_quote(harness)));
+        }
+        if let Some(source_name) = source_name {
+            where_clauses.push(format!("d.source_name = {}", sql_quote(source_name)));
         }
         where_clauses.push(Self::mcp_event_type_filter_clause(
             "d.event_class",
@@ -1168,6 +1176,8 @@ FORMAT JSONEachRow",
         event_types: &[McpEventType],
         session_id: Option<&str>,
         turn_seq: Option<u32>,
+        harness: Option<&str>,
+        source_name: Option<&str>,
         min_should_match: u16,
         min_score: f64,
         limit: u16,
@@ -1184,6 +1194,8 @@ FORMAT JSONEachRow",
                     avgdl,
                     event_types,
                     session_id,
+                    harness,
+                    source_name,
                     min_should_match,
                     min_score,
                     limit,
@@ -1208,6 +1220,8 @@ FORMAT JSONEachRow",
             event_types,
             session_id,
             turn_seq,
+            harness,
+            source_name,
             min_should_match,
             min_score,
             limit,
@@ -1226,6 +1240,8 @@ FORMAT JSONEachRow",
         avgdl: f64,
         event_types: &[McpEventType],
         session_id: Option<&str>,
+        harness: Option<&str>,
+        source_name: Option<&str>,
         min_should_match: u16,
         min_score: f64,
         limit: u16,
@@ -1276,6 +1292,12 @@ FORMAT JSONEachRow",
                     continue;
                 };
                 if session_id.is_some_and(|session_id| extra.session_id != session_id) {
+                    continue;
+                }
+                if harness.is_some_and(|harness| extra.harness != harness) {
+                    continue;
+                }
+                if source_name.is_some_and(|source_name| extra.source_name != source_name) {
                     continue;
                 }
                 let event_type = Self::mcp_event_type_for(
@@ -2887,6 +2909,8 @@ FORMAT JSONEachRow",
             &terms,
             &event_types,
             query.session_id.as_deref(),
+            query.harness.as_deref(),
+            query.source_name.as_deref(),
             query.turn_seq,
             min_should_match,
             min_score,
@@ -2907,6 +2931,8 @@ FORMAT JSONEachRow",
                     &event_types,
                     query.session_id.as_deref(),
                     query.turn_seq,
+                    query.harness.as_deref(),
+                    query.source_name.as_deref(),
                     min_should_match,
                     min_score,
                     fetch_limit,

--- a/crates/moraine-conversations/src/clickhouse_repo/tests.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/tests.rs
@@ -97,6 +97,7 @@ fn sample_file_attention_touch(
         event_uid: event_uid.to_string(),
         tool_call_id: tool_call_id.to_string(),
         harness: "codex".to_string(),
+        source_name: "codex".to_string(),
         tool_name: "Edit".to_string(),
         tool_phase: "request".to_string(),
         match_kind: "path_suffix".to_string(),

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -59,6 +59,10 @@ pub struct McpSessionListFilter {
     pub mode: Option<ConversationMode>,
     #[serde(default)]
     pub sort: ConversationListSort,
+    #[serde(default)]
+    pub harness: Option<String>,
+    #[serde(default)]
+    pub source_name: Option<String>,
 }
 
 /// A single file-touch query for `file_attention`: every captured tool call
@@ -88,6 +92,10 @@ pub struct FileAttentionQuery {
     pub apply_project_scope: bool,
     pub start_unix_ms: Option<i64>,
     pub end_unix_ms: Option<i64>,
+    /// Restrict to one normalized harness name; `None` matches every harness.
+    pub harness: Option<String>,
+    /// Restrict to one configured ingest source name; `None` matches every source.
+    pub source_name: Option<String>,
     /// Restrict to one tool name (case-insensitive); `None` matches all tools.
     pub tool: Option<String>,
     /// Drop common pure-read touches.
@@ -111,6 +119,8 @@ pub struct FileAttentionTouch {
     pub tool_call_id: String,
     #[serde(default)]
     pub harness: String,
+    #[serde(default)]
+    pub source_name: String,
     #[serde(default)]
     pub tool_name: String,
     #[serde(default)]
@@ -394,6 +404,8 @@ pub struct McpSessionListItem {
     pub title: Option<String>,
     #[serde(default)]
     pub source: Option<String>,
+    #[serde(default)]
+    pub harness: Option<String>,
     #[serde(default)]
     pub session_slug: Option<String>,
     #[serde(default)]
@@ -711,6 +723,10 @@ pub struct SearchMcpEventsQuery {
     pub turn_seq: Option<u32>,
     #[serde(default)]
     pub event_types: Option<Vec<McpEventType>>,
+    #[serde(default)]
+    pub harness: Option<String>,
+    #[serde(default)]
+    pub source_name: Option<String>,
     #[serde(default)]
     pub min_score: Option<f64>,
     #[serde(default)]

--- a/crates/moraine-conversations/tests/repository_integration/cache.rs
+++ b/crates/moraine-conversations/tests/repository_integration/cache.rs
@@ -59,16 +59,49 @@ async fn search_mcp_events_result_cache_reuses_repository_across_requests() {
         .remove("took_ms");
     assert_eq!(first_payload, second_payload);
 
-    let requests_before_changed_option = state.queries.lock().expect("queries lock").len();
+    let requests_before_changed_harness = state.queries.lock().expect("queries lock").len();
     repo.search_mcp_events(SearchMcpEventsQuery {
-        turn_seq: Some(2),
+        harness: Some("codex".to_string()),
+        ..query.clone()
+    })
+    .await
+    .expect("MCP event search with changed harness");
+    assert!(
+        state.queries.lock().expect("queries lock").len() > requests_before_changed_harness,
+        "changed harness must miss the result cache"
+    );
+
+    let requests_before_changed_source = state.queries.lock().expect("queries lock").len();
+    repo.search_mcp_events(SearchMcpEventsQuery {
+        source_name: Some("codex".to_string()),
+        ..query.clone()
+    })
+    .await
+    .expect("MCP event search with changed source");
+    assert!(
+        state.queries.lock().expect("queries lock").len() > requests_before_changed_source,
+        "changed source must miss the result cache"
+    );
+
+    repo.search_mcp_events(SearchMcpEventsQuery {
+        harness: Some("codex".to_string()),
+        source_name: Some("custom;source=bar".to_string()),
+        ..query.clone()
+    })
+    .await
+    .expect("MCP event search with delimiter-bearing source");
+    let requests_after_delimited_filter = state.queries.lock().expect("queries lock").len();
+
+    repo.search_mcp_events(SearchMcpEventsQuery {
+        harness: Some("codex;source=custom".to_string()),
+        source_name: Some("bar".to_string()),
         ..query
     })
     .await
-    .expect("MCP event search with changed turn scope");
+    .expect("MCP event search with distinct delimiter-bearing harness");
     assert!(
-        state.queries.lock().expect("queries lock").len() > requests_before_changed_option,
-        "changed normalized search semantics must miss the result cache"
+        state.queries.lock().expect("queries lock").len() > requests_after_delimited_filter,
+        "distinct delimiter-bearing filters must miss the result cache"
     );
 }
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/moraine-conversations/tests/repository_integration/file_attention.rs
+++ b/crates/moraine-conversations/tests/repository_integration/file_attention.rs
@@ -13,6 +13,8 @@ async fn file_attention_merges_normalized_exact_lookup_with_suffix_fallback() {
             apply_project_scope: true,
             start_unix_ms: None,
             end_unix_ms: None,
+            harness: Some("codex".to_string()),
+            source_name: Some("codex".to_string()),
             tool: None,
             mutations_only: false,
             max_rows: 10,
@@ -39,6 +41,8 @@ async fn file_attention_merges_normalized_exact_lookup_with_suffix_fallback() {
         .expect("normalized exact file_attention query should be captured");
     assert!(exact_query.contains("project_id = 'project-a'"));
     assert!(exact_query.contains("tool_phase = 'request'"));
+    assert!(exact_query.contains("harness = 'codex'"));
+    assert!(exact_query.contains("e.source_name = 'codex'"));
     assert!(
         !exact_query.contains("JSONExtractString(input_json"),
         "exact lookup should not depend on legacy JSON suffix extraction: {exact_query}"
@@ -59,6 +63,8 @@ async fn file_attention_merges_normalized_exact_lookup_with_suffix_fallback() {
         .find(|query| query.contains("JSONExtractString(input_json, 'path')"))
         .expect("Tier-0 suffix file_attention query should be captured");
     assert!(fallback_query.contains("crates/foo.rs"));
+    assert!(fallback_query.contains("harness = 'codex'"));
+    assert!(fallback_query.contains("e.source_name = 'codex'"));
     assert!(
         fallback_query.contains("ti.project_id = 'project-a'")
             && fallback_query.contains(
@@ -138,6 +144,8 @@ async fn file_attention_project_scope_migrates_registered_pre_digest_sibling_roo
             apply_project_scope: true,
             start_unix_ms: None,
             end_unix_ms: None,
+            harness: None,
+            source_name: None,
             tool: None,
             mutations_only: false,
             max_rows: 10,
@@ -182,6 +190,8 @@ async fn file_attention_project_scope_excludes_unmapped_pruned_legacy_root() {
             apply_project_scope: true,
             start_unix_ms: None,
             end_unix_ms: None,
+            harness: None,
+            source_name: None,
             tool: None,
             mutations_only: false,
             max_rows: 10,
@@ -205,6 +215,8 @@ async fn file_attention_all_scope_is_the_only_unscoped_widening_path() {
         apply_project_scope: false,
         start_unix_ms: None,
         end_unix_ms: None,
+        harness: None,
+        source_name: None,
         tool: None,
         mutations_only: false,
         max_rows: 10,
@@ -243,6 +255,8 @@ async fn file_attention_all_scope_keeps_the_configured_server_floor_only() {
         apply_project_scope: false,
         start_unix_ms: None,
         end_unix_ms: None,
+        harness: None,
+        source_name: None,
         tool: None,
         mutations_only: false,
         max_rows: 10,
@@ -289,6 +303,8 @@ async fn file_attention_all_scope_preserves_legacy_suffix_fallback_on_schema_ske
             apply_project_scope: false,
             start_unix_ms: None,
             end_unix_ms: None,
+            harness: None,
+            source_name: None,
             tool: None,
             mutations_only: false,
             max_rows: 10,
@@ -318,6 +334,8 @@ async fn file_attention_project_scope_stays_closed_on_schema_skew() {
             apply_project_scope: true,
             start_unix_ms: None,
             end_unix_ms: None,
+            harness: None,
+            source_name: None,
             tool: None,
             mutations_only: false,
             max_rows: 10,
@@ -342,6 +360,8 @@ async fn file_attention_project_scope_without_identity_stays_closed() {
         apply_project_scope: true,
         start_unix_ms: None,
         end_unix_ms: None,
+        harness: None,
+        source_name: None,
         tool: None,
         mutations_only: false,
         max_rows: 10,

--- a/crates/moraine-conversations/tests/repository_integration/search.rs
+++ b/crates/moraine-conversations/tests/repository_integration/search.rs
@@ -11,6 +11,8 @@ async fn search_mcp_events_applies_session_origin_scope() {
             McpEventType::UserInput,
             McpEventType::AssistantResponse,
         ]),
+        harness: Some("claude-code".to_string()),
+        source_name: Some("claude".to_string()),
         min_score: Some(0.0),
         min_should_match: Some(1),
         ..SearchMcpEventsQuery::default()
@@ -27,6 +29,8 @@ async fn search_mcp_events_applies_session_origin_scope() {
     assert!(search_query.contains("d.session_id IN (SELECT session_id FROM ("));
     assert!(search_query.contains("origin_cwd = '/work/project'"));
     assert!(search_query.contains("startsWith(origin_cwd, '/work/project/')"));
+    assert!(search_query.contains("d.harness = 'claude-code'"));
+    assert!(search_query.contains("d.source_name = 'claude'"));
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn search_session_metadata_returns_summary_only_matches() {
@@ -713,6 +717,8 @@ async fn search_mcp_events_supports_turn_scoped_search() {
             session_id: Some("sess_c".to_string()),
             turn_seq: Some(2),
             event_types: Some(vec![McpEventType::ToolResponse]),
+            harness: None,
+            source_name: None,
             min_score: Some(0.0),
             min_should_match: Some(1),
         })

--- a/crates/moraine-conversations/tests/repository_integration/sessions.rs
+++ b/crates/moraine-conversations/tests/repository_integration/sessions.rs
@@ -170,6 +170,8 @@ async fn list_mcp_sessions_uses_overlap_filter_and_cursor_pagination() {
         start_unix_ms: 1767261600000_i64,
         end_unix_ms: 1767500000000_i64,
         mode: Some(ConversationMode::WebSearch),
+        harness: Some("codex".to_string()),
+        source_name: Some("codex".to_string()),
         sort: ConversationListSort::Desc,
     };
 
@@ -188,6 +190,7 @@ async fn list_mcp_sessions_uses_overlap_filter_and_cursor_pagination() {
     assert_eq!(first.items[0].session_id, "sess_c");
     assert_eq!(first.items[0].title.as_deref(), Some("Session C title"));
     assert_eq!(first.items[0].source.as_deref(), Some("codex"));
+    assert_eq!(first.items[0].harness.as_deref(), Some("codex"));
     assert!(first.items[0].completed);
     assert_eq!(first.items[1].session_id, "sess_b");
     assert!(first.next_cursor.is_some());
@@ -217,6 +220,9 @@ async fn list_mcp_sessions_uses_overlap_filter_and_cursor_pagination() {
     assert!(list_query.contains("toUnixTimestamp64Milli(s.last_event_time) >= 1767261600000"));
     assert!(list_query.contains("toUnixTimestamp64Milli(s.first_event_time) < 1767500000000"));
     assert!(list_query.contains("ifNull(r.mode, 'chat') = 'web_search'"));
+    assert!(list_query.contains("r.latest_harness = 'codex'"));
+    assert!(list_query.contains("r.latest_source_name = 'codex'"));
+    assert!(list_query.contains("ifNull(r.latest_source_name, '') AS source"));
     assert!(list_query.contains("ORDER BY w.last_event_unix_ms DESC, w.session_id DESC"));
     assert!(list_query.contains("payload_type IN ('task_complete', 'turn_aborted')"));
     // Blank session_id rows are filtered at the source so they never consume a
@@ -240,6 +246,8 @@ async fn list_mcp_sessions_rejects_cursor_filter_mismatch() {
         start_unix_ms: 1767261600000_i64,
         end_unix_ms: 1767500000000_i64,
         mode: Some(ConversationMode::WebSearch),
+        harness: None,
+        source_name: None,
         sort: ConversationListSort::Desc,
     };
 
@@ -259,6 +267,25 @@ async fn list_mcp_sessions_rejects_cursor_filter_mismatch() {
         .list_mcp_sessions(
             McpSessionListFilter {
                 mode: Some(ConversationMode::Chat),
+                ..base_filter.clone()
+            },
+            PageRequest {
+                limit: 1,
+                cursor: Some(cursor.clone()),
+            },
+        )
+        .await
+        .expect_err("filter mismatch should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "invalid cursor: cursor does not match current list_sessions filter"
+    );
+
+    let err = repo
+        .list_mcp_sessions(
+            McpSessionListFilter {
+                source_name: Some("__none__".to_string()),
                 ..base_filter
             },
             PageRequest {
@@ -267,7 +294,7 @@ async fn list_mcp_sessions_rejects_cursor_filter_mismatch() {
             },
         )
         .await
-        .expect_err("filter mismatch should fail");
+        .expect_err("absent and literal sentinel source filters must not share a cursor");
 
     assert_eq!(
         err.to_string(),
@@ -283,6 +310,8 @@ async fn list_mcp_sessions_applies_session_origin_scope() {
             start_unix_ms: 1767261600000_i64,
             end_unix_ms: 1767500000000_i64,
             mode: None,
+            harness: None,
+            source_name: None,
             sort: ConversationListSort::Desc,
         },
         PageRequest {
@@ -320,6 +349,8 @@ async fn list_mcp_sessions_rejects_cursor_from_differently_scoped_server() {
         start_unix_ms: 1767261600000_i64,
         end_unix_ms: 1767500000000_i64,
         mode: Some(ConversationMode::WebSearch),
+        harness: None,
+        source_name: None,
         sort: ConversationListSort::Desc,
     };
 

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -331,6 +331,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                             "completed": 0_u8,
                             "title": "",
                             "source": "codex",
+                            "harness": "codex",
                             "session_slug": "",
                             "session_summary": ""
                         }
@@ -353,6 +354,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                         "completed": 1_u8,
                         "title": "Session C title",
                         "source": "codex",
+                        "harness": "codex",
                         "session_slug": "project-c",
                         "session_summary": "Session C summary"
                     },
@@ -368,6 +370,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                         "completed": 1_u8,
                         "title": "Session B title",
                         "source": "codex",
+                        "harness": "codex",
                         "session_slug": "project-b",
                         "session_summary": "Session B summary"
                     },
@@ -383,6 +386,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                         "completed": 0_u8,
                         "title": "",
                         "source": "codex",
+                        "harness": "codex",
                         "session_slug": "",
                         "session_summary": ""
                     }

--- a/crates/moraine-mcp-core/src/contract.rs
+++ b/crates/moraine-mcp-core/src/contract.rs
@@ -516,6 +516,10 @@ pub struct SearchSessionsArgs {
     #[serde(default)]
     pub event_types: Option<Vec<String>>,
     #[serde(default)]
+    pub harness: Option<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
     pub n_hits: Option<i64>,
 }
 
@@ -550,6 +554,8 @@ impl SearchSessionsArgs {
             Some(event_types) => canonicalize_search_event_type_names(&event_types)?,
             None => default_search_event_types(),
         };
+        let harness = normalize_optional_filter("harness", self.harness)?;
+        let source = normalize_optional_filter("source", self.source)?;
 
         let n_hits = self
             .n_hits
@@ -568,6 +574,8 @@ impl SearchSessionsArgs {
             query,
             within_id,
             event_types,
+            harness,
+            source,
             n_hits,
         })
     }
@@ -578,6 +586,8 @@ pub struct CanonicalSearchSessionsArgs {
     pub query: String,
     pub within_id: Option<McpId>,
     pub event_types: Vec<McpEventType>,
+    pub harness: Option<String>,
+    pub source: Option<String>,
     pub n_hits: u16,
 }
 
@@ -644,6 +654,10 @@ pub struct ListSessionsArgs {
     #[serde(default)]
     pub mode: Option<ListSessionsMode>,
     #[serde(default)]
+    pub harness: Option<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
     pub sort: Option<ListSessionsSort>,
 }
 
@@ -687,6 +701,9 @@ impl ListSessionsArgs {
             ));
         }
 
+        let harness = normalize_optional_filter("harness", self.harness)?;
+        let source = normalize_optional_filter("source", self.source)?;
+
         Ok(CanonicalListSessionsArgs {
             start_datetime,
             end_datetime,
@@ -695,6 +712,8 @@ impl ListSessionsArgs {
             limit,
             cursor,
             mode: self.mode,
+            harness,
+            source,
             sort: self.sort.unwrap_or_default(),
         })
     }
@@ -709,6 +728,8 @@ pub struct CanonicalListSessionsArgs {
     pub limit: u16,
     pub cursor: Option<String>,
     pub mode: Option<ListSessionsMode>,
+    pub harness: Option<String>,
+    pub source: Option<String>,
     pub sort: ListSessionsSort,
 }
 
@@ -813,6 +834,10 @@ pub struct FileAttentionArgs {
     #[serde(default)]
     pub tool: Option<String>,
     #[serde(default)]
+    pub harness: Option<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
     pub mutations_only: Option<bool>,
     #[serde(default)]
     pub limit: Option<i64>,
@@ -877,6 +902,8 @@ impl FileAttentionArgs {
             .tool
             .map(|tool| tool.trim().to_string())
             .filter(|tool| !tool.is_empty());
+        let harness = normalize_optional_filter("harness", self.harness)?;
+        let source = normalize_optional_filter("source", self.source)?;
 
         Ok(CanonicalFileAttentionArgs {
             path,
@@ -887,6 +914,8 @@ impl FileAttentionArgs {
             start_unix_ms: start.map(|(ms, _)| ms),
             end_unix_ms: end.map(|(ms, _)| ms),
             tool,
+            harness,
+            source,
             mutations_only: self.mutations_only.unwrap_or(false),
             limit,
         })
@@ -903,6 +932,8 @@ pub struct CanonicalFileAttentionArgs {
     pub start_unix_ms: Option<i64>,
     pub end_unix_ms: Option<i64>,
     pub tool: Option<String>,
+    pub harness: Option<String>,
+    pub source: Option<String>,
     pub mutations_only: bool,
     pub limit: u16,
 }
@@ -1188,6 +1219,23 @@ fn list_sessions_datetime_required_error() -> ContractError {
             "end_datetime": "2026-04-30T13:00:00-04:00"
         }
     }))
+}
+
+fn normalize_optional_filter(
+    field: &'static str,
+    input: Option<String>,
+) -> ContractResult<Option<String>> {
+    let Some(raw) = input else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim().to_string();
+    if trimmed.is_empty() {
+        return Err(invalid_request_with_field(
+            field,
+            format!("{field} must be a non-empty string when provided"),
+        ));
+    }
+    Ok(Some(trimmed))
 }
 
 /// Parse an optional datetime bound, returning `(unix_ms, trimmed_input)`.
@@ -1557,6 +1605,8 @@ mod tests {
             query: " migration ".to_string(),
             within_id: None,
             event_types: None,
+            harness: None,
+            source: None,
             n_hits: None,
         }
         .validate()
@@ -1576,6 +1626,8 @@ mod tests {
             query: "query".to_string(),
             within_id: Some(session_id.clone()),
             event_types: Some(vec!["tool_response".to_string(), "user_input".to_string()]),
+            harness: None,
+            source: None,
             n_hits: Some(25),
         };
 
@@ -1591,6 +1643,8 @@ mod tests {
             query: " ".to_string(),
             within_id: None,
             event_types: None,
+            harness: None,
+            source: None,
             n_hits: None,
         }
         .validate()
@@ -1604,11 +1658,38 @@ mod tests {
             query: "query".to_string(),
             within_id: Some(event_id),
             event_types: None,
+            harness: None,
+            source: None,
             n_hits: None,
         }
         .validate()
         .expect_err("event scope");
         assert_eq!(event_scope.code(), ToolErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    fn retrieval_filters_reject_blank_values() {
+        let search_error = SearchSessionsArgs {
+            query: "query".to_string(),
+            within_id: None,
+            event_types: None,
+            harness: Some(" ".to_string()),
+            source: None,
+            n_hits: None,
+        }
+        .validate()
+        .expect_err("blank harness");
+        assert_eq!(search_error.details().expect("details")["field"], "harness");
+
+        let list_error = ListSessionsArgs {
+            start_datetime: Some("2026-04-30T09:00:00-04:00".to_string()),
+            end_datetime: Some("2026-04-30T13:00:00-04:00".to_string()),
+            source: Some(" ".to_string()),
+            ..ListSessionsArgs::default()
+        }
+        .validate(25)
+        .expect_err("blank source");
+        assert_eq!(list_error.details().expect("details")["field"], "source");
     }
 
     #[test]

--- a/crates/moraine-mcp-core/src/file_attention_v1.rs
+++ b/crates/moraine-mcp-core/src/file_attention_v1.rs
@@ -112,6 +112,8 @@ impl AppState {
             start_unix_ms: args.start_unix_ms,
             end_unix_ms: args.end_unix_ms,
             tool: args.tool.clone(),
+            harness: args.harness.clone(),
+            source_name: args.source.clone(),
             mutations_only: args.mutations_only,
             max_rows: FILE_ATTENTION_SCAN_CAP,
             execution_budget_secs: FILE_ATTENTION_DEADLINE_MS.div_ceil(1_000),
@@ -187,6 +189,8 @@ fn canonical_request_json(args: &CanonicalFileAttentionArgs) -> Value {
         "start_datetime": args.start_datetime,
         "end_datetime": args.end_datetime,
         "tool": args.tool,
+        "harness": args.harness,
+        "source": args.source,
         "mutations_only": args.mutations_only,
         "limit": args.limit,
     })
@@ -394,6 +398,7 @@ struct SessionAgg {
     roots: BTreeSet<String>,
     match_kinds: BTreeSet<String>,
     harness: String,
+    source: String,
     /// The most recent touch's event_uid (first seen, since rows arrive
     /// newest-first) — the handle that drills straight to the latest touch.
     latest_event_uid: String,
@@ -574,6 +579,7 @@ fn session_rollups(touches: &[FileAttentionTouch], limit: usize) -> (Vec<Value>,
                 latest_event_uid: touch.event_uid.clone(),
                 latest_turn_seq: touch.turn_seq,
                 harness: touch.harness.clone(),
+                source: touch.source_name.clone(),
                 ..SessionAgg::default()
             }
         });
@@ -589,6 +595,9 @@ fn session_rollups(touches: &[FileAttentionTouch], limit: usize) -> (Vec<Value>,
         }
         if agg.harness.is_empty() {
             agg.harness = touch.harness.clone();
+        }
+        if agg.source.is_empty() {
+            agg.source = touch.source_name.clone();
         }
         if let Some(event_unix_ms) = touch.event_unix_ms {
             agg.first_ms = Some(
@@ -657,6 +666,7 @@ fn session_rollup_json(
         "session": {
             "id": mcp_session_id,
             "harness": agg.harness,
+            "source": agg.source,
             "first_touch": agg.first_ms.map(format_rfc3339_utc_millis),
             "last_touch": agg.last_ms.map(format_rfc3339_utc_millis),
             "touch_count": agg.touch_count,
@@ -724,6 +734,8 @@ fn event_json(rank: usize, touch: &FileAttentionTouch) -> Result<Value, Contract
             "id": event_id,
             "session_id": session_id,
             "timestamp": touch.event_unix_ms.map(format_rfc3339_utc_millis),
+            "harness": touch.harness,
+            "source": touch.source_name,
             "tool_name": touch.tool_name,
             "phase": touch.tool_phase,
             "turn": touch.turn_seq,
@@ -886,6 +898,9 @@ fn format_error_text(payload: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use moraine_config::AppConfig;
+    use moraine_conversations::{InMemoryConversationRepository, RepoConfig};
+    use std::sync::Arc;
 
     #[test]
     fn deadline_envelope_is_a_handled_tool_error() {
@@ -925,6 +940,34 @@ mod tests {
         assert_eq!(error.message(), "limit must be between 1 and 25");
     }
 
+    #[tokio::test]
+    async fn forwards_harness_and_source_filters() {
+        let repository = Arc::new(InMemoryConversationRepository::new(RepoConfig::default()));
+        let state = AppState::embedded(AppConfig::default(), repository.clone());
+
+        let result = state
+            .file_attention_v1(json!({
+                "path": "crates/moraine-mcp-core/src/contract.rs",
+                "scope": "all",
+                "harness": " claude-code ",
+                "source": " claude "
+            }))
+            .await
+            .expect("file attention");
+        assert_eq!(result["isError"], false);
+
+        let calls = repository.calls();
+        assert_eq!(calls.file_attention.len(), 1);
+        assert_eq!(
+            calls.file_attention[0].harness.as_deref(),
+            Some("claude-code")
+        );
+        assert_eq!(
+            calls.file_attention[0].source_name.as_deref(),
+            Some("claude")
+        );
+    }
+
     fn touch(
         session: &str,
         event: &str,
@@ -938,6 +981,7 @@ mod tests {
             event_uid: event.to_string(),
             tool_call_id: format!("call-{event}"),
             harness: "claude-code".to_string(),
+            source_name: "claude".to_string(),
             tool_name: tool.to_string(),
             tool_phase: "request".to_string(),
             match_kind: match_kind.to_string(),
@@ -1150,6 +1194,8 @@ mod tests {
             start_unix_ms: None,
             end_unix_ms: None,
             tool: None,
+            harness: None,
+            source: None,
             mutations_only: false,
             limit: 50,
         }

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -191,6 +191,14 @@ impl AppState {
                                 },
                                 "description": "Optional normalized event type filter. Defaults to user_input, assistant_response, and tool_response."
                             },
+                            "harness": {
+                                "type": ["string", "null"],
+                                "description": "Optional exact, case-sensitive normalized harness filter (for example codex, claude-code, or pi-coding-agent)."
+                            },
+                            "source": {
+                                "type": ["string", "null"],
+                                "description": "Optional exact, case-sensitive ingest source filter (for example codex, claude, or omp). Use source to distinguish sources such as pi and omp that share a harness."
+                            },
                             "n_hits": {
                                 "type": ["integer", "null"],
                                 "minimum": contract::SEARCH_SESSIONS_MIN_N_HITS,
@@ -287,6 +295,14 @@ impl AppState {
                                 ],
                                 "description": "Optional session mode filter."
                             },
+                            "harness": {
+                                "type": ["string", "null"],
+                                "description": "Optional exact, case-sensitive normalized harness filter (for example codex, claude-code, or pi-coding-agent)."
+                            },
+                            "source": {
+                                "type": ["string", "null"],
+                                "description": "Optional exact, case-sensitive ingest source filter (for example codex, claude, or omp). Use source to distinguish sources such as pi and omp that share a harness."
+                            },
                             "sort": {
                                 "anyOf": [
                                     {
@@ -358,6 +374,14 @@ impl AppState {
                             "tool": {
                                 "type": ["string", "null"],
                                 "description": "Optional case-insensitive tool-name filter (e.g. Edit, Write, Read, Bash)."
+                            },
+                            "harness": {
+                                "type": ["string", "null"],
+                                "description": "Optional exact, case-sensitive normalized harness filter (for example codex, claude-code, or pi-coding-agent)."
+                            },
+                            "source": {
+                                "type": ["string", "null"],
+                                "description": "Optional exact, case-sensitive ingest source filter (for example codex, claude, or omp). Use source to distinguish sources such as pi and omp that share a harness."
                             },
                             "mutations_only": {
                                 "type": ["boolean", "null"],

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -8,7 +8,7 @@ mod private_proxy;
 mod search_sessions_v1;
 
 use anyhow::{anyhow, Context, Result};
-use moraine_config::AppConfig;
+use moraine_config::{AppConfig, KNOWN_INGEST_HARNESSES};
 use moraine_conversations::{BackendRepositoryRouter, RepoError};
 pub use moraine_conversations::{ConversationRepository, SessionOriginScope};
 pub use private_proxy::private_route_deadline;
@@ -157,6 +157,28 @@ impl AppState {
     }
 
     fn tools_list_result(&self) -> Value {
+        let harness_filter_description = format!(
+            "Optional exact, case-sensitive normalized harness filter. Supported values: {}.",
+            KNOWN_INGEST_HARNESSES.join(", ")
+        );
+        let mut source_values = self
+            .cfg
+            .ingest
+            .sources
+            .iter()
+            .map(|source| source.name.as_str())
+            .filter(|name| !name.is_empty())
+            .collect::<Vec<_>>();
+        source_values.sort_unstable();
+        source_values.dedup();
+        let source_filter_description = if source_values.is_empty() {
+            "Optional exact, case-sensitive ingest source filter. No ingest sources are configured for this server.".to_string()
+        } else {
+            format!(
+                "Optional exact, case-sensitive ingest source filter. Configured values for this server: {}. Use source to distinguish sources such as pi and omp that share a harness.",
+                source_values.join(", ")
+            )
+        };
         json!({
             "tools": [
                 {
@@ -193,11 +215,11 @@ impl AppState {
                             },
                             "harness": {
                                 "type": ["string", "null"],
-                                "description": "Optional exact, case-sensitive normalized harness filter (for example codex, claude-code, or pi-coding-agent)."
+                                "description": harness_filter_description.as_str()
                             },
                             "source": {
                                 "type": ["string", "null"],
-                                "description": "Optional exact, case-sensitive ingest source filter (for example codex, claude, or omp). Use source to distinguish sources such as pi and omp that share a harness."
+                                "description": source_filter_description.as_str()
                             },
                             "n_hits": {
                                 "type": ["integer", "null"],
@@ -297,11 +319,11 @@ impl AppState {
                             },
                             "harness": {
                                 "type": ["string", "null"],
-                                "description": "Optional exact, case-sensitive normalized harness filter (for example codex, claude-code, or pi-coding-agent)."
+                                "description": harness_filter_description.as_str()
                             },
                             "source": {
                                 "type": ["string", "null"],
-                                "description": "Optional exact, case-sensitive ingest source filter (for example codex, claude, or omp). Use source to distinguish sources such as pi and omp that share a harness."
+                                "description": source_filter_description.as_str()
                             },
                             "sort": {
                                 "anyOf": [
@@ -377,11 +399,11 @@ impl AppState {
                             },
                             "harness": {
                                 "type": ["string", "null"],
-                                "description": "Optional exact, case-sensitive normalized harness filter (for example codex, claude-code, or pi-coding-agent)."
+                                "description": harness_filter_description.as_str()
                             },
                             "source": {
                                 "type": ["string", "null"],
-                                "description": "Optional exact, case-sensitive ingest source filter (for example codex, claude, or omp). Use source to distinguish sources such as pi and omp that share a harness."
+                                "description": source_filter_description.as_str()
                             },
                             "mutations_only": {
                                 "type": ["boolean", "null"],
@@ -1775,6 +1797,27 @@ mod tests {
             "search_sessions should not advertise legacy evidence policy controls"
         );
 
+        let harness_description = json!(
+            "Optional exact, case-sensitive normalized harness filter. Supported values: codex, claude-code, cursor, hermes, kimi-cli, opencode, pi-coding-agent."
+        );
+        let source_description = json!(
+            "Optional exact, case-sensitive ingest source filter. Configured values for this server: claude, codex, cursor, cursor-sqlite, hermes, kimi-cli, omp, opencode, pi. Use source to distinguish sources such as pi and omp that share a harness."
+        );
+        for tool_name in ["search_sessions", "list_sessions", "file_attention"] {
+            let tool = tools
+                .iter()
+                .find(|tool| tool["name"].as_str() == Some(tool_name))
+                .expect("retrieval tool exists");
+            assert_eq!(
+                tool["inputSchema"]["properties"]["harness"]["description"],
+                harness_description
+            );
+            assert_eq!(
+                tool["inputSchema"]["properties"]["source"]["description"],
+                source_description
+            );
+        }
+
         let list_sessions = tools
             .iter()
             .find(|tool| tool["name"].as_str() == Some("list_sessions"))
@@ -1837,6 +1880,28 @@ mod tests {
                 "sessions",
                 "next_cursor"
             ])
+        );
+    }
+
+    #[test]
+    fn tools_list_source_values_follow_server_config() {
+        let mut cfg = AppConfig::default();
+        cfg.ingest.sources.truncate(1);
+        cfg.ingest.sources[0].name = "custom-source".to_string();
+        let state = AppState::embedded(cfg, repository_with_scope(None));
+        let payload = state.tools_list_result();
+        let search = payload["tools"]
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .find(|tool| tool["name"].as_str() == Some("search_sessions"))
+            .expect("search_sessions exists");
+
+        assert_eq!(
+            search["inputSchema"]["properties"]["source"]["description"],
+            json!(
+                "Optional exact, case-sensitive ingest source filter. Configured values for this server: custom-source. Use source to distinguish sources such as pi and omp that share a harness."
+            )
         );
     }
 

--- a/crates/moraine-mcp-core/src/list_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/list_sessions_v1.rs
@@ -38,6 +38,8 @@ impl AppState {
             start_unix_ms: args.start_unix_ms,
             end_unix_ms: args.end_unix_ms,
             mode: args.mode.map(repo_mode),
+            harness: args.harness.clone(),
+            source_name: args.source.clone(),
             sort: repo_sort(args.sort),
         };
         let repo_page = PageRequest {
@@ -120,6 +122,8 @@ fn canonical_request_json(args: &CanonicalListSessionsArgs) -> Value {
         "start_datetime": args.start_datetime,
         "end_datetime": args.end_datetime,
         "mode": args.mode.map(|mode| mode.as_str()),
+        "harness": args.harness.as_deref(),
+        "source": args.source.as_deref(),
         "sort": args.sort.as_str(),
         "limit": args.limit,
         "cursor": args.cursor.as_deref(),
@@ -178,7 +182,7 @@ fn list_sessions_sla_target_ms(args: &CanonicalListSessionsArgs, has_more: bool)
     let is_broad_window =
         args.end_unix_ms.saturating_sub(args.start_unix_ms) >= LIST_SESSIONS_BROAD_WINDOW_MS;
     if is_broad_window || has_more {
-        if args.mode.is_some() {
+        if args.mode.is_some() || args.harness.is_some() || args.source.is_some() {
             LIST_SESSIONS_FILTERED_BROAD_SLA_TARGET_MS
         } else {
             LIST_SESSIONS_BROAD_SLA_TARGET_MS
@@ -197,6 +201,7 @@ fn session_json(rank: usize, session: &McpSessionListItem) -> Result<Value, Cont
         "session": {
             "id": session_id,
             "title": session.title.as_deref(),
+            "harness": session.harness.as_deref(),
             "source": session.source.as_deref(),
             "started_at": format_rfc3339_utc_millis(session.first_event_unix_ms),
             "updated_at": format_rfc3339_utc_millis(session.last_event_unix_ms),
@@ -448,6 +453,7 @@ mod tests {
                 completed: true,
                 title: Some("Build failure triage".to_string()),
                 source: Some("codex".to_string()),
+                harness: Some("codex".to_string()),
                 session_slug: Some("build-failure".to_string()),
                 session_summary: Some("Build failure triage summary.".to_string()),
             }],
@@ -466,6 +472,8 @@ mod tests {
             .list_sessions_v1(json!({
                 "start_datetime": "2026-04-30T09:00:00-04:00",
                 "end_datetime": "2026-04-30T13:00:00-04:00",
+                "harness": " codex ",
+                "source": " codex ",
                 "limit": 1
             }))
             .await
@@ -475,6 +483,7 @@ mod tests {
         let data = &result["structuredContent"]["data"];
         let first = &data["sessions"][0];
         assert_eq!(first["id"], json!("session:c2Vzcy1vcGVu"));
+        assert_eq!(first["session"]["harness"], json!("codex"));
         assert_eq!(first["open"]["session_id"], first["session"]["id"]);
         assert_eq!(first["session"]["turn_count"], json!(3));
         assert_eq!(first["session"]["event_count"], json!(17));
@@ -497,6 +506,8 @@ mod tests {
         assert_eq!(filter.end_unix_ms, 1_777_568_400_000);
         assert_eq!(filter.mode, None);
         assert_eq!(filter.sort, RepoListSort::Desc);
+        assert_eq!(filter.harness.as_deref(), Some("codex"));
+        assert_eq!(filter.source_name.as_deref(), Some("codex"));
         assert_eq!(page.limit, 1);
         assert_eq!(page.cursor, None);
     }
@@ -525,6 +536,7 @@ mod tests {
             completed: true,
             title: None,
             source: Some("claude-code".to_string()),
+            harness: Some("claude-code".to_string()),
             session_slug: None,
             session_summary: None,
         };
@@ -577,6 +589,7 @@ mod tests {
             completed: true,
             title: None,
             source: Some("claude-code".to_string()),
+            harness: Some("claude-code".to_string()),
             session_slug: None,
             session_summary: None,
         };

--- a/crates/moraine-mcp-core/src/search_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/search_sessions_v1.rs
@@ -53,6 +53,8 @@ impl AppState {
                     .map(repo_event_type)
                     .collect(),
             ),
+            harness: args.harness.clone(),
+            source_name: args.source.clone(),
             min_score: None,
             min_should_match: None,
         };
@@ -311,6 +313,7 @@ fn search_hit_json(
         "session": {
             "id": session_id,
             "title": hit.session_title.as_deref().or(hit.session_slug.as_deref()),
+            "harness": hit.harness,
             "source": hit.source_name.as_deref().or(hit.harness.as_deref()),
             "started_at": metadata
                 .map(|metadata| metadata.first_event_unix_ms)
@@ -476,6 +479,8 @@ mod tests {
         let args = parse_search_sessions_args(json!({
             "query": "  cargo test failure  ",
             "event_types": ["tool_response", "user_input", "tool_response"],
+            "harness": " claude-code ",
+            "source": " claude ",
             "n_hits": 3
         }))
         .expect("valid args");
@@ -485,6 +490,8 @@ mod tests {
             args.event_types,
             vec![McpEventType::UserInput, McpEventType::ToolResponse]
         );
+        assert_eq!(args.harness.as_deref(), Some("claude-code"));
+        assert_eq!(args.source.as_deref(), Some("claude"));
         assert_eq!(args.n_hits, 3);
     }
 
@@ -522,7 +529,7 @@ mod tests {
             session_slug: None,
             session_summary: None,
             source_name: Some("codex".to_string()),
-            harness: None,
+            harness: Some("codex".to_string()),
             inference_provider: None,
             event_class: "tool_result".to_string(),
             payload_type: "tool_result".to_string(),
@@ -605,6 +612,7 @@ mod tests {
         assert_eq!(shaped["event"]["timestamp"], "2026-04-29T12:00:01.123Z");
         assert_eq!(shaped["session"]["started_at"], "2026-04-30T13:00:00.000Z");
         assert_eq!(shaped["session"]["updated_at"], "2026-04-30T13:10:00.000Z");
+        assert_eq!(shaped["session"]["harness"], "codex");
         assert_eq!(shaped["turn"]["completed"], true);
         assert_eq!(shaped["session"]["completed"], true);
         assert!(shaped.get("text_content").is_none());
@@ -695,6 +703,8 @@ mod tests {
             query: "   ".to_string(),
             within_id: None,
             event_types: None,
+            harness: None,
+            source: None,
             n_hits: None,
         }
         .validate()

--- a/docs/agent-mcp-search/interface.md
+++ b/docs/agent-mcp-search/interface.md
@@ -74,8 +74,8 @@ Fields:
 | `query` | Required keyword query. Empty strings are rejected. |
 | `within_id` | Optional `session:...` or `turn:...` ID to scope the search. Event IDs are not valid scopes. |
 | `event_types` | Optional filter. Searchable event types are `user_input`, `assistant_response`, `reasoning`, `tool_call`, `tool_response`, `compaction`, `system`, and `runtime`. |
-| `harness` | Optional exact, case-sensitive normalized harness filter, such as `codex`, `claude-code`, or `pi-coding-agent`. |
-| `source` | Optional exact, case-sensitive ingest source filter, such as `codex`, `claude`, or `omp`. |
+| `harness` | Optional exact, case-sensitive normalized harness filter. Supported values are `codex`, `claude-code`, `cursor`, `hermes`, `kimi-cli`, `opencode`, and `pi-coding-agent`. |
+| `source` | Optional exact, case-sensitive ingest source filter. The default configured values are `claude`, `codex`, `cursor`, `cursor-sqlite`, `hermes`, `kimi-cli`, `omp`, `opencode`, and `pi`; each server's MCP tool instructions list its actual configured source names. |
 | `n_hits` | Optional result limit from 1 to 50. Default is 10. |
 
 The default event type filter is `user_input`, `assistant_response`, and

--- a/docs/agent-mcp-search/interface.md
+++ b/docs/agent-mcp-search/interface.md
@@ -61,6 +61,8 @@ Input:
   "query": "mcp open tool oneof top-level schema",
   "within_id": null,
   "event_types": ["user_input", "assistant_response", "tool_response"],
+  "harness": null,
+  "source": null,
   "n_hits": 10
 }
 ```
@@ -72,12 +74,19 @@ Fields:
 | `query` | Required keyword query. Empty strings are rejected. |
 | `within_id` | Optional `session:...` or `turn:...` ID to scope the search. Event IDs are not valid scopes. |
 | `event_types` | Optional filter. Searchable event types are `user_input`, `assistant_response`, `reasoning`, `tool_call`, `tool_response`, `compaction`, `system`, and `runtime`. |
+| `harness` | Optional exact, case-sensitive normalized harness filter, such as `codex`, `claude-code`, or `pi-coding-agent`. |
+| `source` | Optional exact, case-sensitive ingest source filter, such as `codex`, `claude`, or `omp`. |
 | `n_hits` | Optional result limit from 1 to 50. Default is 10. |
 
 The default event type filter is `user_input`, `assistant_response`, and
 `tool_response`. That default is intentionally practical: it searches what the
 user asked, what the assistant concluded, and what tools returned, while leaving
 lower-signal operational records out until you request them.
+
+Use `source` when the configured source is the distinction that matters. For
+example, the `pi` and `omp` sources both use the `pi-coding-agent` harness, so
+`source: "omp"` selects only OMP sessions while `harness: "pi-coding-agent"`
+selects both.
 
 Output data:
 
@@ -145,13 +154,17 @@ Input:
   "limit": 20,
   "cursor": null,
   "mode": null,
+  "harness": null,
+  "source": null,
   "sort": "desc"
 }
 ```
 
 `start_datetime` and `end_datetime` are required and must include an explicit
 timezone. `mode` can filter session mode: `web_search`, `mcp_internal`,
-`tool_calling`, or `chat`. `next_cursor` lets clients continue the same listing.
+`tool_calling`, or `chat`. `harness` and `source` use the same exact,
+case-sensitive semantics as `search_sessions`. `next_cursor` lets clients
+continue the same listing; changing any filter invalidates that cursor.
 
 Output data includes compact session records:
 
@@ -161,6 +174,7 @@ Output data includes compact session records:
   "id": "session:...",
   "session": {
     "title": "...",
+    "harness": "codex",
     "source": "codex",
     "started_at": "2026-05-08T13:00:00.000Z",
     "updated_at": "2026-05-08T13:45:00.000Z",
@@ -196,6 +210,8 @@ Input:
   "start_datetime": null,
   "end_datetime": null,
   "tool": null,
+  "harness": null,
+  "source": null,
   "mutations_only": false,
   "limit": 25
 }
@@ -220,11 +236,11 @@ durable project mapping, and future normalized roots populate that mapping
 automatically. A root pruned before this mapping was installed has no stored Git
 identity and cannot be attributed safely; project scope excludes it rather than
 widening across projects, and the response warns about this one-time upgrade
-limitation. `granularity` is
-`sessions` (default, one rollup per session) or `events` (the flat
-touch-by-touch timeline). `tool` filters by tool name and `mutations_only`
-excludes common pure-read tools. The default limit is `min(50, mcp.max_results)`
-and the maximum is server-configured.
+limitation. `granularity` is `sessions` (default, one rollup per session) or
+`events` (the flat touch-by-touch timeline). `tool` filters by tool name,
+`harness` and `source` apply the same exact filters as the other retrieval
+tools, and `mutations_only` excludes common pure-read tools. The default limit
+is `min(50, mcp.max_results)` and the maximum is server-configured.
 
 Output data carries a summary, the distinct worktree roots the tail matched
 (so over-match is visible, never silently merged), and either per-session

--- a/docs/mcp-search-interface-spec.md
+++ b/docs/mcp-search-interface-spec.md
@@ -284,11 +284,15 @@ search_sessions({
 - Optional and independently nullable.
 - When present, each must contain at least one non-whitespace character after
   trimming; blank values return `invalid_request`.
-- Each is an exact, case-sensitive filter. `harness` matches Moraine's
-  normalized harness name (for example `codex`, `claude-code`, or
-  `pi-coding-agent`); `source` matches the configured ingest source name.
+- Each is an exact, case-sensitive filter. Supported `harness` values are
+  `codex`, `claude-code`, `cursor`, `hermes`, `kimi-cli`, `opencode`, and
+  `pi-coding-agent`.
+- `source` matches a configured ingest source name. The default configured
+  values are `claude`, `codex`, `cursor`, `cursor-sqlite`, `hermes`, `kimi-cli`,
+  `omp`, `opencode`, and `pi`; each server's MCP tool instructions list its
+  actual configured source names.
 - When both are present, both predicates must match. Use `source` to distinguish
-  configured sources such as `pi` and `omp` that share a normalized harness.
+  `pi` and `omp`, which share the `pi-coding-agent` harness.
 
 ### Search Scope Behavior
 

--- a/docs/mcp-search-interface-spec.md
+++ b/docs/mcp-search-interface-spec.md
@@ -198,6 +198,8 @@ Error behavior:
 
 - Invalid inputs must not be silently coerced, except where this specification
   explicitly defines normalization.
+- A provided `harness` or `source` containing only whitespace must return
+  `invalid_request` with `error.details.field` naming that filter.
 - Missing IDs must return `not_found`.
 - Malformed IDs must return `invalid_id`.
 - Unknown event type filters must return `unsupported_event_type`.
@@ -225,6 +227,8 @@ search_sessions({
   query: string,
   within_id?: string | null,
   event_types?: string[] | null,
+  harness?: string | null,
+  source?: string | null,
   n_hits?: number | null
 })
 ```
@@ -274,6 +278,17 @@ search_sessions({
 - Minimum: `1`.
 - Maximum: `50`.
 - Must be an integer.
+
+`harness` and `source`:
+
+- Optional and independently nullable.
+- When present, each must contain at least one non-whitespace character after
+  trimming; blank values return `invalid_request`.
+- Each is an exact, case-sensitive filter. `harness` matches Moraine's
+  normalized harness name (for example `codex`, `claude-code`, or
+  `pi-coding-agent`); `source` matches the configured ingest source name.
+- When both are present, both predicates must match. Use `source` to distinguish
+  configured sources such as `pi` and `omp` that share a normalized harness.
 
 ### Search Scope Behavior
 
@@ -361,6 +376,8 @@ should not compare scores across different queries.
     "query": "clickhouse schema migration failure",
     "within_id": null,
     "event_types": ["user_input", "assistant_response", "tool_response"],
+    "harness": null,
+    "source": null,
     "n_hits": 10
   },
   "data": {
@@ -422,6 +439,7 @@ Each hit must have this shape:
     "id": "session:ses_01J9Q3N7W6F9A8K2M4V5R6T7Y8",
     "title": "Fix ClickHouse schema migration failure",
     "source": "codex",
+    "harness": "codex",
     "started_at": "2026-04-29T18:41:55.000Z",
     "updated_at": "2026-04-29T19:03:12.442Z",
     "completed": true
@@ -444,6 +462,8 @@ Field rules:
 - `id` is the same as `event.id`.
 - `event.ordinal` is one-based within the parent turn.
 - `turn.ordinal` is one-based within the parent session.
+- `session.harness` is the normalized harness; `session.source` is the
+  configured ingest source.
 - `snippet.text` should be short enough to scan and must not contain a full
   payload when the event content is large.
 - `open` repeats the IDs callers are expected to use next.
@@ -750,6 +770,8 @@ and `open` to inspect a selected session.
   "limit": 20,
   "cursor": null,
   "mode": null,
+  "harness": null,
+  "source": null,
   "sort": "desc"
 }
 ```
@@ -763,6 +785,9 @@ Rules:
   `started_at < end_datetime`.
 - `mode`, when present, is one of `web_search`, `mcp_internal`,
   `tool_calling`, or `chat`.
+- `harness` and `source` are optional exact, case-sensitive filters with the
+  same semantics as `search_sessions`. Blank provided values return
+  `invalid_request`; when both are present, both must match.
 - `sort` is `desc` or `asc`, ordered by session `updated_at` and session ID.
 
 ### Response Shape
@@ -787,6 +812,7 @@ session metadata only:
           "id": "session:c2Vzcy0x",
           "title": "Build failure triage",
           "source": "codex",
+          "harness": "codex",
           "started_at": "2026-04-30T13:00:00.000Z",
           "updated_at": "2026-04-30T13:10:00.000Z",
           "completed": true,
@@ -814,6 +840,8 @@ session metadata only:
 
 `list_sessions` must not return event snippets, transcript text, or event
 payloads. To inspect a listed session, pass `open.session_id` to `open`.
+The returned `session.harness` and `session.source` identify the normalized
+harness and configured ingest source that the corresponding filters match.
 
 ## Tool: `file_attention`
 
@@ -838,6 +866,8 @@ Which sessions touched this file, and where do I drill in?
   "start_datetime": null,
   "end_datetime": null,
   "tool": null,
+  "harness": null,
+  "source": null,
   "mutations_only": false,
   "limit": 25
 }
@@ -870,6 +900,9 @@ Rules:
   most millisecond precision.
 - `tool` filters by tool name case-insensitively. `mutations_only` excludes
   common pure-read tools.
+- `harness` and `source` are optional exact, case-sensitive filters with the
+  same semantics as `search_sessions`. Blank provided values return
+  `invalid_request`; when both are present, both must match.
 - The default limit is `min(50, mcp.max_results)` and the maximum is
   server-configured.
 
@@ -915,6 +948,8 @@ root buckets, and either session rollups or a flat event timeline:
         "event": {
           "id": "event:...",
           "session_id": "session:...",
+          "harness": "codex",
+          "source": "codex",
           "timestamp": "2026-06-15T09:30:00.000Z",
           "tool_name": "Edit",
           "phase": "request",
@@ -939,6 +974,8 @@ root buckets, and either session rollups or a flat event timeline:
   }
 }
 ```
+Event rows and session rollups expose `harness` and `source` for the normalized
+harness and configured ingest source that the corresponding filters match.
 
 `event_id` and `session_id` must be present on displayed rows. `turn_id` is
 present when the touch joins to the conversation trace. `truncated` is true when
@@ -1764,6 +1801,10 @@ Missing object:
 | `query` + `within_id=turn` | Search only that turn with default event types. |
 | `query` + `within_id=session` + `event_types` | Search only that session and only those event types. |
 | `query` + `within_id=turn` + `event_types` | Search only that turn and only those event types. |
+| `query` + `harness` | Return only events from the exact normalized harness. |
+| `query` + `source` | Return only events from the exact configured ingest source. |
+| `query` + `harness` + `source` | AND both exact filters. |
+| blank `harness` or `source` | Return `invalid_request`. |
 | `query` + `within_id=event` | Return `invalid_request`. |
 | blank `query` | Return `invalid_request`. |
 | unknown `within_id` | Return `not_found` if ID is well-formed. |
@@ -1783,12 +1824,25 @@ Missing object:
 | range + `cursor` | Return the next deterministic page for the same filter and sort. |
 | range + `mode` | Return only sessions with that mode. |
 | range + `sort=asc` | Return oldest matching sessions first by `updated_at`, then ID. |
+| range + `harness` | Return only sessions from the exact normalized harness. |
+| range + `source` | Return only sessions from the exact configured ingest source. |
+| range + `harness` + `source` | AND both exact filters. |
+| blank `harness` or `source` | Return `invalid_request`. |
 | missing datetime | Return `invalid_request`. |
 | datetime without timezone | Return `invalid_request`. |
 | `end_datetime <= start_datetime` | Return `invalid_request`. |
 | unknown field | Return `invalid_request`. |
 | invalid `mode` or `sort` | Return `invalid_request`. |
 | cursor with changed filter or sort | Return `invalid_request`. |
+
+### `file_attention`
+
+| Input combination | Expected behavior |
+|---|---|
+| `path` + `harness` | Return only touches from the exact normalized harness. |
+| `path` + `source` | Return only touches from the exact configured ingest source. |
+| `path` + `harness` + `source` | AND both exact filters. |
+| blank `harness` or `source` | Return `invalid_request`. |
 
 ### `open`
 
@@ -1932,6 +1986,9 @@ An implementation is successful when:
 - Reasoning, tool calls, compactions, system events, and runtime events are
   excluded by default.
 - Explicit event type filters are honored exactly.
+- Exact `harness` and `source` filters are honored independently and ANDed when
+  combined; every hit exposes the matching normalized harness and configured
+  source.
 - Session and turn scoped search never returns hits outside the requested
   scope.
 - `n_hits` is honored exactly up to the maximum.
@@ -1948,6 +2005,9 @@ An implementation is successful when:
 - Valid requests return sessions overlapping the requested datetime range.
 - Boundary behavior is inclusive at `start_datetime` and exclusive at
   `end_datetime`.
+- Exact `harness` and `source` filters are honored independently and ANDed when
+  combined; every listed session exposes the matching normalized harness and
+  configured source.
 - Results are sorted deterministically and cursor-paginated.
 - Each session includes a typed session ID accepted by `open`.
 - The response contains compact metadata and no event snippets, event payloads,
@@ -1961,6 +2021,8 @@ An implementation is successful when:
 An implementation is successful when:
 
 - Valid requests return the specified response envelope.
+- Exact `harness` and `source` filters are honored independently and ANDed when
+  combined; event rows and session rollups expose the matching values.
 - Invalid paths, unknown fields, bad enum values, bad datetime precision, and
   invalid ranges produce structured errors.
 - The same logical file touched in the main checkout, a sibling worktree, and


### PR DESCRIPTION
## Description

**What.** Adds optional exact, case-sensitive `harness` and `source` filters to the `search_sessions`, `list_sessions`, and `file_attention` MCP retrieval tools.

**Why.** Agents need to narrow history by client family, while configured sources such as `pi` and `omp` require a separate source filter because they share the normalized `pi-coding-agent` harness.

The filters are canonicalized and forwarded through every repository path. They also participate in search result-cache identities and list cursor fingerprints so requests cannot reuse state across filter changes. Search hits, listed sessions, and file-attention rows expose the normalized harness and configured ingest source that the filters match.

Each tool's MCP instructions provide the complete literal harness list and the source names configured on that server. Source instructions are generated from `ingest.sources`, so custom deployments advertise their actual accepted values instead of a hard-coded example list.

The list query now returns the configured ingest source rather than a session payload's self-reported source. Both MCP interface documents cover request fields, supported values, exact/AND semantics, blank-value errors, response metadata, pagination behavior, and success criteria.

## Usage

Filter content search by normalized harness:

```json
{
  "query": "clickhouse migration failure",
  "harness": "codex"
}
```

Filter time-window browsing by configured source:

```json
{
  "start_datetime": "2026-07-01T00:00:00Z",
  "end_datetime": "2026-07-14T00:00:00Z",
  "source": "omp"
}
```

Filters combine with AND semantics, including for file attention:

```json
{
  "path": "crates/moraine-mcp-core/src/lib.rs",
  "scope": "all",
  "harness": "pi-coding-agent",
  "source": "pi"
}
```

## Changelog

- Adds exact `harness` and configured `source` filters to all MCP retrieval tools.
- Lists every supported harness and the server's configured source names in MCP tool instructions.
- Returns matching harness/source metadata in search, list, and file-attention results.
- No configuration, schema migration, or service lifecycle change.

## Validation

Ran `cargo test -p moraine-mcp-core --lib --locked` (100 passed), `cargo test -p moraine-conversations --lib --locked` (59 passed), and `cargo test -p moraine-conversations --test repository_integration --locked` (80 passed). `cargo clippy -p moraine-conversations -p moraine-mcp-core --all-targets --locked -- -D warnings`, `cargo fmt --all -- --check`, and `make docs-build` all passed.

In a fresh Linux dev sandbox, seeded one Codex session (`harness=codex`, `source=fixture-codex`) and one Claude session (`harness=claude-code`, `source=fixture-claude`). For each of `search_sessions`, `list_sessions`, and `file_attention`, harness-only and source-only requests returned the expected session family, including configured source metadata; deliberately mismatched harness-plus-source requests returned zero results. The sandbox was torn down after validation.