### PR TITLE
fix(cli): report and accelerate open backfill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,6 +1163,7 @@ version = "0.6.4"
 dependencies = [
  "anyhow",
  "axum",
+ "futures-util",
  "moraine-config",
  "reqwest",
  "serde",

--- a/apps/moraine/src/commands.rs
+++ b/apps/moraine/src/commands.rs
@@ -206,9 +206,22 @@ fn conversation_repository(cfg: &AppConfig) -> Result<ClickHouseConversationRepo
 async fn cmd_db_migrate(cfg: &AppConfig) -> Result<MigrationOutcome> {
     let ch = ClickHouseClient::new(cfg.clickhouse.clone())?;
     let applied = ch.run_migrations().await?;
-    ch.backfill_mcp_open_read_model()
-        .await
-        .context("failed to backfill MCP open read model")?;
+    let requires_historical_backfill = !ch.mcp_open_read_model_ready().await?;
+    if requires_historical_backfill {
+        eprintln!(
+            "Building the MCP open read model from existing sessions; this one-time step may take several minutes."
+        );
+    }
+    ch.backfill_mcp_open_read_model_with_progress(|refreshed_sessions| {
+        if requires_historical_backfill {
+            eprintln!("  projected {refreshed_sessions} sessions");
+        }
+    })
+    .await
+    .context("failed to backfill MCP open read model")?;
+    if requires_historical_backfill {
+        eprintln!("MCP open read model ready.");
+    }
     Ok(MigrationOutcome { applied })
 }
 

--- a/bindings/python/moraine_conversations/Cargo.lock
+++ b/bindings/python/moraine_conversations/Cargo.lock
@@ -587,6 +587,7 @@ name = "moraine-clickhouse"
 version = "0.6.4"
 dependencies = [
  "anyhow",
+ "futures-util",
  "moraine-config",
  "reqwest",
  "serde",

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -6,6 +6,7 @@ description = "Shared Moraine ClickHouse client and query helpers"
 
 [dependencies]
 anyhow = "1.0"
+futures-util = { version = "0.3", default-features = false, features = ["async-await", "std"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/moraine-clickhouse/src/mcp_open_projection.rs
+++ b/crates/moraine-clickhouse/src/mcp_open_projection.rs
@@ -1,9 +1,11 @@
 use super::{escape_identifier, escape_literal, ClickHouseClient};
 use anyhow::{bail, Context, Result};
+use futures_util::{stream, TryStreamExt};
 use serde::Deserialize;
 use std::collections::BTreeSet;
 
 const BACKFILL_PAGE_SIZE: usize = 64;
+const REFRESH_CONCURRENCY: usize = 4;
 const MAX_UNSTABLE_REFRESH_ATTEMPTS: usize = 8;
 const MAX_PROJECTED_TEXT_SUMMARY_CHARS: usize = 65_536;
 const MAX_PROJECTED_PAYLOAD_SUMMARY_CHARS: usize = 131_071;
@@ -52,15 +54,30 @@ impl ClickHouseClient {
             .filter(|session_id| !session_id.is_empty())
             .collect::<BTreeSet<_>>();
 
-        for session_id in session_ids {
-            self.refresh_mcp_open_session(&session_id).await?;
-        }
-        Ok(())
+        stream::iter(session_ids.into_iter().map(Ok::<_, anyhow::Error>))
+            .try_for_each_concurrent(REFRESH_CONCURRENCY, |session_id| async move {
+                self.refresh_mcp_open_session(&session_id).await
+            })
+            .await
     }
 
     /// Resume the historical projection and reconcile sessions dirtied while
     /// the DDL/backfill was running. Safe to call after every migrate command.
     pub async fn backfill_mcp_open_read_model(&self) -> Result<()> {
+        self.backfill_mcp_open_read_model_with_progress(|_| {})
+            .await
+    }
+
+    /// Backfill the read model and report the cumulative number of refreshed
+    /// sessions after each bounded page.
+    pub async fn backfill_mcp_open_read_model_with_progress<F>(
+        &self,
+        mut on_progress: F,
+    ) -> Result<()>
+    where
+        F: FnMut(usize),
+    {
+        let mut refreshed_sessions = 0;
         let state = self.mcp_open_projection_state().await?;
         let historical_complete = state.as_ref().is_some_and(|state| state.ready == 1);
         let mut cursor = state.map_or_else(String::new, |state| state.backfill_cursor);
@@ -92,6 +109,8 @@ impl ClickHouseClient {
                     .await?;
                 cursor = rows.last().expect("non-empty page").session_id.clone();
                 self.set_mcp_open_projection_state(false, &cursor).await?;
+                refreshed_sessions += rows.len();
+                on_progress(refreshed_sessions);
             }
         }
 
@@ -123,6 +142,8 @@ impl ClickHouseClient {
             }
             self.refresh_mcp_open_read_model(rows.iter().map(|row| row.session_id.as_str()))
                 .await?;
+            refreshed_sessions += rows.len();
+            on_progress(refreshed_sessions);
         }
 
         self.set_mcp_open_projection_state(true, "").await?;


### PR DESCRIPTION
## Description

**What.** Reports MCP open read-model backfill progress during `moraine up` and refreshes up to four independent sessions concurrently.

**Why.** PR #533 made the initial historical projection synchronous, but the CLI rendered nothing until it completed. On an existing corpus that made a healthy, advancing migration look indefinitely hung.

The existing slot/generation publication barrier remains per session. A page cursor still advances only after every refresh in that page succeeds, and global readiness is still published last.

## Bug Evidence

On installed `main` at `84ca132`, `moraine up` stayed silent while projecting 2,698 existing sessions sequentially. The process remained alive for about 24 minutes before the projection reached `ready=1` and startup completed; `moraine status` then reported ClickHouse, ingest, and backend healthy.

The shared migration path now prints an immediate one-time notice, cumulative page counts, and a final ready notice:

```text
Building the MCP open read model from existing sessions; this one-time step may take several minutes.
  projected 64 sessions
  projected 128 sessions
MCP open read model ready.
```

Repeat startup after readiness remains quiet and follows the normal startup summary path.

## Performance

Environment: fresh repository Linux dev sandboxes on the same Apple Silicon host, ClickHouse 25.12, 256 synthetic one-event sessions, cold initial read model, measured around `moraine up --no-ingest`.

| Revision | Elapsed |
| --- | ---: |
| `main` (`84ca132`), sequential refresh | 66.185 s |
| This PR, concurrency 4 | 19.887 s |

That fixture completed 69.9% faster (3.33x). It isolates per-session scheduling overhead; it is not a large-session memory benchmark. Concurrency remains bounded at four.

## Usage

No configuration change is required. Run:

```bash
moraine up
```

Existing installations with an incomplete PR #533 backfill resume from the durable cursor and now show progress. Already-ready installations skip the messages.

## Operational Impact

Historical and steady-state multi-session projection refreshes may issue up to four ClickHouse refreshes concurrently. Publication remains session-isolated and retry-safe. No schema or configuration changes are added.

## Changelog

- Shows one-time MCP open read-model backfill progress during startup.
- Reduces initial backfill wall time with four-way bounded session refreshes.

## Validation

`cargo test -p moraine-clickhouse --lib --locked` passed 35 tests and `cargo test -p moraine --bin moraine --locked` passed 162 tests. `cargo check -p moraine-clickhouse -p moraine --locked`, focused strict clippy, `cargo fmt --all -- --check`, and the dependency policy check passed.

In an owned sandbox, a 128-session cold projection printed progress at 64 and 128, completed `moraine up`, and produced `ready=1` with 128 session heads and 128 event rows. A repeat `moraine up` completed without backfill messages. The same-host 256-session baseline/patch sandboxes produced the timing table above and the patched projection ended with `ready=1`, 256 session heads, and 256 event rows. All owned sandboxes were removed.

The seven-persona delegated review completed with no actionable findings. Residual risk is limited to pathological large-session resource pressure and mid-page failure/cancellation behavior beyond the successful live scenarios exercised here.