### PR TITLE
fix(mcp): bound typed open retrieval

### DIFF
--- a/apps/moraine/src/commands.rs
+++ b/apps/moraine/src/commands.rs
@@ -206,6 +206,9 @@ fn conversation_repository(cfg: &AppConfig) -> Result<ClickHouseConversationRepo
 async fn cmd_db_migrate(cfg: &AppConfig) -> Result<MigrationOutcome> {
     let ch = ClickHouseClient::new(cfg.clickhouse.clone())?;
     let applied = ch.run_migrations().await?;
+    ch.backfill_mcp_open_read_model()
+        .await
+        .context("failed to backfill MCP open read model")?;
     Ok(MigrationOutcome { applied })
 }
 

--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -8,6 +8,8 @@ use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::Value;
 
+mod mcp_open_projection;
+
 const MAX_INSERT_PAYLOAD_BYTES: usize = 8 * 1024 * 1024;
 use std::collections::{BTreeSet, HashSet};
 use std::time::Duration;
@@ -355,6 +357,22 @@ impl ClickHouseClient {
     }
 
     pub async fn insert_json_rows(&self, table: &str, rows: &[Value]) -> Result<()> {
+        self.insert_json_rows_with_mode(table, rows, true).await
+    }
+
+    /// Insert rows synchronously even when the client is configured for
+    /// ClickHouse async inserts. Projection maintenance uses this boundary so
+    /// canonical events are visible before it rebuilds their session.
+    pub async fn insert_json_rows_sync(&self, table: &str, rows: &[Value]) -> Result<()> {
+        self.insert_json_rows_with_mode(table, rows, false).await
+    }
+
+    async fn insert_json_rows_with_mode(
+        &self,
+        table: &str,
+        rows: &[Value],
+        async_insert: bool,
+    ) -> Result<()> {
         if rows.is_empty() {
             return Ok(());
         }
@@ -371,15 +389,21 @@ impl ClickHouseClient {
                 && payload.len().saturating_add(line.len()).saturating_add(1)
                     > MAX_INSERT_PAYLOAD_BYTES
             {
-                self.request_text(&query, Some(std::mem::take(&mut payload)), None, true, None)
-                    .await?;
+                self.request_text(
+                    &query,
+                    Some(std::mem::take(&mut payload)),
+                    None,
+                    async_insert,
+                    None,
+                )
+                .await?;
             }
             payload.extend_from_slice(&line);
             payload.push(b'\n');
         }
 
         if !payload.is_empty() {
-            self.request_text(&query, Some(payload), None, true, None)
+            self.request_text(&query, Some(payload), None, async_insert, None)
                 .await?;
         }
         Ok(())
@@ -569,6 +593,11 @@ impl ClickHouseClient {
             "search_query_log",
             "search_hit_log",
             "search_interaction_log",
+            "mcp_open_sessions",
+            "mcp_open_turns",
+            "mcp_open_events",
+            "mcp_open_dirty_sessions",
+            "mcp_open_projection_state",
             "schema_migrations",
         ];
 
@@ -776,6 +805,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             version: "026",
             name: "026_file_attention_project_roots.sql",
             sql: include_str!("../../../sql/026_file_attention_project_roots.sql"),
+        },
+        Migration {
+            version: "027",
+            name: "027_mcp_open_read_model.sql",
+            sql: include_str!("../../../sql/027_mcp_open_read_model.sql"),
         },
     ]
 }

--- a/crates/moraine-clickhouse/src/mcp_open_projection.rs
+++ b/crates/moraine-clickhouse/src/mcp_open_projection.rs
@@ -1,0 +1,561 @@
+use super::{escape_identifier, escape_literal, ClickHouseClient};
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::collections::BTreeSet;
+
+const BACKFILL_PAGE_SIZE: usize = 64;
+const MAX_UNSTABLE_REFRESH_ATTEMPTS: usize = 8;
+const MAX_PROJECTED_TEXT_SUMMARY_CHARS: usize = 65_536;
+const MAX_PROJECTED_PAYLOAD_SUMMARY_CHARS: usize = 131_071;
+
+#[derive(Debug, Deserialize)]
+struct SessionHeadRow {
+    slot: u8,
+    generation: u64,
+    source_revision: u64,
+    dirty_revision: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct SourceRevisionRow {
+    source_revision: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct DirtyRevisionRow {
+    dirty_revision: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionIdRow {
+    session_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectionStateRow {
+    ready: u8,
+    #[serde(default)]
+    backfill_cursor: String,
+}
+
+impl ClickHouseClient {
+    /// Rebuild complete canonical snapshots for the affected sessions and
+    /// publish each session head only after its inactive children are durable.
+    pub async fn refresh_mcp_open_read_model<I, S>(&self, session_ids: I) -> Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let session_ids = session_ids
+            .into_iter()
+            .map(|session_id| session_id.as_ref().trim().to_string())
+            .filter(|session_id| !session_id.is_empty())
+            .collect::<BTreeSet<_>>();
+
+        for session_id in session_ids {
+            self.refresh_mcp_open_session(&session_id).await?;
+        }
+        Ok(())
+    }
+
+    /// Resume the historical projection and reconcile sessions dirtied while
+    /// the DDL/backfill was running. Safe to call after every migrate command.
+    pub async fn backfill_mcp_open_read_model(&self) -> Result<()> {
+        let state = self.mcp_open_projection_state().await?;
+        let historical_complete = state.as_ref().is_some_and(|state| state.ready == 1);
+        let mut cursor = state.map_or_else(String::new, |state| state.backfill_cursor);
+
+        if !historical_complete {
+            loop {
+                let query = format!(
+                    "SELECT session_id\n\
+                     FROM (\n\
+                       SELECT DISTINCT session_id\n\
+                       FROM {}.events FINAL\n\
+                       WHERE session_id > {}\n\
+                     )\n\
+                     ORDER BY session_id ASC\n\
+                     LIMIT {}\n\
+                     FORMAT JSONEachRow",
+                    escape_identifier(&self.cfg.database),
+                    escape_literal(&cursor),
+                    BACKFILL_PAGE_SIZE,
+                );
+                let rows: Vec<SessionIdRow> = self
+                    .query_json_each_row(&query, Some(&self.cfg.database))
+                    .await
+                    .context("failed to page MCP open backfill sessions")?;
+                if rows.is_empty() {
+                    break;
+                }
+                self.refresh_mcp_open_read_model(rows.iter().map(|row| row.session_id.as_str()))
+                    .await?;
+                cursor = rows.last().expect("non-empty page").session_id.clone();
+                self.set_mcp_open_projection_state(false, &cursor).await?;
+            }
+        }
+
+        loop {
+            let query = format!(
+                "SELECT d.session_id AS session_id\n\
+                 FROM (\n\
+                   SELECT session_id, dirty_revision\n\
+                   FROM {}.mcp_open_dirty_sessions FINAL\n\
+                 ) AS d\n\
+                 LEFT JOIN (\n\
+                   SELECT session_id, dirty_revision\n\
+                   FROM {}.mcp_open_sessions FINAL\n\
+                 ) AS s ON s.session_id = d.session_id\n\
+                 WHERE d.dirty_revision > ifNull(s.dirty_revision, 0)\n\
+                 ORDER BY d.session_id ASC\n\
+                 LIMIT {}\n\
+                 FORMAT JSONEachRow",
+                escape_identifier(&self.cfg.database),
+                escape_identifier(&self.cfg.database),
+                BACKFILL_PAGE_SIZE,
+            );
+            let rows: Vec<SessionIdRow> = self
+                .query_json_each_row(&query, Some(&self.cfg.database))
+                .await
+                .context("failed to read dirty MCP open sessions")?;
+            if rows.is_empty() {
+                break;
+            }
+            self.refresh_mcp_open_read_model(rows.iter().map(|row| row.session_id.as_str()))
+                .await?;
+        }
+
+        self.set_mcp_open_projection_state(true, "").await?;
+        Ok(())
+    }
+
+    pub async fn mcp_open_read_model_ready(&self) -> Result<bool> {
+        Ok(self
+            .mcp_open_projection_state()
+            .await?
+            .is_some_and(|state| state.ready == 1))
+    }
+
+    async fn mcp_open_projection_state(&self) -> Result<Option<ProjectionStateRow>> {
+        let query = format!(
+            "SELECT ready, backfill_cursor\n\
+             FROM {}.mcp_open_projection_state FINAL\n\
+             WHERE state_key = 'global'\n\
+             LIMIT 1\n\
+             FORMAT JSONEachRow",
+            escape_identifier(&self.cfg.database),
+        );
+        let rows: Vec<ProjectionStateRow> = self
+            .query_json_each_row(&query, Some(&self.cfg.database))
+            .await?;
+        Ok(rows.into_iter().next())
+    }
+
+    async fn set_mcp_open_projection_state(&self, ready: bool, cursor: &str) -> Result<()> {
+        let statement = format!(
+            "INSERT INTO {}.mcp_open_projection_state\n\
+             (state_key, ready, generation, backfill_cursor)\n\
+             VALUES ('global', {}, generateSnowflakeID(), {})",
+            escape_identifier(&self.cfg.database),
+            u8::from(ready),
+            escape_literal(cursor),
+        );
+        self.request_text(&statement, None, Some(&self.cfg.database), false, None)
+            .await?;
+        Ok(())
+    }
+
+    async fn refresh_mcp_open_session(&self, session_id: &str) -> Result<()> {
+        for _ in 0..MAX_UNSTABLE_REFRESH_ATTEMPTS {
+            let source_revision = self.session_source_revision(session_id).await?;
+            if source_revision == 0 {
+                return Ok(());
+            }
+            let dirty_revision = self.session_dirty_revision(session_id).await?;
+            let head = self.mcp_open_session_head(session_id).await?;
+            if head.as_ref().is_some_and(|head| {
+                head.source_revision == source_revision && head.dirty_revision == dirty_revision
+            }) {
+                return Ok(());
+            }
+
+            let slot = head
+                .as_ref()
+                .map_or(0, |head| 1_u8.saturating_sub(head.slot));
+            let generation = self.next_projection_generation().await?;
+
+            self.insert_projected_events(session_id, slot, generation, source_revision)
+                .await?;
+            self.insert_projected_turns(session_id, slot, generation, source_revision)
+                .await?;
+
+            if self.session_source_revision(session_id).await? != source_revision
+                || self.session_dirty_revision(session_id).await? != dirty_revision
+            {
+                continue;
+            }
+            if self
+                .insert_projected_session_head(
+                    session_id,
+                    slot,
+                    generation,
+                    source_revision,
+                    dirty_revision,
+                )
+                .await?
+            {
+                return Ok(());
+            }
+        }
+
+        bail!(
+            "MCP open projection source kept changing for session after {} attempts",
+            MAX_UNSTABLE_REFRESH_ATTEMPTS
+        )
+    }
+
+    async fn mcp_open_session_head(&self, session_id: &str) -> Result<Option<SessionHeadRow>> {
+        let query = format!(
+            "SELECT slot, generation, source_revision, dirty_revision\n\
+             FROM {}.mcp_open_sessions FINAL\n\
+             WHERE session_id = {}\n\
+             LIMIT 1\n\
+             FORMAT JSONEachRow",
+            escape_identifier(&self.cfg.database),
+            escape_literal(session_id),
+        );
+        let rows: Vec<SessionHeadRow> = self
+            .query_json_each_row(&query, Some(&self.cfg.database))
+            .await?;
+        Ok(rows.into_iter().next())
+    }
+
+    async fn next_projection_generation(&self) -> Result<u64> {
+        let rows: Vec<SourceRevisionRow> = self
+            .query_json_each_row(
+                "SELECT toUInt64(generateSnowflakeID()) AS source_revision FORMAT JSONEachRow",
+                Some(&self.cfg.database),
+            )
+            .await?;
+        rows.first()
+            .map(|row| row.source_revision)
+            .context("ClickHouse did not allocate an MCP open projection generation")
+    }
+
+    async fn session_source_revision(&self, session_id: &str) -> Result<u64> {
+        let query = format!(
+            "SELECT\n\
+               if(count() = 0, toUInt64(0), toUInt64(cityHash64(arraySort(groupArray(tuple(event_uid, event_version)))))) AS source_revision\n\
+             FROM (\n\
+               SELECT event_uid, event_version\n\
+               FROM {}.events FINAL\n\
+               WHERE session_id = {}\n\
+               ORDER BY event_uid ASC\n\
+             )\n\
+             FORMAT JSONEachRow",
+            escape_identifier(&self.cfg.database),
+            escape_literal(session_id),
+        );
+        let rows: Vec<SourceRevisionRow> = self
+            .query_json_each_row(&query, Some(&self.cfg.database))
+            .await?;
+        Ok(rows.first().map_or(0, |row| row.source_revision))
+    }
+
+    async fn session_dirty_revision(&self, session_id: &str) -> Result<u64> {
+        let query = format!(
+            "SELECT dirty_revision\n\
+             FROM {}.mcp_open_dirty_sessions FINAL\n\
+             WHERE session_id = {}\n\
+             LIMIT 1\n\
+             FORMAT JSONEachRow",
+            escape_identifier(&self.cfg.database),
+            escape_literal(session_id),
+        );
+        let rows: Vec<DirtyRevisionRow> = self
+            .query_json_each_row(&query, Some(&self.cfg.database))
+            .await?;
+        Ok(rows.first().map_or(0, |row| row.dirty_revision))
+    }
+
+    async fn insert_projected_events(
+        &self,
+        session_id: &str,
+        slot: u8,
+        generation: u64,
+        source_revision: u64,
+    ) -> Result<()> {
+        let database = escape_identifier(&self.cfg.database);
+        let ctes = projection_ctes(&database, session_id, source_revision);
+        let statement = format!(
+            "INSERT INTO {database}.mcp_open_events\n\
+             (event_uid, slot, generation, session_id, event_order, turn_seq,\n\
+              event_time, actor_role, event_class, payload_type, event_type, event_ordinal,\n\
+              call_id, name, phase, item_id, source_ref, text_content, payload_json,\n\
+              token_usage_json, endpoint_kind, token_usage_buckets, token_usage_native_units,\n\
+              previous_event_uid, next_event_uid)\n\
+             {ctes}\n\
+             SELECT\n\
+               event_uid, {slot}, {generation}, session_id, event_order, turn_seq,\n\
+               event_time, actor_role, event_class, payload_type, event_type, event_ordinal,\n\
+               call_id, name, phase, item_id, source_ref, text_content, payload_json,\n\
+               token_usage_json, endpoint_kind, token_usage_buckets, token_usage_native_units,\n\
+               previous_event_uid, next_event_uid\n\
+             FROM enriched",
+        );
+        self.request_text(&statement, None, Some(&self.cfg.database), false, None)
+            .await?;
+        Ok(())
+    }
+
+    async fn insert_projected_turns(
+        &self,
+        session_id: &str,
+        slot: u8,
+        generation: u64,
+        source_revision: u64,
+    ) -> Result<()> {
+        let database = escape_identifier(&self.cfg.database);
+        let ctes = projection_ctes(&database, session_id, source_revision);
+        let message = "(event_class = 'message' OR (event_class = 'event_msg' AND payload_type IN ('user_message', 'agent_message', 'message', 'text')))";
+        let user_message = format!("(lowerUTF8(actor_role) = 'user' AND {message})");
+        let assistant_message = format!("(lowerUTF8(actor_role) = 'assistant' AND {message})");
+        let statement = format!(
+            "INSERT INTO {database}.mcp_open_turns\n\
+             (session_id, slot, generation, turn_seq, turn_id, started_at, ended_at,\n\
+              total_events, user_messages, assistant_messages, tool_calls, tool_results, reasoning_items,\n\
+              user_input_summary_source, final_response_summary_source, user_input_summary_is_payload, final_response_summary_is_payload,\n\
+              user_input_event_uid, user_input_event_order, user_input_event_time, user_input_event_type,\n\
+              final_response_event_uid, final_response_event_order, final_response_event_time, final_response_event_type,\n\
+              tools_called, normalized_event_types, completed, terminal_event_uid,\n\
+              first_event_uid, first_event_order, first_event_time, first_event_type,\n\
+              last_event_uid, last_event_order, last_event_time, last_event_type,\n\
+              previous_turn_seq, previous_turn_id, previous_turn_started_at, previous_turn_ended_at,\n\
+              next_turn_seq, next_turn_id, next_turn_started_at, next_turn_ended_at, event_summaries_json)\n\
+             {ctes},\n\
+             turn_rows AS (\n\
+               SELECT\n\
+                 session_id, turn_seq, anyIf(turn_id, turn_id != '') AS turn_id,\n\
+                 min(event_time) AS started_at, max(event_time) AS ended_at, count() AS total_events,\n\
+                 countIf(actor_role = 'user' AND event_class = 'message') AS user_messages,\n\
+                 countIf(actor_role = 'assistant' AND event_class = 'message') AS assistant_messages,\n\
+                 countIf(event_class = 'tool_call') AS tool_calls, countIf(event_class = 'tool_result') AS tool_results,\n\
+                 countIf(event_class = 'reasoning') AS reasoning_items,\n\
+                 argMinIf(summary_source, tuple(event_order, event_uid), {user_message}) AS user_input_summary_source,\n\
+                 argMaxIf(summary_source, tuple(event_order, event_uid), {assistant_message}) AS final_response_summary_source,\n\
+                 argMinIf(toUInt8(summary_is_payload), tuple(event_order, event_uid), {user_message}) AS user_input_summary_is_payload,\n\
+                 argMaxIf(toUInt8(summary_is_payload), tuple(event_order, event_uid), {assistant_message}) AS final_response_summary_is_payload,\n\
+                 argMinIf(event_uid, tuple(event_order, event_uid), {user_message}) AS user_input_event_uid,\n\
+                 argMinIf(event_order, tuple(event_order, event_uid), {user_message}) AS user_input_event_order,\n\
+                 argMinIf(event_time, tuple(event_order, event_uid), {user_message}) AS user_input_event_time,\n\
+                 argMinIf(event_type, tuple(event_order, event_uid), {user_message}) AS user_input_event_type,\n\
+                 argMaxIf(event_uid, tuple(event_order, event_uid), {assistant_message}) AS final_response_event_uid,\n\
+                 argMaxIf(event_order, tuple(event_order, event_uid), {assistant_message}) AS final_response_event_order,\n\
+                 argMaxIf(event_time, tuple(event_order, event_uid), {assistant_message}) AS final_response_event_time,\n\
+                 argMaxIf(event_type, tuple(event_order, event_uid), {assistant_message}) AS final_response_event_type,\n\
+                 arrayDistinct(arrayMap(x -> x.2, arraySort(groupArrayIf(tuple(event_order, tool_label), event_type = 'tool_call' AND tool_label != '')))) AS tools_called,\n\
+                 arrayDistinct(arrayMap(x -> x.2, arraySort(groupArray(tuple(event_order, event_type))))) AS normalized_event_types,\n\
+                 argMaxIf(toUInt8(payload_type = 'task_complete'), tuple(event_order, event_uid), payload_type IN ('task_complete', 'turn_aborted')) AS completed,\n\
+                 argMaxIf(event_uid, tuple(event_order, event_uid), payload_type IN ('task_complete', 'turn_aborted')) AS terminal_event_uid,\n\
+                 argMin(event_uid, tuple(event_order, event_uid)) AS first_event_uid,\n\
+                 argMin(event_order, tuple(event_order, event_uid)) AS first_event_order,\n\
+                 argMin(event_time, tuple(event_order, event_uid)) AS first_event_time,\n\
+                 argMin(event_type, tuple(event_order, event_uid)) AS first_event_type,\n\
+                 argMax(event_uid, tuple(event_order, event_uid)) AS last_event_uid,\n\
+                 argMax(event_order, tuple(event_order, event_uid)) AS last_event_order,\n\
+                 argMax(event_time, tuple(event_order, event_uid)) AS last_event_time,\n\
+                 argMax(event_type, tuple(event_order, event_uid)) AS last_event_type,\n\
+                 toJSONString(arrayMap(x -> x.2, arraySort(groupArray(tuple(event_order, event_summary))))) AS event_summaries_json\n\
+               FROM summarized\n\
+               GROUP BY session_id, turn_seq\n\
+             ),\n\
+             turn_neighbors AS (\n\
+               SELECT *,\n\
+                 lagInFrame(turn_seq, 1, toUInt32(0)) OVER turn_window AS previous_turn_seq,\n\
+                 lagInFrame(turn_id, 1, '') OVER turn_window AS previous_turn_id,\n\
+                 lagInFrame(started_at, 1, toDateTime64(0, 3)) OVER turn_window AS previous_turn_started_at,\n\
+                 lagInFrame(ended_at, 1, toDateTime64(0, 3)) OVER turn_window AS previous_turn_ended_at,\n\
+                 leadInFrame(turn_seq, 1, toUInt32(0)) OVER turn_window AS next_turn_seq,\n\
+                 leadInFrame(turn_id, 1, '') OVER turn_window AS next_turn_id,\n\
+                 leadInFrame(started_at, 1, toDateTime64(0, 3)) OVER turn_window AS next_turn_started_at,\n\
+                 leadInFrame(ended_at, 1, toDateTime64(0, 3)) OVER turn_window AS next_turn_ended_at\n\
+               FROM turn_rows\n\
+               WINDOW turn_window AS (PARTITION BY session_id ORDER BY turn_seq ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)\n\
+             )\n\
+             SELECT\n\
+               session_id, {slot}, {generation}, turn_seq, turn_id, started_at, ended_at,\n\
+               total_events, user_messages, assistant_messages, tool_calls, tool_results, reasoning_items,\n\
+               user_input_summary_source, final_response_summary_source, user_input_summary_is_payload, final_response_summary_is_payload,\n\
+               user_input_event_uid, user_input_event_order, user_input_event_time, user_input_event_type,\n\
+               final_response_event_uid, final_response_event_order, final_response_event_time, final_response_event_type,\n\
+               tools_called, normalized_event_types, completed, terminal_event_uid,\n\
+               first_event_uid, first_event_order, first_event_time, first_event_type,\n\
+               last_event_uid, last_event_order, last_event_time, last_event_type,\n\
+               previous_turn_seq, previous_turn_id, previous_turn_started_at, previous_turn_ended_at,\n\
+               next_turn_seq, next_turn_id, next_turn_started_at, next_turn_ended_at, event_summaries_json\n\
+             FROM turn_neighbors",
+        );
+        self.request_text(&statement, None, Some(&self.cfg.database), false, None)
+            .await?;
+        Ok(())
+    }
+
+    async fn insert_projected_session_head(
+        &self,
+        session_id: &str,
+        slot: u8,
+        generation: u64,
+        expected_source_revision: u64,
+        dirty_revision: u64,
+    ) -> Result<bool> {
+        let database = escape_identifier(&self.cfg.database);
+        let ctes = projection_ctes(&database, session_id, expected_source_revision);
+        let statement = format!(
+            "INSERT INTO {database}.mcp_open_sessions\n\
+             (session_id, slot, generation, source_revision, dirty_revision, first_event_time,\n\
+              last_event_time, total_turns, total_events, user_messages, assistant_messages,\n\
+              tool_calls, tool_results, mode, first_event_uid, last_event_uid, last_actor_role,\n\
+              title, source, harness, inference_provider, session_slug, session_summary,\n\
+              completed, terminal_event_uid, origin_cwd)\n\
+             {ctes},\n\
+             header AS (\n\
+               SELECT\n\
+                 session_id, max(source_revision) AS source_revision, min(event_time) AS first_event_time,\n\
+                 max(event_time) AS last_event_time, toUInt32(max(turn_seq)) AS total_turns, count() AS total_events,\n\
+                 countIf(actor_role = 'user' AND event_class = 'message') AS user_messages,\n\
+                 countIf(actor_role = 'assistant' AND event_class = 'message') AS assistant_messages,\n\
+                 countIf(event_class = 'tool_call') AS tool_calls, countIf(event_class = 'tool_result') AS tool_results,\n\
+                 multiIf(\n\
+                   countIf(payload_type = 'web_search_call' OR payload_type = 'search_results_received' OR (payload_type = 'tool_use' AND name IN ('WebSearch', 'WebFetch'))) > 0, 'web_search',\n\
+                   countIf(source_name = 'codex-mcp' OR lowerUTF8(name) IN ('search', 'open', 'list_sessions', 'file_attention')) > 0, 'mcp_internal',\n\
+                   countIf(event_class IN ('tool_call', 'tool_result') OR payload_type = 'tool_use') > 0, 'tool_calling', 'chat') AS mode,\n\
+                 argMin(event_uid, tuple(event_time, event_order, event_uid)) AS first_event_uid,\n\
+                 argMax(event_uid, tuple(event_time, event_order, event_uid)) AS last_event_uid,\n\
+                 argMax(actor_role, tuple(event_time, event_order, event_uid)) AS last_actor_role,\n\
+                 ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'title'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'),\n\
+                   ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'name'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'), '')) AS title,\n\
+                 ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'source'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'),\n\
+                   ifNull(argMax(nullIf(source_name, ''), tuple(event_ts, event_uid)), '')) AS source,\n\
+                 ifNull(argMax(nullIf(harness, ''), tuple(event_ts, event_uid)), '') AS harness,\n\
+                 ifNull(argMax(nullIf(inference_provider, ''), tuple(event_ts, event_uid)), '') AS inference_provider,\n\
+                 ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'slug'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'), '') AS session_slug,\n\
+                 ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'summary'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'),\n\
+                   ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'title'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'),\n\
+                     ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'name'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'), ''))) AS session_summary,\n\
+                 ifNull(argMinIf(cwd, tuple(event_ts, event_uid), cwd != ''), '') AS origin_cwd\n\
+               FROM enriched\n\
+               GROUP BY session_id\n\
+               HAVING source_revision = {expected_source_revision}\n\
+             ),\n\
+             current_dirty AS (\n\
+               SELECT if(count() = 0, toUInt64(0), toUInt64(max(dirty_revision))) AS dirty_revision\n\
+               FROM {database}.mcp_open_dirty_sessions FINAL\n\
+               WHERE session_id = {session_sql}\n\
+             ),\n\
+             terminal AS (\n\
+               SELECT\n\
+                 session_id, argMax(completed, turn_seq) AS completed, argMax(terminal_event_uid, turn_seq) AS terminal_event_uid\n\
+               FROM {database}.mcp_open_turns FINAL\n\
+               WHERE session_id = {session_sql} AND slot = {slot} AND generation = {generation} AND turn_seq > 0\n\
+               GROUP BY session_id\n\
+             )\n\
+             SELECT\n\
+               h.session_id, {slot}, {generation}, h.source_revision, {dirty_revision},\n\
+               h.first_event_time, h.last_event_time, h.total_turns, h.total_events,\n\
+               h.user_messages, h.assistant_messages, h.tool_calls, h.tool_results, h.mode,\n\
+               h.first_event_uid, h.last_event_uid, h.last_actor_role, h.title, h.source,\n\
+               h.harness, h.inference_provider, h.session_slug, h.session_summary,\n\
+               ifNull(t.completed, 0), ifNull(t.terminal_event_uid, ''), h.origin_cwd\n\
+             FROM header AS h\n\
+             CROSS JOIN current_dirty AS d\n\
+             LEFT JOIN terminal AS t ON t.session_id = h.session_id\n\
+             WHERE d.dirty_revision = {dirty_revision}",
+            session_sql = escape_literal(session_id),
+        );
+        self.request_text(&statement, None, Some(&self.cfg.database), false, None)
+            .await?;
+        let head = self.mcp_open_session_head(session_id).await?;
+        Ok(head.is_some_and(|head| {
+            head.generation == generation
+                && head.slot == slot
+                && head.source_revision == expected_source_revision
+                && head.dirty_revision == dirty_revision
+        }))
+    }
+}
+
+fn projection_ctes(database: &str, session_id: &str, source_revision: u64) -> String {
+    let session_id = escape_literal(session_id);
+    let event_type = event_type_sql();
+    format!(
+        "WITH\n\
+         canonical AS (\n\
+           SELECT\n\
+             ingested_at, event_uid, session_id, source_name, harness, inference_provider, source_file,\n\
+             source_generation, source_line_no, source_offset, source_ref, record_ts, event_ts,\n\
+             event_kind AS event_class, actor_kind AS actor_role, payload_type, turn_index, toString(turn_index) AS turn_id, item_id,\n\
+             tool_call_id AS call_id, tool_name AS name, if(tool_phase != '', tool_phase, op_status) AS phase,\n\
+             text_content, payload_json, token_usage_json, endpoint_kind, token_usage_buckets,\n\
+             token_usage_native_units, cwd, event_version\n\
+           FROM {database}.events FINAL\n\
+           WHERE session_id = {session_id}\n\
+         ),\n\
+         canonical_revision AS (\n\
+           SELECT if(count() = 0, toUInt64(0), toUInt64(cityHash64(arraySort(groupArray(tuple(event_uid, event_version)))))) AS source_revision\n\
+           FROM canonical\n\
+         ),\n\
+         ordered AS (\n\
+           SELECT canonical.*,\n\
+             ifNull(parseDateTime64BestEffortOrNull(record_ts), ingested_at) AS event_time,\n\
+             row_number() OVER canonical_window AS event_order,\n\
+             if(toUInt32(turn_index) > 0, toUInt32(turn_index), greatest(toUInt32(1), toUInt32(sum(if(actor_role = 'user' AND event_class = 'message', 1, 0)) OVER canonical_rows))) AS turn_seq,\n\
+             revision.source_revision AS source_revision\n\
+           FROM canonical\n\
+           CROSS JOIN canonical_revision AS revision\n\
+           WHERE revision.source_revision = {source_revision}\n\
+           WINDOW\n\
+             canonical_window AS (PARTITION BY session_id ORDER BY ifNull(parseDateTime64BestEffortOrNull(record_ts), ingested_at), source_file, source_generation, source_offset, source_line_no, event_uid),\n\
+             canonical_rows AS (PARTITION BY session_id ORDER BY ifNull(parseDateTime64BestEffortOrNull(record_ts), ingested_at), source_file, source_generation, source_offset, source_line_no, event_uid ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\n\
+         ),\n\
+         typed AS (\n\
+           SELECT *, {event_type} AS event_type,\n\
+             empty(trimBoth(text_content)) AS summary_is_payload,\n\
+             if(summary_is_payload,\n\
+               leftUTF8(payload_json, {payload_summary_chars}),\n\
+               leftUTF8(text_content, {text_summary_chars})) AS summary_source,\n\
+             if(notEmpty(trimBoth(name)), trimBoth(name), trimBoth(call_id)) AS tool_label\n\
+           FROM ordered\n\
+         ),\n\
+         enriched AS (\n\
+           SELECT *,\n\
+             toUInt32(row_number() OVER (PARTITION BY session_id, turn_seq ORDER BY event_order, event_uid)) AS event_ordinal,\n\
+             lagInFrame(event_uid, 1, '') OVER event_window AS previous_event_uid,\n\
+             leadInFrame(event_uid, 1, '') OVER event_window AS next_event_uid\n\
+           FROM typed\n\
+           WINDOW event_window AS (PARTITION BY session_id ORDER BY event_order, event_uid ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)\n\
+         ),\n\
+         summarized AS (\n\
+           SELECT *, CAST(tuple(\n\
+             event_uid, event_order, toString(event_time),\n\
+             toInt64(toUnixTimestamp64Milli(event_time)), actor_role, event_class, payload_type,\n\
+             event_type, call_id, name, phase, summary_source, toUInt8(summary_is_payload)\n\
+           ), 'Tuple(event_uid String, event_order UInt64, event_time String, event_unix_ms Int64, actor_role String, event_class String, payload_type String, event_type String, call_id String, name String, phase String, summary_source String, summary_is_payload UInt8)') AS event_summary\n\
+           FROM enriched\n\
+         )",
+        payload_summary_chars = MAX_PROJECTED_PAYLOAD_SUMMARY_CHARS,
+        text_summary_chars = MAX_PROJECTED_TEXT_SUMMARY_CHARS,
+    )
+}
+
+fn event_type_sql() -> &'static str {
+    "multiIf(\
+      lowerUTF8(actor_role) = 'user' AND (event_class = 'message' OR (event_class = 'event_msg' AND payload_type IN ('user_message', 'agent_message', 'message', 'text', 'event_msg'))), 'user_input',\
+      lowerUTF8(actor_role) = 'assistant' AND (event_class = 'message' OR (event_class = 'event_msg' AND payload_type IN ('user_message', 'agent_message', 'message', 'text', 'event_msg'))), 'assistant_response',\
+      lowerUTF8(actor_role) != 'system' AND (event_class = 'reasoning' OR payload_type IN ('agent_reasoning', 'reasoning', 'thinking')), 'reasoning',\
+      lowerUTF8(actor_role) != 'system' AND (event_class = 'tool_call' OR payload_type IN ('tool_use', 'function_call', 'custom_tool_call', 'web_search_call')), 'tool_call',\
+      lowerUTF8(actor_role) != 'system' AND (event_class = 'tool_result' OR payload_type IN ('tool_result', 'function_call_output', 'custom_tool_call_output', 'search_results_received')), 'tool_response',\
+      event_class IN ('compacted_raw', 'summary') OR payload_type IN ('compacted', 'summary'), 'compaction',\
+      event_class = 'queue_operation' OR payload_type IN ('task_started', 'task_complete', 'turn_aborted', 'item_completed', 'queue-operation'), 'runtime',\
+      lowerUTF8(actor_role) = 'system' OR event_class IN ('system', 'progress', 'file_history_snapshot') OR payload_type IN ('system', 'progress', 'file-history-snapshot', 'file_history_snapshot'), 'system',\
+      'unknown')"
+}

--- a/crates/moraine-conversations/src/clickhouse_repo/helpers.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/helpers.rs
@@ -685,12 +685,6 @@ pub(super) fn non_empty_string(value: String) -> Option<String> {
     (!value.is_empty()).then_some(value)
 }
 
-pub(super) fn push_first_seen(items: &mut Vec<String>, value: String) {
-    if !items.iter().any(|item| item == &value) {
-        items.push(value);
-    }
-}
-
 pub(super) fn compact_whitespace(value: &str) -> String {
     value.split_whitespace().collect::<Vec<_>>().join(" ")
 }

--- a/crates/moraine-conversations/src/clickhouse_repo/mcp_open_read.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/mcp_open_read.rs
@@ -1,0 +1,510 @@
+use super::*;
+
+pub(super) struct ProjectedSession {
+    pub(super) row: McpOpenSessionRow,
+    pub(super) metadata: SessionMetadata,
+}
+
+impl ProjectedSession {
+    pub(super) fn same_snapshot(&self, other: &Self) -> bool {
+        self.row.slot == other.row.slot && self.row.generation == other.row.generation
+    }
+}
+
+pub(super) struct ProjectedTurn {
+    pub(super) compact: McpTurnCompact,
+    pub(super) events: Vec<McpEventSummary>,
+    pub(super) previous_turn: Option<McpTurnRef>,
+    pub(super) next_turn: Option<McpTurnRef>,
+}
+
+impl ClickHouseConversationRepository {
+    pub(super) async fn ensure_mcp_open_read_model_ready(&self) -> RepoResult<()> {
+        let ready = self.map_backend(self.ch.mcp_open_read_model_ready().await)?;
+        if ready {
+            Ok(())
+        } else {
+            Err(RepoError::backend(
+                "MCP open read model is not ready; run `moraine db migrate`",
+            ))
+        }
+    }
+
+    pub(super) async fn projected_snapshot_still_current(
+        &self,
+        pinned: &ProjectedSession,
+    ) -> RepoResult<bool> {
+        Ok(self
+            .load_projected_session(&pinned.row.session_id)
+            .await?
+            .is_some_and(|current| pinned.same_snapshot(&current)))
+    }
+
+    pub(super) async fn load_projected_session(
+        &self,
+        session_id: &str,
+    ) -> RepoResult<Option<ProjectedSession>> {
+        let sessions = self.table_ref("mcp_open_sessions");
+        let query = format!(
+            "SELECT
+  session_id,
+  toUInt8(slot) AS slot,
+  toUInt64(generation) AS generation,
+  toString(s.first_event_time) AS first_event_time,
+  toInt64(toUnixTimestamp64Milli(s.first_event_time)) AS first_event_unix_ms,
+  toString(s.last_event_time) AS last_event_time,
+  toInt64(toUnixTimestamp64Milli(s.last_event_time)) AS last_event_unix_ms,
+  toUInt32(total_turns) AS total_turns,
+  toUInt64(total_events) AS total_events,
+  toUInt64(user_messages) AS user_messages,
+  toUInt64(assistant_messages) AS assistant_messages,
+  toUInt64(tool_calls) AS tool_calls,
+  toUInt64(tool_results) AS tool_results,
+  mode,
+  first_event_uid,
+  last_event_uid,
+  last_actor_role,
+  title,
+  source,
+  harness,
+  inference_provider,
+  session_slug,
+  session_summary,
+  toUInt8(completed) AS completed,
+  terminal_event_uid,
+  origin_cwd
+FROM {sessions} AS s FINAL
+WHERE s.session_id = {}
+LIMIT 1
+FORMAT JSONEachRow",
+            sql_quote(session_id),
+        );
+        let rows: Vec<McpOpenSessionRow> = self.map_backend(self.query_rows(&query, None).await)?;
+        Ok(rows.into_iter().next().map(|row| {
+            let metadata = SessionMetadata {
+                session_id: row.session_id.clone(),
+                first_event_time: row.first_event_time.clone(),
+                first_event_unix_ms: row.first_event_unix_ms,
+                last_event_time: row.last_event_time.clone(),
+                last_event_unix_ms: row.last_event_unix_ms,
+                total_turns: row.total_turns,
+                total_events: row.total_events,
+                user_messages: row.user_messages,
+                assistant_messages: row.assistant_messages,
+                tool_calls: row.tool_calls,
+                tool_results: row.tool_results,
+                mode: Self::parse_mode(&row.mode),
+                first_event_uid: row.first_event_uid.clone(),
+                last_event_uid: row.last_event_uid.clone(),
+                last_actor_role: row.last_actor_role.clone(),
+            };
+            ProjectedSession { row, metadata }
+        }))
+    }
+
+    pub(super) fn projected_session_in_scope(&self, session: &ProjectedSession) -> bool {
+        let Some(scope) = self.cfg.session_scope.as_ref() else {
+            return true;
+        };
+        let origin = session.row.origin_cwd.trim_end_matches('/');
+        !origin.is_empty()
+            && scope.roots.iter().any(|root| {
+                origin == root
+                    || origin
+                        .strip_prefix(root)
+                        .is_some_and(|tail| tail.starts_with('/'))
+            })
+    }
+
+    pub(super) async fn load_projected_turns(
+        &self,
+        session: &ProjectedSession,
+        turn_seq: Option<u32>,
+        include_events: bool,
+    ) -> RepoResult<Vec<ProjectedTurn>> {
+        let turns = self.table_ref("mcp_open_turns");
+        let event_json = if include_events {
+            "event_summaries_json"
+        } else {
+            "'[]'"
+        };
+        let turn_filter = turn_seq
+            .map(|turn_seq| format!(" AND turn_seq = {turn_seq}"))
+            .unwrap_or_default();
+        let query = format!(
+            "SELECT
+  session_id,
+  toUInt32(turn_seq) AS turn_seq,
+  turn_id,
+  toString(t.started_at) AS started_at,
+  toInt64(toUnixTimestamp64Milli(t.started_at)) AS started_at_unix_ms,
+  toString(t.ended_at) AS ended_at,
+  toInt64(toUnixTimestamp64Milli(t.ended_at)) AS ended_at_unix_ms,
+  toUInt64(total_events) AS total_events,
+  toUInt64(user_messages) AS user_messages,
+  toUInt64(assistant_messages) AS assistant_messages,
+  toUInt64(tool_calls) AS tool_calls,
+  toUInt64(tool_results) AS tool_results,
+  toUInt64(reasoning_items) AS reasoning_items,
+  user_input_summary_source,
+  final_response_summary_source,
+  toUInt8(user_input_summary_is_payload) AS user_input_summary_is_payload,
+  toUInt8(final_response_summary_is_payload) AS final_response_summary_is_payload,
+  user_input_event_uid,
+  toUInt64(user_input_event_order) AS user_input_event_order,
+  toString(user_input_event_time) AS user_input_event_time,
+  user_input_event_type,
+  final_response_event_uid,
+  toUInt64(final_response_event_order) AS final_response_event_order,
+  toString(final_response_event_time) AS final_response_event_time,
+  final_response_event_type,
+  tools_called,
+  normalized_event_types,
+  toUInt8(completed) AS completed,
+  terminal_event_uid,
+  first_event_uid,
+  toUInt64(first_event_order) AS first_event_order,
+  toString(first_event_time) AS first_event_time,
+  first_event_type,
+  last_event_uid,
+  toUInt64(last_event_order) AS last_event_order,
+  toString(last_event_time) AS last_event_time,
+  last_event_type,
+  toUInt32(previous_turn_seq) AS previous_turn_seq,
+  previous_turn_id,
+  toString(previous_turn_started_at) AS previous_turn_started_at,
+  toString(previous_turn_ended_at) AS previous_turn_ended_at,
+  toUInt32(next_turn_seq) AS next_turn_seq,
+  next_turn_id,
+  toString(next_turn_started_at) AS next_turn_started_at,
+  toString(next_turn_ended_at) AS next_turn_ended_at,
+  {event_json} AS event_summaries_json
+FROM {turns} AS t FINAL
+WHERE t.session_id = {session_id} AND t.slot = {slot} AND t.generation = {generation} AND t.turn_seq > 0{turn_filter}
+ORDER BY t.turn_seq ASC
+FORMAT JSONEachRow",
+            session_id = sql_quote(&session.row.session_id),
+            slot = session.row.slot,
+            generation = session.row.generation,
+        );
+        let rows: Vec<McpOpenTurnRow> = self.map_backend(self.query_rows(&query, None).await)?;
+        rows.into_iter()
+            .map(|row| self.map_projected_turn(row))
+            .collect()
+    }
+
+    pub(super) async fn load_projected_event_candidates(
+        &self,
+        event_uid: &str,
+    ) -> RepoResult<Vec<McpOpenEventLookupRow>> {
+        let events = self.table_ref("mcp_open_events");
+        let query = format!(
+            "SELECT
+  event_uid,
+  session_id,
+  toUInt8(slot) AS slot,
+  toUInt64(generation) AS generation
+FROM {events} FINAL
+WHERE event_uid = {}
+ORDER BY generation DESC
+FORMAT JSONEachRow",
+            sql_quote(event_uid),
+        );
+        self.map_backend(self.query_rows(&query, None).await)
+    }
+
+    pub(super) async fn load_projected_event(
+        &self,
+        lookup: &McpOpenEventLookupRow,
+    ) -> RepoResult<Option<McpOpenEventRow>> {
+        let events = self.table_ref("mcp_open_events");
+        let query = format!(
+            "SELECT
+  session_id,
+  event_uid,
+  toUInt64(event_order) AS event_order,
+  toUInt32(turn_seq) AS turn_seq,
+  toString(e.event_time) AS event_time,
+  toInt64(toUnixTimestamp64Milli(e.event_time)) AS event_unix_ms,
+  actor_role,
+  event_class,
+  payload_type,
+  event_type,
+  toUInt32(event_ordinal) AS event_ordinal,
+  call_id,
+  name,
+  phase,
+  item_id,
+  source_ref,
+  text_content,
+  payload_json,
+  token_usage_json,
+  endpoint_kind,
+  token_usage_buckets,
+  token_usage_native_units,
+  previous_event_uid,
+  next_event_uid
+FROM {events} AS e FINAL
+WHERE e.event_uid = {event_uid} AND e.slot = {slot} AND e.generation = {generation}
+LIMIT 1
+FORMAT JSONEachRow",
+            event_uid = sql_quote(&lookup.event_uid),
+            slot = lookup.slot,
+            generation = lookup.generation,
+        );
+        let rows: Vec<McpOpenEventRow> = self.map_backend(self.query_rows(&query, None).await)?;
+        Ok(rows.into_iter().next())
+    }
+
+    pub(super) async fn load_projected_event_refs(
+        &self,
+        event_uids: Vec<String>,
+        slot: u8,
+        generation: u64,
+    ) -> RepoResult<HashMap<String, McpEventRef>> {
+        if event_uids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        #[derive(Deserialize)]
+        struct RefRow {
+            session_id: String,
+            event_uid: String,
+            event_order: u64,
+            turn_seq: u32,
+            event_time: String,
+            event_type: String,
+        }
+        let events = self.table_ref("mcp_open_events");
+        let query = format!(
+            "SELECT
+  session_id,
+  event_uid,
+  toUInt64(event_order) AS event_order,
+  toUInt32(turn_seq) AS turn_seq,
+  toString(event_time) AS event_time,
+  event_type
+FROM {events} FINAL
+WHERE event_uid IN {} AND slot = {} AND generation = {}
+FORMAT JSONEachRow",
+            sql_array_strings(&event_uids),
+            slot,
+            generation,
+        );
+        let rows: Vec<RefRow> = self.map_backend(self.query_rows(&query, None).await)?;
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                let event_uid = row.event_uid.clone();
+                (
+                    event_uid,
+                    McpEventRef {
+                        session_id: row.session_id,
+                        event_uid: row.event_uid,
+                        event_order: row.event_order,
+                        turn_seq: row.turn_seq,
+                        event_time: row.event_time,
+                        event_type: row.event_type,
+                    },
+                )
+            })
+            .collect())
+    }
+
+    fn map_projected_turn(&self, row: McpOpenTurnRow) -> RepoResult<ProjectedTurn> {
+        let metadata = TurnSummary {
+            session_id: row.session_id.clone(),
+            turn_seq: row.turn_seq,
+            turn_id: row.turn_id.clone(),
+            started_at: row.started_at.clone(),
+            started_at_unix_ms: row.started_at_unix_ms,
+            ended_at: row.ended_at.clone(),
+            ended_at_unix_ms: row.ended_at_unix_ms,
+            total_events: row.total_events,
+            user_messages: row.user_messages,
+            assistant_messages: row.assistant_messages,
+            tool_calls: row.tool_calls,
+            tool_results: row.tool_results,
+            reasoning_items: row.reasoning_items,
+        };
+        let user_input_event = projected_event_ref(
+            &row.session_id,
+            row.turn_seq,
+            &row.user_input_event_uid,
+            row.user_input_event_order,
+            &row.user_input_event_time,
+            &row.user_input_event_type,
+        );
+        let final_response_event = projected_event_ref(
+            &row.session_id,
+            row.turn_seq,
+            &row.final_response_event_uid,
+            row.final_response_event_order,
+            &row.final_response_event_time,
+            &row.final_response_event_type,
+        );
+        let first_event = projected_event_ref(
+            &row.session_id,
+            row.turn_seq,
+            &row.first_event_uid,
+            row.first_event_order,
+            &row.first_event_time,
+            &row.first_event_type,
+        );
+        let last_event = projected_event_ref(
+            &row.session_id,
+            row.turn_seq,
+            &row.last_event_uid,
+            row.last_event_order,
+            &row.last_event_time,
+            &row.last_event_type,
+        );
+        let events: Vec<ProjectedEventSummaryRow> = serde_json::from_str(&row.event_summaries_json)
+            .map_err(|error| {
+                RepoError::internal(format!("invalid projected event summaries: {error}"))
+            })?;
+        let event_session_id = row.session_id.clone();
+        let event_turn_seq = row.turn_seq;
+        let events = events
+            .into_iter()
+            .map(|event| McpEventSummary {
+                session_id: event_session_id.clone(),
+                event_uid: event.event_uid,
+                event_order: event.event_order,
+                turn_seq: event_turn_seq,
+                event_time: event.event_time,
+                event_unix_ms: event.event_unix_ms,
+                actor_role: event.actor_role,
+                event_class: event.event_class,
+                payload_type: event.payload_type,
+                event_type: event.event_type,
+                call_id: event.call_id,
+                name: event.name,
+                phase: event.phase,
+                text_preview: compact_projected_source(
+                    &event.summary_source,
+                    event.summary_is_payload != 0,
+                    self.cfg.preview_chars,
+                ),
+            })
+            .collect();
+        let previous_turn = projected_turn_ref(
+            &row.session_id,
+            row.previous_turn_seq,
+            &row.previous_turn_id,
+            &row.previous_turn_started_at,
+            &row.previous_turn_ended_at,
+        );
+        let next_turn = projected_turn_ref(
+            &row.session_id,
+            row.next_turn_seq,
+            &row.next_turn_id,
+            &row.next_turn_started_at,
+            &row.next_turn_ended_at,
+        );
+        Ok(ProjectedTurn {
+            compact: McpTurnCompact {
+                metadata,
+                user_input_summary: compact_projected_source(
+                    &row.user_input_summary_source,
+                    row.user_input_summary_is_payload != 0,
+                    self.cfg.preview_chars,
+                ),
+                final_response_summary: compact_projected_source(
+                    &row.final_response_summary_source,
+                    row.final_response_summary_is_payload != 0,
+                    self.cfg.preview_chars,
+                ),
+                user_input_event,
+                final_response_event,
+                tools_called: row.tools_called,
+                normalized_event_types: row.normalized_event_types,
+                completed: row.completed != 0,
+                terminal_event_uid: non_empty_string(row.terminal_event_uid),
+                first_event,
+                last_event,
+            },
+            events,
+            previous_turn,
+            next_turn,
+        })
+    }
+}
+
+fn projected_event_ref(
+    session_id: &str,
+    turn_seq: u32,
+    event_uid: &str,
+    event_order: u64,
+    event_time: &str,
+    event_type: &str,
+) -> Option<McpEventRef> {
+    (!event_uid.is_empty()).then(|| McpEventRef {
+        session_id: session_id.to_string(),
+        event_uid: event_uid.to_string(),
+        event_order,
+        turn_seq,
+        event_time: event_time.to_string(),
+        event_type: event_type.to_string(),
+    })
+}
+
+fn projected_turn_ref(
+    session_id: &str,
+    turn_seq: u32,
+    turn_id: &str,
+    started_at: &str,
+    ended_at: &str,
+) -> Option<McpTurnRef> {
+    (turn_seq > 0).then(|| McpTurnRef {
+        session_id: session_id.to_string(),
+        turn_seq,
+        turn_id: turn_id.to_string(),
+        started_at: started_at.to_string(),
+        ended_at: ended_at.to_string(),
+    })
+}
+
+fn compact_projected_source(source: &str, is_payload: bool, preview_chars: u16) -> Option<String> {
+    if source.trim().is_empty() {
+        return None;
+    }
+    let output_limit = usize::from(preview_chars).max(1);
+    let source_limit = if is_payload {
+        output_limit.max(4).saturating_mul(2)
+    } else {
+        output_limit.max(4)
+    };
+    let truncated = truncate_with_ellipsis(source, source_limit);
+    let compact = compact_text_line(&truncated, output_limit);
+    (!compact.is_empty()).then_some(compact)
+}
+
+fn truncate_with_ellipsis(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let prefix = value
+        .chars()
+        .take(max_chars.saturating_sub(3))
+        .collect::<String>();
+    format!("{prefix}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compact_projected_source;
+
+    #[test]
+    fn projected_summary_sentinel_preserves_max_preview_ellipsis() {
+        let text = "x".repeat(65_536);
+        let text_preview = compact_projected_source(&text, false, u16::MAX).expect("text preview");
+        assert_eq!(text_preview.chars().count(), usize::from(u16::MAX));
+        assert!(text_preview.ends_with("..."));
+
+        let payload = "y".repeat(131_071);
+        let payload_preview =
+            compact_projected_source(&payload, true, u16::MAX).expect("payload preview");
+        assert_eq!(payload_preview.chars().count(), usize::from(u16::MAX));
+        assert!(payload_preview.ends_with("..."));
+    }
+}

--- a/crates/moraine-conversations/src/clickhouse_repo/mod.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/mod.rs
@@ -84,6 +84,7 @@ mod cache;
 mod file_attention;
 mod helpers;
 mod list;
+mod mcp_open_read;
 mod open;
 mod operations;
 mod repo_impl;
@@ -190,6 +191,6 @@ impl ClickHouseConversationRepository {
     }
 
     pub(super) fn map_backend<T>(&self, result: AnyResult<T>) -> RepoResult<T> {
-        result.map_err(|err| RepoError::backend(err.to_string()))
+        result.map_err(|err| RepoError::backend(format!("{err:#}")))
     }
 }

--- a/crates/moraine-conversations/src/clickhouse_repo/open.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/open.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+const MAX_MCP_OPEN_SNAPSHOT_ATTEMPTS: usize = 4;
+
 impl ClickHouseConversationRepository {
     pub(super) async fn load_turns_for_session(
         &self,
@@ -117,88 +119,6 @@ FORMAT JSONEachRow",
         Ok(rows.into_iter().next().map(Self::map_session_metadata_row))
     }
 
-    pub(super) async fn load_mcp_session_header(
-        &self,
-        session_id: &str,
-    ) -> RepoResult<Option<(SessionMetadata, McpSessionInfoRow)>> {
-        let session_summary = self.table_ref("v_session_summary");
-        let trace_table = self.table_ref("v_conversation_trace");
-        let events_source = canonical_events_source(&self.table_ref("events"));
-        let session_id_sql = sql_quote(session_id);
-        let mode_aggregate = Self::mode_aggregate_sql();
-        let query = format!(
-            "SELECT
-  s.session_id AS session_id,
-  toString(s.first_event_time) AS first_event_time,
-  toInt64(toUnixTimestamp64Milli(s.first_event_time)) AS first_event_unix_ms,
-  toString(s.last_event_time) AS last_event_time,
-  toInt64(toUnixTimestamp64Milli(s.last_event_time)) AS last_event_unix_ms,
-  toUInt32(s.total_turns) AS total_turns,
-  toUInt64(s.total_events) AS total_events,
-  toUInt64(s.user_messages) AS user_messages,
-  toUInt64(s.assistant_messages) AS assistant_messages,
-  toUInt64(s.tool_calls) AS tool_calls,
-  toUInt64(s.tool_results) AS tool_results,
-  ifNull(i.mode, 'chat') AS mode,
-  ifNull(e.first_event_uid, '') AS first_event_uid,
-  ifNull(e.last_event_uid, '') AS last_event_uid,
-  ifNull(e.last_actor_role, '') AS last_actor_role,
-  ifNull(i.title, '') AS title,
-  ifNull(i.source, '') AS source,
-  ifNull(i.harness, '') AS harness,
-  ifNull(i.inference_provider, '') AS inference_provider,
-  ifNull(i.session_slug, '') AS session_slug,
-  ifNull(i.session_summary, '') AS session_summary
-FROM {session_summary} AS s
-LEFT JOIN (
-  SELECT
-    session_id,
-    argMin(event_uid, tuple(event_time, event_order, event_uid)) AS first_event_uid,
-    argMax(event_uid, tuple(event_time, event_order, event_uid)) AS last_event_uid,
-    argMax(actor_role, tuple(event_time, event_order, event_uid)) AS last_actor_role
-  FROM {trace_table}
-  WHERE session_id = {session_id_sql}
-  GROUP BY session_id
-) AS e ON e.session_id = s.session_id
-LEFT JOIN (
-  SELECT
-    {mode_aggregate} AS mode,
-    session_id,
-    ifNull(
-      argMaxIf(nullIf(JSONExtractString(payload_json, 'title'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'),
-      ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'name'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'), '')
-    ) AS title,
-    ifNull(
-      argMaxIf(nullIf(JSONExtractString(payload_json, 'source'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'),
-      ifNull(argMax(nullIf(source_name, ''), tuple(event_ts, event_uid)), '')
-    ) AS source,
-    ifNull(argMax(nullIf(harness, ''), tuple(event_ts, event_uid)), '') AS harness,
-    ifNull(argMax(nullIf(inference_provider, ''), tuple(event_ts, event_uid)), '') AS inference_provider,
-    ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'slug'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'), '') AS session_slug,
-    ifNull(
-      argMaxIf(nullIf(JSONExtractString(payload_json, 'summary'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'),
-      ifNull(
-        argMaxIf(nullIf(JSONExtractString(payload_json, 'title'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'),
-        ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'name'), ''), tuple(event_ts, event_uid), event_kind = 'session_meta'), '')
-      )
-    ) AS session_summary
-  FROM {events_source}
-  WHERE session_id = {session_id_sql}
-  GROUP BY session_id
-) AS i ON i.session_id = s.session_id
-WHERE s.session_id = {session_id_sql}
-LIMIT 1
-FORMAT JSONEachRow"
-        );
-
-        let rows: Vec<McpSessionHeaderRow> =
-            self.map_backend(self.query_rows(&query, None).await)?;
-        Ok(rows
-            .into_iter()
-            .next()
-            .map(|row| (Self::map_session_metadata_row(row.metadata), row.info)))
-    }
-
     pub(super) async fn load_turn_summary(
         &self,
         session_id: &str,
@@ -230,143 +150,6 @@ FORMAT JSONEachRow",
 
         let rows: Vec<TurnSummaryRow> = self.map_backend(self.query_rows(&query, None).await)?;
         Ok(rows.into_iter().next().map(Self::map_turn_row))
-    }
-
-    pub(super) async fn load_event_by_uid(
-        &self,
-        event_uid: &str,
-    ) -> RepoResult<Option<TraceEvent>> {
-        let trace_table = self.table_ref("v_conversation_trace");
-        let query = format!(
-            "SELECT
-  session_id,
-  event_uid,
-  toUInt64(event_order) AS event_order,
-  toUInt32(turn_seq) AS turn_seq,
-  toString(tr.event_time) AS event_time,
-  toInt64(toUnixTimestamp64Milli(tr.event_time)) AS event_unix_ms,
-  actor_role,
-  event_class,
-  payload_type,
-  call_id,
-  name,
-  phase,
-  item_id,
-  source_ref,
-  text_content,
-  payload_json,
-  token_usage_json,
-  endpoint_kind,
-  token_usage_buckets,
-  token_usage_native_units
-FROM {trace_table} AS tr
-WHERE event_uid = {}
-ORDER BY event_order DESC
-LIMIT 1
-FORMAT JSONEachRow",
-            sql_quote(event_uid),
-        );
-
-        let rows: Vec<TraceEventRow> = self.map_backend(self.query_rows(&query, None).await)?;
-        Ok(rows.into_iter().next().map(Self::map_trace_event))
-    }
-
-    pub(super) async fn load_event_session_id(
-        &self,
-        event_uid: &str,
-    ) -> RepoResult<Option<String>> {
-        let documents_table = self.table_ref("search_documents");
-        let docs_query = format!(
-            "SELECT
-  argMax(session_id, doc_version) AS session_id
-FROM {documents_table}
-WHERE event_uid = {}
-GROUP BY event_uid
-LIMIT 1
-FORMAT JSONEachRow",
-            sql_quote(event_uid),
-        );
-        let rows: Vec<EventSessionRow> =
-            self.map_backend(self.query_rows(&docs_query, None).await)?;
-        if let Some(row) = rows.into_iter().next() {
-            if !row.session_id.is_empty() {
-                return Ok(Some(row.session_id));
-            }
-        }
-
-        let trace_table = self.table_ref("v_conversation_trace");
-        let trace_query = format!(
-            "SELECT session_id
-FROM {trace_table}
-WHERE event_uid = {}
-ORDER BY event_time DESC, event_order DESC, session_id ASC
-LIMIT 1
-FORMAT JSONEachRow",
-            sql_quote(event_uid),
-        );
-        let rows: Vec<EventSessionRow> =
-            self.map_backend(self.query_rows(&trace_query, None).await)?;
-        Ok(rows
-            .into_iter()
-            .next()
-            .map(|row| row.session_id)
-            .filter(|session_id| !session_id.is_empty()))
-    }
-
-    pub(super) async fn load_mcp_session_events(
-        &self,
-        session_id: &str,
-        turn_seq: Option<u32>,
-        target_full_event_uid: Option<&str>,
-    ) -> RepoResult<Vec<TraceEvent>> {
-        let trace_table = self.table_ref("v_conversation_trace");
-        let text_limit = usize::from(self.cfg.preview_chars).max(4);
-        let payload_limit = text_limit.saturating_mul(2);
-        let text_preview_expr = truncated_utf8_sql("text_content", text_limit);
-        let payload_preview_expr = truncated_utf8_sql("payload_json", payload_limit);
-        let (text_expr, payload_expr) = if let Some(event_uid) = target_full_event_uid {
-            let event_uid_sql = sql_quote(event_uid);
-            (
-                format!("if(event_uid = {event_uid_sql}, text_content, {text_preview_expr})"),
-                format!("if(event_uid = {event_uid_sql}, payload_json, {payload_preview_expr})"),
-            )
-        } else {
-            (text_preview_expr, payload_preview_expr)
-        };
-        let turn_filter = turn_seq
-            .map(|turn_seq| format!(" AND turn_seq = {turn_seq}"))
-            .unwrap_or_default();
-        let query = format!(
-            "SELECT
-  session_id,
-  event_uid,
-  toUInt64(event_order) AS event_order,
-  toUInt32(turn_seq) AS turn_seq,
-  toString(tr.event_time) AS event_time,
-  toInt64(toUnixTimestamp64Milli(tr.event_time)) AS event_unix_ms,
-  actor_role,
-  event_class,
-  payload_type,
-  call_id,
-  name,
-  phase,
-  item_id,
-  source_ref,
-  {text_expr} AS text_content,
-  {payload_expr} AS payload_json,
-  token_usage_json,
-  endpoint_kind,
-  token_usage_buckets,
-  token_usage_native_units
-FROM {trace_table} AS tr
-WHERE session_id = {}{turn_filter}
-ORDER BY event_order ASC, event_uid ASC
-FORMAT JSONEachRow",
-            sql_quote(session_id),
-        );
-
-        let rows: Vec<TraceEventRow> = self.map_backend(self.query_rows(&query, None).await)?;
-        Ok(rows.into_iter().map(Self::map_trace_event).collect())
     }
 
     pub(super) async fn load_events_for_turn(
@@ -409,182 +192,6 @@ FORMAT JSONEachRow",
         Ok(rows.into_iter().map(Self::map_trace_event).collect())
     }
 
-    pub(super) fn mcp_event_ref(event: &TraceEvent) -> McpEventRef {
-        McpEventRef {
-            session_id: event.session_id.clone(),
-            event_uid: event.event_uid.clone(),
-            event_order: event.event_order,
-            turn_seq: event.turn_seq,
-            event_time: event.event_time.clone(),
-            event_type: Self::normalized_event_type(
-                &event.event_class,
-                &event.payload_type,
-                &event.actor_role,
-            ),
-        }
-    }
-
-    pub(super) fn mcp_turn_ref_from_summary(summary: &TurnSummary) -> McpTurnRef {
-        McpTurnRef {
-            session_id: summary.session_id.clone(),
-            turn_seq: summary.turn_seq,
-            turn_id: summary.turn_id.clone(),
-            started_at: summary.started_at.clone(),
-            ended_at: summary.ended_at.clone(),
-        }
-    }
-
-    pub(super) fn mcp_event_summary(&self, event: &TraceEvent) -> McpEventSummary {
-        McpEventSummary {
-            session_id: event.session_id.clone(),
-            event_uid: event.event_uid.clone(),
-            event_order: event.event_order,
-            turn_seq: event.turn_seq,
-            event_time: event.event_time.clone(),
-            event_unix_ms: event.event_unix_ms,
-            actor_role: event.actor_role.clone(),
-            event_class: event.event_class.clone(),
-            payload_type: event.payload_type.clone(),
-            event_type: Self::normalized_event_type(
-                &event.event_class,
-                &event.payload_type,
-                &event.actor_role,
-            ),
-            call_id: event.call_id.clone(),
-            name: event.name.clone(),
-            phase: event.phase.clone(),
-            text_preview: Self::compact_event_text(event, self.cfg.preview_chars),
-        }
-    }
-
-    pub(super) fn compact_event_text(event: &TraceEvent, preview_chars: u16) -> Option<String> {
-        let source = if event.text_content.trim().is_empty() {
-            event.payload_json.as_str()
-        } else {
-            event.text_content.as_str()
-        };
-        let compact = compact_text_line(source, usize::from(preview_chars).max(1));
-        (!compact.is_empty()).then_some(compact)
-    }
-
-    pub(super) fn mcp_turn_compact(
-        &self,
-        summary: TurnSummary,
-        events: &[TraceEvent],
-    ) -> McpTurnCompact {
-        let user_input_event = events.iter().find(|event| {
-            event.actor_role.eq_ignore_ascii_case("user")
-                && Self::matches_event_kind(
-                    &event.event_class,
-                    &event.payload_type,
-                    SearchEventKind::Message,
-                )
-        });
-        let user_input_summary = user_input_event
-            .and_then(|event| Self::compact_event_text(event, self.cfg.preview_chars));
-
-        let final_response_event = events.iter().rev().find(|event| {
-            event.actor_role.eq_ignore_ascii_case("assistant")
-                && Self::matches_event_kind(
-                    &event.event_class,
-                    &event.payload_type,
-                    SearchEventKind::Message,
-                )
-        });
-        let final_response_summary = final_response_event
-            .and_then(|event| Self::compact_event_text(event, self.cfg.preview_chars));
-
-        let mut tools_called = Vec::<String>::new();
-        let mut normalized_event_types = Vec::<String>::new();
-        for event in events {
-            let event_type = Self::normalized_event_type(
-                &event.event_class,
-                &event.payload_type,
-                &event.actor_role,
-            );
-            push_first_seen(&mut normalized_event_types, event_type.clone());
-            if event_type == McpEventType::ToolCall.as_str() {
-                let tool_name = if event.name.trim().is_empty() {
-                    event.call_id.trim()
-                } else {
-                    event.name.trim()
-                };
-                if !tool_name.is_empty() {
-                    push_first_seen(&mut tools_called, tool_name.to_string());
-                }
-            }
-        }
-
-        let terminal_event = events.iter().rev().find_map(|event| {
-            Self::turn_terminal_completed(event).map(|completed| (event, completed))
-        });
-        let completed = terminal_event
-            .map(|(_, completed)| completed)
-            .unwrap_or(false);
-        let terminal_event_uid = terminal_event.map(|(event, _)| event.event_uid.clone());
-
-        McpTurnCompact {
-            metadata: summary,
-            user_input_summary,
-            final_response_summary,
-            user_input_event: user_input_event.map(Self::mcp_event_ref),
-            final_response_event: final_response_event.map(Self::mcp_event_ref),
-            tools_called,
-            normalized_event_types,
-            completed,
-            terminal_event_uid,
-            first_event: events.first().map(Self::mcp_event_ref),
-            last_event: events.last().map(Self::mcp_event_ref),
-        }
-    }
-
-    pub(super) fn mcp_turn_open(
-        &self,
-        summary: TurnSummary,
-        events: Vec<TraceEvent>,
-        previous_turn: Option<McpTurnRef>,
-        next_turn: Option<McpTurnRef>,
-    ) -> McpTurnOpen {
-        let compact = self.mcp_turn_compact(summary, &events);
-        let events = events
-            .iter()
-            .map(|event| self.mcp_event_summary(event))
-            .collect();
-
-        McpTurnOpen {
-            metadata: compact.metadata,
-            events,
-            user_input_summary: compact.user_input_summary,
-            final_response_summary: compact.final_response_summary,
-            tools_called: compact.tools_called,
-            normalized_event_types: compact.normalized_event_types,
-            completed: compact.completed,
-            terminal_event_uid: compact.terminal_event_uid,
-            previous_turn,
-            next_turn,
-            first_event: compact.first_event,
-            last_event: compact.last_event,
-        }
-    }
-
-    pub(super) fn normalized_event_type(
-        event_class: &str,
-        payload_type: &str,
-        actor_role: &str,
-    ) -> String {
-        Self::mcp_event_type_for(event_class, payload_type, actor_role)
-            .as_str()
-            .to_string()
-    }
-
-    pub(super) fn turn_terminal_completed(event: &TraceEvent) -> Option<bool> {
-        match event.payload_type.as_str() {
-            "task_complete" => Some(true),
-            "turn_aborted" => Some(false),
-            _ => None,
-        }
-    }
-
     pub(super) async fn get_conversation_impl(
         &self,
         session_id: &str,
@@ -621,60 +228,45 @@ FORMAT JSONEachRow",
         session_id: &str,
     ) -> RepoResult<Option<McpSessionOpen>> {
         Self::validate_session_id(session_id)?;
-        if !self.session_in_scope(session_id).await? {
-            return Ok(None);
+        self.ensure_mcp_open_read_model_ready().await?;
+        for _ in 0..MAX_MCP_OPEN_SNAPSHOT_ATTEMPTS {
+            let Some(session) = self.load_projected_session(session_id).await? else {
+                return Ok(None);
+            };
+            if !self.projected_session_in_scope(&session) {
+                return Ok(None);
+            }
+
+            let load_started = Instant::now();
+            let turns = self
+                .load_projected_turns(&session, None, false)
+                .await?
+                .into_iter()
+                .map(|turn| turn.compact)
+                .collect();
+            if !self.projected_snapshot_still_current(&session).await? {
+                continue;
+            }
+            tracing::debug!(
+                elapsed_ms = load_started.elapsed().as_millis() as u64,
+                "mcp_open_session_load"
+            );
+            return Ok(Some(McpSessionOpen {
+                metadata: session.metadata,
+                title: non_empty_string(session.row.title),
+                source: non_empty_string(session.row.source),
+                harness: non_empty_string(session.row.harness),
+                inference_provider: non_empty_string(session.row.inference_provider),
+                session_slug: non_empty_string(session.row.session_slug),
+                session_summary: non_empty_string(session.row.session_summary),
+                turns,
+                completed: session.row.completed != 0,
+                terminal_event_uid: non_empty_string(session.row.terminal_event_uid),
+            }));
         }
-
-        let load_started = Instant::now();
-        let (header, events, turn_summaries) = tokio::join!(
-            self.load_mcp_session_header(session_id),
-            self.load_mcp_session_events(session_id, None, None),
-            self.load_turns_for_session(session_id),
-        );
-        tracing::debug!(
-            elapsed_ms = load_started.elapsed().as_millis() as u64,
-            "mcp_open_session_load"
-        );
-        let Some((metadata, session_info)) = header? else {
-            return Ok(None);
-        };
-        let events = events?;
-        let turn_summaries = turn_summaries?;
-        let mut events_by_turn = BTreeMap::<u32, Vec<TraceEvent>>::new();
-        for event in events {
-            events_by_turn
-                .entry(event.turn_seq)
-                .or_default()
-                .push(event);
-        }
-
-        let turns = turn_summaries
-            .into_iter()
-            .map(|summary| {
-                let events = events_by_turn
-                    .get(&summary.turn_seq)
-                    .map(Vec::as_slice)
-                    .unwrap_or(&[]);
-                self.mcp_turn_compact(summary, events)
-            })
-            .collect::<Vec<_>>();
-
-        let completed = turns.last().map(|turn| turn.completed).unwrap_or(false);
-        let terminal_event_uid = turns
-            .last()
-            .and_then(|turn| turn.terminal_event_uid.clone());
-        Ok(Some(McpSessionOpen {
-            metadata,
-            title: non_empty_string(session_info.title),
-            source: non_empty_string(session_info.source),
-            harness: non_empty_string(session_info.harness),
-            inference_provider: non_empty_string(session_info.inference_provider),
-            session_slug: non_empty_string(session_info.session_slug),
-            session_summary: non_empty_string(session_info.session_summary),
-            completed,
-            terminal_event_uid,
-            turns,
-        }))
+        Err(RepoError::backend(
+            "MCP open session snapshot changed repeatedly",
+        ))
     }
 
     pub(super) async fn get_turn_impl(
@@ -698,44 +290,49 @@ FORMAT JSONEachRow",
         turn_seq: u32,
     ) -> RepoResult<Option<McpTurnOpen>> {
         Self::validate_session_id(session_id)?;
-        if !self.session_in_scope(session_id).await? {
-            return Ok(None);
+        self.ensure_mcp_open_read_model_ready().await?;
+        for _ in 0..MAX_MCP_OPEN_SNAPSHOT_ATTEMPTS {
+            let Some(session) = self.load_projected_session(session_id).await? else {
+                return Ok(None);
+            };
+            if !self.projected_session_in_scope(&session) {
+                return Ok(None);
+            }
+
+            let load_started = Instant::now();
+            let turn = self
+                .load_projected_turns(&session, Some(turn_seq), true)
+                .await?
+                .into_iter()
+                .next();
+            if !self.projected_snapshot_still_current(&session).await? {
+                continue;
+            }
+            let Some(turn) = turn else {
+                return Ok(None);
+            };
+            tracing::debug!(
+                elapsed_ms = load_started.elapsed().as_millis() as u64,
+                "mcp_open_turn_load"
+            );
+            return Ok(Some(McpTurnOpen {
+                metadata: turn.compact.metadata,
+                events: turn.events,
+                user_input_summary: turn.compact.user_input_summary,
+                final_response_summary: turn.compact.final_response_summary,
+                tools_called: turn.compact.tools_called,
+                normalized_event_types: turn.compact.normalized_event_types,
+                completed: turn.compact.completed,
+                terminal_event_uid: turn.compact.terminal_event_uid,
+                previous_turn: turn.previous_turn,
+                next_turn: turn.next_turn,
+                first_event: turn.compact.first_event,
+                last_event: turn.compact.last_event,
+            }));
         }
-
-        let load_started = Instant::now();
-        let (turn_summaries, events) = tokio::join!(
-            self.load_turns_for_session(session_id),
-            self.load_mcp_session_events(session_id, Some(turn_seq), None),
-        );
-        tracing::debug!(
-            elapsed_ms = load_started.elapsed().as_millis() as u64,
-            "mcp_open_turn_load"
-        );
-        let turn_summaries = turn_summaries?;
-        let Some(summary) = turn_summaries
-            .iter()
-            .find(|summary| summary.turn_seq == turn_seq)
-            .cloned()
-        else {
-            return Ok(None);
-        };
-        let events = events?;
-        let previous_turn = turn_summaries
-            .iter()
-            .rev()
-            .find(|summary| summary.turn_seq < turn_seq)
-            .map(Self::mcp_turn_ref_from_summary);
-        let next_turn = turn_summaries
-            .iter()
-            .find(|summary| summary.turn_seq > turn_seq)
-            .map(Self::mcp_turn_ref_from_summary);
-
-        Ok(Some(self.mcp_turn_open(
-            summary,
-            events,
-            previous_turn,
-            next_turn,
-        )))
+        Err(RepoError::backend(
+            "MCP open turn snapshot changed repeatedly",
+        ))
     }
 
     pub(super) async fn open_event_impl(&self, req: OpenEventRequest) -> RepoResult<OpenContext> {
@@ -946,89 +543,108 @@ FORMAT JSONEachRow",
             return Err(RepoError::invalid_argument("event_uid cannot be empty"));
         }
         Self::validate_event_uid(event_uid)?;
+        self.ensure_mcp_open_read_model_ready().await?;
 
-        let session_id = if let Some(session_id) = self.load_event_session_id(event_uid).await? {
-            session_id
-        } else if let Some(event) = self.load_event_by_uid(event_uid).await? {
-            event.session_id
-        } else {
-            return Ok(None);
-        };
-        // Out-of-scope events answer exactly like missing ones, so an event
-        // ID cannot be used to probe sessions outside the project scope.
-        if !self.session_in_scope(&session_id).await? {
-            return Ok(None);
+        for _ in 0..MAX_MCP_OPEN_SNAPSHOT_ATTEMPTS {
+            let candidates = self.load_projected_event_candidates(event_uid).await?;
+            let stale_candidates_observed = !candidates.is_empty();
+            let mut pinned = None;
+            for lookup in candidates {
+                let Some(session) = self.load_projected_session(&lookup.session_id).await? else {
+                    continue;
+                };
+                if session.row.slot == lookup.slot && session.row.generation == lookup.generation {
+                    pinned = Some((lookup, session));
+                    break;
+                }
+            }
+            let Some((lookup, session)) = pinned else {
+                if stale_candidates_observed {
+                    continue;
+                }
+                return Ok(None);
+            };
+            // Authorize the narrow UID ownership row before reading event content.
+            if !self.projected_session_in_scope(&session) {
+                return Ok(None);
+            }
+
+            let load_started = Instant::now();
+            let row = self.load_projected_event(&lookup).await?;
+            let parent_turn = match &row {
+                Some(row) => self
+                    .load_projected_turns(&session, Some(row.turn_seq), false)
+                    .await?
+                    .into_iter()
+                    .next(),
+                None => None,
+            };
+            let mut neighbors = match &row {
+                Some(row) => {
+                    let neighbor_uids =
+                        [row.previous_event_uid.clone(), row.next_event_uid.clone()]
+                            .into_iter()
+                            .filter(|event_uid| !event_uid.is_empty())
+                            .collect::<Vec<_>>();
+                    self.load_projected_event_refs(neighbor_uids, lookup.slot, lookup.generation)
+                        .await?
+                }
+                None => HashMap::new(),
+            };
+            if !self.projected_snapshot_still_current(&session).await? {
+                continue;
+            }
+            let (Some(row), Some(parent_turn)) = (row, parent_turn) else {
+                return Ok(None);
+            };
+            tracing::debug!(
+                elapsed_ms = load_started.elapsed().as_millis() as u64,
+                "mcp_open_event_load"
+            );
+
+            let previous_event = neighbors.remove(&row.previous_event_uid);
+            let next_event = neighbors.remove(&row.next_event_uid);
+            let event_type = row.event_type;
+            let event_ordinal = row.event_ordinal;
+            let event = TraceEvent {
+                session_id: row.session_id,
+                event_uid: row.event_uid,
+                event_order: row.event_order,
+                turn_seq: row.turn_seq,
+                event_time: row.event_time,
+                event_unix_ms: row.event_unix_ms,
+                actor_role: row.actor_role,
+                event_class: row.event_class,
+                payload_type: row.payload_type,
+                call_id: row.call_id,
+                name: row.name,
+                phase: row.phase,
+                item_id: row.item_id,
+                source_ref: row.source_ref,
+                text_content: row.text_content,
+                payload_json: row.payload_json,
+                token_usage_json: row.token_usage_json,
+                endpoint_kind: row.endpoint_kind,
+                token_usage_buckets: row.token_usage_buckets,
+                token_usage_native_units: row.token_usage_native_units,
+            };
+            return Ok(Some(McpEventOpen {
+                event,
+                event_type,
+                event_ordinal,
+                turn_completed: parent_turn.compact.completed,
+                turn_terminal_event_uid: parent_turn.compact.terminal_event_uid,
+                parent_session: session.metadata,
+                parent_session_source: non_empty_string(session.row.source),
+                parent_turn: parent_turn.compact.metadata,
+                previous_event,
+                next_event,
+                previous_turn: parent_turn.previous_turn,
+                next_turn: parent_turn.next_turn,
+            }));
         }
-
-        let load_started = Instant::now();
-        let (events, header, turn_summaries) = tokio::join!(
-            self.load_mcp_session_events(&session_id, None, Some(event_uid)),
-            self.load_mcp_session_header(&session_id),
-            self.load_turns_for_session(&session_id),
-        );
-        tracing::debug!(
-            elapsed_ms = load_started.elapsed().as_millis() as u64,
-            "mcp_open_event_load"
-        );
-        let events = events?;
-        let Some(target_index) = events.iter().position(|event| event.event_uid == event_uid)
-        else {
-            return Ok(None);
-        };
-        let event = events[target_index].clone();
-        let Some((parent_session, parent_session_info)) = header? else {
-            return Ok(None);
-        };
-        let turn_summaries = turn_summaries?;
-        let Some(parent_turn) = turn_summaries
-            .iter()
-            .find(|summary| summary.turn_seq == event.turn_seq)
-            .cloned()
-        else {
-            return Ok(None);
-        };
-        let previous_turn = turn_summaries
-            .iter()
-            .rev()
-            .find(|summary| summary.turn_seq < event.turn_seq)
-            .map(Self::mcp_turn_ref_from_summary);
-        let next_turn = turn_summaries
-            .iter()
-            .find(|summary| summary.turn_seq > event.turn_seq)
-            .map(Self::mcp_turn_ref_from_summary);
-        let previous_event = target_index
-            .checked_sub(1)
-            .map(|index| Self::mcp_event_ref(&events[index]));
-        let next_event = events.get(target_index + 1).map(Self::mcp_event_ref);
-        let turn_events = events
-            .iter()
-            .filter(|candidate| candidate.turn_seq == event.turn_seq)
-            .cloned()
-            .collect::<Vec<_>>();
-        let event_ordinal = turn_events
-            .iter()
-            .position(|turn_event| turn_event.event_uid == event_uid)
-            .map(|index| (index + 1) as u32)
-            .unwrap_or(1);
-        let turn_compact = self.mcp_turn_compact(parent_turn.clone(), &turn_events);
-
-        Ok(Some(McpEventOpen {
-            event_type: Self::normalized_event_type(
-                &event.event_class,
-                &event.payload_type,
-                &event.actor_role,
-            ),
-            event,
-            event_ordinal,
-            turn_completed: turn_compact.completed,
-            turn_terminal_event_uid: turn_compact.terminal_event_uid,
-            parent_session,
-            parent_session_source: non_empty_string(parent_session_info.source),
-            parent_turn,
-            previous_event,
-            next_event,
-            previous_turn,
-            next_turn,
-        }))
+        Err(RepoError::backend(
+            "MCP open event snapshot changed repeatedly",
+        ))
     }
 }

--- a/crates/moraine-conversations/src/clickhouse_repo/rows.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/rows.rs
@@ -42,14 +42,6 @@ pub(super) struct SessionMetadataRow {
     pub(super) last_actor_role: String,
 }
 
-#[derive(Debug, Deserialize)]
-pub(super) struct McpSessionHeaderRow {
-    #[serde(flatten)]
-    pub(super) metadata: SessionMetadataRow,
-    #[serde(flatten)]
-    pub(super) info: McpSessionInfoRow,
-}
-
 #[derive(Debug, Clone, Deserialize)]
 pub(super) struct McpSessionListRow {
     pub(super) session_id: String,
@@ -169,31 +161,143 @@ pub(super) struct TraceEventRow {
 }
 
 #[derive(Debug, Deserialize)]
-pub(super) struct EventSessionRow {
-    pub(super) session_id: String,
-}
-
-#[derive(Debug, Deserialize)]
 pub(super) struct OpenTargetRow {
     pub(super) session_id: String,
     pub(super) event_order: u64,
     pub(super) turn_seq: u32,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
-pub(super) struct McpSessionInfoRow {
-    #[serde(default)]
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct McpOpenSessionRow {
+    pub(super) session_id: String,
+    pub(super) slot: u8,
+    pub(super) generation: u64,
+    pub(super) first_event_time: String,
+    pub(super) first_event_unix_ms: i64,
+    pub(super) last_event_time: String,
+    pub(super) last_event_unix_ms: i64,
+    pub(super) total_turns: u32,
+    pub(super) total_events: u64,
+    pub(super) user_messages: u64,
+    pub(super) assistant_messages: u64,
+    pub(super) tool_calls: u64,
+    pub(super) tool_results: u64,
+    pub(super) mode: String,
+    pub(super) first_event_uid: String,
+    pub(super) last_event_uid: String,
+    pub(super) last_actor_role: String,
     pub(super) title: String,
-    #[serde(default)]
     pub(super) source: String,
-    #[serde(default)]
     pub(super) harness: String,
-    #[serde(default)]
     pub(super) inference_provider: String,
-    #[serde(default)]
     pub(super) session_slug: String,
-    #[serde(default)]
     pub(super) session_summary: String,
+    pub(super) completed: u8,
+    pub(super) terminal_event_uid: String,
+    pub(super) origin_cwd: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct McpOpenTurnRow {
+    pub(super) session_id: String,
+    pub(super) turn_seq: u32,
+    pub(super) turn_id: String,
+    pub(super) started_at: String,
+    pub(super) started_at_unix_ms: i64,
+    pub(super) ended_at: String,
+    pub(super) ended_at_unix_ms: i64,
+    pub(super) total_events: u64,
+    pub(super) user_messages: u64,
+    pub(super) assistant_messages: u64,
+    pub(super) tool_calls: u64,
+    pub(super) tool_results: u64,
+    pub(super) reasoning_items: u64,
+    pub(super) user_input_summary_source: String,
+    pub(super) final_response_summary_source: String,
+    pub(super) user_input_summary_is_payload: u8,
+    pub(super) final_response_summary_is_payload: u8,
+    pub(super) user_input_event_uid: String,
+    pub(super) user_input_event_order: u64,
+    pub(super) user_input_event_time: String,
+    pub(super) user_input_event_type: String,
+    pub(super) final_response_event_uid: String,
+    pub(super) final_response_event_order: u64,
+    pub(super) final_response_event_time: String,
+    pub(super) final_response_event_type: String,
+    pub(super) tools_called: Vec<String>,
+    pub(super) normalized_event_types: Vec<String>,
+    pub(super) completed: u8,
+    pub(super) terminal_event_uid: String,
+    pub(super) first_event_uid: String,
+    pub(super) first_event_order: u64,
+    pub(super) first_event_time: String,
+    pub(super) first_event_type: String,
+    pub(super) last_event_uid: String,
+    pub(super) last_event_order: u64,
+    pub(super) last_event_time: String,
+    pub(super) last_event_type: String,
+    pub(super) previous_turn_seq: u32,
+    pub(super) previous_turn_id: String,
+    pub(super) previous_turn_started_at: String,
+    pub(super) previous_turn_ended_at: String,
+    pub(super) next_turn_seq: u32,
+    pub(super) next_turn_id: String,
+    pub(super) next_turn_started_at: String,
+    pub(super) next_turn_ended_at: String,
+    pub(super) event_summaries_json: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct McpOpenEventLookupRow {
+    pub(super) event_uid: String,
+    pub(super) session_id: String,
+    pub(super) slot: u8,
+    pub(super) generation: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct McpOpenEventRow {
+    pub(super) session_id: String,
+    pub(super) event_uid: String,
+    pub(super) event_order: u64,
+    pub(super) turn_seq: u32,
+    pub(super) event_time: String,
+    pub(super) event_unix_ms: i64,
+    pub(super) actor_role: String,
+    pub(super) event_class: String,
+    pub(super) payload_type: String,
+    pub(super) event_type: String,
+    pub(super) event_ordinal: u32,
+    pub(super) call_id: String,
+    pub(super) name: String,
+    pub(super) phase: String,
+    pub(super) item_id: String,
+    pub(super) source_ref: String,
+    pub(super) text_content: String,
+    pub(super) payload_json: String,
+    pub(super) token_usage_json: String,
+    pub(super) endpoint_kind: String,
+    pub(super) token_usage_buckets: BTreeMap<String, u64>,
+    pub(super) token_usage_native_units: BTreeMap<String, f64>,
+    pub(super) previous_event_uid: String,
+    pub(super) next_event_uid: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct ProjectedEventSummaryRow {
+    pub(super) event_uid: String,
+    pub(super) event_order: u64,
+    pub(super) event_time: String,
+    pub(super) event_unix_ms: i64,
+    pub(super) actor_role: String,
+    pub(super) event_class: String,
+    pub(super) payload_type: String,
+    pub(super) event_type: String,
+    pub(super) call_id: String,
+    pub(super) name: String,
+    pub(super) phase: String,
+    pub(super) summary_source: String,
+    pub(super) summary_is_payload: u8,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/moraine-conversations/src/clickhouse_repo/sql.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/sql.rs
@@ -10,14 +10,6 @@ pub(super) fn canonical_events_source(events_ref: &str) -> String {
     format!("(SELECT * FROM {events_ref} FINAL)")
 }
 
-pub(super) fn truncated_utf8_sql(column: &str, max_chars: usize) -> String {
-    let max_chars = max_chars.max(4);
-    let prefix_chars = max_chars.saturating_sub(3);
-    format!(
-        "if(lengthUTF8({column}) > {max_chars}, concat(leftUTF8({column}, {prefix_chars}), '...'), {column})"
-    )
-}
-
 pub(super) fn sql_array_strings(items: &[String]) -> String {
     let parts = items.iter().map(|item| sql_quote(item)).collect::<Vec<_>>();
     format!("[{}]", parts.join(","))

--- a/crates/moraine-conversations/tests/live_clickhouse.rs
+++ b/crates/moraine-conversations/tests/live_clickhouse.rs
@@ -2,13 +2,14 @@ use anyhow::{anyhow, bail, Context, Result};
 use moraine_clickhouse::ClickHouseClient;
 use moraine_config::{AppConfig, ClickHouseConfig, DEFAULT_BACKEND_NAME};
 use moraine_conversations::{
-    AnalyticsRange, BackendRepositoryRouter, ClickHouseConversationRepository,
-    ConversationRepository, PageRequest, RepoConfig, SessionAnalyticsQuery, SessionLookback,
-    TurnListFilter,
+    with_repository_query_id, AnalyticsRange, BackendRepositoryRouter,
+    ClickHouseConversationRepository, ConversationRepository, PageRequest, RepoConfig,
+    SessionAnalyticsQuery, SessionLookback, TurnListFilter,
 };
 use reqwest::{Client, Url};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::{self, Write};
@@ -323,6 +324,315 @@ VALUES
     Ok(())
 }
 
+#[derive(Debug)]
+struct OpenSuite {
+    semantic: Value,
+    event_ms: u64,
+    turn_ms: u64,
+    session_ms: u64,
+    wall_ms: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct OpenCostMetrics {
+    phase: String,
+    query_count: u64,
+    read_rows: u64,
+    read_bytes: u64,
+    peak_memory: u64,
+    duration_ms: u64,
+}
+
+async fn seed_mcp_open_benchmark_targets(clickhouse: &ClickHouseClient) -> Result<()> {
+    let timestamp = "2026-07-14 18:00:00.000";
+    let session_rows = [
+        ("issue532-target-session", 100_u32, 1_000_u64),
+        ("issue532-target-turn", 1_u32, 1_000_u64),
+        ("issue532-target-event", 1_u32, 500_u64),
+    ]
+    .into_iter()
+    .map(|(session_id, total_turns, total_events)| {
+        json!({
+            "session_id": session_id,
+            "slot": 0_u8,
+            "generation": 1_u64,
+            "source_revision": 1_u64,
+            "dirty_revision": 1_u64,
+            "first_event_time": timestamp,
+            "last_event_time": timestamp,
+            "total_turns": total_turns,
+            "total_events": total_events,
+            "user_messages": total_turns,
+            "assistant_messages": total_turns,
+            "tool_calls": 0_u64,
+            "tool_results": 0_u64,
+            "mode": "chat",
+            "first_event_uid": format!("{session_id}-0001"),
+            "last_event_uid": format!("{session_id}-{total_events:04}"),
+            "last_actor_role": "assistant",
+            "title": "Bounded-open benchmark target",
+            "source": "benchmark",
+            "harness": "codex",
+            "inference_provider": "openai",
+            "session_slug": session_id,
+            "session_summary": "Realistic bounded-open benchmark target",
+            "completed": 1_u8,
+            "terminal_event_uid": format!("{session_id}-{total_events:04}"),
+            "origin_cwd": "/repo"
+        })
+    })
+    .collect::<Vec<_>>();
+    clickhouse
+        .insert_json_rows_sync("mcp_open_sessions", &session_rows)
+        .await
+        .context("failed to seed realistic MCP session targets")?;
+
+    let substantial_summary = repeat_text("substantial projected summary ", 512);
+    let mut turn_rows = (1_u32..=100)
+        .map(|turn_seq| {
+            json!({
+                "session_id": "issue532-target-session",
+                "slot": 0_u8,
+                "generation": 1_u64,
+                "turn_seq": turn_seq,
+                "turn_id": format!("turn-{turn_seq}"),
+                "started_at": timestamp,
+                "ended_at": timestamp,
+                "total_events": 10_u64,
+                "user_messages": 1_u64,
+                "assistant_messages": 1_u64,
+                "user_input_summary_source": substantial_summary,
+                "final_response_summary_source": substantial_summary,
+                "completed": 1_u8,
+                "first_event_uid": format!("issue532-target-session-{:04}", (turn_seq - 1) * 10 + 1),
+                "last_event_uid": format!("issue532-target-session-{:04}", turn_seq * 10),
+                "event_summaries_json": "[]"
+            })
+        })
+        .collect::<Vec<_>>();
+    let event_summaries = (1_u64..=1_000)
+        .map(|event_order| {
+            json!({
+                "event_uid": format!("issue532-target-turn-{event_order:04}"),
+                "event_order": event_order,
+                "event_time": timestamp,
+                "event_unix_ms": 1_752_516_000_000_i64,
+                "actor_role": if event_order % 2 == 0 { "assistant" } else { "user" },
+                "event_class": "message",
+                "payload_type": "text",
+                "event_type": if event_order % 2 == 0 { "assistant_response" } else { "user_input" },
+                "call_id": "",
+                "name": "",
+                "phase": "",
+                "summary_source": substantial_summary,
+                "summary_is_payload": 0_u8
+            })
+        })
+        .collect::<Vec<_>>();
+    turn_rows.push(json!({
+        "session_id": "issue532-target-turn",
+        "slot": 0_u8,
+        "generation": 1_u64,
+        "turn_seq": 1_u32,
+        "turn_id": "turn-1",
+        "started_at": timestamp,
+        "ended_at": timestamp,
+        "total_events": 1_000_u64,
+        "user_messages": 500_u64,
+        "assistant_messages": 500_u64,
+        "user_input_summary_source": substantial_summary,
+        "final_response_summary_source": substantial_summary,
+        "completed": 1_u8,
+        "first_event_uid": "issue532-target-turn-0001",
+        "last_event_uid": "issue532-target-turn-1000",
+        "event_summaries_json": serde_json::to_string(&event_summaries)?
+    }));
+    turn_rows.push(json!({
+        "session_id": "issue532-target-event",
+        "slot": 0_u8,
+        "generation": 1_u64,
+        "turn_seq": 1_u32,
+        "turn_id": "turn-1",
+        "started_at": timestamp,
+        "ended_at": timestamp,
+        "total_events": 500_u64,
+        "user_messages": 250_u64,
+        "assistant_messages": 250_u64,
+        "completed": 1_u8,
+        "first_event_uid": "issue532-target-event-0001",
+        "last_event_uid": "issue532-target-event-0500",
+        "event_summaries_json": "[]"
+    }));
+    clickhouse
+        .insert_json_rows_sync("mcp_open_turns", &turn_rows)
+        .await
+        .context("failed to seed realistic MCP turn targets")?;
+
+    let event_rows = (1_u64..=500)
+        .map(|event_order| {
+            json!({
+                "event_uid": format!("issue532-target-event-{event_order:04}"),
+                "slot": 0_u8,
+                "generation": 1_u64,
+                "session_id": "issue532-target-event",
+                "event_order": event_order,
+                "turn_seq": 1_u32,
+                "event_time": timestamp,
+                "actor_role": if event_order % 2 == 0 { "assistant" } else { "user" },
+                "event_class": "message",
+                "payload_type": "text",
+                "event_type": if event_order % 2 == 0 { "assistant_response" } else { "user_input" },
+                "event_ordinal": event_order,
+                "call_id": "",
+                "name": "",
+                "phase": "",
+                "item_id": "",
+                "source_ref": format!("benchmark:{event_order}"),
+                "text_content": repeat_text("substantial transcript text ", 1_024),
+                "payload_json": json!({"text": repeat_text("substantial payload ", 2_048)}).to_string(),
+                "token_usage_json": "{}",
+                "endpoint_kind": "",
+                "token_usage_buckets": {},
+                "token_usage_native_units": {},
+                "previous_event_uid": if event_order == 1 { String::new() } else { format!("issue532-target-event-{:04}", event_order - 1) },
+                "next_event_uid": if event_order == 500 { String::new() } else { format!("issue532-target-event-{:04}", event_order + 1) }
+            })
+        })
+        .collect::<Vec<_>>();
+    clickhouse
+        .insert_json_rows_sync("mcp_open_events", &event_rows)
+        .await
+        .context("failed to seed realistic MCP event targets")
+}
+
+fn repeat_text(fragment: &str, minimum_chars: usize) -> String {
+    fragment.repeat(minimum_chars.div_ceil(fragment.len()))
+}
+
+async fn run_open_suite(
+    repository: &ClickHouseConversationRepository,
+    phase: &str,
+    concurrent: bool,
+) -> Result<OpenSuite> {
+    let wall_started = Instant::now();
+    let (session, session_ms, turn, turn_ms, event, event_ms) = if concurrent {
+        let session = async {
+            let started = Instant::now();
+            let value = with_repository_query_id(
+                format!("issue532-{phase}-session"),
+                repository.get_mcp_session("issue532-target-session"),
+            )
+            .await
+            .context("bounded session open failed")?
+            .context("bounded session target missing")?;
+            Ok::<_, anyhow::Error>((value, started.elapsed().as_millis() as u64))
+        };
+        let turn = async {
+            let started = Instant::now();
+            let value = with_repository_query_id(
+                format!("issue532-{phase}-turn"),
+                repository.get_mcp_turn("issue532-target-turn", 1),
+            )
+            .await
+            .context("bounded turn open failed")?
+            .context("bounded turn target missing")?;
+            Ok::<_, anyhow::Error>((value, started.elapsed().as_millis() as u64))
+        };
+        let event = async {
+            let started = Instant::now();
+            let value = with_repository_query_id(
+                format!("issue532-{phase}-event"),
+                repository.get_mcp_event("issue532-target-event-0250"),
+            )
+            .await
+            .context("bounded event open failed")?
+            .context("bounded event target missing")?;
+            Ok::<_, anyhow::Error>((value, started.elapsed().as_millis() as u64))
+        };
+        let (session, turn, event) = tokio::join!(session, turn, event);
+        let (session, session_ms) = session?;
+        let (turn, turn_ms) = turn?;
+        let (event, event_ms) = event?;
+        (session, session_ms, turn, turn_ms, event, event_ms)
+    } else {
+        let started = Instant::now();
+        let session = with_repository_query_id(
+            format!("issue532-{phase}-session"),
+            repository.get_mcp_session("issue532-target-session"),
+        )
+        .await
+        .context("bounded session open failed")?
+        .context("bounded session target missing")?;
+        let session_ms = started.elapsed().as_millis() as u64;
+
+        let started = Instant::now();
+        let turn = with_repository_query_id(
+            format!("issue532-{phase}-turn"),
+            repository.get_mcp_turn("issue532-target-turn", 1),
+        )
+        .await
+        .context("bounded turn open failed")?
+        .context("bounded turn target missing")?;
+        let turn_ms = started.elapsed().as_millis() as u64;
+
+        let started = Instant::now();
+        let event = with_repository_query_id(
+            format!("issue532-{phase}-event"),
+            repository.get_mcp_event("issue532-target-event-0250"),
+        )
+        .await
+        .context("bounded event open failed")?
+        .context("bounded event target missing")?;
+        let event_ms = started.elapsed().as_millis() as u64;
+        (session, session_ms, turn, turn_ms, event, event_ms)
+    };
+
+    Ok(OpenSuite {
+        semantic: json!({
+            "session": session,
+            "turn": turn,
+            "event": event,
+        }),
+        event_ms,
+        turn_ms,
+        session_ms,
+        wall_ms: wall_started.elapsed().as_millis() as u64,
+    })
+}
+
+async fn read_open_cost_metrics(
+    clickhouse: &ClickHouseClient,
+    database: &str,
+) -> Result<HashMap<String, OpenCostMetrics>> {
+    clickhouse
+        .request_text("SYSTEM FLUSH LOGS", None, None, false, None)
+        .await
+        .context("failed to flush query log")?;
+    let rows: Vec<OpenCostMetrics> = clickhouse
+        .query_rows(
+            "SELECT
+  extract(query_id, '^issue532-([^-]+)-') AS phase,
+  toUInt64(count()) AS query_count,
+  toUInt64(sum(read_rows)) AS read_rows,
+  toUInt64(sum(read_bytes)) AS read_bytes,
+  toUInt64(max(memory_usage)) AS peak_memory,
+  toUInt64(sum(query_duration_ms)) AS duration_ms
+FROM system.query_log
+WHERE type = 'QueryFinish'
+  AND startsWith(query_id, 'issue532-')
+  AND current_database = currentDatabase()
+GROUP BY phase
+FORMAT JSONEachRow",
+            Some(database),
+        )
+        .await
+        .context("failed to aggregate MCP open query-log cost")?;
+    Ok(rows
+        .into_iter()
+        .map(|row| (row.phase.clone(), row))
+        .collect())
+}
+
 #[tokio::test]
 #[ignore = "requires wrapper-owned live ClickHouse and destructive opt-in"]
 async fn live_schema_semantics_and_teardown() -> Result<()> {
@@ -376,6 +686,10 @@ async fn live_schema_semantics_and_teardown() -> Result<()> {
         assert!(legacy_heartbeat.latest.is_none());
 
         install_schema_fixture(&clickhouse, &database).await?;
+        clickhouse
+            .backfill_mcp_open_read_model()
+            .await
+            .context("failed to project live-schema fixtures for bounded MCP open")?;
 
         #[derive(Deserialize)]
         struct TurnTimestampTypeRow {
@@ -504,6 +818,20 @@ async fn live_schema_semantics_and_teardown() -> Result<()> {
             mcp_session.turns[0].metadata.started_at_unix_ms,
             FIXTURE_EVENT_UNIX_MS
         );
+        let mcp_turn = populated_repository
+            .get_mcp_turn("issue454-dedup-session", 1)
+            .await
+            .context("bounded MCP turn projection failed")?
+            .context("bounded MCP turn missing")?;
+        assert_eq!(mcp_turn.events.len(), 1);
+        assert_eq!(mcp_turn.events[0].text_preview.as_deref(), Some("new"));
+        let mcp_event = populated_repository
+            .get_mcp_event("issue454-dedup")
+            .await
+            .context("bounded MCP event projection failed")?
+            .context("bounded MCP event missing")?;
+        assert_eq!(mcp_event.event.text_content, "new");
+        assert_eq!(mcp_event.parent_turn.turn_seq, 1);
         let turn = populated_repository
             .get_turn("issue454-dedup-session", 1)
             .await
@@ -524,12 +852,463 @@ async fn live_schema_semantics_and_teardown() -> Result<()> {
             .map(|event| event.source_ref.as_str())
             .collect::<Vec<_>>();
         assert_eq!(fixture_refs, vec!["issue454-web-z", "issue454-web-a"]);
+
+        #[derive(Deserialize)]
+        struct ProjectionHead {
+            slot: u8,
+            generation: u64,
+            source_revision: u64,
+            dirty_revision: u64,
+        }
+        let head_query = format!(
+            "SELECT slot, generation, source_revision, dirty_revision FROM `{}`.`mcp_open_sessions` FINAL \
+             WHERE session_id = 'issue454-dedup-session' FORMAT JSONEachRow",
+            database.as_str()
+        );
+        let before_head = clickhouse
+            .query_rows::<ProjectionHead>(&head_query, Some(database.as_str()))
+            .await
+            .context("failed to read pre-replacement projection head")?
+            .into_iter()
+            .next()
+            .context("pre-replacement projection head missing")?;
+        clickhouse
+            .request_text(
+                &format!(
+                    r#"INSERT INTO `{0}`.`events`
+(
+  ingested_at, event_uid, session_id, session_date, source_name, harness, source_file,
+  source_ref, record_ts, event_ts, event_kind, actor_kind, payload_type, op_kind, request_id,
+  trace_id, turn_index, model, input_tokens, output_tokens, text_content, payload_json,
+  event_version
+)
+SELECT
+  now64(3), 'issue454-dedup', 'issue454-dedup-session', today(), 'fixture', 'codex',
+  'fixture-dedup', 'fixture-final', '2026-01-02T03:04:06.789Z',
+  (SELECT any(event_ts) FROM `{0}`.`events` FINAL WHERE event_uid = 'issue454-dedup'),
+  'message', 'assistant', 'text', '', 'issue454-request', 'issue454-trace', 1,
+  'final-model', 17, 0, 'replacement-final', '{{}}', 3"#,
+                    database.as_str()
+                ),
+                None,
+                Some(database.as_str()),
+                false,
+                None,
+            )
+            .await
+            .context("failed to insert canonical replacement fixture")?;
+        clickhouse
+            .refresh_mcp_open_read_model(["issue454-dedup-session"])
+            .await
+            .context("failed to refresh replacement projection")?;
+        let after_head = clickhouse
+            .query_rows::<ProjectionHead>(&head_query, Some(database.as_str()))
+            .await
+            .context("failed to read post-replacement projection head")?
+            .into_iter()
+            .next()
+            .context("post-replacement projection head missing")?;
+        assert_ne!(after_head.slot, before_head.slot);
+        assert!(after_head.generation > before_head.generation);
+        assert_ne!(after_head.source_revision, before_head.source_revision);
+        assert!(after_head.dirty_revision > before_head.dirty_revision);
+
+        let replaced_turn = populated_repository
+            .get_mcp_turn("issue454-dedup-session", 1)
+            .await
+            .context("replacement MCP turn projection failed")?
+            .context("replacement MCP turn missing")?;
+        assert_eq!(
+            replaced_turn.final_response_summary.as_deref(),
+            Some("replacement-final")
+        );
+        let replaced_event = populated_repository
+            .get_mcp_event("issue454-dedup")
+            .await
+            .context("replacement MCP event projection failed")?
+            .context("replacement MCP event missing")?;
+        assert_eq!(replaced_event.event.text_content, "replacement-final");
+
+        clickhouse
+            .request_text(
+                &format!(
+                    r#"INSERT INTO `{0}`.`events`
+(
+  ingested_at, event_uid, session_id, session_date, source_name, harness, source_file,
+  source_ref, record_ts, event_ts, event_kind, actor_kind, payload_type, op_kind, request_id,
+  trace_id, turn_index, model, input_tokens, output_tokens, text_content, payload_json,
+  event_version
+)
+SELECT
+  now64(3), 'issue454-dedup', 'issue454-dedup-session', today(), 'fixture', 'codex',
+  'fixture-dedup', 'fixture-resumed', '2026-01-02T03:04:07.890Z',
+  (SELECT any(event_ts) FROM `{0}`.`events` FINAL WHERE event_uid = 'issue454-dedup'),
+  'message', 'assistant', 'text', '', 'issue454-request', 'issue454-trace', 1,
+  'resumed-model', 19, 0, 'replacement-resumed', '{{}}', 4"#,
+                    database.as_str()
+                ),
+                None,
+                Some(database.as_str()),
+                false,
+                None,
+            )
+            .await
+            .context("failed to insert unprojected canonical replacement")?;
+        let still_committed = populated_repository
+            .get_mcp_event("issue454-dedup")
+            .await
+            .context("committed event read failed during dirty window")?
+            .context("committed event missing during dirty window")?;
+        assert_eq!(still_committed.event.text_content, "replacement-final");
+        clickhouse
+            .backfill_mcp_open_read_model()
+            .await
+            .context("failed to resume dirty MCP open projection")?;
+        let resumed_event = populated_repository
+            .get_mcp_event("issue454-dedup")
+            .await
+            .context("resumed MCP event projection failed")?
+            .context("resumed MCP event missing")?;
+        assert_eq!(resumed_event.event.text_content, "replacement-resumed");
+        clickhouse
+            .request_text(
+                &format!(
+                    r#"INSERT INTO `{}`.`events`
+(
+  ingested_at, event_uid, session_id, session_date, source_name, harness, source_file,
+  source_ref, record_ts, event_ts, event_kind, actor_kind, payload_type, turn_index,
+  text_content, payload_json, event_version
+)
+VALUES
+  (now64(3), 'issue532-order-a', 'issue532-order-session', today(), 'fixture', 'codex',
+   'fixture-order', 'order-a-v1', '2026-07-14T18:00:00.000Z', toDateTime64('2026-07-14 18:00:00', 3),
+   'message', 'user', 'text', 0, 'first user input', '{{}}', 1),
+  (now64(3), 'issue532-order-b', 'issue532-order-session', today(), 'fixture', 'codex',
+   'fixture-order', 'order-b-v1', '2026-07-14T18:00:01.000Z', toDateTime64('2026-07-14 18:00:00', 3),
+   'message', 'assistant', 'text', 0, 'initial assistant response', '{{}}', 1),
+  (now64(3), 'issue532-order-c', 'issue532-order-session', today(), 'fixture', 'codex',
+   'fixture-order', 'order-c-v1', '2026-07-14T18:00:02.000Z', toDateTime64('2026-07-14 18:00:00', 3),
+   'queue_operation', 'assistant', 'task_complete', 0, '', '{{}}', 1)"#,
+                    database.as_str()
+                ),
+                None,
+                Some(database.as_str()),
+                false,
+                None,
+            )
+            .await
+            .context("failed to insert ordering fixture")?;
+        clickhouse
+            .refresh_mcp_open_read_model(["issue532-order-session"])
+            .await
+            .context("failed to project ordering fixture")?;
+        clickhouse
+            .request_text(
+                &format!(
+                    r#"INSERT INTO `{}`.`events`
+(
+  ingested_at, event_uid, session_id, session_date, source_name, harness, source_file,
+  source_ref, record_ts, event_ts, event_kind, actor_kind, payload_type, turn_index,
+  text_content, payload_json, event_version
+)
+VALUES
+  (now64(3), 'issue532-order-b', 'issue532-order-session', today(), 'fixture', 'codex',
+   'fixture-order', 'order-b-v2', '2026-07-14T17:59:59.000Z', toDateTime64('2026-07-14 18:00:00', 3),
+   'message', 'user', 'text', 0, 'replacement user input', '{{}}', 2)"#,
+                    database.as_str()
+                ),
+                None,
+                Some(database.as_str()),
+                false,
+                None,
+            )
+            .await
+            .context("failed to insert ordering replacement")?;
+        clickhouse
+            .refresh_mcp_open_read_model(["issue532-order-session"])
+            .await
+            .context("failed to refresh reordered projection")?;
+
+        let reordered = populated_repository
+            .get_mcp_event("issue532-order-b")
+            .await
+            .context("reordered MCP event projection failed")?
+            .context("reordered MCP event missing")?;
+        assert_eq!(reordered.event.event_order, 1);
+        assert_eq!(reordered.event.turn_seq, 1);
+        assert_eq!(reordered.event.text_content, "replacement user input");
+        assert_eq!(
+            reordered
+                .next_event
+                .as_ref()
+                .map(|event| event.event_uid.as_str()),
+            Some("issue532-order-a")
+        );
+        assert_eq!(
+            reordered.next_turn.as_ref().map(|turn| turn.turn_seq),
+            Some(2)
+        );
+        let reordered_session = populated_repository
+            .get_mcp_session("issue532-order-session")
+            .await
+            .context("reordered MCP session projection failed")?
+            .context("reordered MCP session missing")?;
+        assert_eq!(reordered_session.turns.len(), 2);
+        assert!(reordered_session.completed);
         Ok(())
     }
     .await;
 
     let cleanup = cleanup_database(&clickhouse, &database).await;
     let census = assert_owned_database_census_empty(&clickhouse, "after cleanup").await;
+    finish_with_cleanup(outcome, finish_with_cleanup(cleanup, census))
+}
+
+#[tokio::test]
+#[ignore = "requires wrapper-owned live ClickHouse, destructive opt-in, and ~2 GB free"]
+async fn live_mcp_open_boundedness_benchmark() -> Result<()> {
+    const UNRELATED_EVENTS: u64 = 1_000_000;
+    const UNRELATED_SESSIONS: u64 = 100_000;
+    const CANONICAL_BATCH_SIZE: u64 = 10_000;
+    const READ_ROW_GROWTH_BUDGET: u64 = 32_768;
+    const READ_BYTE_GROWTH_BUDGET: u64 = 16 * 1024 * 1024;
+    const MEMORY_GROWTH_BUDGET: u64 = 64 * 1024 * 1024;
+
+    let prerequisites = LivePrerequisites::load()?;
+    let database = prepare_owned_database_identity(&prerequisites.sandbox_id)?;
+    let clickhouse = live_client(&prerequisites, &database)?;
+    assert_owned_database_census_empty(&clickhouse, "before bounded-open benchmark").await?;
+
+    let outcome = async {
+        clickhouse
+            .run_migrations()
+            .await
+            .context("failed to migrate bounded-open benchmark database")?;
+        install_schema_fixture(&clickhouse, &database).await?;
+        clickhouse
+            .backfill_mcp_open_read_model()
+            .await
+            .context("failed to project bounded-open benchmark targets")?;
+        seed_mcp_open_benchmark_targets(&clickhouse).await?;
+        let repository =
+            ClickHouseConversationRepository::new(clickhouse.clone(), RepoConfig::default());
+
+        // Warm code paths before either measured phase; all measured IDs remain
+        // distinct and uncached at the MCP repository boundary.
+        let _ = run_open_suite(&repository, "warm", false).await?;
+        let before = run_open_suite(&repository, "before", false).await?;
+
+        let database_name = database.as_str();
+        for offset in (0..UNRELATED_EVENTS).step_by(CANONICAL_BATCH_SIZE as usize) {
+            let batch_size = CANONICAL_BATCH_SIZE.min(UNRELATED_EVENTS - offset);
+            let seed_canonical_events = format!(
+                "INSERT INTO `{database_name}`.`events`
+                 (ingested_at, event_uid, session_id, session_date, source_name, harness, source_file,
+                  source_ref, record_ts, event_ts, event_kind, actor_kind, payload_type, turn_index,
+                  text_content, payload_json, event_version)
+                 SELECT
+                   now64(3),
+                   concat('issue532-unrelated-event-', leftPad(toString(event_number), 8, '0')),
+                   concat('issue532-unrelated-session-', leftPad(toString(intDiv(event_number, 10)), 7, '0')),
+                   today(), 'fixture', 'codex', 'issue532-unrelated-corpus',
+                   concat('issue532-unrelated:', toString(event_number)),
+                   '2026-07-14T18:00:00.000Z', now64(3), 'message', 'assistant', 'text', toUInt32(1),
+                   repeat('substantial transcript text ', 20),
+                   concat('{{\"text\":\"', repeat('substantial payload ', 40), '\"}}'),
+                   toUInt64(event_number + 1)
+                 FROM (
+                   SELECT number + {offset} AS event_number
+                   FROM numbers({batch_size})
+                 )"
+            );
+            clickhouse
+                .request_text(
+                    &seed_canonical_events,
+                    None,
+                    Some(database_name),
+                    false,
+                    None,
+                )
+                .await
+                .context("failed to seed one-million-event canonical corpus")?;
+        }
+        let seed_sessions = format!(
+            "INSERT INTO `{database_name}`.`mcp_open_sessions`
+             (session_id, slot, generation, source_revision, first_event_time, last_event_time,
+              total_turns, total_events, origin_cwd)
+             SELECT
+               concat('issue532-unrelated-session-', leftPad(toString(number), 7, '0')),
+               toUInt8(0), toUInt64(1), toUInt64(1), now64(3), now64(3),
+               toUInt32(1), toUInt64(10), '/benchmark'
+             FROM numbers({UNRELATED_SESSIONS})"
+        );
+        clickhouse
+            .request_text(&seed_sessions, None, Some(database_name), false, None)
+            .await
+            .context("failed to seed unrelated MCP session rows")?;
+        let seed_turns = format!(
+            "INSERT INTO `{database_name}`.`mcp_open_turns`
+             (session_id, slot, generation, turn_seq, total_events, event_summaries_json)
+             SELECT
+               concat('issue532-unrelated-session-', leftPad(toString(number), 7, '0')),
+               toUInt8(0), toUInt64(1), toUInt32(1), toUInt64(10), '[]'
+             FROM numbers({UNRELATED_SESSIONS})"
+        );
+        clickhouse
+            .request_text(&seed_turns, None, Some(database_name), false, None)
+            .await
+            .context("failed to seed unrelated MCP turn rows")?;
+        let seed_events = format!(
+            "INSERT INTO `{database_name}`.`mcp_open_events`
+             (event_uid, slot, generation, session_id, event_order, turn_seq,
+              event_time, actor_role, event_class, payload_type, event_type, event_ordinal,
+              text_content, payload_json)
+             SELECT
+               concat('issue532-unrelated-event-', leftPad(toString(number), 8, '0')),
+               toUInt8(0), toUInt64(1),
+               concat('issue532-unrelated-session-', leftPad(toString(intDiv(number, 10)), 7, '0')),
+               toUInt64((number % 10) + 1), toUInt32(1), now64(3), 'assistant', 'message',
+               'text', 'assistant_response', toUInt32((number % 10) + 1),
+               repeat('substantial transcript text ', 20),
+               concat('{{\"text\":\"', repeat('substantial payload ', 40), '\"}}')
+             FROM numbers({UNRELATED_EVENTS})"
+        );
+        clickhouse
+            .request_text(&seed_events, None, Some(database_name), false, None)
+            .await
+            .context("failed to seed one-million-event MCP projection corpus")?;
+
+        let after = run_open_suite(&repository, "after", false).await?;
+        let concurrent = run_open_suite(&repository, "concurrent", true).await?;
+        let recovery = run_open_suite(&repository, "recovery", false).await?;
+        assert_eq!(after.semantic, before.semantic);
+        assert_eq!(concurrent.semantic, before.semantic);
+        assert_eq!(recovery.semantic, before.semantic);
+        assert!(
+            after.event_ms <= 500,
+            "warm event open exceeded 500 ms SLA: {} ms",
+            after.event_ms
+        );
+        assert!(
+            after.turn_ms <= 750,
+            "warm turn open exceeded 750 ms SLA: {} ms",
+            after.turn_ms
+        );
+        assert!(
+            after.session_ms <= 1_000,
+            "warm session open exceeded 1,000 ms SLA: {} ms",
+            after.session_ms
+        );
+        assert!(
+            concurrent.event_ms <= 500
+                && concurrent.turn_ms <= 750
+                && concurrent.session_ms <= 1_000,
+            "concurrent open missed an SLA: {concurrent:?}"
+        );
+        assert!(
+            recovery.event_ms <= 500 && recovery.turn_ms <= 750 && recovery.session_ms <= 1_000,
+            "post-concurrency recovery missed an open SLA: {recovery:?}"
+        );
+
+        let metrics = read_open_cost_metrics(&clickhouse, database_name).await?;
+        let before_cost = metrics
+            .get("before")
+            .context("before-corpus query-log metrics missing")?;
+        let after_cost = metrics
+            .get("after")
+            .context("after-corpus query-log metrics missing")?;
+        let concurrent_cost = metrics
+            .get("concurrent")
+            .context("concurrent query-log metrics missing")?;
+        let recovery_cost = metrics
+            .get("recovery")
+            .context("recovery query-log metrics missing")?;
+
+        assert_eq!(after_cost.query_count, before_cost.query_count);
+        assert!(
+            after_cost.read_rows <= before_cost.read_rows + READ_ROW_GROWTH_BUDGET,
+            "unrelated corpus caused row growth: before={before_cost:?} after={after_cost:?}"
+        );
+        assert!(
+            after_cost.read_rows < UNRELATED_EVENTS / 10,
+            "open read rows grew linearly with unrelated events: {after_cost:?}"
+        );
+        assert!(
+            after_cost.read_bytes <= before_cost.read_bytes + READ_BYTE_GROWTH_BUDGET,
+            "unrelated corpus caused byte growth: before={before_cost:?} after={after_cost:?}"
+        );
+        assert!(
+            after_cost.peak_memory <= before_cost.peak_memory + MEMORY_GROWTH_BUDGET,
+            "unrelated corpus caused memory growth: before={before_cost:?} after={after_cost:?}"
+        );
+        assert_eq!(concurrent_cost.query_count, after_cost.query_count);
+        assert_eq!(recovery_cost.query_count, after_cost.query_count);
+
+        println!(
+            "{}",
+            json!({
+                "benchmark_id": "mcp-open-boundedness",
+                "unrelated_sessions": UNRELATED_SESSIONS,
+                "unrelated_events": UNRELATED_EVENTS,
+                "sequential": {
+                    "before": {
+                        "latency_ms": {
+                            "event": before.event_ms,
+                            "turn": before.turn_ms,
+                            "session": before.session_ms,
+                            "wall": before.wall_ms,
+                        },
+                        "throughput_opens_per_second": 3_000.0 / before.wall_ms.max(1) as f64,
+                        "errors": 0,
+                        "query_log": before_cost,
+                    },
+                    "after": {
+                        "latency_ms": {
+                            "event": after.event_ms,
+                            "turn": after.turn_ms,
+                            "session": after.session_ms,
+                            "wall": after.wall_ms,
+                        },
+                        "throughput_opens_per_second": 3_000.0 / after.wall_ms.max(1) as f64,
+                        "errors": 0,
+                        "query_log": after_cost,
+                    },
+                    "recovery": {
+                        "latency_ms": {
+                            "event": recovery.event_ms,
+                            "turn": recovery.turn_ms,
+                            "session": recovery.session_ms,
+                            "wall": recovery.wall_ms,
+                        },
+                        "throughput_opens_per_second": 3_000.0 / recovery.wall_ms.max(1) as f64,
+                        "errors": 0,
+                        "query_log": recovery_cost,
+                    },
+                },
+                "concurrent": {
+                    "latency_ms": {
+                        "event": concurrent.event_ms,
+                        "turn": concurrent.turn_ms,
+                        "session": concurrent.session_ms,
+                        "wall": concurrent.wall_ms,
+                    },
+                    "throughput_opens_per_second": if concurrent.wall_ms == 0 {
+                        0.0
+                    } else {
+                        3_000.0 / concurrent.wall_ms as f64
+                    },
+                    "errors": 0,
+                    "query_log": concurrent_cost,
+                },
+            })
+        );
+        Ok(())
+    }
+    .await;
+
+    let cleanup = cleanup_database(&clickhouse, &database).await;
+    let census =
+        assert_owned_database_census_empty(&clickhouse, "after bounded-open benchmark").await;
     finish_with_cleanup(outcome, finish_with_cleanup(cleanup, census))
 }
 

--- a/crates/moraine-conversations/tests/repository_integration/health.rs
+++ b/crates/moraine-conversations/tests/repository_integration/health.rs
@@ -145,7 +145,17 @@ async fn diagnostics_maps_doctor_partial_report_and_ping_short_circuit() {
     assert!(diagnostics.database_exists);
     assert!(diagnostics.applied_schema_versions.is_empty());
     assert!(!diagnostics.pending_schema_versions.is_empty());
-    assert_eq!(diagnostics.missing_tables, vec!["ingest_errors"]);
+    assert_eq!(
+        diagnostics.missing_tables,
+        vec![
+            "ingest_errors",
+            "mcp_open_sessions",
+            "mcp_open_turns",
+            "mcp_open_events",
+            "mcp_open_dirty_sessions",
+            "mcp_open_projection_state",
+        ]
+    );
     assert_eq!(diagnostics.errors.len(), 2);
     assert!(diagnostics.errors[0].contains("version query failed"));
     assert!(diagnostics.errors[0].contains("doctor version probe failed"));

--- a/crates/moraine-conversations/tests/repository_integration/main.rs
+++ b/crates/moraine-conversations/tests/repository_integration/main.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "512"]
 #![allow(clippy::collapsible_if, clippy::too_many_arguments)]
 
 use std::sync::Arc;

--- a/crates/moraine-conversations/tests/repository_integration/sessions.rs
+++ b/crates/moraine-conversations/tests/repository_integration/sessions.rs
@@ -411,21 +411,33 @@ async fn scoped_point_lookups_hide_out_of_scope_sessions() {
     assert!(event.is_none(), "out-of-scope event must be hidden");
 
     let queries = state.queries.lock().expect("queries lock").clone();
-    let gate_queries: Vec<&String> = queries
+    let legacy_gate_count = queries
         .iter()
-        .filter(|q| {
-            q.starts_with("SELECT session_id FROM (")
-                && q.contains("argMin(cwd, tuple(event_ts, event_uid))")
+        .filter(|query| {
+            query.starts_with("SELECT session_id FROM (")
+                && query.contains("argMin(cwd, tuple(event_ts, event_uid))")
         })
-        .collect();
-    assert!(
-        gate_queries.len() >= 4,
-        "each point lookup should run the scope gate, saw {}",
-        gate_queries.len()
+        .count();
+    assert_eq!(
+        legacy_gate_count, 1,
+        "only the legacy metadata lookup should need the canonical scope gate"
     );
-    assert!(gate_queries
-        .iter()
-        .any(|q| q.contains("session_id = 'sess-out-of-scope'")));
+    assert!(
+        queries
+            .iter()
+            .filter(|query| {
+                query.contains("FROM `moraine`.`mcp_open_sessions`")
+                    && query.contains("session_id = 'sess-out-of-scope'")
+            })
+            .count()
+            >= 3
+    );
+    assert!(
+        !queries
+            .iter()
+            .any(|query| query.contains("FROM `moraine`.`mcp_open_turns`")),
+        "an out-of-scope committed session must be rejected before child rows are read"
+    );
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn scoped_point_lookups_serve_in_scope_sessions() {
@@ -621,138 +633,142 @@ async fn get_mcp_session_includes_turn_summaries_and_latest_completion() {
     assert_eq!(opened_turn.summary.turn_seq, 2);
 
     let queries = state.queries.lock().expect("queries lock").clone();
-    assert!(queries.iter().any(|query| {
-        query.contains("FROM `moraine`.`v_conversation_trace` AS tr")
+    let open_turn_query = queries
+        .iter()
+        .find(|query| {
+            query.contains("FROM `moraine`.`mcp_open_turns`")
+                && query.contains("WHERE t.session_id = 'sess-open'")
+        })
+        .expect("session open must read its committed turn projection");
+    assert!(open_turn_query.contains("t.slot = 0 AND t.generation = 100"));
+    assert!(open_turn_query.contains("ORDER BY t.turn_seq ASC"));
+    assert!(!open_turn_query.contains("v_conversation_trace"));
+    assert!(!queries.iter().any(|query| {
+        query.contains("v_conversation_trace")
             && query.contains("WHERE session_id = 'sess-open'")
             && query.contains("ORDER BY event_order ASC, event_uid ASC")
-            && query.contains("toInt64(toUnixTimestamp64Milli(tr.event_time)) AS event_unix_ms")
     }));
-    let turn_summary_queries = queries
+    let legacy_turn_summary_queries = queries
         .iter()
         .filter(|query| query.contains("FROM `moraine`.`v_turn_summary`"))
         .collect::<Vec<_>>();
     assert_eq!(
-        turn_summary_queries.len(),
-        3,
-        "expected session-open, turn-list, and turn-detail projections"
+        legacy_turn_summary_queries.len(),
+        2,
+        "only the explicit turn-list and turn-detail calls use legacy detail projections"
     );
-    for query in turn_summary_queries {
+    for query in legacy_turn_summary_queries {
         assert_typed_turn_timestamp_projection(query);
     }
-    assert!(queries.iter().any(|query| {
-        query.contains("FROM `moraine`.`v_session_summary` AS s")
-            && query.contains("AS inference_provider")
-            && query.contains("AS session_summary")
-    }));
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn get_mcp_session_does_not_serialize_independent_clickhouse_queries() {
-    let reached = Arc::new(Notify::new());
-    let release = Arc::new(Notify::new());
-    let header = ScriptedResponse::rows(
-        &[
-            "FROM `moraine`.`v_session_summary` AS s",
-            "AS session_summary",
-        ],
-        json!([{
-            "session_id": "sess-parallel",
-            "first_event_time": "2026-02-01 10:00:00",
-            "first_event_unix_ms": 1769940000000_i64,
-            "last_event_time": "2026-02-01 10:00:01",
-            "last_event_unix_ms": 1769940001000_i64,
-            "total_turns": 1_u32,
-            "total_events": 1_u64,
-            "user_messages": 1_u64,
-            "assistant_messages": 0_u64,
-            "tool_calls": 0_u64,
-            "tool_results": 0_u64,
-            "mode": "chat",
-            "first_event_uid": "evt-parallel",
-            "last_event_uid": "evt-parallel",
-            "last_actor_role": "user",
-            "title": "",
-            "source": "fixture",
-            "harness": "codex",
-            "inference_provider": "openai",
-            "session_slug": "",
-            "session_summary": ""
-        }]),
-    )
-    .blocked(reached.clone(), release.clone());
-    let events = ScriptedResponse::rows(
-        &["ORDER BY event_order ASC, event_uid ASC"],
-        json!([trace_event_row(
-            "sess-parallel",
-            "evt-parallel",
-            1,
-            1,
-            "user",
-            "message",
-            "message",
-            "parallel lookup",
-            "{}",
-            "",
-            "",
-        )]),
-    );
-    let turns = ScriptedResponse::rows(
-        &["FROM `moraine`.`v_turn_summary`"],
-        json!([turn_summary_row("sess-parallel", 1, 1, 1, 0, 0, 0, 0,)]),
-    );
-    let (repo, state) = build_unordered_scripted_repo(vec![header, events, turns]).await;
-    let repo = Arc::new(repo);
-    let open = {
-        let repo = Arc::clone(&repo);
-        tokio::spawn(async move { repo.get_mcp_session("sess-parallel").await })
-    };
-
-    tokio::time::timeout(Duration::from_secs(2), reached.notified())
-        .await
-        .expect("header query reached the wire barrier");
-    tokio::time::timeout(Duration::from_secs(2), async {
-        loop {
-            if state.queries.lock().expect("queries lock").len() >= 2 {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("a second query reached ClickHouse while the header query was blocked");
-
-    release.notify_one();
-    let session = open
-        .await
-        .expect("open task joins")
-        .expect("parallel session queries succeed")
-        .expect("session exists");
-    assert_eq!(session.metadata.session_id, "sess-parallel");
-    assert_eq!(state.queries.lock().expect("queries lock").len(), 3);
 }
 #[tokio::test(flavor = "multi_thread")]
-async fn get_mcp_session_missing_header_ignores_concurrent_sibling_failures() {
-    let header = ScriptedResponse::rows(
-        &[
-            "FROM `moraine`.`v_session_summary` AS s",
-            "AS session_summary",
-        ],
-        json!([]),
-    );
-    let events = ScriptedResponse::failure(
-        &["ORDER BY event_order ASC, event_uid ASC"],
-        "events unavailable",
-    );
-    let turns =
-        ScriptedResponse::failure(&["FROM `moraine`.`v_turn_summary`"], "turns unavailable");
-    let (repo, state) = build_unordered_scripted_repo(vec![header, events, turns]).await;
+async fn get_mcp_session_uses_only_bounded_projection_queries() {
+    let (repo, state) = build_repo().await;
 
     let session = repo
-        .get_mcp_session("sess-missing-parallel")
+        .get_mcp_session("sess-open")
         .await
-        .expect("missing authoritative header takes precedence over sibling failures");
+        .expect("bounded session open succeeds")
+        .expect("session exists");
+    assert_eq!(session.metadata.session_id, "sess-open");
+
+    let queries = state.queries.lock().expect("queries lock").clone();
+    assert_eq!(queries.len(), 4);
+    assert!(queries[0].contains("mcp_open_projection_state"));
+    assert!(queries[1].contains("FROM `moraine`.`mcp_open_sessions`"));
+    assert!(queries[1].contains("WHERE s.session_id = 'sess-open'"));
+    assert!(queries[2].contains("FROM `moraine`.`mcp_open_turns`"));
+    assert!(queries[2]
+        .contains("WHERE t.session_id = 'sess-open' AND t.slot = 0 AND t.generation = 100"));
+    assert!(queries[3].contains("FROM `moraine`.`mcp_open_sessions`"));
+    assert!(queries
+        .iter()
+        .all(|query| !query.contains("v_conversation_trace") && !query.contains("events FINAL")));
+}
+#[tokio::test(flavor = "multi_thread")]
+async fn get_mcp_session_retries_when_projection_head_changes_during_open() {
+    let mut generation_100 = session_row("sess-open").expect("fixture session");
+    generation_100["generation"] = json!(100_u64);
+    let mut generation_101 = generation_100.clone();
+    generation_101["slot"] = json!(1_u8);
+    generation_101["generation"] = json!(101_u64);
+    let responses = vec![
+        ScriptedResponse::rows(
+            &["mcp_open_projection_state", "state_key = 'global'"],
+            json!([{ "ready": 1_u8 }]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`mcp_open_sessions`",
+                "s.session_id = 'sess-open'",
+            ],
+            json!([generation_100]),
+        ),
+        ScriptedResponse::rows(
+            &["FROM `moraine`.`mcp_open_turns`", "t.generation = 100"],
+            json!(turn_rows("sess-open", None)),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`mcp_open_sessions`",
+                "s.session_id = 'sess-open'",
+            ],
+            json!([generation_101.clone()]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`mcp_open_sessions`",
+                "s.session_id = 'sess-open'",
+            ],
+            json!([generation_101.clone()]),
+        ),
+        ScriptedResponse::rows(
+            &["FROM `moraine`.`mcp_open_turns`", "t.generation = 101"],
+            json!(turn_rows("sess-open", None)),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`mcp_open_sessions`",
+                "s.session_id = 'sess-open'",
+            ],
+            json!([generation_101]),
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let session = repo
+        .get_mcp_session("sess-open")
+        .await
+        .expect("snapshot retry succeeds")
+        .expect("session exists");
+
+    assert_eq!(session.turns.len(), 2);
+    assert_script_consumed(&state, 7);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_mcp_session_missing_committed_header_skips_child_queries() {
+    let responses = vec![
+        ScriptedResponse::rows(
+            &["mcp_open_projection_state", "state_key = 'global'"],
+            json!([{ "ready": 1_u8 }]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`mcp_open_sessions`",
+                "WHERE s.session_id = 'sess-missing-projection'",
+            ],
+            json!([]),
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let session = repo
+        .get_mcp_session("sess-missing-projection")
+        .await
+        .expect("missing committed header is a not-found result");
     assert!(session.is_none());
-    assert_eq!(state.queries.lock().expect("queries lock").len(), 3);
+    assert_script_consumed(&state, 2);
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn get_mcp_turn_returns_compact_events_and_incomplete_state() {
@@ -806,6 +822,79 @@ async fn get_mcp_turn_returns_compact_events_and_incomplete_state() {
     );
 }
 #[tokio::test(flavor = "multi_thread")]
+async fn get_mcp_event_retries_stale_lookup_generation() {
+    let mut stale_lookup = event_lookup("evt-open-full").expect("fixture event lookup");
+    stale_lookup["generation"] = json!(100_u64);
+    let mut current_lookup = stale_lookup.clone();
+    current_lookup["generation"] = json!(101_u64);
+    let mut current_session = session_row("sess-event").expect("fixture session");
+    current_session["generation"] = json!(101_u64);
+    let responses = vec![
+        ScriptedResponse::rows(
+            &["mcp_open_projection_state", "state_key = 'global'"],
+            json!([{ "ready": 1_u8 }]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`mcp_open_events` FINAL",
+                "event_uid = 'evt-open-full'",
+            ],
+            json!([stale_lookup]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`mcp_open_sessions`",
+                "s.session_id = 'sess-event'",
+            ],
+            json!([current_session.clone()]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`mcp_open_events` FINAL",
+                "event_uid = 'evt-open-full'",
+            ],
+            json!([current_lookup]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`mcp_open_sessions`",
+                "s.session_id = 'sess-event'",
+            ],
+            json!([current_session.clone()]),
+        ),
+        ScriptedResponse::rows(
+            &["FROM `moraine`.`mcp_open_events`", "previous_event_uid"],
+            json!([full_event_row("evt-open-full").expect("fixture full event")]),
+        ),
+        ScriptedResponse::rows(
+            &["FROM `moraine`.`mcp_open_turns`", "t.generation = 101"],
+            json!(turn_rows("sess-event", Some(1))),
+        ),
+        ScriptedResponse::rows(
+            &["FROM `moraine`.`mcp_open_events` FINAL", "event_uid IN"],
+            json!(event_ref_rows()),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`mcp_open_sessions`",
+                "s.session_id = 'sess-event'",
+            ],
+            json!([current_session]),
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let event = repo
+        .get_mcp_event("evt-open-full")
+        .await
+        .expect("stale event lookup retries")
+        .expect("event exists");
+
+    assert_eq!(event.event.event_uid, "evt-open-full");
+    assert_script_consumed(&state, 9);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn get_mcp_event_returns_full_content_and_navigation_refs() {
     let (repo, state) = build_repo().await;
 
@@ -847,11 +936,16 @@ async fn get_mcp_event_returns_full_content_and_navigation_refs() {
     assert_eq!(event.next_turn.as_ref().map(|turn| turn.turn_seq), Some(2));
 
     let queries = state.queries.lock().expect("queries lock").clone();
-    assert_eq!(
-        queries.len(),
-        4,
-        "event open should issue one identity query plus three parallel parent queries"
-    );
+    assert_eq!(queries.len(), 7);
+    assert!(queries.iter().all(|query| {
+        query.contains("mcp_open_projection_state")
+            || query.contains("mcp_open_sessions")
+            || query.contains("mcp_open_turns")
+            || query.contains("mcp_open_events")
+    }));
+    assert!(queries
+        .iter()
+        .all(|query| !query.contains("v_conversation_trace")));
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn list_session_events_supports_forward_cursor_pagination() {

--- a/crates/moraine-conversations/tests/repository_integration/support/mcp_open_fixtures.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mcp_open_fixtures.rs
@@ -1,0 +1,461 @@
+use serde_json::{json, Value};
+
+pub(crate) fn session_row(session_id: &str) -> Option<Value> {
+    let (
+        first_time,
+        last_time,
+        total_turns,
+        total_events,
+        mode,
+        title,
+        source,
+        slug,
+        completed,
+        terminal,
+        origin,
+    ) = match session_id {
+        "sess-open" => (
+            "2026-02-01 10:01:00.000",
+            "2026-02-01 10:02:30.000",
+            2_u32,
+            8_u64,
+            "tool_calling",
+            "Open model session",
+            "codex-source",
+            "open-model-session",
+            1_u8,
+            "evt-open-8",
+            "/work/project",
+        ),
+        "sess-incomplete" => (
+            "2026-02-02 10:00:00.000",
+            "2026-02-02 10:02:00.000",
+            2,
+            5,
+            "tool_calling",
+            "",
+            "fixture",
+            "",
+            0,
+            "",
+            "/work/project",
+        ),
+        "sess-event" => (
+            "2026-02-03 10:00:00.000",
+            "2026-02-03 10:03:00.000",
+            2,
+            4,
+            "chat",
+            "",
+            "fixture",
+            "",
+            0,
+            "",
+            "/work/project",
+        ),
+        "sess-out-of-scope" => (
+            "2026-02-04 10:00:00.000",
+            "2026-02-04 10:00:00.000",
+            1,
+            1,
+            "chat",
+            "",
+            "fixture",
+            "",
+            0,
+            "",
+            "/other/project",
+        ),
+        _ => return None,
+    };
+    Some(json!({
+        "session_id": session_id,
+        "slot": 0_u8,
+        "generation": 100_u64,
+        "first_event_time": first_time,
+        "first_event_unix_ms": 1769940060000_i64,
+        "last_event_time": last_time,
+        "last_event_unix_ms": 1769940150000_i64,
+        "total_turns": total_turns,
+        "total_events": total_events,
+        "user_messages": 2_u64,
+        "assistant_messages": 2_u64,
+        "tool_calls": 1_u64,
+        "tool_results": 1_u64,
+        "mode": mode,
+        "first_event_uid": format!("{session_id}-first"),
+        "last_event_uid": terminal,
+        "last_actor_role": "assistant",
+        "title": title,
+        "source": source,
+        "harness": "codex",
+        "inference_provider": "openai",
+        "session_slug": slug,
+        "session_summary": title,
+        "completed": completed,
+        "terminal_event_uid": terminal,
+        "origin_cwd": origin
+    }))
+}
+
+pub(crate) fn turn_rows(session_id: &str, turn_seq: Option<u32>) -> Vec<Value> {
+    let rows = match session_id {
+        "sess-open" => vec![
+            turn_row(
+                session_id,
+                1,
+                5,
+                1,
+                1,
+                1,
+                1,
+                0,
+                "How should repository open models work?",
+                "First answer with repository context.",
+                vec!["search_repo"],
+                vec![
+                    "user_input",
+                    "tool_call",
+                    "tool_response",
+                    "assistant_response",
+                    "runtime",
+                ],
+                true,
+                "evt-open-5",
+                "evt-open-1",
+                "evt-open-5",
+                0,
+                2,
+                "[]".to_string(),
+            ),
+            turn_row(
+                session_id,
+                2,
+                3,
+                1,
+                1,
+                0,
+                0,
+                0,
+                "Continue.",
+                "Done.",
+                vec![],
+                vec!["user_input", "assistant_response", "runtime"],
+                true,
+                "evt-open-8",
+                "evt-open-6",
+                "evt-open-8",
+                1,
+                0,
+                "[]".to_string(),
+            ),
+        ],
+        "sess-incomplete" => vec![
+            turn_row(
+                session_id,
+                1,
+                2,
+                1,
+                1,
+                0,
+                0,
+                0,
+                "Earlier turn.",
+                "Earlier answer.",
+                vec![],
+                vec!["user_input", "assistant_response"],
+                false,
+                "",
+                "evt-inc-0",
+                "evt-inc-1",
+                0,
+                2,
+                "[]".to_string(),
+            ),
+            turn_row(
+                session_id,
+                2,
+                3,
+                1,
+                0,
+                1,
+                1,
+                0,
+                "Run the incomplete workflow.",
+                "",
+                vec!["inspect"],
+                vec!["user_input", "tool_call", "tool_response"],
+                false,
+                "",
+                "evt-inc-2",
+                "evt-inc-4",
+                1,
+                0,
+                serde_json::to_string(&json!([
+                    event_summary(
+                        "evt-inc-2",
+                        2,
+                        "user",
+                        "message",
+                        "message",
+                        "user_input",
+                        "",
+                        "",
+                        "",
+                        "Run the incomplete workflow."
+                    ),
+                    event_summary(
+                        "evt-inc-3",
+                        3,
+                        "assistant",
+                        "tool_call",
+                        "tool_use",
+                        "tool_call",
+                        "call-inc",
+                        "inspect",
+                        "",
+                        "{}"
+                    ),
+                    event_summary(
+                        "evt-inc-4",
+                        4,
+                        "tool",
+                        "tool_result",
+                        "tool_result",
+                        "tool_response",
+                        "call-inc",
+                        "inspect",
+                        "",
+                        "inspection output"
+                    )
+                ]))
+                .expect("event summaries serialize"),
+            ),
+        ],
+        "sess-event" => vec![
+            turn_row(
+                session_id,
+                1,
+                3,
+                1,
+                1,
+                0,
+                0,
+                0,
+                "Question",
+                "Answer",
+                vec![],
+                vec!["user_input", "assistant_response"],
+                false,
+                "",
+                "evt-event-1",
+                "evt-event-3",
+                0,
+                2,
+                "[]".to_string(),
+            ),
+            turn_row(
+                session_id,
+                2,
+                1,
+                1,
+                0,
+                0,
+                0,
+                0,
+                "Next",
+                "",
+                vec![],
+                vec!["user_input"],
+                false,
+                "",
+                "evt-event-4",
+                "evt-event-4",
+                1,
+                0,
+                "[]".to_string(),
+            ),
+        ],
+        _ => Vec::new(),
+    };
+    rows.into_iter()
+        .filter(|row| turn_seq.is_none_or(|seq| row["turn_seq"] == seq))
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn turn_row(
+    session_id: &str,
+    turn_seq: u32,
+    total_events: u64,
+    user_messages: u64,
+    assistant_messages: u64,
+    tool_calls: u64,
+    tool_results: u64,
+    reasoning_items: u64,
+    user_summary: &str,
+    final_summary: &str,
+    tools_called: Vec<&str>,
+    event_types: Vec<&str>,
+    completed: bool,
+    terminal: &str,
+    first_uid: &str,
+    last_uid: &str,
+    previous_turn_seq: u32,
+    next_turn_seq: u32,
+    event_summaries_json: String,
+) -> Value {
+    let event_type = |uid: &str| {
+        if uid.is_empty() {
+            ""
+        } else if uid == terminal {
+            "runtime"
+        } else {
+            "user_input"
+        }
+    };
+    json!({
+        "session_id": session_id,
+        "turn_seq": turn_seq,
+        "turn_id": format!("turn-{turn_seq}"),
+        "started_at": "2026-02-01 10:00:00.000",
+        "started_at_unix_ms": 1769940000000_i64,
+        "ended_at": "2026-02-01 10:01:00.000",
+        "ended_at_unix_ms": 1769940060000_i64,
+        "total_events": total_events,
+        "user_messages": user_messages,
+        "assistant_messages": assistant_messages,
+        "tool_calls": tool_calls,
+        "tool_results": tool_results,
+        "reasoning_items": reasoning_items,
+        "user_input_summary_source": user_summary,
+        "final_response_summary_source": final_summary,
+        "user_input_summary_is_payload": 0_u8,
+        "final_response_summary_is_payload": 0_u8,
+        "user_input_event_uid": first_uid,
+        "user_input_event_order": 1_u64,
+        "user_input_event_time": "2026-02-01 10:00:00.000",
+        "user_input_event_type": "user_input",
+        "final_response_event_uid": if final_summary.is_empty() { "" } else { last_uid },
+        "final_response_event_order": total_events,
+        "final_response_event_time": "2026-02-01 10:01:00.000",
+        "final_response_event_type": if final_summary.is_empty() { "" } else { "assistant_response" },
+        "tools_called": tools_called,
+        "normalized_event_types": event_types,
+        "completed": u8::from(completed),
+        "terminal_event_uid": terminal,
+        "first_event_uid": first_uid,
+        "first_event_order": 1_u64,
+        "first_event_time": "2026-02-01 10:00:00.000",
+        "first_event_type": event_type(first_uid),
+        "last_event_uid": last_uid,
+        "last_event_order": total_events,
+        "last_event_time": "2026-02-01 10:01:00.000",
+        "last_event_type": event_type(last_uid),
+        "previous_turn_seq": previous_turn_seq,
+        "previous_turn_id": if previous_turn_seq == 0 { "".to_string() } else { format!("turn-{previous_turn_seq}") },
+        "previous_turn_started_at": "2026-02-01 09:59:00.000",
+        "previous_turn_ended_at": "2026-02-01 10:00:00.000",
+        "next_turn_seq": next_turn_seq,
+        "next_turn_id": if next_turn_seq == 0 { "".to_string() } else { format!("turn-{next_turn_seq}") },
+        "next_turn_started_at": "2026-02-01 10:02:00.000",
+        "next_turn_ended_at": "2026-02-01 10:03:00.000",
+        "event_summaries_json": event_summaries_json
+    })
+}
+
+fn event_summary(
+    event_uid: &str,
+    event_order: u64,
+    actor_role: &str,
+    event_class: &str,
+    payload_type: &str,
+    event_type: &str,
+    call_id: &str,
+    name: &str,
+    phase: &str,
+    summary_source: &str,
+) -> Value {
+    json!({
+        "event_uid": event_uid,
+        "event_order": event_order,
+        "event_time": "2026-02-02 10:00:00.000",
+        "event_unix_ms": 1770026400000_i64,
+        "actor_role": actor_role,
+        "event_class": event_class,
+        "payload_type": payload_type,
+        "event_type": event_type,
+        "call_id": call_id,
+        "name": name,
+        "phase": phase,
+        "summary_source": summary_source,
+        "summary_is_payload": 0_u8
+    })
+}
+
+pub(crate) fn event_lookup(event_uid: &str) -> Option<Value> {
+    let session_id = match event_uid {
+        "evt-open-full" | "evt-event-1" | "evt-event-3" => "sess-event",
+        "evt-out-of-scope" => "sess-out-of-scope",
+        _ => return None,
+    };
+    Some(json!({
+        "event_uid": event_uid,
+        "session_id": session_id,
+        "slot": 0_u8,
+        "generation": 100_u64
+    }))
+}
+
+pub(crate) fn full_event_row(event_uid: &str) -> Option<Value> {
+    if event_uid != "evt-open-full" {
+        return None;
+    }
+    Some(json!({
+        "session_id": "sess-event",
+        "event_uid": event_uid,
+        "event_order": 2_u64,
+        "turn_seq": 1_u32,
+        "event_time": "2026-02-03 10:01:00.000",
+        "event_unix_ms": 1770112860000_i64,
+        "actor_role": "assistant",
+        "event_class": "message",
+        "payload_type": "text",
+        "event_type": "assistant_response",
+        "event_ordinal": 1_u32,
+        "call_id": "",
+        "name": "",
+        "phase": "",
+        "item_id": "",
+        "source_ref": "",
+        "text_content": "This is the full available event content that must not be clipped by the repository open model.",
+        "payload_json": "{\"text\":\"This is the full payload JSON value that must also remain intact\",\"nested\":{\"answer\":42}}",
+        "token_usage_json": "",
+        "endpoint_kind": "",
+        "token_usage_buckets": {},
+        "token_usage_native_units": {},
+        "previous_event_uid": "evt-event-1",
+        "next_event_uid": "evt-event-3"
+    }))
+}
+
+pub(crate) fn event_ref_rows() -> Vec<Value> {
+    vec![
+        json!({
+            "session_id": "sess-event",
+            "event_uid": "evt-event-1",
+            "event_order": 1_u64,
+            "turn_seq": 1_u32,
+            "event_time": "2026-02-03 10:00:00.000",
+            "event_type": "user_input"
+        }),
+        json!({
+            "session_id": "sess-event",
+            "event_uid": "evt-event-3",
+            "event_order": 3_u64,
+            "turn_seq": 1_u32,
+            "event_time": "2026-02-03 10:02:00.000",
+            "event_type": "assistant_response"
+        }),
+    ]
+}

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -13,6 +13,9 @@ use moraine_conversations::{ClickHouseConversationRepository, RepoConfig, Sessio
 use serde_json::json;
 use tokio::sync::Notify;
 
+use super::mcp_open_fixtures::{
+    event_lookup, event_ref_rows, full_event_row, session_row, turn_rows,
+};
 use super::responses::{json_each_row, trace_event_row, turn_summary_row};
 
 #[derive(Clone)]
@@ -83,7 +86,6 @@ impl ScriptedResponse {
 pub(crate) struct MockOptions {
     pub(crate) omit_second_snippet_row: bool,
     pub(crate) scripted_responses: Vec<ScriptedResponse>,
-    pub(crate) unordered_scripted_responses: bool,
     pub(crate) query_barrier: Option<QueryBarrier>,
 }
 
@@ -148,25 +150,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                 .scripted_responses
                 .lock()
                 .expect("scripted response lock");
-            scripted.as_mut().map(|responses| {
-                if state.options.unordered_scripted_responses {
-                    responses
-                        .iter()
-                        .position(|response| {
-                            response
-                                .required
-                                .iter()
-                                .all(|required| query.contains(*required))
-                                && response
-                                    .forbidden
-                                    .iter()
-                                    .all(|forbidden| !query.contains(*forbidden))
-                        })
-                        .and_then(|position| responses.remove(position))
-                } else {
-                    responses.pop_front()
-                }
-            })
+            scripted.as_mut().map(VecDeque::pop_front)
         };
         if let Some(scripted_response) = scripted_response {
             let Some(response) = scripted_response else {
@@ -200,6 +184,70 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                 barrier.release.notified().await;
             }
             return (response.status, response.body);
+        }
+
+        if query.contains("mcp_open_projection_state")
+            && query.contains("WHERE state_key = 'global'")
+        {
+            return (StatusCode::OK, json_each_row(json!([{ "ready": 1_u8 }])));
+        }
+
+        if query.contains("FROM `moraine`.`mcp_open_sessions`") && query.contains("FINAL") {
+            let session_id = query
+                .split("session_id = '")
+                .nth(1)
+                .and_then(|rest| rest.split('\'').next())
+                .unwrap_or("");
+            let rows = session_row(session_id).into_iter().collect::<Vec<_>>();
+            return (StatusCode::OK, json_each_row(json!(rows)));
+        }
+
+        if query.contains("FROM `moraine`.`mcp_open_turns`") && query.contains("FINAL") {
+            let session_id = query
+                .split("session_id = '")
+                .nth(1)
+                .and_then(|rest| rest.split('\'').next())
+                .unwrap_or("");
+            let turn_seq = query
+                .split(" AND turn_seq = ")
+                .nth(1)
+                .and_then(|rest| rest.split_whitespace().next())
+                .and_then(|value| value.parse::<u32>().ok());
+            return (
+                StatusCode::OK,
+                json_each_row(json!(turn_rows(session_id, turn_seq))),
+            );
+        }
+
+        if query.contains("FROM `moraine`.`mcp_open_events` FINAL")
+            && query.contains("SELECT\n  event_uid,\n  session_id,")
+        {
+            let event_uid = query
+                .split("WHERE event_uid = '")
+                .nth(1)
+                .and_then(|rest| rest.split('\'').next())
+                .unwrap_or("");
+            let rows = event_lookup(event_uid).into_iter().collect::<Vec<_>>();
+            return (StatusCode::OK, json_each_row(json!(rows)));
+        }
+
+        if query.contains("FROM `moraine`.`mcp_open_events`")
+            && query.contains("FINAL")
+            && query.contains("previous_event_uid")
+        {
+            let event_uid = query
+                .split("event_uid = '")
+                .nth(1)
+                .and_then(|rest| rest.split('\'').next())
+                .unwrap_or("");
+            let rows = full_event_row(event_uid).into_iter().collect::<Vec<_>>();
+            return (StatusCode::OK, json_each_row(json!(rows)));
+        }
+
+        if query.contains("FROM `moraine`.`mcp_open_events` FINAL")
+            && query.contains("event_uid IN")
+        {
+            return (StatusCode::OK, json_each_row(json!(event_ref_rows())));
         }
 
         if query.starts_with("INSERT INTO `moraine`.`file_attention_project_roots`") {
@@ -1863,20 +1911,6 @@ pub(crate) async fn build_scripted_repo(
         100,
         MockOptions {
             scripted_responses,
-            ..MockOptions::default()
-        },
-    )
-    .await
-}
-
-pub(crate) async fn build_unordered_scripted_repo(
-    scripted_responses: Vec<ScriptedResponse>,
-) -> (ClickHouseConversationRepository, Arc<MockState>) {
-    build_repo_with_options(
-        100,
-        MockOptions {
-            scripted_responses,
-            unordered_scripted_responses: true,
             ..MockOptions::default()
         },
     )

--- a/crates/moraine-conversations/tests/repository_integration/support/mod.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mod.rs
@@ -1,7 +1,11 @@
 mod assertions;
+mod mcp_open_fixtures;
 mod mock_clickhouse;
 mod responses;
 
 pub(crate) use assertions::*;
+pub(crate) use mcp_open_fixtures::{
+    event_lookup, event_ref_rows, full_event_row, session_row, turn_rows,
+};
 pub(crate) use mock_clickhouse::*;
 pub(crate) use responses::*;

--- a/crates/moraine-ingest-core/src/sink.rs
+++ b/crates/moraine-ingest-core/src/sink.rs
@@ -15,7 +15,7 @@ use anyhow::Context;
 use chrono::{DateTime, Utc};
 use moraine_clickhouse::{is_oversized_json_each_row_insert_error, ClickHouseClient};
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -518,10 +518,11 @@ fn oversized_row_fragment(row: &Value) -> String {
         .unwrap_or_default()
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SinkStage {
     RawEvents,
     Events,
+    McpOpenProjection,
     EventLinks,
     ToolIo,
     IngestErrors,
@@ -533,6 +534,7 @@ impl SinkStage {
         match self {
             Self::RawEvents => "raw_events",
             Self::Events => "events",
+            Self::McpOpenProjection => "mcp_open_projection",
             Self::EventLinks => "event_links",
             Self::ToolIo => "tool_io",
             Self::IngestErrors => "ingest_errors",
@@ -578,6 +580,7 @@ impl PendingSinkData<'_> {
         let stage_rows = match stage {
             SinkStage::RawEvents => self.raw_rows,
             SinkStage::Events => self.event_rows,
+            SinkStage::McpOpenProjection => self.event_rows,
             SinkStage::EventLinks => self.link_rows,
             SinkStage::ToolIo => self.tool_rows,
             SinkStage::IngestErrors => self.error_rows,
@@ -604,6 +607,7 @@ impl PendingSinkData<'_> {
         match stage {
             SinkStage::RawEvents => self.raw_rows.len(),
             SinkStage::Events => self.event_rows.len(),
+            SinkStage::McpOpenProjection => self.event_rows.len(),
             SinkStage::EventLinks => self.link_rows.len(),
             SinkStage::ToolIo => self.tool_rows.len(),
             SinkStage::IngestErrors => self.error_rows.len(),
@@ -900,6 +904,16 @@ async fn flush_pending(
         );
     }
 
+    let projected_session_ids = event_rows
+        .iter()
+        .filter_map(|row| {
+            row.get("session_id")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+        .filter(|session_id| !session_id.is_empty())
+        .collect::<BTreeSet<_>>();
+
     let flush_result = async {
         if !raw_rows.is_empty() {
             clickhouse
@@ -922,9 +936,13 @@ async fn flush_pending(
 
         if !event_rows.is_empty() {
             clickhouse
-                .insert_json_rows("events", event_rows)
+                .insert_json_rows_sync("events", event_rows)
                 .await
                 .map_err(|error| SinkFlushFailure::new(SinkStage::Events, error))?;
+            clickhouse
+                .refresh_mcp_open_read_model(projected_session_ids.iter().map(String::as_str))
+                .await
+                .map_err(|error| SinkFlushFailure::new(SinkStage::McpOpenProjection, error))?;
             metrics
                 .event_rows_written
                 .fetch_add(event_rows.len() as u64, Ordering::Relaxed);
@@ -982,7 +1000,9 @@ async fn flush_pending(
         Err(failure) => {
             metrics.flush_failures.fetch_add(1, Ordering::Relaxed);
             let error_text = failure.error.to_string();
-            if is_oversized_json_each_row_insert_error(&failure.error) {
+            if failure.stage != SinkStage::McpOpenProjection
+                && is_oversized_json_each_row_insert_error(&failure.error)
+            {
                 let last_error = format!(
                     "non-retryable sink flush failure at {}: {error_text}",
                     failure.stage.table()

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -95,7 +95,7 @@ it returns.
 | --- | --- | --- | --- | --- |
 | `moraine-conversations/repository_integration` | `integration`; repository, SQL-wire, cache, search, sessions, analytics | `cargo test -p moraine-conversations --test repository_integration --locked` | Rust/Cargo. One executable uses owned Axum mock-ClickHouse listeners on `127.0.0.1:0`; Tokio owns task/socket teardown; no real ClickHouse or persistent files. | T0; the owning CI job supplies the wall-clock timeout. The 67-test move map is `crates/moraine-conversations/tests/repository_integration/test-name-map.json`. |
 | `moraine-conversations/analytics_benchmark_support` | `integration`; benchmark serialization, digest, percentile, cardinality, profile, comparison | `cargo test -p moraine-conversations --test analytics_benchmark_support --locked` | Rust/Cargo; deterministic shared bench support only, no live endpoint. | T0. |
-| `moraine-conversations/live_clickhouse` deterministic support | `integration`; destructive guards, ownership, cleanup composition, corpus oracle | `cargo test -p moraine-conversations --test live_clickhouse --locked` | Rust/Cargo; deterministic tests use no live endpoint. The two ignored functions are separately owned below and remain unexecuted by this command. | T0; zero/failure is fail, exactly two live functions remain ignored. |
+| `moraine-conversations/live_clickhouse` deterministic support | `integration`; destructive guards, ownership, cleanup composition, corpus oracle | `cargo test -p moraine-conversations --test live_clickhouse --locked` | Rust/Cargo; deterministic tests use no live endpoint. The three ignored functions are separately owned below and remain unexecuted by this command. | T0; zero/failure is fail. |
 | `moraine-ingest-core/golden_fixtures` | `integration`; golden, normalization, schema | `cargo test -p moraine-ingest-core --test golden_fixtures --locked` | Rust/Cargo and committed raw/golden families; read-only unless the explicit update mode below is used. | T0; byte drift fails. |
 | `moraine-ingest-core/hermes_fixture` | `integration`; ingest, serialization | `cargo test -p moraine-ingest-core --test hermes_fixture --locked` | Committed Hermes trajectory; no external service. | T0. |
 | `moraine-ingest-core/hermes_session_fixture` | `integration`; ingest, serialization | `cargo test -p moraine-ingest-core --test hermes_session_fixture --locked` | Committed Hermes session JSON; no external service. | T0. |
@@ -139,8 +139,8 @@ coverage for the standalone binding or legacy trees.
 
 ## Live ClickHouse suites
 
-Only these two ignored tests are supported. Never use a blanket `--ignored` command.
-The wrapper is the contributor entry point; the raw commands document exact routing
+Only these three ignored tests are supported. Never use a blanket `--ignored` command.
+The wrapper is the contributor entry point where listed; the raw commands document exact routing
 and intentionally fail unless `MORAINE_ALLOW_DESTRUCTIVE_TESTS=1` and the endpoint is
 the wrapper-owned sandbox.
 
@@ -148,6 +148,7 @@ the wrapper-owned sandbox.
 | --- | --- | --- | --- |
 | `moraine-conversations/live_clickhouse::live_schema_semantics_and_teardown` | `scripts/dev/sandbox/run-live-test analytics-schema`; raw: `cargo test -p moraine-conversations --test live_clickhouse --locked live_schema_semantics_and_teardown -- --exact --ignored --nocapture` | Bash, Docker/Compose, sandbox toolchain. Default wrapper timeout 1,800s (`MORAINE_LIVE_TEST_TIMEOUT_SECONDS` accepts a positive integer). Wrapper owns a fresh `sb-xxxxxx` sandbox and Rust generates an uncaller-controlled `moraine_test_<uuid>` database. Empty, `moraine`, or non-prefix names are refused before SQL. | T3 manual/scheduled. Direct missing/unsafe prerequisites fail. Success and every catchable failure with successful cleanup leave no owned sandbox/database. |
 | `moraine-conversations/live_clickhouse::live_monitor_repository_semantic_parity` | `scripts/dev/sandbox/run-live-test analytics-parity`; raw: `cargo test -p moraine-conversations --test live_clickhouse --locked live_monitor_repository_semantic_parity -- --exact --ignored --nocapture` | Same owned sandbox; both arms use the same generated database/dataset. Cardinality, digest, or oracle mismatch fails independently of timing. | T3 unless the same semantics are already proven in T1. Timing is not the pass condition. |
+| `moraine-conversations/live_clickhouse::live_mcp_open_boundedness_benchmark` | Raw: `cargo test -p moraine-conversations --test live_clickhouse --locked live_mcp_open_boundedness_benchmark -- --exact --ignored --nocapture` inside a caller-owned sandbox | Same owned database guard and cleanup. Opens separate realistic targets spanning 100 turns, 500 full-payload events, and a 1,000-event compact turn; then seeds 100,000 unrelated sessions and 1,000,000 substantial unrelated events into both canonical `events` and the bounded MCP read model. Compares exact session/turn/event semantics before and after growth, exercises sequential/concurrent/recovery opens, and records labeled `system.query_log` latency, throughput, errors, rows, bytes, and memory. Fails on SLA misses, errors, semantic drift, or corpus-linear row/byte/memory growth. Requires about 2 GB free. | T3 manual regression benchmark. Timing and bounded-cost assertions are pass conditions. |
 
 Each wrapper run records its sandbox ID, exact Cargo command, generated database and a
 redacted cleanup command before mutation in

--- a/sql/027_mcp_open_read_model.sql
+++ b/sql/027_mcp_open_read_model.sql
@@ -1,0 +1,160 @@
+-- Canonical, entity-keyed read model for typed MCP open.
+--
+-- Complete affected sessions are rebuilt into the inactive child slot. The
+-- session row is inserted last and is therefore the publication barrier. Every
+-- child read filters both slot and generation; an incomplete rebuild cannot
+-- replace or become visible through the active slot.
+
+CREATE TABLE IF NOT EXISTS moraine.mcp_open_sessions (
+  session_id String,
+  slot UInt8,
+  generation UInt64,
+  source_revision UInt64,
+  dirty_revision UInt64,
+  first_event_time DateTime64(3),
+  last_event_time DateTime64(3),
+  total_turns UInt32,
+  total_events UInt64,
+  user_messages UInt64,
+  assistant_messages UInt64,
+  tool_calls UInt64,
+  tool_results UInt64,
+  mode LowCardinality(String),
+  first_event_uid String,
+  last_event_uid String,
+  last_actor_role LowCardinality(String),
+  title String,
+  source String,
+  harness LowCardinality(String),
+  inference_provider LowCardinality(String),
+  session_slug String,
+  session_summary String,
+  completed UInt8,
+  terminal_event_uid String,
+  origin_cwd String,
+  projected_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(generation)
+PARTITION BY cityHash64(session_id) % 64
+ORDER BY (session_id);
+
+CREATE TABLE IF NOT EXISTS moraine.mcp_open_turns (
+  session_id String,
+  slot UInt8,
+  generation UInt64,
+  turn_seq UInt32,
+  turn_id String DEFAULT '',
+  started_at DateTime64(3) DEFAULT toDateTime64(0, 3),
+  ended_at DateTime64(3) DEFAULT toDateTime64(0, 3),
+  total_events UInt64 DEFAULT 0,
+  user_messages UInt64 DEFAULT 0,
+  assistant_messages UInt64 DEFAULT 0,
+  tool_calls UInt64 DEFAULT 0,
+  tool_results UInt64 DEFAULT 0,
+  reasoning_items UInt64 DEFAULT 0,
+  user_input_summary_source String DEFAULT '',
+  final_response_summary_source String DEFAULT '',
+  user_input_summary_is_payload UInt8 DEFAULT 0,
+  final_response_summary_is_payload UInt8 DEFAULT 0,
+  user_input_event_uid String DEFAULT '',
+  user_input_event_order UInt64 DEFAULT 0,
+  user_input_event_time DateTime64(3) DEFAULT toDateTime64(0, 3),
+  user_input_event_type LowCardinality(String) DEFAULT '',
+  final_response_event_uid String DEFAULT '',
+  final_response_event_order UInt64 DEFAULT 0,
+  final_response_event_time DateTime64(3) DEFAULT toDateTime64(0, 3),
+  final_response_event_type LowCardinality(String) DEFAULT '',
+  tools_called Array(String) DEFAULT [],
+  normalized_event_types Array(String) DEFAULT [],
+  completed UInt8 DEFAULT 0,
+  terminal_event_uid String DEFAULT '',
+  first_event_uid String DEFAULT '',
+  first_event_order UInt64 DEFAULT 0,
+  first_event_time DateTime64(3) DEFAULT toDateTime64(0, 3),
+  first_event_type LowCardinality(String) DEFAULT '',
+  last_event_uid String DEFAULT '',
+  last_event_order UInt64 DEFAULT 0,
+  last_event_time DateTime64(3) DEFAULT toDateTime64(0, 3),
+  last_event_type LowCardinality(String) DEFAULT '',
+  previous_turn_seq UInt32 DEFAULT 0,
+  previous_turn_id String DEFAULT '',
+  previous_turn_started_at DateTime64(3) DEFAULT toDateTime64(0, 3),
+  previous_turn_ended_at DateTime64(3) DEFAULT toDateTime64(0, 3),
+  next_turn_seq UInt32 DEFAULT 0,
+  next_turn_id String DEFAULT '',
+  next_turn_started_at DateTime64(3) DEFAULT toDateTime64(0, 3),
+  next_turn_ended_at DateTime64(3) DEFAULT toDateTime64(0, 3),
+  event_summaries_json String DEFAULT '[]',
+  projected_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(generation)
+PARTITION BY cityHash64(session_id) % 64
+ORDER BY (session_id, slot, turn_seq);
+
+CREATE TABLE IF NOT EXISTS moraine.mcp_open_events (
+  event_uid String,
+  slot UInt8,
+  generation UInt64,
+  session_id String,
+  event_order UInt64,
+  turn_seq UInt32,
+  event_time DateTime64(3),
+  actor_role LowCardinality(String),
+  event_class LowCardinality(String),
+  payload_type LowCardinality(String),
+  event_type LowCardinality(String),
+  event_ordinal UInt32,
+  call_id String,
+  name LowCardinality(String),
+  phase LowCardinality(String),
+  item_id String,
+  source_ref String,
+  text_content String,
+  payload_json String,
+  token_usage_json String,
+  endpoint_kind LowCardinality(String),
+  token_usage_buckets Map(String, UInt64),
+  token_usage_native_units Map(String, Float64),
+  previous_event_uid String,
+  next_event_uid String,
+  projected_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(generation)
+PARTITION BY cityHash64(event_uid) % 64
+ORDER BY (event_uid, slot);
+
+CREATE TABLE IF NOT EXISTS moraine.mcp_open_dirty_sessions (
+  session_id String,
+  dirty_revision UInt64,
+  observed_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(dirty_revision)
+PARTITION BY cityHash64(session_id) % 64
+ORDER BY (session_id);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS moraine.mv_mcp_open_dirty_sessions_from_events
+TO moraine.mcp_open_dirty_sessions AS
+SELECT
+  session_id,
+  generateSnowflakeID() AS dirty_revision,
+  now64(3) AS observed_at
+FROM moraine.events
+GROUP BY session_id;
+
+CREATE TABLE IF NOT EXISTS moraine.mcp_open_projection_state (
+  state_key LowCardinality(String),
+  ready UInt8,
+  generation UInt64,
+  backfill_cursor String,
+  updated_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(generation)
+ORDER BY (state_key);
+
+INSERT INTO moraine.mcp_open_projection_state (state_key, ready, generation, backfill_cursor)
+SELECT 'global', 0, 0, ''
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM moraine.mcp_open_projection_state FINAL
+  WHERE state_key = 'global'
+);


### PR DESCRIPTION
## Description

**What.** Replaces typed MCP `open` reconstruction over global canonical views with a bounded ClickHouse read model keyed by session, turn, and event.

**Why.** A point open on the reported host corpus scanned roughly 947,756 unrelated events, read gigabytes, and exceeded the 1-second session SLA.

- Adds migration `027_mcp_open_read_model.sql` with session heads, compact turn rows, event rows, dirty-session tracking, and resumable projection state.
- Refreshes affected sessions synchronously after canonical event writes; initial migration backfills historical sessions and resumes from a durable cursor.
- Publishes complete snapshots through guarded slot/generation heads. Readers pin and revalidate a generation, retrying on concurrent refresh rather than returning mixed data.
- Routes `open(session)`, `open(turn)`, and `open(event)` through bounded entity-keyed queries while preserving typed IDs, summaries, ordering, completion state, and traversal handles.
- Adds replacement/reordering coverage and a one-million-event boundedness benchmark with realistic 100-turn, 500-event, and 1,000-event targets.

Closes #532.

## Usage

No new configuration is required. `moraine db migrate` (and the normal stack migration path) creates and backfills the read model. Typed `open` calls retain their existing IDs and response schemas.

During an incomplete initial backfill, typed opens return an explicit read-model-not-ready backend error instead of falling back to the unbounded global reconstruction path.

## Performance

Environment: the repository Linux dev sandbox on Apple Silicon, ClickHouse 25.12. The regression benchmark inserted 1,000,000 substantial unrelated canonical events plus matching bounded-model rows and 100,000 unrelated sessions.

| Metric | Legacy evidence from #532 | This PR |
| --- | ---: | ---: |
| Dominant event-open query latency | 14.2–14.6 s | 23 ms warm |
| Warm turn open | ~0.9 s additional summary query | 49 ms |
| Warm session open SLA | exceeded 1,000 ms | 20 ms |
| Rows read | 947,756 per dominant event query | 12,518 total across session + turn + event |
| Bytes read | ~6.46 GB per dominant event query | 6,557,806 total |
| Peak query memory | ~3.39 GB per dominant event query | 12,354,284 bytes |
| Concurrent three-open throughput | memory errors observed | 51.7 opens/s, 0 errors |

The legacy numbers are the sanitized production reproducer from #532; the PR numbers are the deterministic repository benchmark, so the table demonstrates removal of corpus-scale growth rather than a same-host microbenchmark delta. After adding the million unrelated rows, all warm entity opens remained within the 500/750/1,000 ms event/turn/session SLAs.

## Operational Impact

Migration 027 performs a one-time, resumable historical backfill. Completed installations skip the historical sweep on later migrations and reconcile only dirty sessions. Projection writes add bounded read-optimized storage; full event bodies remain only in the event projection, while turn previews are capped before aggregation.

## Changelog

- Makes typed MCP session, turn, and event opens use bounded point reads.
- Preserves canonical replacement, ordering, summary, completion, and traversal behavior during reingest.
- Adds query-log assertions against corpus-linear rows, bytes, and memory growth.

## Validation

`cargo test -p moraine-clickhouse -p moraine-conversations -p moraine-ingest-core -p moraine --locked` passed 582 tests across 18 suites; four live tests remained ignored by that command. `cargo clippy -p moraine-clickhouse -p moraine-conversations -p moraine-ingest-core -p moraine --all-targets --locked -- -D warnings -A clippy::too-many-arguments` passed, as did `cargo fmt --all -- --check` and `make docs-build`.

In an owned sandbox, `live_schema_semantics_and_teardown` passed replacement content, canonical reorder/turn reassignment, traversal, dirty-window, and resumable-backfill assertions. `live_mcp_open_boundedness_benchmark` passed after seeding one million canonical and projected unrelated events: warm after-growth event/turn/session opens were 23/49/20 ms; concurrent opens were 53/47/45 ms with zero errors and 51.7 opens/s. Both generated databases and both QA sandboxes were removed.

A fresh migrated sandbox was then seeded with a two-event session. Embedded `moraine-mcp` `open` calls for its session, turn, and event handles all returned `isError: false` with the expected session, compact event list, and full event content. The delegated seven-persona review completed with no remaining concrete correctness findings.
