### PR TITLE
fix(mcp): queue saturated retrieval requests

### DIFF
--- a/config/moraine.toml
+++ b/config/moraine.toml
@@ -159,6 +159,9 @@ default_exclude_codex_mcp = true
 prewarm_on_initialize = false
 async_log_writes = true
 protocol_version = "2024-11-05"
+# Valid retrievals beyond this process-wide parallel limit wait for capacity.
+# Omit to use the CPU parallelism available to the Moraine process.
+# max_parallel_requests = 16
 # MCP clients first try the unified backend's Unix socket, then transparently
 # fall back to an embedded server when the socket is absent or unreachable.
 # This proxy preference is independent of whether `moraine up` launches the

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -164,6 +164,11 @@ pub struct McpConfig {
     pub async_log_writes: bool,
     #[serde(default = "default_protocol_version")]
     pub protocol_version: String,
+    /// Maximum retrieval requests executed concurrently by each MCP server
+    /// process. When omitted, the server uses the process's available CPU
+    /// parallelism. Additional valid requests wait for capacity.
+    #[serde(default)]
+    pub max_parallel_requests: Option<u16>,
     /// When true, `moraine run mcp` first tries to reach the shared central
     /// MCP server over its Unix socket and proxies to it; if the socket is
     /// absent or unreachable it transparently falls back to an embedded
@@ -430,6 +435,7 @@ impl Default for McpConfig {
             prewarm_on_initialize: false,
             async_log_writes: true,
             protocol_version: default_protocol_version(),
+            max_parallel_requests: None,
             use_central_server: true,
             central_socket_path: default_mcp_socket(),
             start_central_on_up: true,
@@ -1167,6 +1173,12 @@ fn migrate_legacy_pi_source(sources: &mut Vec<IngestSource>) {
 }
 
 fn normalize_config(mut cfg: AppConfig) -> Result<AppConfig> {
+    if cfg.mcp.max_parallel_requests == Some(0) {
+        return Err(anyhow::anyhow!(
+            "mcp.max_parallel_requests must be greater than zero when configured"
+        ));
+    }
+
     migrate_legacy_pi_source(&mut cfg.ingest.sources);
     for (source_idx, source) in cfg.ingest.sources.iter_mut().enumerate() {
         source.harness = normalize_harness(&source.harness, source_idx, &source.name)?;
@@ -1996,6 +2008,36 @@ prewarm_on_initialize = true
         let cfg = load_config(&path).expect("mcp prewarm toggle should load");
         std::fs::remove_file(&path).ok();
         assert!(cfg.mcp.prewarm_on_initialize);
+    }
+
+    #[test]
+    fn mcp_parallel_request_limit_is_optional_and_positive() {
+        let default_cfg = McpConfig::default();
+        assert_eq!(default_cfg.max_parallel_requests, None);
+
+        let explicit_path = write_temp_config(
+            r#"
+[mcp]
+max_parallel_requests = 12
+"#,
+            "mcp-parallel-requests",
+        );
+        let explicit = load_config(&explicit_path).expect("positive limit should load");
+        std::fs::remove_file(&explicit_path).ok();
+        assert_eq!(explicit.mcp.max_parallel_requests, Some(12));
+
+        let zero_path = write_temp_config(
+            r#"
+[mcp]
+max_parallel_requests = 0
+"#,
+            "mcp-parallel-requests-zero",
+        );
+        let error = load_config(&zero_path).expect_err("zero limit must fail");
+        std::fs::remove_file(&zero_path).ok();
+        assert!(error
+            .to_string()
+            .contains("mcp.max_parallel_requests must be greater than zero"));
     }
 
     #[test]

--- a/crates/moraine-mcp-core/src/concurrency_tests.rs
+++ b/crates/moraine-mcp-core/src/concurrency_tests.rs
@@ -21,6 +21,7 @@ const PANIC_SEARCH: u8 = 4;
 const BLOCK_SCOPE: u8 = 5;
 const BLOCK_LIST: u8 = 6;
 const BLOCK_OPEN: u8 = 7;
+const TEST_MAX_PARALLEL_REQUESTS: usize = 2;
 
 struct BlockingRepository {
     inner: InMemoryConversationRepository,
@@ -284,6 +285,16 @@ impl ConversationRepository for BlockingRepository {
 type ClientReader = BufReader<ReadHalf<tokio::io::DuplexStream>>;
 type ClientWriter = WriteHalf<tokio::io::DuplexStream>;
 
+fn test_state(repository: Arc<BlockingRepository>, max_parallel_requests: usize) -> Arc<AppState> {
+    AppState::with_repository(
+        Arc::new(AppConfig::default()),
+        repository,
+        Arc::new(AtomicBool::new(false)),
+        std::env::current_dir().ok(),
+        Arc::new(Semaphore::new(max_parallel_requests)),
+    )
+}
+
 fn start_connection(
     repository: Arc<BlockingRepository>,
 ) -> (
@@ -291,7 +302,18 @@ fn start_connection(
     ClientWriter,
     tokio::task::JoinHandle<Result<()>>,
 ) {
-    let state = AppState::embedded(AppConfig::default(), repository);
+    start_connection_with_capacity(repository, TEST_MAX_PARALLEL_REQUESTS)
+}
+
+fn start_connection_with_capacity(
+    repository: Arc<BlockingRepository>,
+    max_parallel_requests: usize,
+) -> (
+    ClientReader,
+    ClientWriter,
+    tokio::task::JoinHandle<Result<()>>,
+) {
+    let state = test_state(repository, max_parallel_requests);
     let (client, server) = tokio::io::duplex(64 * 1024);
     let (client_read, client_write) = tokio::io::split(client);
     let (server_read, server_write) = tokio::io::split(server);
@@ -311,7 +333,7 @@ fn start_connection_with_shutdown(
     oneshot::Sender<()>,
     tokio::task::JoinHandle<Result<()>>,
 ) {
-    let state = AppState::embedded(AppConfig::default(), repository);
+    let state = test_state(repository, TEST_MAX_PARALLEL_REQUESTS);
     let (client, server) = tokio::io::duplex(64 * 1024);
     let (client_read, client_write) = tokio::io::split(client);
     let (server_read, server_write) = tokio::io::split(server);
@@ -361,7 +383,10 @@ fn tool_request(id: &str, name: &str, arguments: Value) -> String {
     request
 }
 
-async fn read_response(reader: &mut ClientReader) -> Value {
+async fn read_response<R>(reader: &mut R) -> Value
+where
+    R: AsyncBufRead + Unpin,
+{
     let mut line = String::new();
     tokio::time::timeout(
         std::time::Duration::from_millis(500),
@@ -374,76 +399,129 @@ async fn read_response(reader: &mut ClientReader) -> Value {
 }
 
 #[tokio::test]
-async fn blocked_burst_preserves_fast_validation_backpressure_and_recovery() {
-    let repository = Arc::new(BlockingRepository::new(BLOCK_SEARCH));
+async fn blocked_burst_queues_retrieval_while_control_requests_stay_responsive() {
+    let repository = Arc::new(BlockingRepository::new(DELAY_SEARCH));
     let (mut reader, mut writer, server) = start_connection(repository.clone());
 
-    let burst = (1..=MAX_IN_FLIGHT_REQUESTS)
-        .map(search_request)
+    let burst = (1..=TEST_MAX_PARALLEL_REQUESTS)
+        .map(|id| search_request_with_query(json!(id), "slow"))
         .collect::<String>();
     writer
         .write_all(burst.as_bytes())
         .await
-        .expect("send burst");
-    repository.wait_for_started(MAX_IN_FLIGHT_REQUESTS).await;
+        .expect("send admitted burst");
+    repository
+        .wait_for_started(TEST_MAX_PARALLEL_REQUESTS)
+        .await;
 
     writer
-        .write_all(
-            b"{\"jsonrpc\":\"2.0\",\"id\":\"invalid\",\"method\":\"tools/call\",\"params\":{\"name\":\"open\",\"arguments\":{\"id\":\"unknown:123\"}}}\n",
-        )
+        .write_all(search_request_with_query(json!(3), "slow").as_bytes())
         .await
-        .expect("send invalid request");
+        .expect("send queued request");
     writer
-        .write_all(search_request(9).as_bytes())
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":\"ping\",\"method\":\"ping\",\"params\":{}}\n")
         .await
-        .expect("send over-capacity request");
+        .expect("send control request");
+    writer
+        .write_all(tool_request("invalid-open", "open", json!({})).as_bytes())
+        .await
+        .expect("send invalid retrieval request");
+    writer
+        .write_all(tool_request("unknown-tool", "not_a_tool", json!({})).as_bytes())
+        .await
+        .expect("send unknown tool request");
+    writer
+        .write_all(search_request_with_query(json!(3), "slow").as_bytes())
+        .await
+        .expect("send duplicate queued id");
 
-    let first = read_response(&mut reader).await;
-    let second = read_response(&mut reader).await;
-    let responses = [first, second];
+    let responses = [
+        read_response(&mut reader).await,
+        read_response(&mut reader).await,
+        read_response(&mut reader).await,
+        read_response(&mut reader).await,
+    ];
+    let ping = responses
+        .iter()
+        .find(|response| response["id"] == json!("ping"))
+        .expect("ping bypassed saturated retrievals");
+    assert_eq!(ping["result"], json!({}));
+    let duplicate = responses
+        .iter()
+        .find(|response| response["id"] == json!(3))
+        .expect("queued request id was reserved");
+    assert_eq!(duplicate["error"]["code"], json!(-32600));
     let invalid = responses
         .iter()
-        .find(|response| response["id"] == json!("invalid"))
-        .expect("invalid request bypassed blocked retrievals");
+        .find(|response| response["id"] == json!("invalid-open"))
+        .expect("invalid arguments bypassed saturated retrievals");
+    assert_eq!(invalid["result"]["isError"], json!(true));
+    let unknown = responses
+        .iter()
+        .find(|response| response["id"] == json!("unknown-tool"))
+        .expect("unknown tool bypassed saturated retrievals");
+    assert_eq!(unknown["result"]["isError"], json!(true));
     assert_eq!(
-        invalid["result"]["structuredContent"]["error"]["code"],
-        json!("invalid_id")
+        repository.started.load(Ordering::Acquire),
+        TEST_MAX_PARALLEL_REQUESTS
     );
-    let rejected = responses
-        .iter()
-        .find(|response| response["id"] == json!(9))
-        .expect("bounded burst was rejected promptly");
-    assert_eq!(rejected["error"]["code"], json!(-32000));
 
-    for id in 1..=MAX_IN_FLIGHT_REQUESTS {
-        writer
-            .write_all(
-                format!(
-                    "{{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\",\"params\":{{\"requestId\":{id},\"reason\":\"test\"}}}}\n"
-                )
-                .as_bytes(),
-            )
-            .await
-            .expect("cancel request");
+    repository.release_search.notify_one();
+    repository
+        .wait_for_started(TEST_MAX_PARALLEL_REQUESTS + 1)
+        .await;
+    repository.release_search.notify_waiters();
+
+    let mut completed_ids = Vec::new();
+    for _ in 0..=TEST_MAX_PARALLEL_REQUESTS {
+        let response = read_response(&mut reader).await;
+        assert!(response.get("result").is_some());
+        completed_ids.push(response["id"].as_u64().expect("numeric response id"));
     }
-    repository.wait_for_dropped(MAX_IN_FLIGHT_REQUESTS).await;
-    repository.wait_for_cancelled(MAX_IN_FLIGHT_REQUESTS).await;
-    let mut cancelled_searches = repository.cancelled_queries.lock().await.clone();
-    cancelled_searches.sort();
-    cancelled_searches.dedup();
-    assert_eq!(cancelled_searches.len(), MAX_IN_FLIGHT_REQUESTS);
-    assert!(cancelled_searches
-        .iter()
-        .all(|query_id| query_id.starts_with("moraine-search-sessions-")));
-    repository.mode.store(0, Ordering::Release);
+    completed_ids.sort_unstable();
+    assert_eq!(completed_ids, vec![1, 2, 3]);
+
+    writer.shutdown().await.expect("half-close request stream");
+    drop(writer);
+    tokio::time::timeout(std::time::Duration::from_secs(1), server)
+        .await
+        .expect("connection drained")
+        .expect("connection task joined")
+        .expect("connection succeeded");
+}
+
+#[tokio::test]
+async fn queued_cancellation_never_reaches_repository_or_backend_cancel() {
+    let repository = Arc::new(BlockingRepository::new(DELAY_SEARCH));
+    let (mut reader, mut writer, server) = start_connection_with_capacity(repository.clone(), 1);
 
     writer
-        .write_all(search_request(10).as_bytes())
+        .write_all(search_request_with_query(json!(1), "slow").as_bytes())
         .await
-        .expect("send recovery request");
-    let recovered = read_response(&mut reader).await;
-    assert_eq!(recovered["id"], json!(10));
-    assert!(recovered.get("result").is_some());
+        .expect("send admitted request");
+    repository.wait_for_started(1).await;
+    writer
+        .write_all(search_request_with_query(json!(2), "slow").as_bytes())
+        .await
+        .expect("send queued request");
+    writer
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\",\"params\":{\"requestId\":2,\"reason\":\"test\"}}\n",
+        )
+        .await
+        .expect("cancel queued request");
+    writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":\"barrier\",\"method\":\"ping\",\"params\":{}}\n")
+        .await
+        .expect("send dispatch barrier");
+
+    let barrier = read_response(&mut reader).await;
+    assert_eq!(barrier["id"], json!("barrier"));
+    repository.release_search.notify_one();
+    let completed = read_response(&mut reader).await;
+    assert_eq!(completed["id"], json!(1));
+    assert_eq!(repository.started.load(Ordering::Acquire), 1);
+    assert!(repository.cancelled_queries.lock().await.is_empty());
 
     writer.shutdown().await.expect("half-close request stream");
     drop(writer);
@@ -586,12 +664,13 @@ async fn full_socket_disconnect_cancels_blocked_repository_work() {
     use std::os::fd::AsRawFd;
 
     let repository = Arc::new(BlockingRepository::new(BLOCK_SEARCH));
-    let state = AppState::embedded(AppConfig::default(), repository.clone());
+    let state = test_state(repository.clone(), 1);
     let (server_stream, client_stream) =
         tokio::net::UnixStream::pair().expect("create socket pair");
     let peer_fd = server_stream.as_raw_fd();
     let (server_read, server_write) = server_stream.into_split();
     let (client_read, mut client_write) = client_stream.into_split();
+    let mut client_read = BufReader::new(client_read);
     let server = tokio::spawn(serve_connection_with_lifecycle(
         state,
         BufReader::new(server_read),
@@ -601,11 +680,19 @@ async fn full_socket_disconnect_cancels_blocked_repository_work() {
         wait_for_socket_disconnect(peer_fd),
     ));
 
+    let burst = format!(
+        "{}{}{}",
+        search_request(1),
+        search_request(2),
+        "{\"jsonrpc\":\"2.0\",\"id\":\"disconnect-barrier\",\"method\":\"ping\"}\n"
+    );
     client_write
-        .write_all(search_request(1).as_bytes())
+        .write_all(burst.as_bytes())
         .await
-        .expect("send blocked request");
+        .expect("send running, queued, and barrier requests");
     repository.wait_for_started(1).await;
+    let barrier = read_response(&mut client_read).await;
+    assert_eq!(barrier["id"], json!("disconnect-barrier"));
     drop(client_read);
     drop(client_write);
 
@@ -616,6 +703,8 @@ async fn full_socket_disconnect_cancels_blocked_repository_work() {
         .expect("connection succeeded");
     repository.wait_for_dropped(1).await;
     repository.wait_for_cancelled(1).await;
+    assert_eq!(repository.started.load(Ordering::Acquire), 1);
+    assert_eq!(repository.cancelled_queries.lock().await.len(), 1);
     assert!(repository.cancelled_queries.lock().await[0].starts_with("moraine-search-sessions-"));
 }
 
@@ -716,13 +805,20 @@ async fn service_shutdown_cancels_in_flight_backend_query() {
     let (_reader, mut writer, shutdown, server) =
         start_connection_with_shutdown(repository.clone());
 
-    writer
-        .write_all(
-            b"{\"jsonrpc\":\"2.0\",\"id\":\"shutdown\",\"method\":\"tools/call\",\"params\":{\"name\":\"file_attention\",\"arguments\":{\"path\":\"src/lib.rs\"}}}\n",
-        )
-        .await
-        .expect("send blocked request");
-    repository.wait_for_started(1).await;
+    for id in ["shutdown-a", "shutdown-b", "shutdown-queued"] {
+        writer
+            .write_all(
+                format!(
+                    "{{\"jsonrpc\":\"2.0\",\"id\":\"{id}\",\"method\":\"tools/call\",\"params\":{{\"name\":\"file_attention\",\"arguments\":{{\"path\":\"src/lib.rs\"}}}}}}\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .expect("send shutdown request");
+    }
+    repository
+        .wait_for_started(TEST_MAX_PARALLEL_REQUESTS)
+        .await;
     shutdown.send(()).expect("request service shutdown");
 
     tokio::time::timeout(std::time::Duration::from_secs(2), server)
@@ -730,9 +826,105 @@ async fn service_shutdown_cancels_in_flight_backend_query() {
         .expect("service shutdown deadline")
         .expect("connection task joined")
         .expect("connection succeeded");
+    repository
+        .wait_for_dropped(TEST_MAX_PARALLEL_REQUESTS)
+        .await;
+    repository
+        .wait_for_cancelled(TEST_MAX_PARALLEL_REQUESTS)
+        .await;
+    assert_eq!(
+        repository.started.load(Ordering::Acquire),
+        TEST_MAX_PARALLEL_REQUESTS
+    );
+    assert!(repository
+        .cancelled_queries
+        .lock()
+        .await
+        .iter()
+        .all(|query_id| query_id.starts_with("moraine-file-attention-")));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn central_service_shutdown_cancels_process_wide_queued_requests() {
+    async fn connect(path: &std::path::Path) -> tokio::net::UnixStream {
+        for _ in 0..100 {
+            if let Ok(stream) = tokio::net::UnixStream::connect(path).await {
+                return stream;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        panic!("failed to connect to test socket {}", path.display());
+    }
+
+    let repository = Arc::new(BlockingRepository::new(BLOCK_FILE_ATTENTION));
+    let mut cfg = AppConfig::default();
+    cfg.mcp.max_parallel_requests = Some(1);
+    let cfg = Arc::new(cfg);
+    let repository_trait: Arc<dyn ConversationRepository> = repository.clone();
+    let router = Arc::new(
+        BackendRepositoryRouter::from_preloaded_for_testing(
+            cfg.clone(),
+            [("default".to_string(), repository_trait)],
+        )
+        .expect("preload blocking repository"),
+    );
+    let socket_path = PathBuf::from(format!(
+        "/tmp/moraine-shutdown-{}-{}.sock",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_file(&socket_path);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let server_socket_path = socket_path.clone();
+    let server = tokio::spawn(async move {
+        run_socket_with_router(cfg, router, server_socket_path, async move {
+            let _ = shutdown_rx.await;
+        })
+        .await
+    });
+
+    let running_client = connect(&socket_path).await;
+    let queued_client = connect(&socket_path).await;
+    let (running_read, mut running_writer) = running_client.into_split();
+    let _running_reader = BufReader::new(running_read);
+    let (queued_read, mut queued_writer) = queued_client.into_split();
+    let mut queued_reader = BufReader::new(queued_read);
+
+    running_writer
+        .write_all(
+            tool_request("running", "file_attention", json!({"path": "src/lib.rs"})).as_bytes(),
+        )
+        .await
+        .expect("send running request");
+    repository.wait_for_started(1).await;
+    queued_writer
+        .write_all(
+            tool_request("queued", "file_attention", json!({"path": "src/lib.rs"})).as_bytes(),
+        )
+        .await
+        .expect("send queued request");
+    queued_writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":\"barrier\",\"method\":\"ping\",\"params\":{}}\n")
+        .await
+        .expect("send queued-connection barrier");
+    let barrier = read_response(&mut queued_reader).await;
+    assert_eq!(barrier["id"], json!("barrier"));
+
+    shutdown_tx.send(()).expect("request central shutdown");
+    tokio::time::timeout(std::time::Duration::from_secs(2), server)
+        .await
+        .expect("central shutdown deadline")
+        .expect("central server task joined")
+        .expect("central server shutdown succeeded");
     repository.wait_for_dropped(1).await;
     repository.wait_for_cancelled(1).await;
-    assert!(repository.cancelled_queries.lock().await[0].starts_with("moraine-file-attention-"));
+    assert_eq!(repository.started.load(Ordering::Acquire), 1);
+    assert_eq!(repository.cancelled_queries.lock().await.len(), 1);
+    assert!(!socket_path.exists(), "central socket was cleaned up");
 }
 
 #[tokio::test]
@@ -740,13 +932,20 @@ async fn malformed_transport_still_cancels_in_flight_backend_query() {
     let repository = Arc::new(BlockingRepository::new(BLOCK_FILE_ATTENTION));
     let (_reader, mut writer, server) = start_connection(repository.clone());
 
-    writer
-        .write_all(
-            b"{\"jsonrpc\":\"2.0\",\"id\":\"malformed\",\"method\":\"tools/call\",\"params\":{\"name\":\"file_attention\",\"arguments\":{\"path\":\"src/lib.rs\"}}}\n",
-        )
-        .await
-        .expect("send blocked request");
-    repository.wait_for_started(1).await;
+    for id in ["malformed-a", "malformed-b", "malformed-queued"] {
+        writer
+            .write_all(
+                format!(
+                    "{{\"jsonrpc\":\"2.0\",\"id\":\"{id}\",\"method\":\"tools/call\",\"params\":{{\"name\":\"file_attention\",\"arguments\":{{\"path\":\"src/lib.rs\"}}}}}}\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .expect("send malformed-transport request");
+    }
+    repository
+        .wait_for_started(TEST_MAX_PARALLEL_REQUESTS)
+        .await;
     writer
         .write_all(&[0xff, b'\n'])
         .await
@@ -760,6 +959,14 @@ async fn malformed_transport_still_cancels_in_flight_backend_query() {
     assert!(error
         .to_string()
         .contains("stream did not contain valid UTF-8"));
-    repository.wait_for_dropped(1).await;
-    repository.wait_for_cancelled(1).await;
+    repository
+        .wait_for_dropped(TEST_MAX_PARALLEL_REQUESTS)
+        .await;
+    repository
+        .wait_for_cancelled(TEST_MAX_PARALLEL_REQUESTS)
+        .await;
+    assert_eq!(
+        repository.started.load(Ordering::Acquire),
+        TEST_MAX_PARALLEL_REQUESTS
+    );
 }

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -26,14 +26,50 @@ use std::sync::{
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::sync::{oneshot, watch, Semaphore};
 use tokio::task::JoinSet;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
-// The widest retrieval stage runs three independent ClickHouse reads.
-// Eight admitted requests therefore cap MCP-owned backend reads at 24 while
-// retaining that per-request fan-out.
-const MAX_REPOSITORY_READ_FAN_OUT: usize = 3;
-const MAX_IN_FLIGHT_BACKEND_READS: usize = 24;
-const MAX_IN_FLIGHT_REQUESTS: usize = MAX_IN_FLIGHT_BACKEND_READS / MAX_REPOSITORY_READ_FAN_OUT;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RequestLimitSource {
+    Automatic,
+    Config,
+}
+
+impl RequestLimitSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Automatic => "automatic",
+            Self::Config => "config",
+        }
+    }
+}
+
+fn effective_max_parallel_requests(
+    configured: Option<u16>,
+    detected_parallelism: Option<usize>,
+) -> (usize, RequestLimitSource) {
+    let (requested, source) = match configured {
+        Some(configured) => (usize::from(configured), RequestLimitSource::Config),
+        None => (
+            detected_parallelism.unwrap_or(1),
+            RequestLimitSource::Automatic,
+        ),
+    };
+    (requested.clamp(1, Semaphore::MAX_PERMITS), source)
+}
+
+fn build_request_permits(cfg: &AppConfig) -> Arc<Semaphore> {
+    let detected_parallelism = std::thread::available_parallelism()
+        .ok()
+        .map(std::num::NonZeroUsize::get);
+    let (max_parallel_requests, source) =
+        effective_max_parallel_requests(cfg.mcp.max_parallel_requests, detected_parallelism);
+    info!(
+        max_parallel_requests,
+        source = source.as_str(),
+        "configured MCP retrieval concurrency"
+    );
+    Arc::new(Semaphore::new(max_parallel_requests))
+}
 const QUERY_CANCELLATION_DEADLINE: std::time::Duration = std::time::Duration::from_millis(1_000);
 const SERVICE_DRAIN_GRACE: std::time::Duration = std::time::Duration::from_millis(1_250);
 
@@ -547,12 +583,13 @@ impl AppState {
     }
 
     fn embedded(cfg: AppConfig, repo: Arc<dyn ConversationRepository>) -> Arc<AppState> {
+        let request_permits = build_request_permits(&cfg);
         Self::with_repository(
             cfg.into(),
             repo,
             Arc::new(AtomicBool::new(false)),
             std::env::current_dir().ok(),
-            Arc::new(Semaphore::new(MAX_IN_FLIGHT_REQUESTS)),
+            request_permits,
         )
     }
 }
@@ -588,8 +625,8 @@ impl QueryCancellationGuard {
 ///
 /// Slow repository requests execute concurrently and may complete out of order.
 /// Response encoding and writes stay on this connection task so JSON frames can
-/// never interleave. Admission is shared across socket connections and rejects
-/// excess work immediately instead of building an unbounded queue.
+/// never interleave. Admission is shared across socket connections; requests
+/// wait asynchronously when all execution permits are in use.
 async fn serve_connection_with_first_line<R, W>(
     state: Arc<AppState>,
     reader: R,
@@ -618,6 +655,17 @@ where
     serve_connection_with_lifecycle(state, reader, writer, first_line, shutdown, pending()).await
 }
 
+async fn wait_for_connection_shutdown(shutdown: &mut watch::Receiver<bool>) {
+    if *shutdown.borrow_and_update() {
+        return;
+    }
+    while shutdown.changed().await.is_ok() {
+        if *shutdown.borrow_and_update() {
+            return;
+        }
+    }
+}
+
 async fn serve_connection_with_lifecycle<R, W, S, D>(
     state: Arc<AppState>,
     reader: R,
@@ -634,6 +682,7 @@ where
 {
     let mut requests = JoinSet::new();
     let mut active = HashMap::new();
+    let (request_shutdown_tx, request_shutdown_rx) = watch::channel(false);
     let mut shutdown_requested = false;
     let mut connection_error = None;
     tokio::pin!(shutdown);
@@ -642,8 +691,14 @@ where
     if let Some(first_line) = first_line {
         let first_line =
             std::str::from_utf8(&first_line).context("incoming RPC line is not valid UTF-8")?;
-        if let Some(response) =
-            dispatch_rpc_line(&state, first_line, &mut requests, &mut active).await?
+        if let Some(response) = dispatch_rpc_line(
+            &state,
+            first_line,
+            &mut requests,
+            &mut active,
+            request_shutdown_rx.clone(),
+        )
+        .await?
         {
             tokio::select! {
                 result = write_rpc_response(&mut writer, &response) => result?,
@@ -679,7 +734,13 @@ where
                         continue;
                     }
                 };
-                match dispatch_rpc_line(&state, &line, &mut requests, &mut active).await {
+                match dispatch_rpc_line(
+                    &state,
+                    &line,
+                    &mut requests,
+                    &mut active,
+                    request_shutdown_rx.clone(),
+                ).await {
                     Ok(Some(response)) => {
                         tokio::select! {
                             result = write_rpc_response(&mut writer, &response) => {
@@ -723,6 +784,8 @@ where
             }
         }
     }
+
+    let _ = request_shutdown_tx.send(true);
 
     for request in active.values_mut() {
         if let Some(cancellation) = request.cancellation.take() {
@@ -773,6 +836,7 @@ async fn dispatch_rpc_line(
     line: &str,
     requests: &mut JoinSet<RequestResult>,
     active: &mut HashMap<String, ActiveRequest>,
+    mut connection_shutdown: watch::Receiver<bool>,
 ) -> Result<Option<Value>> {
     let line = line.trim();
     if line.is_empty() {
@@ -816,26 +880,28 @@ async fn dispatch_rpc_line(
         )));
     }
 
-    let permit = match state.request_permits.clone().try_acquire_owned() {
-        Ok(permit) => permit,
-        Err(_) => {
-            return Ok(Some(rpc_err(
-                id,
-                -32000,
-                "server busy: concurrent request limit reached",
-            )))
-        }
-    };
-
     let (cancel_tx, mut cancel_rx) = oneshot::channel();
     let request_query_id = backend_query_id("request");
-    let query_cancellation = Arc::new(StdMutex::new(Some(request_query_id.clone())));
+    let query_cancellation = Arc::new(StdMutex::new(None));
     let task_query_cancellation = query_cancellation.clone();
     let request_state = state.clone();
     let task_key = key.clone();
     let task = requests.spawn(async move {
+        let permit = tokio::select! {
+            biased;
+            _ = &mut cancel_rx => None,
+            _ = wait_for_connection_shutdown(&mut connection_shutdown) => None,
+            permit = request_state.request_permits.clone().acquire_owned() => permit.ok(),
+        };
+        let Some(permit) = permit else {
+            return (task_key, None);
+        };
         let _permit = permit;
         let query_cancellation = task_query_cancellation;
+        *query_cancellation
+            .lock()
+            .expect("query cancellation slot poisoned") = Some(request_query_id.clone());
+
         enum Outcome {
             Completed(Option<Value>),
             Cancelled,
@@ -852,6 +918,7 @@ async fn dispatch_rpc_line(
             tokio::select! {
                 biased;
                 _ = &mut cancel_rx => Outcome::Cancelled,
+                _ = wait_for_connection_shutdown(&mut connection_shutdown) => Outcome::Cancelled,
                 response = &mut request => Outcome::Completed(response),
             }
         };
@@ -1055,9 +1122,10 @@ where
     use tokio::task::JoinSet;
 
     let (connection_shutdown_tx, connection_shutdown_rx) = watch::channel(false);
+    let request_permits = build_request_permits(&cfg);
     let state = SocketState {
         prewarm_gates: BackendPrewarmGates::new(&cfg),
-        request_permits: Arc::new(Semaphore::new(MAX_IN_FLIGHT_REQUESTS)),
+        request_permits,
         shutdown: connection_shutdown_rx,
         cfg,
         router,
@@ -1210,6 +1278,7 @@ where
         }
     }
 
+    state.request_permits.close();
     let _ = connection_shutdown_tx.send(true);
     let drain_deadline = tokio::time::Instant::now() + SERVICE_DRAIN_GRACE;
     while !connections.is_empty() {
@@ -1584,6 +1653,42 @@ mod tests {
 
     fn test_state() -> Arc<AppState> {
         AppState::embedded(AppConfig::default(), repository_with_scope(None))
+    }
+
+    #[test]
+    fn effective_parallel_request_limit_prefers_config_and_falls_back_safely() {
+        assert_eq!(
+            effective_max_parallel_requests(Some(12), Some(8)),
+            (12, RequestLimitSource::Config)
+        );
+        assert_eq!(
+            effective_max_parallel_requests(None, Some(1)),
+            (1, RequestLimitSource::Automatic)
+        );
+        assert_eq!(
+            effective_max_parallel_requests(None, Some(2)),
+            (2, RequestLimitSource::Automatic)
+        );
+        assert_eq!(
+            effective_max_parallel_requests(None, Some(8)),
+            (8, RequestLimitSource::Automatic)
+        );
+        assert_eq!(
+            effective_max_parallel_requests(None, None),
+            (1, RequestLimitSource::Automatic)
+        );
+        assert_eq!(
+            effective_max_parallel_requests(None, Some(Semaphore::MAX_PERMITS.saturating_add(1))),
+            (Semaphore::MAX_PERMITS, RequestLimitSource::Automatic)
+        );
+    }
+
+    #[test]
+    fn embedded_state_uses_configured_parallel_request_limit() {
+        let mut cfg = AppConfig::default();
+        cfg.mcp.max_parallel_requests = Some(3);
+        let state = AppState::embedded(cfg, repository_with_scope(None));
+        assert_eq!(state.request_permits.available_permits(), 3);
     }
 
     fn successful_test_state() -> Arc<AppState> {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -582,6 +582,7 @@ default_exclude_codex_mcp = true
 prewarm_on_initialize = false
 async_log_writes = true
 protocol_version = "2024-11-05"
+# max_parallel_requests = 16 # optional; omitted uses available CPU parallelism
 use_central_server = true
 central_socket_path = "mcp.sock"
 central_connect_timeout_ms = 250
@@ -598,6 +599,7 @@ central_connect_timeout_ms = 250
 | `prewarm_on_initialize` | `false` | Warms query metadata during MCP initialize, trading startup work for lower first-search latency. |
 | `async_log_writes` | `true` | Writes MCP observability rows asynchronously so tool calls stay responsive. |
 | `protocol_version` | `2024-11-05` | MCP protocol version advertised by the server. |
+| `max_parallel_requests` | automatic | Maximum retrieval requests executed concurrently by each MCP server process. Omitted uses the CPU parallelism available to that process; additional valid requests wait for capacity. A configured value must be greater than zero. |
 | `use_central_server` | `true` | Makes `moraine run mcp` prefer the shared central server socket, with embedded fallback. |
 | `central_socket_path` | `mcp.sock` | Unix socket path. Bare filenames resolve under `runtime.pids_dir`; absolute paths are used verbatim. |
 | `central_connect_timeout_ms` | `250` | Milliseconds a proxy client waits for the central socket before falling back to embedded mode. |
@@ -607,6 +609,13 @@ context defaults when retrieval snippets are too narrow.
 Leave `prewarm_on_initialize` disabled for harnesses that launch multiple MCP
 processes at once; enabling it trades startup CPU/database work for lower
 first-search latency.
+
+The shared central server applies one parallel-request budget across every MCP
+socket connection and queues valid retrievals when that budget is busy. An
+embedded fallback is a separate process, so its automatic or configured budget
+is process-local. Saturation does not produce a `server busy` JSON-RPC error;
+queued requests remain cancellable while validation and control requests
+continue to run.
 
 ### Shared central MCP server
 

--- a/docs/full-config.toml
+++ b/docs/full-config.toml
@@ -248,6 +248,11 @@ async_log_writes = true
 
 # MCP protocol version advertised by the server.
 protocol_version = "2024-11-05"
+# Maximum retrieval requests executed concurrently by this MCP server process.
+# Additional valid requests wait rather than returning a saturation error.
+# Omit to use the CPU parallelism available to the Moraine process.
+# max_parallel_requests = 16
+
 
 # Prefer the shared central MCP server when running "moraine run mcp". If the
 # socket is unavailable, Moraine falls back to an embedded stdio server.


### PR DESCRIPTION
## Description

**What.** Replaces the MCP retrieval service's fixed eight-request rejection threshold with cancellable asynchronous queueing and a CPU-scaled process-wide parallel request budget.

**Why.** Valid agent retrievals should wait for available capacity instead of receiving `-32000 server busy`, and larger Moraine installations should not be capped by an arbitrary constant.

- Derives the default parallel request limit from `std::thread::available_parallelism()` at server startup.
- Adds an optional positive `[mcp].max_parallel_requests` override for constrained or remote deployments.
- Keeps permit waits inside independent request tasks so each connection continues parsing cancellation, validation, duplicate-ID, and control frames while retrieval capacity is saturated.
- Cancels queued requests without issuing a backend `KILL QUERY`, while preserving query-family cancellation for requests that reached the repository.
- Shares one semaphore across central socket connections and closes it before broadcasting service shutdown.
- Documents the automatic default, override, queueing behavior, and process-local scope.

Fixes #483.

## Bug Evidence

Before this change, MCP admission was derived from fixed constants:

```text
MAX_IN_FLIGHT_BACKEND_READS = 24
MAX_REPOSITORY_READ_FAN_OUT = 3
MAX_IN_FLIGHT_REQUESTS = 8
```

A ninth otherwise-valid `search_sessions`, `list_sessions`, `open`, or `file_attention` request used `try_acquire_owned()` and immediately returned JSON-RPC error `-32000` with `server busy: concurrent request limit reached`.

The dispatch path now reserves the request ID, spawns the request task, and awaits the shared semaphore there. Focused regressions cover queued completion, saturated control and validation responses, duplicate IDs, pre-admission cancellation, cancellation/permit races, panic cleanup, full disconnect, malformed transport, half-close framing, per-connection shutdown, and process-wide central socket shutdown with a waiter on another connection.

## Usage

Automatic sizing is the default; no configuration change is required:

```toml
[mcp]
# max_parallel_requests omitted: use CPU parallelism available to Moraine
```

Operators can set an explicit process-local execution limit when Moraine and ClickHouse have different resource allocations:

```toml
[mcp]
max_parallel_requests = 16
```

The value must be greater than zero and takes effect when the MCP server process starts. Additional valid retrievals wait for capacity. There is no schema migration or data-format change.

## Changelog

- Queues valid MCP retrievals instead of returning a load-saturation JSON-RPC error.
- Scales the default MCP parallel request budget with the CPU parallelism available to the Moraine process.
- Adds the optional `[mcp].max_parallel_requests` configuration field.

## Validation

- `cargo fmt --all -- --check` — passed.
- `cargo test -p moraine-config -p moraine-mcp-core --locked` — 183 tests passed across four suites.
- `cargo clippy -p moraine-config -p moraine-mcp-core --all-targets --locked -- -D warnings` — passed.
- `make docs-build` — completed with no issues.
- `bash scripts/ci/e2e-stack.sh` inside an isolated Linux Moraine sandbox — passed the full daemon, named-backend, embedded-fallback, monitor, and MCP smoke flow.
- Existing concurrent retrieval runner against a 200-document sandbox corpus, with `max_parallel_requests = 2` and requested concurrency 8 — 8/8 burst requests and 2/2 recovery probes succeeded; admission rejections, client/JSON-RPC/MCP errors, deadline failures, and timeouts were all zero.
