### PR TITLE
fix(cli): preserve PID files during status

### DIFF
--- a/apps/moraine/src/commands/status.rs
+++ b/apps/moraine/src/commands/status.rs
@@ -4,8 +4,8 @@ use crate::managed_clickhouse::{
 };
 use crate::paths::RuntimePaths;
 use crate::process::{
-    backend_endpoint_status, backend_http_connect_host, legacy_service_running, service_running,
-    BackendEndpointStatus, LEGACY_MCP_PID_FILE, LEGACY_MONITOR_PID_FILE,
+    backend_endpoint_status, backend_http_connect_host, legacy_service_running_read_only,
+    service_running_read_only, BackendEndpointStatus, LEGACY_MCP_PID_FILE, LEGACY_MONITOR_PID_FILE,
 };
 use crate::render::{
     HeartbeatSnapshot, ServiceRuntimeState, ServiceRuntimeStatus, StatusDataSource, StatusSnapshot,
@@ -357,10 +357,16 @@ pub(super) async fn cmd_status(
     let services = vec![
         managed_runtime_status(
             Service::ClickHouse,
-            service_running(paths, Service::ClickHouse),
+            service_running_read_only(paths, Service::ClickHouse),
         ),
-        managed_runtime_status(Service::Ingest, service_running(paths, Service::Ingest)),
-        backend_runtime_status(service_running(paths, Service::Backend), backend_endpoints),
+        managed_runtime_status(
+            Service::Ingest,
+            service_running_read_only(paths, Service::Ingest),
+        ),
+        backend_runtime_status(
+            service_running_read_only(paths, Service::Backend),
+            backend_endpoints,
+        ),
     ];
     let managed_server = managed_clickhouse_bin(paths, "clickhouse-server");
     let (source, source_path) = active_clickhouse_source(paths);
@@ -385,7 +391,7 @@ pub(super) async fn cmd_status(
         ("monitor", LEGACY_MONITOR_PID_FILE),
         ("MCP", LEGACY_MCP_PID_FILE),
     ] {
-        if let Some(pid) = legacy_service_running(paths, pid_file) {
+        if let Some(pid) = legacy_service_running_read_only(paths, pid_file) {
             status_notes.push(format!(
                 "legacy managed {name} process (pid {pid}) is still tracked; run `moraine down` before starting the unified backend"
             ));

--- a/apps/moraine/src/process.rs
+++ b/apps/moraine/src/process.rs
@@ -388,6 +388,11 @@ fn is_pid_running(pid: u32) -> bool {
         .unwrap_or(false)
 }
 
+fn pid_if_running(path: &Path) -> Option<u32> {
+    let pid = read_pid(path)?;
+    is_pid_running(pid).then_some(pid)
+}
+
 fn ensure_pid_fresh(path: &Path) {
     if let Some(pid) = read_pid(path) {
         if !is_pid_running(pid) {
@@ -399,19 +404,24 @@ fn ensure_pid_fresh(path: &Path) {
 pub(crate) fn service_running(paths: &RuntimePaths, service: Service) -> Option<u32> {
     let path = pid_path(paths, service);
     ensure_pid_fresh(&path);
-    let pid = read_pid(&path)?;
-    if is_pid_running(pid) {
-        Some(pid)
-    } else {
-        None
-    }
+    pid_if_running(&path)
+}
+
+pub(crate) fn service_running_read_only(paths: &RuntimePaths, service: Service) -> Option<u32> {
+    pid_if_running(&pid_path(paths, service))
 }
 
 pub(crate) fn legacy_service_running(paths: &RuntimePaths, pid_file: &str) -> Option<u32> {
     let path = paths.pids_dir.join(pid_file);
     ensure_pid_fresh(&path);
-    let pid = read_pid(&path)?;
-    is_pid_running(pid).then_some(pid)
+    pid_if_running(&path)
+}
+
+pub(crate) fn legacy_service_running_read_only(
+    paths: &RuntimePaths,
+    pid_file: &str,
+) -> Option<u32> {
+    pid_if_running(&paths.pids_dir.join(pid_file))
 }
 
 /// True when something is currently accepting connections on the central MCP
@@ -1143,6 +1153,31 @@ mod tests {
 
         remove_pid_if_matches(&path, 42);
         assert!(!path.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn lifecycle_pid_probes_remove_stale_files() {
+        let root = temp_dir("stale-service-pids");
+        let pids_dir = root.join("run");
+        fs::create_dir_all(&pids_dir).expect("create PID directory");
+        let mut cfg = AppConfig::default();
+        cfg.runtime.pids_dir = pids_dir.to_string_lossy().to_string();
+        let paths = crate::paths::runtime_paths(&cfg);
+        let canonical_path = pid_path(&paths, Service::Ingest);
+        let legacy_path = pids_dir.join(LEGACY_MONITOR_PID_FILE);
+        let stale_pid = i32::MAX as u32;
+        write_pid(&canonical_path, stale_pid).expect("write canonical PID");
+        write_pid(&legacy_path, stale_pid).expect("write legacy PID");
+
+        assert_eq!(service_running(&paths, Service::Ingest), None);
+        assert!(!canonical_path.exists());
+        assert_eq!(
+            legacy_service_running(&paths, LEGACY_MONITOR_PID_FILE),
+            None
+        );
+        assert!(!legacy_path.exists());
+
         let _ = fs::remove_dir_all(root);
     }
 

--- a/apps/moraine/tests/status_cli.rs
+++ b/apps/moraine/tests/status_cli.rs
@@ -333,3 +333,99 @@ fn backend_status_distinguishes_endpoint_combinations_and_gates_monitor_url() {
         let _ = fs::remove_dir_all(root);
     }
 }
+
+#[cfg(unix)]
+#[test]
+fn status_preserves_pid_files_when_processes_are_not_visible() {
+    let root = temp_dir();
+    let config = write_config(&root, 0);
+    let run_dir = root.join("runtime/run");
+    fs::create_dir_all(&run_dir).expect("create PID directory");
+    let pid_bytes = b"2147483647\n";
+    let pid_files = [
+        "clickhouse.pid",
+        "ingest.pid",
+        "backend.pid",
+        "monitor.pid",
+        "mcp.pid",
+    ];
+    for pid_file in pid_files {
+        fs::write(run_dir.join(pid_file), pid_bytes).expect("write PID file");
+    }
+
+    let output = run_status(&config);
+    assert!(
+        output.status.success(),
+        "status failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let status: Value = serde_json::from_slice(&output.stdout).expect("status JSON output");
+
+    let services = status["services"].as_array().expect("services array");
+    for service_name in ["clickhouse", "ingest", "backend"] {
+        let service = services
+            .iter()
+            .find(|service| service["service"] == service_name)
+            .expect("service row");
+        assert_eq!(service["state"], "stopped", "{service}");
+        assert_eq!(service["pid"], Value::Null, "{service}");
+    }
+    let status_notes = status["status_notes"].as_array().expect("status notes");
+    assert!(
+        status_notes.iter().all(|note| !note
+            .as_str()
+            .expect("status note string")
+            .contains("legacy managed")),
+        "{status_notes:?}"
+    );
+    for pid_file in pid_files {
+        assert_eq!(
+            fs::read(run_dir.join(pid_file)).expect("read preserved PID file"),
+            pid_bytes,
+            "{pid_file} changed"
+        );
+    }
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn status_preserves_and_reports_visible_legacy_pid_files() {
+    let root = temp_dir();
+    let config = write_config(&root, 0);
+    let run_dir = root.join("runtime/run");
+    fs::create_dir_all(&run_dir).expect("create PID directory");
+    let pid_bytes = format!("{}\n", std::process::id());
+    for pid_file in ["monitor.pid", "mcp.pid"] {
+        fs::write(run_dir.join(pid_file), &pid_bytes).expect("write legacy PID file");
+    }
+
+    let output = run_status(&config);
+    assert!(
+        output.status.success(),
+        "status failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let status: Value = serde_json::from_slice(&output.stdout).expect("status JSON output");
+    let status_notes = status["status_notes"].as_array().expect("status notes");
+    for service_name in ["monitor", "MCP"] {
+        let expected = format!(
+            "legacy managed {service_name} process (pid {}) is still tracked; run `moraine down` before starting the unified backend",
+            std::process::id()
+        );
+        assert!(
+            status_notes.iter().any(|note| note == &expected),
+            "missing {expected:?} in {status_notes:?}"
+        );
+    }
+    for pid_file in ["monitor.pid", "mcp.pid"] {
+        assert_eq!(
+            fs::read_to_string(run_dir.join(pid_file)).expect("read preserved legacy PID file"),
+            pid_bytes,
+            "{pid_file} changed"
+        );
+    }
+
+    let _ = fs::remove_dir_all(root);
+}


### PR DESCRIPTION
## Description

**What.** Makes `moraine status` use non-mutating PID probes for canonical and legacy managed services.

**Why.** A failed `kill -0` check is not proof that a shared PID belongs to a dead process when the caller runs in an isolated PID namespace; deleting that PID file causes live host services to become untracked.

The process layer now exposes explicit read-only probes for status while retaining the existing cleanup-capable probes for `up`, ClickHouse startup, and other mutating lifecycle paths. Status output remains compatible: a PID that is not locally visible is still reported as stopped/null, but its metadata is preserved for the namespace that owns it.

## Bug Evidence

Before this change, the new `status_preserves_pid_files_when_processes_are_not_visible` regression failed after `moraine status` removed the fixture PID files:

```text
read preserved PID file: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

The root cause was `cmd_status()` calling `service_running()` and `legacy_service_running()`, both of which invoke `ensure_pid_fresh()` and unlink a PID file whenever the caller's `kill -0` probe fails. The fix routes all three canonical status rows and both legacy status diagnostics through read-only helpers instead.

The regression now passes while asserting that all five PID files remain byte-identical, canonical services retain stopped/null output for an invisible PID, visible legacy PIDs still produce their existing warnings, and lifecycle probes still remove genuinely stale files.

## Usage

No command, configuration, or output-schema change. `moraine status` is now safe to run from a PID-isolated environment that shares the runtime directory; it no longer deletes PID metadata it cannot validate locally.

## Changelog

- Prevents `moraine status` from deleting canonical or legacy service PID files when local process visibility checks fail.
- Preserves existing startup/down stale-PID cleanup and status output contracts.

## Operational Impact

No migration or restart is required. This changes only status-time PID-file mutation; service startup, shutdown, endpoint probing, daemon/direct-database fallback, and process topology are unchanged.

## Validation

The exact new invisible-PID regression was run before the production change and failed because the PID files were deleted; it passed after the fix. `cargo test -p moraine --test status_cli --locked` then passed all 5 integration tests, and the focused lifecycle cleanup unit regression passed.

Inside owned sandbox `sb-83fc7a`, `make ci-check` passed dependency policy, formatting, the strict Clippy baseline, locked workspace build, and workspace tests. `scripts/ci/e2e-stack.sh` also passed in the sandbox, including exact live canonical PID checks, daemon-preferred status, abrupt backend-loss fallback, embedded MCP smoke, and all-down lifecycle assertions. The sandbox was torn down afterward.

A seven-persona review wave covering elegance, idiomatic Rust, correctness, completeness, security, YAGNI, and scope returned no actionable findings.

## References

Closes #527.
