### PR TITLE
feat(ingest): exclude project directories

### DIFF
--- a/config/moraine.toml
+++ b/config/moraine.toml
@@ -42,6 +42,8 @@ ruleset = "builtin"
 # extra_patterns = ["acme_internal_[A-Za-z0-9]{32}"]
 
 [ingest]
+# Session cwd globs; a trailing `/**` includes the project directory itself.
+exclude_project_dirs = []
 batch_size = 4000
 max_batch_bytes = 8388608
 flush_interval_seconds = 0.5

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -119,6 +119,10 @@ pub struct IdentityConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct IngestConfig {
+    /// Directory globs matched against each session's first non-empty working
+    /// directory. Matching sessions are omitted from ingestion.
+    #[serde(default)]
+    pub exclude_project_dirs: Vec<String>,
     #[serde(default = "default_sources")]
     pub sources: Vec<IngestSource>,
     #[serde(default = "default_batch_size")]
@@ -310,27 +314,40 @@ impl AppConfig {
     /// project root. `*` does not cross `/`, matching the per-component
     /// semantics of the filesystem glob enumeration used by ingest sources.
     pub fn route_for_dir(&self, dir: &str) -> Option<&RouteConfig> {
-        if dir.trim().is_empty() {
-            return None;
-        }
-        let trimmed = dir.trim_end_matches('/');
-        let candidate = if trimmed.is_empty() { "/" } else { trimmed };
-        let options = glob::MatchOptions {
-            case_sensitive: true,
-            require_literal_separator: true,
-            require_literal_leading_dot: false,
-        };
-        self.routes.iter().find(|route| {
-            // Route globs are validated at load time; a programmatically
-            // built config with an invalid glob simply never matches.
-            let Ok(pattern) = glob::Pattern::new(&route.dir) else {
-                return false;
-            };
-            pattern.matches_with(candidate, options)
-                || (route.dir.ends_with("/**")
-                    && pattern.matches_with(&format!("{candidate}/"), options))
-        })
+        self.routes
+            .iter()
+            .find(|route| directory_glob_matches(&route.dir, dir))
     }
+
+    /// Returns whether the absolute working directory `dir` matches any
+    /// ingest exclusion. Empty directories never match.
+    pub fn is_project_dir_excluded(&self, dir: &str) -> bool {
+        self.ingest
+            .exclude_project_dirs
+            .iter()
+            .any(|pattern| directory_glob_matches(pattern, dir))
+    }
+}
+
+fn directory_glob_matches(pattern: &str, dir: &str) -> bool {
+    if dir.trim().is_empty() {
+        return false;
+    }
+    let trimmed = dir.trim_end_matches('/');
+    let candidate = if trimmed.is_empty() { "/" } else { trimmed };
+    let options = glob::MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
+    };
+    // Directory globs are validated at load time; a programmatically built
+    // config with an invalid glob simply never matches.
+    let Ok(pattern_glob) = glob::Pattern::new(pattern) else {
+        return false;
+    };
+    pattern_glob.matches_with(candidate, options)
+        || (pattern.ends_with("/**")
+            && pattern_glob.matches_with(&format!("{candidate}/"), options))
 }
 
 impl Default for ClickHouseConfig {
@@ -397,6 +414,7 @@ impl Default for AppConfig {
 impl Default for IngestConfig {
     fn default() -> Self {
         Self {
+            exclude_project_dirs: Vec::new(),
             sources: default_sources(),
             batch_size: default_batch_size(),
             max_batch_bytes: default_max_batch_bytes(),
@@ -1177,6 +1195,20 @@ fn normalize_config(mut cfg: AppConfig) -> Result<AppConfig> {
         return Err(anyhow::anyhow!(
             "mcp.max_parallel_requests must be greater than zero when configured"
         ));
+    }
+
+    for (exclude_idx, pattern) in cfg.ingest.exclude_project_dirs.iter_mut().enumerate() {
+        *pattern = expand_path(pattern.trim());
+        if pattern.is_empty() {
+            return Err(anyhow::anyhow!(
+                "ingest.exclude_project_dirs[{exclude_idx}] must be a non-empty directory glob"
+            ));
+        }
+        glob::Pattern::new(pattern.as_str()).map_err(|exc| {
+            anyhow::anyhow!(
+                "invalid ingest.exclude_project_dirs[{exclude_idx}] glob `{pattern}`: {exc}"
+            )
+        })?;
     }
 
     migrate_legacy_pi_source(&mut cfg.ingest.sources);
@@ -3240,6 +3272,46 @@ backend = "team"
             .route_for_dir(&format!("{home}/src/teamproject2"))
             .is_none());
         assert!(cfg.route_for_dir("").is_none());
+    }
+
+    #[test]
+    fn ingest_exclude_project_dirs_expand_tilde_and_match_route_semantics() {
+        let home = std::env::var("HOME").expect("HOME set in test env");
+        let path = write_temp_config(
+            r#"
+[ingest]
+exclude_project_dirs = ["~/src/large-project/**"]
+"#,
+            "ingest-exclude-project-dirs",
+        );
+        let cfg = load_config(&path).expect("ingest exclusions should load");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(
+            cfg.ingest.exclude_project_dirs,
+            vec![format!("{home}/src/large-project/**")]
+        );
+        assert!(cfg.is_project_dir_excluded(&format!("{home}/src/large-project")));
+        assert!(cfg.is_project_dir_excluded(&format!("{home}/src/large-project/sub/dir")));
+        assert!(!cfg.is_project_dir_excluded(&format!("{home}/src/large-project2")));
+        assert!(!cfg.is_project_dir_excluded(""));
+    }
+
+    #[test]
+    fn ingest_exclude_project_dirs_reject_invalid_globs() {
+        let path = write_temp_config(
+            r#"
+[ingest]
+exclude_project_dirs = ["/work/a**"]
+"#,
+            "ingest-exclude-project-dirs-invalid",
+        );
+        let err = load_config(&path).expect_err("invalid ingest exclusion should fail");
+        std::fs::remove_file(&path).ok();
+        assert!(
+            format!("{err:#}").contains("invalid ingest.exclude_project_dirs[0] glob"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[test]

--- a/crates/moraine-ingest-core/src/dispatch.rs
+++ b/crates/moraine-ingest-core/src/dispatch.rs
@@ -442,6 +442,73 @@ fn infer_initial_source_hints(source_file: &str, harness: &str) -> InitialSource
     hints
 }
 
+/// Reads a bounded JSONL prefix to find the session's first non-empty absolute
+/// working directory. For Codex this stops at the initial `session_meta`
+/// record, avoiding normalization and sink work for excluded trajectories.
+fn infer_first_source_cwd(source_file: &str, harness: &str, max_line_bytes: usize) -> String {
+    const MAX_CWD_SCAN_LINES: usize = 256;
+    const MAX_CWD_SCAN_BYTES: usize = 1024 * 1024;
+
+    let Some(source) = crate::sources::registry().get(harness) else {
+        return String::new();
+    };
+    if !source.jsonl_carries_cwd() {
+        return String::new();
+    }
+    let Ok(file) = std::fs::File::open(source_file) else {
+        return String::new();
+    };
+    let mut reader = BufReader::new(file.take(MAX_CWD_SCAN_BYTES as u64));
+    let mut bytes_scanned = 0usize;
+
+    for _ in 0..MAX_CWD_SCAN_LINES {
+        let Ok(read) = read_bounded_jsonl_line(&mut reader, max_line_bytes.min(MAX_CWD_SCAN_BYTES))
+        else {
+            return String::new();
+        };
+        let (buf, bytes_read) = match read {
+            JsonlLineRead::Eof => return String::new(),
+            JsonlLineRead::Normal { buf, bytes_read } => (Some(buf), bytes_read),
+            JsonlLineRead::Oversized { bytes_read } => (None, bytes_read),
+        };
+        bytes_scanned = bytes_scanned.saturating_add(bytes_read);
+        if bytes_scanned > MAX_CWD_SCAN_BYTES {
+            return String::new();
+        }
+        let Some(buf) = buf else {
+            continue;
+        };
+        let Ok(record) = serde_json::from_slice::<Value>(&buf) else {
+            continue;
+        };
+        let cwd = source.cwd(&record);
+        if std::path::Path::new(&cwd).is_absolute() {
+            return cwd;
+        }
+    }
+    String::new()
+}
+
+pub(crate) fn record_project_dir_is_excluded(
+    config: &AppConfig,
+    harness: &str,
+    record: &Value,
+    session_cwd: &str,
+) -> bool {
+    if config.ingest.exclude_project_dirs.is_empty() {
+        return false;
+    }
+    let Some(source) = crate::sources::registry().get(harness) else {
+        return false;
+    };
+    let cwd = if session_cwd.is_empty() {
+        source.cwd(record)
+    } else {
+        session_cwd.to_string()
+    };
+    std::path::Path::new(&cwd).is_absolute() && config.is_project_dir_excluded(&cwd)
+}
+
 /// Post-process event rows from a single Claude Code record:
 ///   * if the session's prior event was a `tool_result`, stamp `latency_ms`
 ///     on the first assistant-actor event in this record (= wall-clock time
@@ -730,6 +797,23 @@ pub(crate) async fn process_file(
 
     if file_size == checkpoint.last_offset && !generation_changed {
         return Ok(());
+    }
+    if !config.ingest.exclude_project_dirs.is_empty() {
+        let cwd = infer_first_source_cwd(
+            source_file,
+            &work.harness,
+            jsonl_source_line_byte_limit(config),
+        );
+        if config.is_project_dir_excluded(&cwd) {
+            debug!(
+                source_name = %work.source_name,
+                harness = %work.harness,
+                source_file,
+                project_dir = %cwd,
+                "skipping session from excluded project directory"
+            );
+            return Ok(());
+        }
     }
 
     let mut file = std::fs::File::open(source_file)
@@ -1789,6 +1873,128 @@ mod tests {
             out.push(batch);
         }
         out
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn process_file_skips_codex_session_from_excluded_initial_cwd_before_sink() {
+        let path = unique_test_file("excluded-codex-session");
+        fs::write(
+            &path,
+            [
+                json!({
+                    "timestamp": "2026-07-14T11:59:59Z",
+                    "type": "turn_context",
+                    "payload": {"cwd": "."}
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-07-14T12:00:00Z",
+                    "type": "session_meta",
+                    "payload": {
+                        "id": "excluded-session",
+                        "cwd": "/work/excluded",
+                    }
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-07-14T12:00:01Z",
+                    "type": "turn_context",
+                    "payload": {"cwd": "/work/included"}
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        )
+        .expect("write excluded Codex session");
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.exclude_project_dirs = vec!["/work/excluded/**".to_string()];
+        let checkpoints = Arc::new(RwLock::new(HashMap::<String, Checkpoint>::new()));
+        let metrics = Arc::new(Metrics::default());
+        let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(4);
+        let work = WorkItem {
+            source_name: "codex".to_string(),
+            harness: "codex".to_string(),
+            format: "jsonl".to_string(),
+            path: path.to_string_lossy().to_string(),
+        };
+
+        process_file(
+            &config,
+            &work,
+            checkpoints.clone(),
+            &VolatilePollMap::new(),
+            sink_tx,
+            &metrics,
+        )
+        .await
+        .expect("excluded Codex session should be skipped cleanly");
+
+        assert!(
+            drain_batches(&mut sink_rx).await.is_empty(),
+            "excluded session must not reach the sink"
+        );
+        assert!(
+            checkpoints.read().await.is_empty(),
+            "excluded session must not create a checkpoint through the sink"
+        );
+        let _ = fs::remove_file(&path);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn process_file_keeps_session_when_only_later_cwd_is_excluded() {
+        let path = unique_test_file("later-excluded-cwd");
+        fs::write(
+            &path,
+            [
+                json!({
+                    "timestamp": "2026-07-14T12:00:00Z",
+                    "type": "session_meta",
+                    "payload": {
+                        "id": "included-session",
+                        "cwd": "/work/included",
+                    }
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-07-14T12:00:01Z",
+                    "type": "turn_context",
+                    "payload": {"cwd": "/work/excluded"}
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        )
+        .expect("write included Codex session");
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.exclude_project_dirs = vec!["/work/excluded/**".to_string()];
+        let checkpoints = Arc::new(RwLock::new(HashMap::<String, Checkpoint>::new()));
+        let metrics = Arc::new(Metrics::default());
+        let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(4);
+        let work = WorkItem {
+            source_name: "codex".to_string(),
+            harness: "codex".to_string(),
+            format: "jsonl".to_string(),
+            path: path.to_string_lossy().to_string(),
+        };
+
+        process_file(
+            &config,
+            &work,
+            checkpoints,
+            &VolatilePollMap::new(),
+            sink_tx,
+            &metrics,
+        )
+        .await
+        .expect("included Codex session should process");
+
+        assert!(
+            !drain_batches(&mut sink_rx).await.is_empty(),
+            "a later cd must not change the session's initial inclusion decision"
+        );
+        let _ = fs::remove_file(&path);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/moraine-ingest-core/src/sources/claude_code.rs
+++ b/crates/moraine-ingest-core/src/sources/claude_code.rs
@@ -29,6 +29,10 @@ impl IngestSource for ClaudeCode {
         }
     }
 
+    fn jsonl_carries_cwd(&self) -> bool {
+        true
+    }
+
     fn cwd(&self, record: &Value) -> String {
         // Claude Code stamps the working directory on every JSONL record.
         to_str(record.get("cwd"))

--- a/crates/moraine-ingest-core/src/sources/codex.rs
+++ b/crates/moraine-ingest-core/src/sources/codex.rs
@@ -34,6 +34,10 @@ impl IngestSource for Codex {
         }
     }
 
+    fn jsonl_carries_cwd(&self) -> bool {
+        true
+    }
+
     fn cwd(&self, record: &Value) -> String {
         // Codex carries the working directory in `payload.cwd` on
         // `session_meta` (and on `turn_context` in newer rollouts); other

--- a/crates/moraine-ingest-core/src/sources/mod.rs
+++ b/crates/moraine-ingest-core/src/sources/mod.rs
@@ -113,6 +113,13 @@ pub(crate) trait IngestSource: Send + Sync {
         shared::to_str(record.get("type"))
     }
 
+    /// Whether file-backed JSONL records can expose a session working
+    /// directory. SQLite pollers may still synthesize cwd-bearing records for
+    /// an adapter that returns false here.
+    fn jsonl_carries_cwd(&self) -> bool {
+        false
+    }
+
     /// Working directory carried by the record content itself (never derived
     /// from file paths). Harnesses that only expose a session-level cwd return
     /// it on the records that carry it; the normalizer handles the

--- a/crates/moraine-ingest-core/src/sources/opencode.rs
+++ b/crates/moraine-ingest-core/src/sources/opencode.rs
@@ -62,6 +62,10 @@ impl IngestSource for Opencode {
         epoch_ms_or_string_ts(raw)
     }
 
+    fn jsonl_carries_cwd(&self) -> bool {
+        true
+    }
+
     fn cwd(&self, record: &Value) -> String {
         first_text([
             record.get("cwd"),

--- a/crates/moraine-ingest-core/src/sources/pi.rs
+++ b/crates/moraine-ingest-core/src/sources/pi.rs
@@ -37,6 +37,10 @@ impl IngestSource for PiCodingAgent {
         }
     }
 
+    fn jsonl_carries_cwd(&self) -> bool {
+        true
+    }
+
     fn cwd(&self, record: &Value) -> String {
         // Only the `session` header record carries the working directory;
         // later records inherit it via the normalizer's session-level fallback.

--- a/crates/moraine-ingest-core/src/sqlite_poll.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll.rs
@@ -98,6 +98,9 @@ struct CursorState {
     /// kv key → content-hash (hex u64). `BTreeMap` keeps serialization stable.
     #[serde(default)]
     kv_hashes: BTreeMap<String, String>,
+    /// Hash of normalized project exclusion globs used for this scan.
+    #[serde(default)]
+    project_exclusions_hash: u64,
     /// Last error kind reported for this database; used to emit each failure
     /// mode once instead of once per reconcile tick.
     #[serde(default)]
@@ -252,6 +255,8 @@ impl VolatilePollMap {
 #[derive(Debug, Clone)]
 pub struct SyntheticRecord {
     pub record: Value,
+    /// Session-sticky directory used only for project exclusion decisions.
+    pub project_dir: String,
     pub source_line_no: u64,
     pub source_offset: u64,
 }
@@ -282,6 +287,16 @@ fn hash_bytes(bytes: &[u8]) -> u64 {
 
 fn hash_str(text: &str) -> u64 {
     hash_bytes(text.as_bytes())
+}
+
+fn project_exclusions_hash(config: &AppConfig) -> u64 {
+    if config.ingest.exclude_project_dirs.is_empty() {
+        return 0;
+    }
+    hash_str(
+        &serde_json::to_string(&config.ingest.exclude_project_dirs)
+            .expect("serializing string exclusion globs cannot fail"),
+    )
 }
 
 fn stat_fingerprint(db_path: &str) -> Option<StatFingerprint> {
@@ -367,16 +382,22 @@ pub(crate) async fn process_cursor_sqlite_db(
     });
 
     let mut state = CursorState::parse(&checkpoint.cursor_json);
+    let current_exclusions_hash = project_exclusions_hash(config);
 
     // A replaced database file is a new generation: every logical identity
     // (and therefore every event UID) starts over, and the hash cursor is
-    // meaningless for the new file's contents.
+    // meaningless for the new file's contents. A changed exclusion set also
+    // replays the database so rows skipped under the prior policy can return.
     let generation_changed = checkpoint.source_inode != inode;
+    let exclusions_changed = state.project_exclusions_hash != current_exclusions_hash;
     if generation_changed {
         checkpoint.source_inode = inode;
         checkpoint.source_generation = checkpoint.source_generation.saturating_add(1).max(1);
+    }
+    if generation_changed || exclusions_changed {
         state = CursorState::fresh();
     }
+    state.project_exclusions_hash = current_exclusions_hash;
 
     // Cheap no-change short-circuit: nothing touched the database or its WAL
     // sidecars since the last successful poll.
@@ -420,6 +441,7 @@ pub(crate) async fn process_cursor_sqlite_db(
             };
             let scan_is_noop = had_committed
                 && !generation_changed
+                && !exclusions_changed
                 && records.is_empty()
                 && checkpoint.status == "active"
                 && new_state == prior_state_covered
@@ -432,6 +454,14 @@ pub(crate) async fn process_cursor_sqlite_db(
 
             let mut batch = RowBatch::default();
             for synthetic in &records {
+                if crate::dispatch::record_project_dir_is_excluded(
+                    config,
+                    &work.harness,
+                    &synthetic.record,
+                    &synthetic.project_dir,
+                ) {
+                    continue;
+                }
                 let raw_json =
                     serde_json::to_string(&synthetic.record).unwrap_or_else(|_| "{}".to_string());
                 // No cwd hint: kv rows interleave many composers, so a linear
@@ -626,6 +656,7 @@ fn scan_database(db_path: &str, prior: &CursorState) -> ScanOutcome {
         version: CURSOR_STATE_VERSION,
         format: SOURCE_FORMAT_CURSOR_SQLITE.to_string(),
         stat: StatFingerprint::default(),
+        project_exclusions_hash: prior.project_exclusions_hash,
         kv_hashes: BTreeMap::new(),
         last_error: String::new(),
     };
@@ -1041,6 +1072,7 @@ fn synthesize_composer_record(composer_id: &str, data: &Value) -> Option<Synthet
     let (line_no, offset) = stable_coordinates("composerData", composer_id, "cursor_composer");
     Some(SyntheticRecord {
         record: Value::Object(record),
+        project_dir: String::new(),
         source_line_no: line_no,
         source_offset: offset,
     })
@@ -1126,6 +1158,7 @@ fn synthesize_bubble_record(
     let (line_no, offset) = stable_coordinates("bubbleId", &pk, "cursor_bubble");
     Some(SyntheticRecord {
         record: Value::Object(record),
+        project_dir: String::new(),
         source_line_no: line_no,
         source_offset: offset,
     })
@@ -1586,6 +1619,63 @@ mod tests {
         assert_eq!(checkpoint.last_line_no, 4, "relevant keys observed");
         assert!(checkpoint.cursor_json.contains("kv_hashes"));
         assert_ne!(checkpoint.schema_fingerprint, 0);
+
+        cleanup(&path);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cursor_sqlite_replays_rows_when_exclusions_change() {
+        let path = unique_db_path("exclusion-replay");
+        let _db = seed_fixture_db(&path);
+        let work = sqlite_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let metrics = Arc::new(Metrics::default());
+        let poll_state = VolatilePollMap::new();
+
+        let mut excluded_config = moraine_config::AppConfig::default();
+        excluded_config.ingest.exclude_project_dirs = vec!["/Users/demo/project/**".to_string()];
+        let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(64);
+        process_cursor_sqlite_db(
+            &excluded_config,
+            &work,
+            checkpoints.clone(),
+            &poll_state,
+            sink_tx,
+            &metrics,
+        )
+        .await
+        .expect("excluded Cursor poll");
+        let excluded_batches = drain_batches(&mut sink_rx).await;
+        assert!(
+            all_event_rows(&excluded_batches).is_empty(),
+            "excluded session rows must not reach the sink"
+        );
+        let checkpoint = excluded_batches
+            .last()
+            .and_then(|batch| batch.checkpoint.clone())
+            .expect("excluded poll must persist its cursor");
+        checkpoints.write().await.insert(
+            checkpoint_key(&checkpoint.source_name, &checkpoint.source_file),
+            checkpoint,
+        );
+
+        let included_config = moraine_config::AppConfig::default();
+        let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(64);
+        process_cursor_sqlite_db(
+            &included_config,
+            &work,
+            checkpoints,
+            &poll_state,
+            sink_tx,
+            &metrics,
+        )
+        .await
+        .expect("Cursor replay after exclusion removal");
+        let replayed = drain_batches(&mut sink_rx).await;
+        assert!(
+            !all_event_rows(&replayed).is_empty(),
+            "removing exclusions must replay previously skipped rows"
+        );
 
         cleanup(&path);
     }

--- a/crates/moraine-ingest-core/src/sqlite_poll/opencode.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/opencode.rs
@@ -57,6 +57,8 @@ struct OpenCodeState {
     #[serde(default)]
     aggregate_sequences: BTreeMap<String, i64>,
     #[serde(default)]
+    project_exclusions_hash: u64,
+    #[serde(default)]
     last_error: String,
 }
 
@@ -185,15 +187,20 @@ pub(crate) async fn process_opencode_sqlite_db(
     });
 
     let mut state = OpenCodeState::parse(&checkpoint.cursor_json);
+    let current_exclusions_hash = super::project_exclusions_hash(config);
 
-    // A replaced database file is a new generation: logical identities (and so
-    // event UIDs) restart, and the old event cursor no longer applies.
+    // Replaced databases restart logical identities. Changed exclusions replay
+    // the event history so rows skipped under the prior policy can return.
     let generation_changed = checkpoint.source_inode != inode;
+    let exclusions_changed = state.project_exclusions_hash != current_exclusions_hash;
     if generation_changed {
         checkpoint.source_inode = inode;
         checkpoint.source_generation = checkpoint.source_generation.saturating_add(1).max(1);
+    }
+    if generation_changed || exclusions_changed {
         state = OpenCodeState::fresh();
     }
+    state.project_exclusions_hash = current_exclusions_hash;
 
     // Cheap no-change short-circuit: nothing touched the database or its WAL
     // sidecars since the last poll. `event_scan_complete` also forces one real
@@ -239,6 +246,7 @@ pub(crate) async fn process_opencode_sqlite_db(
             };
             let scan_is_noop = had_committed
                 && !generation_changed
+                && !exclusions_changed
                 && records.is_empty()
                 && checkpoint.status == "active"
                 && new_state == prior_state_covered
@@ -250,6 +258,14 @@ pub(crate) async fn process_opencode_sqlite_db(
 
             let mut batch = RowBatch::default();
             for synthetic in &records {
+                if crate::dispatch::record_project_dir_is_excluded(
+                    config,
+                    &work.harness,
+                    &synthetic.record,
+                    &synthetic.project_dir,
+                ) {
+                    continue;
+                }
                 let raw_json =
                     serde_json::to_string(&synthetic.record).unwrap_or_else(|_| "{}".to_string());
                 match normalize_record(
@@ -622,24 +638,25 @@ fn scan_opencode_rows(
     }
 
     for (_, record) in accumulated.sessions {
-        push_opencode_record("session", &record, &mut records);
+        push_opencode_record("session", &record, &session_contexts, &mut records);
     }
     for (_, mut record) in accumulated.messages {
         enrich_message_record(&mut record, &session_contexts);
-        push_opencode_record("message", &record, &mut records);
+        push_opencode_record("message", &record, &session_contexts, &mut records);
     }
     for (_, mut record) in accumulated.parts {
         enrich_part_record(&mut record, &session_contexts, &message_contexts);
-        push_opencode_record("part", &record, &mut records);
+        push_opencode_record("part", &record, &session_contexts, &mut records);
     }
     for (_, mut record) in accumulated.session_messages {
         enrich_session_message_record(&mut record, &session_contexts);
         if opencode_record_is_relevant(&record) {
-            push_opencode_record("session_message", &record, &mut records);
+            push_opencode_record("session_message", &record, &session_contexts, &mut records);
         }
     }
 
     let mut new_state = OpenCodeState::fresh();
+    new_state.project_exclusions_hash = prior.project_exclusions_hash;
     new_state.event_scan_complete = true;
     new_state.aggregate_sequences = aggregate_sequences;
     Ok((records, new_state, relevant_events))
@@ -694,13 +711,35 @@ fn update_opencode_context(
         "session.created.1" | "session.updated.1" => {
             let info = event.data.get("info").unwrap_or(&event.data);
             if let Some((id, record)) = build_session_event_record(info) {
-                session_contexts.insert(id, session_context_from_record(&record));
+                let next = session_context_from_record(&record);
+                session_contexts
+                    .entry(id)
+                    .and_modify(|current| {
+                        if !std::path::Path::new(&current.directory).is_absolute()
+                            && std::path::Path::new(&next.directory).is_absolute()
+                        {
+                            current.directory.clone_from(&next.directory);
+                        }
+                        if next.model.is_some() {
+                            current.model.clone_from(&next.model);
+                        }
+                    })
+                    .or_insert(next);
             }
         }
         "message.updated.1" => {
             let info = event.data.get("info").unwrap_or(&event.data);
             if let Some((id, record)) = build_message_event_record(info) {
-                message_contexts.insert(id, message_context_from_record(&record));
+                let context = message_context_from_record(&record);
+                if let Some(session_id) = record.get("session_id").and_then(Value::as_str) {
+                    if std::path::Path::new(&context.directory).is_absolute() {
+                        let session = session_contexts.entry(session_id.to_string()).or_default();
+                        if !std::path::Path::new(&session.directory).is_absolute() {
+                            session.directory.clone_from(&context.directory);
+                        }
+                    }
+                }
+                message_contexts.insert(id, context);
             }
         }
         _ => {}
@@ -1203,6 +1242,7 @@ fn copy_message_context_pointer(
 fn push_opencode_record(
     table: &str,
     record: &Map<String, Value>,
+    session_contexts: &BTreeMap<String, OpenCodeSessionContext>,
     records: &mut Vec<SyntheticRecord>,
 ) {
     let id = record.get("id").and_then(Value::as_str).unwrap_or("");
@@ -1215,12 +1255,23 @@ fn push_opencode_record(
         .get("type")
         .and_then(Value::as_str)
         .unwrap_or("opencode_sqlite");
+    let session_id = record
+        .get("session_id")
+        .and_then(Value::as_str)
+        .or_else(|| (record_kind == "opencode_session").then_some(id))
+        .unwrap_or_default();
+    let project_dir = session_contexts
+        .get(session_id)
+        .map(|context| context.directory.clone())
+        .filter(|dir| std::path::Path::new(dir).is_absolute())
+        .unwrap_or_default();
     let source_line_no = hash_str(&format!("{table}:{id}"));
     let source_offset = hash_str(&format!(
         "{SOURCE_FORMAT_OPENCODE_SQLITE}:{table}:{id}:{record_kind}"
     ));
     records.push(SyntheticRecord {
         record: value,
+        project_dir,
         source_line_no,
         source_offset,
     });

--- a/crates/moraine-ingest-core/src/sqlite_poll/opencode/tests.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/opencode/tests.rs
@@ -1034,6 +1034,132 @@ fn opencode_sqlite_scan_paginates_past_single_event_page() {
     cleanup(&path);
 }
 
+#[test]
+fn opencode_sqlite_project_dir_stays_on_first_absolute_session_directory() {
+    let path = unique_opencode_db_path("sticky-project-dir");
+    let connection = seed_opencode_db(&path);
+    let last_seq: i64 = connection
+        .query_row(
+            "SELECT seq FROM event_sequence WHERE aggregate_id = 'ses_demo'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read event sequence");
+    let next_seq = last_seq + 1;
+    connection
+        .execute(
+            "INSERT INTO event (id, aggregate_id, seq, type, data) \
+             VALUES ('evt_session_cd', 'ses_demo', ?1, 'session.updated.1', ?2)",
+            rusqlite::params![
+                next_seq,
+                serde_json::to_string(&json!({
+                    "sessionID": "ses_demo",
+                    "info": {
+                        "id": "ses_demo",
+                        "directory": "/work/after-cd",
+                        "title": "Moved session",
+                        "time": {
+                            "created": 1780000000000_i64,
+                            "updated": 1780000005000_i64
+                        }
+                    }
+                }))
+                .unwrap(),
+            ],
+        )
+        .expect("insert session directory update");
+    connection
+        .execute(
+            "UPDATE event_sequence SET seq = ?1 WHERE aggregate_id = 'ses_demo'",
+            rusqlite::params![next_seq],
+        )
+        .expect("advance event sequence");
+    drop(connection);
+
+    let outcome =
+        scan_opencode_database(path.to_str().expect("utf-8 path"), &OpenCodeState::fresh());
+    let records = match outcome {
+        OpenCodeScanOutcome::Scanned { records, .. } => records,
+        OpenCodeScanOutcome::Failed {
+            error_kind,
+            error_text,
+        } => panic!("scan failed: {error_kind}: {error_text}"),
+    };
+    assert!(!records.is_empty());
+    assert!(
+        records
+            .iter()
+            .all(|record| record.project_dir == "/work/opencode-demo"),
+        "every record must retain the session's first absolute directory"
+    );
+    assert!(
+        records.iter().any(|record| {
+            record.record.get("type").and_then(Value::as_str) == Some("opencode_session")
+                && record.record.get("directory").and_then(Value::as_str) == Some("/work/after-cd")
+        }),
+        "fixture must retain the later cwd on the raw session update"
+    );
+
+    cleanup(&path);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn opencode_sqlite_replays_rows_when_exclusions_change() {
+    let path = unique_opencode_db_path("exclusion-replay");
+    drop(seed_opencode_db(&path));
+    let work = opencode_sqlite_work(&path);
+    let checkpoints = Arc::new(RwLock::new(HashMap::<String, Checkpoint>::new()));
+    let metrics = Arc::new(Metrics::default());
+    let poll_state = VolatilePollMap::new();
+
+    let mut excluded_config = moraine_config::AppConfig::default();
+    excluded_config.ingest.exclude_project_dirs = vec!["/work/opencode-demo/**".to_string()];
+    let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(64);
+    process_opencode_sqlite_db(
+        &excluded_config,
+        &work,
+        checkpoints.clone(),
+        &poll_state,
+        sink_tx,
+        &metrics,
+    )
+    .await
+    .expect("excluded OpenCode poll");
+    let excluded_batches = drain_batches(&mut sink_rx).await;
+    assert!(
+        all_event_rows(&excluded_batches).is_empty(),
+        "excluded session rows must not reach the sink"
+    );
+    let checkpoint = excluded_batches
+        .last()
+        .and_then(|batch| batch.checkpoint.clone())
+        .expect("excluded poll must persist its cursor");
+    checkpoints.write().await.insert(
+        checkpoint_key(&checkpoint.source_name, &checkpoint.source_file),
+        checkpoint,
+    );
+
+    let included_config = moraine_config::AppConfig::default();
+    let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(64);
+    process_opencode_sqlite_db(
+        &included_config,
+        &work,
+        checkpoints,
+        &poll_state,
+        sink_tx,
+        &metrics,
+    )
+    .await
+    .expect("OpenCode replay after exclusion removal");
+    let replayed = drain_batches(&mut sink_rx).await;
+    assert!(
+        !all_event_rows(&replayed).is_empty(),
+        "removing exclusions must replay previously skipped rows"
+    );
+
+    cleanup(&path);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn opencode_sqlite_ignores_events_above_sequence_bound() {
     let path = unique_opencode_db_path("future-row-bound");

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -542,6 +542,7 @@ The `[ingest]` table controls batching and watcher behavior:
 
 ```toml
 [ingest]
+exclude_project_dirs = []
 batch_size = 4000
 max_batch_bytes = 8388608
 flush_interval_seconds = 0.5
@@ -556,6 +557,7 @@ heartbeat_interval_seconds = 5.0
 
 | Field | Default | Purpose |
 | --- | --- | --- |
+| `exclude_project_dirs` | `[]` | Directory globs for sessions to omit, matched against each session's first non-empty absolute working directory. |
 | `batch_size` | `4000` | Maximum rows collected before a sink flushes to ClickHouse. |
 | `max_batch_bytes` | `8388608` | Maximum serialized JSONEachRow batch size, in bytes, before flushing. |
 | `flush_interval_seconds` | `0.5` | Maximum time a non-empty batch waits before flushing. |
@@ -566,6 +568,24 @@ heartbeat_interval_seconds = 5.0
 | `debounce_ms` | `50` | Milliseconds to coalesce repeated filesystem notifications for the same tracked file. |
 | `reconcile_interval_seconds` | `30.0` | Seconds between reconciliation scans for missed watcher events, deleted files, and lagging backend replay. |
 | `heartbeat_interval_seconds` | `5.0` | Seconds between ingest heartbeat writes. |
+
+Exclusions use the same directory matching semantics as [`[[routes]]`](#routes):
+`~` expands when configuration loads, `*` stays within one path component, and
+a trailing `/**` matches both the project directory itself and everything
+below it. Moraine keeps the first non-empty working directory for the whole
+session, so a later `cd` cannot change the decision. For example:
+
+```toml
+[ingest]
+exclude_project_dirs = [
+  "~/code/project-with-large-trajectories/**",
+]
+```
+
+For JSONL sources, Moraine reads only far enough to find that initial working
+directory before normalization. Codex provides it in the early `session_meta`
+record, so excluded Codex trajectories do not require a full-file read and
+never reach the sink.
 
 ## MCP
 


### PR DESCRIPTION
## Description

**What.** Adds `[ingest].exclude_project_dirs` globs that omit complete sessions based on their first absolute working directory.

**Why.** Operators need to keep unusually large project trajectories out of Moraine without disabling an entire ingest source.

The configuration loader expands `~`, validates every glob, and reuses the directory semantics documented for `[[routes]].dir`, including base-directory matching for a trailing `/**`. JSONL sources with cwd-bearing records probe a bounded prefix before normalization; Codex resolves from its early `session_meta`. The inclusion decision remains sticky across later `cd` records.

Cursor and OpenCode SQLite pollers apply the same policy per session. Their durable cursor includes the exclusion-policy signature so changing or removing exclusions replays previously skipped rows rather than losing them permanently.

Closes #535.

## Usage

```toml
[ingest]
exclude_project_dirs = [
  "~/code/project-with-large-trajectories/**",
]
```

This matches the project root and every directory below it. A later working-directory change does not alter the session decision.

## Changelog

- Adds ingest-level project-directory exclusions for JSONL and SQLite-polled sessions.
- Documents matching, sticky-cwd, and early-skip behavior.

Operational impact: the option is empty by default. Changing SQLite exclusion rules causes a one-time source replay so the new policy is applied without permanently suppressing previously skipped rows.

## Validation

`cargo test -p moraine-config --lib --locked` passed 81 tests. `cargo test -p moraine-ingest-core --lib --locked` passed 152 tests, including Codex early exclusion, sticky cwd, SQLite policy replay, and OpenCode sticky-directory coverage. The five path-relevant ingest fixture suites passed 48 tests via `cargo test -p moraine-ingest-core --locked --test golden_fixtures --test hermes_fixture --test hermes_session_fixture --test kimi_cli_fixture --test normalize_unit`.

`make clippy`, `cargo fmt --all -- --check`, and `make docs-build` all passed.

A fresh dev sandbox loaded an exclusion for `/sandbox/projects/blocked/**`, then ingested one blocked and one allowed Codex session. The ClickHouse verification query returned only `issue-535-final-included` with two raw rows; `issue-535-final-excluded` produced none. The sandbox was torn down after the check.
