### PR TITLE
chore(release): cut v0.7.0

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.6.4)"
+        description: "Tag to release (for example v0.7.0)"
         required: true
         type: string
       target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "moraine"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "glob",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest-core"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp-core"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1274,11 +1274,11 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor"
-version = "0.6.4"
+version = "0.7.0"
 
 [[package]]
 name = "moraine-monitor-core"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/moraine-ingest/Cargo.toml
+++ b/apps/moraine-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 description = "Moraine ingest service binary"
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 description = "Moraine MCP stdio entry and unified backend daemon"
 

--- a/apps/moraine-monitor/Cargo.toml
+++ b/apps/moraine-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 description = "Deprecated alias for the unified Moraine backend"
 

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 description = "Unified runtime control plane for Moraine services"
 

--- a/bindings/python/moraine_conversations/Cargo.lock
+++ b/bindings/python/moraine_conversations/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "glob",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-clickhouse"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 description = "Shared Moraine ClickHouse client and query helpers"
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-config"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 description = "Shared Moraine configuration schema and loaders"
 

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-conversations"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 description = "High-level read/query APIs for Moraine conversations"
 

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest-core"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 description = "Core ingestion pipeline internals for Moraine"
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp-core"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 description = "MCP protocol and tool routing core for Moraine"
 

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor-core"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 description = "Analytics and query logic for Moraine monitor service"
 

--- a/plugins/hermes-moraine/plugin.yaml
+++ b/plugins/hermes-moraine/plugin.yaml
@@ -1,6 +1,6 @@
 manifest_version: 1
 name: moraine
-version: "0.6.4"
+version: "0.7.0"
 description: "Hermes integration for Moraine MCP session search, realtime agent awareness, sanitized bug reports, and setup diagnostics."
 author: "Moraine maintainers"
 provides_tools:

--- a/plugins/moraine/.claude-plugin/plugin.json
+++ b/plugins/moraine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "displayName": "Moraine",
   "description": "Claude Code plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {

--- a/plugins/moraine/.codex-plugin/plugin.json
+++ b/plugins/moraine/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "Codex plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {
     "name": "Moraine maintainers",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ install directory precedence:
 
 examples:
   scripts/install.sh
-  MORAINE_INSTALL_VERSION=v0.6.4 scripts/install.sh
+  MORAINE_INSTALL_VERSION=v0.7.0 scripts/install.sh
   MORAINE_INSTALL_ASSET_BASE_URL=http://127.0.0.1:8080 \
     MORAINE_INSTALL_VERSION=ci-e2e scripts/install.sh
   MORAINE_INSTALL_DIR="$HOME/bin" MORAINE_INSTALL_SKIP_CLICKHOUSE=1 scripts/install.sh


### PR DESCRIPTION
## Description

**What.** Bumps Moraine from `v0.6.4` to `v0.7.0` across every release-managed Rust crate, the root and standalone-binding lockfiles, release workflow/install examples, and bundled runtime plugin manifests.

**Why.** This minor release packages the unified backend architecture, stronger multi-harness ingestion and identity controls, managed ClickHouse recovery, and a substantial MCP retrieval correctness/performance pass.

## User-facing changes since v0.6.4

- [#476](https://github.com/eric-tramel/moraine/pull/476) consolidates monitor, MCP, and status reads behind one conversation repository and introduces the unified backend daemon, stable `/api/v1` monitor API, capabilities discovery, named-backend routing, and deliberate direct-database status fallback.
- [#446](https://github.com/eric-tramel/moraine/pull/446), [#470](https://github.com/eric-tramel/moraine/pull/470), [#448](https://github.com/eric-tramel/moraine/pull/448), and [#536](https://github.com/eric-tramel/moraine/pull/536) add explicit author attribution, restore automatic OMP ingestion, link Kimi subagents to parents, and let operators exclude complete sessions by project-directory glob.
- [#450](https://github.com/eric-tramel/moraine/pull/450), [#516](https://github.com/eric-tramel/moraine/pull/516), [#519](https://github.com/eric-tramel/moraine/pull/519), and [#529](https://github.com/eric-tramel/moraine/pull/529) add managed ClickHouse crash recovery, bound supervisor logs to 32 MiB, tolerate clean child output EOF, and keep `moraine status` from deleting PID metadata it cannot validate.
- [#526](https://github.com/eric-tramel/moraine/pull/526) adds exact `harness` and configured `source` filters to `search_sessions`, `list_sessions`, and `file_attention`.
- [#513](https://github.com/eric-tramel/moraine/pull/513), [#511](https://github.com/eric-tramel/moraine/pull/511), [#510](https://github.com/eric-tramel/moraine/pull/510), and [#521](https://github.com/eric-tramel/moraine/pull/521) tighten project scoping, make retrieval timestamps epoch-authoritative, flag handled MCP errors correctly, and return actionable negative-limit validation messages.
- [#531](https://github.com/eric-tramel/moraine/pull/531), [#530](https://github.com/eric-tramel/moraine/pull/530), [#525](https://github.com/eric-tramel/moraine/pull/525), and [#514](https://github.com/eric-tramel/moraine/pull/514) increase concurrent retrieval throughput, queue excess valid work instead of rejecting it, and reduce ranking/query-plan overhead.
- [#533](https://github.com/eric-tramel/moraine/pull/533) and [#534](https://github.com/eric-tramel/moraine/pull/534) replace corpus-wide typed `open` reconstruction with a bounded read model and make its one-time historical projection visible and about 3.3x faster in the published fixture.

## Usage

No release-bump-only action is required. After `v0.7.0` is published, existing PyPI users can upgrade with:

```bash
moraine down
uv tool upgrade moraine-cli
moraine up && moraine status
```

To opt into the unified managed backend lifecycle introduced in this series:

```toml
[backend]
start_on_up = true
bind = "127.0.0.1"
```

## Operational impact

- Pushing the annotated `v0.7.0` tag after this PR merges will run `.github/workflows/release-moraine.yml`, build four platform bundles, create the GitHub release, and publish `moraine-cli` `0.7.0` to PyPI.
- Normal startup applies migrations `024` through `027`. Migration `027` builds the bounded MCP open read model once and resumes safely if interrupted; the CLI now reports progress while it runs.
- Named mirror sinks require a non-empty `[identity].author`; local-only installs may leave it empty.
- The version bump itself changes no runtime behavior beyond selecting the released version.

## Changelog

- Releases the unified backend daemon and stable versioned monitor API.
- Adds identity attribution, OMP restoration, Kimi parent links, and project-directory exclusions.
- Adds managed ClickHouse recovery with bounded logs.
- Improves MCP retrieval filtering, correctness, boundedness, and concurrent throughput.

## Validation

`git diff --check` and `cargo fmt --all -- --check` passed. `cargo test --workspace --locked` passed 801 tests across 26 suites with four intentional ignores.

The standalone PyO3 binding was also verified with `cargo check --manifest-path bindings/python/moraine_conversations/Cargo.toml --locked`; its lockfile now records the `0.7.0` path dependencies without changing the internal binding package version.

A fresh Linux development sandbox (`sb-58e08d`) ran `scripts/ci/e2e-stack.sh` against the release worktree with the sandbox-built binaries. The full managed ClickHouse, migrations `001`–`027`, ingest, unified backend/monitor, named routing, MCP search/open/list/file-attention, fallback, status, and teardown flow exited `0`; all MCP smoke invocations passed. The sandbox and its volumes were removed afterward.

`ANTHROPIC_API_KEY` was unavailable, so the optional paid real-agent smoke was not run. The commit hook also passed formatting and the repository strict Clippy baseline.
