### PR TITLE
perf(retrieval): increase concurrent search throughput

### DIFF
--- a/autoresearch.sh
+++ b/autoresearch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export RUST_BACKTRACE=0
+export RUST_TEST_THREADS=1
+
+cargo test \
+  -p moraine-conversations \
+  --lib \
+  --release \
+  --locked \
+  clickhouse_repo::tests::autoresearch_retrieval_benchmark \
+  -- \
+  --exact \
+  --ignored \
+  --nocapture \
+  --test-threads=1

--- a/autoresearch.sh
+++ b/autoresearch.sh
@@ -1,17 +1,45 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export RUST_BACKTRACE=0
-export RUST_TEST_THREADS=1
+sandbox_id="${MORAINE_AUTORESEARCH_SANDBOX_ID:-sb-a0735e}"
+container="moraine-sandbox-${sandbox_id}"
+results_dir="/tmp/autoresearch-concurrent-results"
+oracle="/tmp/autoresearch-concurrent-oracle.json"
 
-cargo test \
-  -p moraine-conversations \
-  --lib \
-  --release \
-  --locked \
-  clickhouse_repo::tests::autoresearch_retrieval_benchmark \
-  -- \
-  --exact \
-  --ignored \
-  --nocapture \
-  --test-threads=1
+if [[ "$(docker inspect --format '{{.State.Running}}' "$container" 2>/dev/null || true)" != "true" ]]; then
+  scripts/dev/sandbox/moraine-sandbox up --id "$sandbox_id" --quiet >/dev/null
+fi
+
+docker exec -w /repo "$container" \
+  cargo build -p moraine-mcp --release --locked --quiet
+
+docker exec "$container" \
+  python3 /repo/scripts/bench/seed_concurrent_mcp_benchmark.py seed \
+  --clickhouse-url http://clickhouse:8123 \
+  --database moraine \
+  --documents 100000 \
+  --measured-cases 64 \
+  --recovery-cases 2 \
+  --oracle-json "$oracle"
+
+docker exec "$container" rm -rf "$results_dir"
+docker exec -w /repo "$container" \
+  python3 scripts/bench/concurrent_mcp_retrieval.py \
+  --moraine-mcp /home/moraine/target/release/moraine-mcp \
+  --clickhouse-url http://clickhouse:8123 \
+  --database moraine \
+  --oracle-json "$oracle" \
+  --concurrency 8 \
+  --concurrency 16 \
+  --reps 5 \
+  --profile full \
+  --startup-timeout-seconds 10 \
+  --request-timeout-seconds 20 \
+  --run-timeout-seconds 600 \
+  --max-processes 64 \
+  --output-dir "$results_dir"
+
+docker exec -w /repo "$container" \
+  python3 scripts/bench/autoresearch_retrieval_metrics.py \
+  "$results_dir/concurrent-mcp-retrieval-n8-full.json" \
+  "$results_dir/concurrent-mcp-retrieval-n16-full.json"

--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -293,18 +293,10 @@ impl ClickHouseClient {
         let raw = self
             .request_text_with_params(query, None, database, false, None, params)
             .await?;
-        let mut rows = Vec::new();
-
-        for line in raw.lines() {
-            if line.trim().is_empty() {
-                continue;
-            }
-            let row = serde_json::from_str::<T>(line)
-                .with_context(|| format!("failed to parse JSONEachRow line: {}", line))?;
-            rows.push(row);
-        }
-
-        Ok(rows)
+        serde_json::Deserializer::from_str(&raw)
+            .into_iter::<T>()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .context("failed to parse JSONEachRow response")
     }
 
     pub async fn query_json_data<T: DeserializeOwned>(

--- a/crates/moraine-conversations/src/clickhouse_repo/mod.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/mod.rs
@@ -18,8 +18,10 @@ use tokio::time::Instant;
 use tracing::warn;
 use uuid::Uuid;
 
-const REPOSITORY_READ_SETTINGS: [(&str, &str); 1] =
-    [("do_not_merge_across_partitions_select_final", "0")];
+const REPOSITORY_READ_SETTINGS: [(&str, &str); 2] = [
+    ("do_not_merge_across_partitions_select_final", "0"),
+    ("max_threads", "1"),
+];
 
 #[derive(Clone)]
 struct ActiveMcpQueryId {
@@ -149,7 +151,11 @@ impl ClickHouseConversationRepository {
         database: Option<&str>,
     ) -> AnyResult<Vec<T>> {
         if let Ok(query_id) = ACTIVE_MCP_QUERY_ID.try_with(ActiveMcpQueryId::next) {
-            let params = [("query_id", query_id.as_str()), REPOSITORY_READ_SETTINGS[0]];
+            let params = [
+                ("query_id", query_id.as_str()),
+                REPOSITORY_READ_SETTINGS[0],
+                REPOSITORY_READ_SETTINGS[1],
+            ];
             self.ch
                 .query_rows_with_params(query, database, &params)
                 .await

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -773,7 +773,7 @@ FORMAT JSONEachRow",
             .min(posting_count)
             .min(TERM_POSTINGS_CACHE_MAX_ROWS_TOTAL);
         let mut index_by_uid = HashMap::<&str, u32>::with_capacity(initial_capacity);
-        let mut accum_by_uid = Vec::<SearchScoreAccum<'a>>::with_capacity(initial_capacity);
+        let mut candidates = Vec::<RankedPosting<'a>>::with_capacity(initial_capacity);
         let bm25_base = k1 * (1.0 - b);
         let bm25_length_scale = k1 * b / avgdl.max(1.0);
         for (idx, term) in terms.iter().take(64).enumerate() {
@@ -789,36 +789,29 @@ FORMAT JSONEachRow",
                         *index_by_uid
                             .entry(row.event_uid.as_str())
                             .or_insert_with(|| {
-                                let index = u32::try_from(accum_by_uid.len())
+                                let index = u32::try_from(candidates.len())
                                     .expect("posting candidate count exceeds u32");
-                                accum_by_uid.push(SearchScoreAccum {
+                                candidates.push(RankedPosting {
                                     row,
                                     score: 0.0,
-                                    matched_mask: 0,
+                                    matched_terms: 0,
                                 });
                                 index
                             }) as usize;
-                    let entry = &mut accum_by_uid[entry_index];
+                    let entry = &mut candidates[entry_index];
                     let tf = f64::from(row.tf);
                     let norm = tf + bm25_base + bm25_length_scale * f64::from(row.doc_len);
                     entry.score += idf * tf * (k1 + 1.0) / norm;
-                    entry.matched_mask |= 1u64 << idx;
+                    entry.matched_terms |= 1u64 << idx;
                 }
             }
         }
 
-        let mut candidates = Vec::<RankedPosting<'a>>::with_capacity(accum_by_uid.len());
-        for acc in &accum_by_uid {
-            let matched_terms = acc.matched_mask.count_ones() as u64;
-            if matched_terms < min_should_match as u64 || acc.score < min_score {
-                continue;
-            }
-            candidates.push(RankedPosting {
-                row: acc.row,
-                score: acc.score,
-                matched_terms,
-            });
-        }
+        candidates.retain_mut(|candidate| {
+            let matched_terms = u64::from(candidate.matched_terms.count_ones());
+            candidate.matched_terms = matched_terms;
+            matched_terms >= u64::from(min_should_match) && candidate.score >= min_score
+        });
         Self::order_ranked_posting_prefix(&mut candidates, 256);
         candidates
     }

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -772,7 +772,7 @@ FORMAT JSONEachRow",
             .unwrap_or(usize::MAX)
             .min(posting_count)
             .min(TERM_POSTINGS_CACHE_MAX_ROWS_TOTAL);
-        let mut index_by_uid = HashMap::<&str, u32>::with_capacity(initial_capacity);
+        let mut index_by_uid = HashMap::<&str, usize>::with_capacity(initial_capacity);
         let mut candidates = Vec::<RankedPosting<'a>>::with_capacity(initial_capacity);
         let bm25_base = k1 * (1.0 - b);
         let bm25_length_scale = k1 * b / avgdl.max(1.0);
@@ -789,15 +789,14 @@ FORMAT JSONEachRow",
                         *index_by_uid
                             .entry(row.event_uid.as_str())
                             .or_insert_with(|| {
-                                let index = u32::try_from(candidates.len())
-                                    .expect("posting candidate count exceeds u32");
+                                let index = candidates.len();
                                 candidates.push(RankedPosting {
                                     row,
                                     score: 0.0,
                                     matched_terms: 0,
                                 });
                                 index
-                            }) as usize;
+                            });
                     let entry = &mut candidates[entry_index];
                     let tf = f64::from(row.tf);
                     let norm = tf + bm25_base + bm25_length_scale * f64::from(row.doc_len);

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -807,11 +807,17 @@ FORMAT JSONEachRow",
             }
         }
 
-        candidates.retain_mut(|candidate| {
+        let mut candidate_index = 0;
+        while candidate_index < candidates.len() {
+            let candidate = &mut candidates[candidate_index];
             let matched_terms = u64::from(candidate.matched_terms.count_ones());
             candidate.matched_terms = matched_terms;
-            matched_terms >= u64::from(min_should_match) && candidate.score >= min_score
-        });
+            if matched_terms < u64::from(min_should_match) || candidate.score < min_score {
+                candidates.swap_remove(candidate_index);
+            } else {
+                candidate_index += 1;
+            }
+        }
         Self::order_ranked_posting_prefix(&mut candidates, 256);
         candidates
     }

--- a/crates/moraine-conversations/src/clickhouse_repo/tests.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/tests.rs
@@ -662,3 +662,121 @@ fn cached_posting_ranker_matches_full_sort_reference() {
         );
     }
 }
+
+#[test]
+#[ignore = "autoresearch benchmark harness"]
+fn autoresearch_retrieval_benchmark() {
+    const DOCS: usize = 65_536;
+    const TERM_COUNT: usize = 8;
+    const SERIAL_BATCH: usize = 20;
+    const SERIAL_SAMPLES: usize = 9;
+    const CONCURRENT_THREADS: usize = 4;
+    const CONCURRENT_BATCH: usize = 10;
+    const CONCURRENT_SAMPLES: usize = 7;
+
+    let terms = (0..TERM_COUNT)
+        .map(|term| format!("term-{term}"))
+        .collect::<Vec<_>>();
+    let postings_by_term = terms
+        .iter()
+        .enumerate()
+        .map(|(term_index, term)| {
+            let rows = (0..DOCS)
+                .filter_map(|doc| {
+                    let mixed = (doc as u64)
+                        .wrapping_mul(0x9e37_79b9_7f4a_7c15)
+                        .rotate_left((term_index * 7) as u32)
+                        ^ (term_index as u64).wrapping_mul(0xd6e8_feb8_6659_fd93);
+                    mixed.is_multiple_of(5).then(|| CachedPostingRow {
+                        event_uid: format!("event-{doc:05}"),
+                        doc_len: 64 + (mixed % 448) as u32,
+                        tf: 1 + ((mixed >> 11) % 7) as u16,
+                    })
+                })
+                .collect::<Vec<_>>();
+            (term.clone(), Arc::from(rows.into_boxed_slice()))
+        })
+        .collect::<HashMap<String, Arc<[CachedPostingRow]>>>();
+    let df_by_term = postings_by_term
+        .iter()
+        .map(|(term, rows)| (term.clone(), rows.len() as u64))
+        .collect::<HashMap<_, _>>();
+
+    let rank_once = || {
+        ClickHouseConversationRepository::rank_cached_postings(
+            &terms,
+            &postings_by_term,
+            &df_by_term,
+            DOCS as u64,
+            256.0,
+            1.2,
+            0.75,
+            2,
+            0.0,
+        )
+    };
+    let expected = rank_once();
+    assert!(expected.len() > 256, "benchmark corpus is too small");
+    let expected_len = expected.len();
+    let expected_first = expected[0].row.event_uid.as_str();
+
+    for _ in 0..3 {
+        let ranked = std::hint::black_box(rank_once());
+        assert_eq!(ranked.len(), expected_len);
+        assert_eq!(ranked[0].row.event_uid, expected_first);
+    }
+
+    let mut serial_samples = Vec::with_capacity(SERIAL_SAMPLES);
+    for _ in 0..SERIAL_SAMPLES {
+        let started = Instant::now();
+        let mut observed = 0_usize;
+        for _ in 0..SERIAL_BATCH {
+            let ranked = std::hint::black_box(rank_once());
+            observed ^= ranked.len();
+            observed ^= ranked[0].row.event_uid.len();
+        }
+        std::hint::black_box(observed);
+        serial_samples.push(started.elapsed().as_nanos() as u64 / SERIAL_BATCH as u64);
+    }
+    serial_samples.sort_unstable();
+    let serial_ns = serial_samples[SERIAL_SAMPLES / 2];
+
+    let mut concurrent_samples = Vec::with_capacity(CONCURRENT_SAMPLES);
+    for _ in 0..CONCURRENT_SAMPLES {
+        let started = Instant::now();
+        std::thread::scope(|scope| {
+            let handles = (0..CONCURRENT_THREADS)
+                .map(|_| {
+                    scope.spawn(|| {
+                        let mut observed = 0_usize;
+                        for _ in 0..CONCURRENT_BATCH {
+                            let ranked = std::hint::black_box(rank_once());
+                            observed ^= ranked.len();
+                            observed ^= ranked[0].row.event_uid.len();
+                        }
+                        observed
+                    })
+                })
+                .collect::<Vec<_>>();
+            for handle in handles {
+                std::hint::black_box(handle.join().expect("benchmark worker panicked"));
+            }
+        });
+        let query_count = CONCURRENT_THREADS * CONCURRENT_BATCH;
+        concurrent_samples.push(started.elapsed().as_nanos() as u64 / query_count as u64);
+    }
+    concurrent_samples.sort_unstable();
+    let concurrent_ns = concurrent_samples[CONCURRENT_SAMPLES / 2];
+
+    println!("METRIC retrieval_concurrent_ns_per_query={concurrent_ns}");
+    println!("METRIC retrieval_serial_ns_per_query={serial_ns}");
+    println!(
+        "METRIC retrieval_concurrent_qps={:.3}",
+        1_000_000_000.0 / concurrent_ns as f64
+    );
+    println!(
+        "METRIC retrieval_serial_qps={:.3}",
+        1_000_000_000.0 / serial_ns as f64
+    );
+    println!("METRIC retrieval_candidate_count={expected_len}");
+}

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -43,6 +43,8 @@ impl RequestLimitSource {
     }
 }
 
+const AUTOMATIC_MAX_PARALLEL_REQUESTS: usize = 8;
+
 fn effective_max_parallel_requests(
     configured: Option<u16>,
     detected_parallelism: Option<usize>,
@@ -50,7 +52,9 @@ fn effective_max_parallel_requests(
     let (requested, source) = match configured {
         Some(configured) => (usize::from(configured), RequestLimitSource::Config),
         None => (
-            detected_parallelism.unwrap_or(1).min(8),
+            detected_parallelism
+                .unwrap_or(1)
+                .min(AUTOMATIC_MAX_PARALLEL_REQUESTS),
             RequestLimitSource::Automatic,
         ),
     };
@@ -1678,8 +1682,18 @@ mod tests {
             (1, RequestLimitSource::Automatic)
         );
         assert_eq!(
+            effective_max_parallel_requests(None, Some(12)),
+            (
+                AUTOMATIC_MAX_PARALLEL_REQUESTS,
+                RequestLimitSource::Automatic
+            )
+        );
+        assert_eq!(
             effective_max_parallel_requests(None, Some(Semaphore::MAX_PERMITS.saturating_add(1))),
-            (Semaphore::MAX_PERMITS, RequestLimitSource::Automatic)
+            (
+                AUTOMATIC_MAX_PARALLEL_REQUESTS,
+                RequestLimitSource::Automatic
+            )
         );
     }
 

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -50,7 +50,7 @@ fn effective_max_parallel_requests(
     let (requested, source) = match configured {
         Some(configured) => (usize::from(configured), RequestLimitSource::Config),
         None => (
-            detected_parallelism.unwrap_or(1),
+            detected_parallelism.unwrap_or(1).min(8),
             RequestLimitSource::Automatic,
         ),
     };

--- a/scripts/bench/autoresearch_retrieval_metrics.py
+++ b/scripts/bench/autoresearch_retrieval_metrics.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Emit autoresearch metrics from fixed concurrent MCP retrieval artifacts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def load(path: Path) -> dict:
+    artifact = json.loads(path.read_text(encoding="utf-8"))
+    if artifact["semantic"]["status"] != "pass":
+        raise SystemExit(f"semantic oracle failed: {path}")
+    quality = artifact["metrics"]["quality"]
+    if quality["success_rate"] != 1.0 or quality["error_rate"] != 0.0:
+        raise SystemExit(f"retrieval requests failed: {path}")
+    return artifact
+
+
+def resource_metric(artifact: dict, name: str) -> float:
+    return float(artifact["metrics"]["resources"][name])
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: autoresearch_retrieval_metrics.py N8_ARTIFACT N16_ARTIFACT")
+    n8 = load(Path(sys.argv[1]))
+    n16 = load(Path(sys.argv[2]))
+    n8_qps = resource_metric(n8, "mean_throughput_per_second")
+    n16_qps = resource_metric(n16, "mean_throughput_per_second")
+    if n16_qps <= 0.0:
+        raise SystemExit("n16 throughput must be positive")
+
+    print(f"METRIC retrieval_operational_ns_per_query={round(1_000_000_000 / n16_qps)}")
+    print(f"METRIC retrieval_n16_qps={n16_qps:.6f}")
+    print(f"METRIC retrieval_n16_p50_ms={resource_metric(n16, 'p50_latency_ms'):.6f}")
+    print(f"METRIC retrieval_n16_p95_ms={resource_metric(n16, 'p95_latency_ms'):.6f}")
+    print(f"METRIC retrieval_n8_qps={n8_qps:.6f}")
+    print(f"METRIC retrieval_n8_p50_ms={resource_metric(n8, 'p50_latency_ms'):.6f}")
+    print(f"METRIC retrieval_n8_p95_ms={resource_metric(n8, 'p95_latency_ms'):.6f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description

**What.** Improves `search_sessions` throughput under concurrent agent load by bounding query parallelism, reducing MCP admission pressure, streamlining JSON row parsing, and tightening the cached-posting ranker.

**Why.** The previous defaults allowed every retrieval request to ask ClickHouse for up to 16 worker threads while the MCP server admitted work up to the process CPU count. With many agents searching simultaneously, that multiplies runnable work faster than the machine can execute it: throughput falls, queues move into ClickHouse, and both median and tail latency rise.

The request path now applies backpressure at deliberate boundaries:

1. **MCP admission.** Automatic retrieval concurrency is capped at eight executing requests. Additional valid requests wait asynchronously instead of adding database contention. An explicit `mcp.max_parallel_requests` value still takes precedence.
2. **ClickHouse execution.** Repository reads set `max_threads=1`. Search requests are independent, so the fixed CPU budget is better spent running several queries concurrently than parallelizing every individual query.
3. **Response decoding.** JSONEachRow responses use one streaming serde deserializer rather than constructing a parser for every line.
4. **Local ranking.** Cached postings accumulate directly into the returned candidate vector, discard non-matching candidates without stable compaction, and use native-width indexes. The total-order prefix selection still determines the externally visible ranking.

The PR also adds a reproducible operational benchmark. It seeds an owned 100,000-document ClickHouse corpus, launches release-mode central MCP services, drives distinct uncached searches at 8 and 16 simultaneous clients, checks every result against a semantic oracle, and emits autoresearch metrics.

## Usage

No configuration change is required. When `mcp.max_parallel_requests` is omitted, Moraine now admits at most eight retrieval executions concurrently:

```toml
[mcp]
# Optional: explicit values still override the automatic limit.
# max_parallel_requests = 12
```

This is queued admission, not rejection: excess valid requests wait for a permit.

Developers can reproduce the workload with:

```bash
bash autoresearch.sh
```

The harness owns an isolated Moraine sandbox and never points the destructive benchmark seed at the host database.

## Performance

Environment: isolated Linux/aarch64 development sandbox, release `moraine-mcp`, fixed Docker resources, 100,000 documents, distinct uncached `search_sessions` requests, five fresh-central-service repetitions at each concurrency. All measured requests passed the semantic oracle with no errors, rejections, timeouts, or deadline violations.

The table uses the conservative final no-change confirmation run rather than the fastest retained sample:

| Metric | Baseline | This PR | Delta |
| --- | ---: | ---: | ---: |
| 16-client throughput | 33.75 QPS | 58.24 QPS | **+72.6%** |
| 16-client p50 latency | 366.06 ms | 183.66 ms | **-49.8%** |
| 16-client p95 latency | 695.31 ms | 355.99 ms | **-48.8%** |
| 8-client throughput | 39.31 QPS | 63.73 QPS | **+62.1%** |
| 8-client p50 latency | 168.18 ms | 114.57 ms | **-31.9%** |
| 8-client p95 latency | 384.73 ms | 200.25 ms | **-47.9%** |

The best retained sample reached 83.48 QPS at 16 clients (2.47x baseline) and 77.00 QPS at 8 clients (1.96x baseline). Cold-service timing varies, so the confirmation figures above are the safer expectation. The change is a categorical fixed-resource win, but it does not claim the originally explored 10x target.

## Operational Impact

- The automatic MCP limit is lower only when no explicit limit is configured.
- The limit queues requests asynchronously; it does not introduce admission failures.
- Repository reads trade single-query ClickHouse parallelism for higher multi-query throughput. This is intentional for agent retrieval traffic and lowers the maximum CPU demand per query.
- No connection, memory, cache, thread, or process ceiling is increased.
- Response and ranking contracts are unchanged.

## Changelog

- Improves concurrent MCP retrieval throughput and latency under fixed resources.
- Caps automatic retrieval execution at eight requests while preserving explicit configuration overrides.
- Limits ClickHouse repository reads to one worker thread per query.
- Reduces JSONEachRow parsing and cached-posting ranking overhead.
- Adds a semantic, concurrent retrieval benchmark harness.

## Validation

Ran `bash autoresearch.sh` across the complete 12-run operational experiment segment. Every retained and candidate run required 100% successful, oracle-correct responses at both 8 and 16 clients; the final retained run had no errors, admission rejections, timeouts, or hard-deadline violations.

Ran `cargo test -p moraine-clickhouse -p moraine-conversations -p moraine-mcp-core --locked`: 318 tests passed across nine suites, three live/benchmark tests remained ignored, and no tests failed. The owned benchmark sandbox was torn down after validation.