### PR TITLE
fix(mcp): remove response SLA reporting

### DIFF
--- a/crates/moraine-mcp-core/src/concurrency_tests.rs
+++ b/crates/moraine-mcp-core/src/concurrency_tests.rs
@@ -534,7 +534,11 @@ async fn queued_success_reports_wall_time_from_frame_acceptance() {
         performance["elapsed_ms"].as_u64().expect("elapsed_ms") >= 750,
         "queue time must be included: {performance}"
     );
-    assert_eq!(performance["met_sla"], json!(false));
+    assert_eq!(
+        performance.as_object().expect("performance object").len(),
+        1,
+        "performance must only report elapsed time: {performance}"
+    );
 
     writer.shutdown().await.expect("half-close request stream");
     drop(writer);

--- a/crates/moraine-mcp-core/src/contract.rs
+++ b/crates/moraine-mcp-core/src/contract.rs
@@ -22,20 +22,13 @@ pub const SEARCH_SESSIONS_DEFAULT_N_HITS: u16 = 10;
 pub const SEARCH_SESSIONS_MIN_N_HITS: u16 = 1;
 pub const SEARCH_SESSIONS_MAX_N_HITS: u16 = 50;
 pub const SEARCH_SESSIONS_MAX_QUERY_CHARS: usize = 4096;
-pub const SEARCH_SESSIONS_SLA_TARGET_MS: u64 = 750;
-pub const OPEN_SLA_TARGET_MS: u64 = 500;
 pub const LIST_SESSIONS_DEFAULT_LIMIT: u16 = 20;
 pub const LIST_SESSIONS_MIN_LIMIT: u16 = 1;
-pub const LIST_SESSIONS_DEFAULT_SLA_TARGET_MS: u64 = 300;
-pub const LIST_SESSIONS_BROAD_SLA_TARGET_MS: u64 = 1_000;
-pub const LIST_SESSIONS_FILTERED_BROAD_SLA_TARGET_MS: u64 = 1_200;
 pub const LIST_SESSIONS_DEADLINE_MS: u64 = 3_000;
 pub const FILE_ATTENTION_TOOL: &str = "file_attention";
 pub const FILE_ATTENTION_SCHEMA_VERSION: &str = "moraine.mcp.file_attention.v1";
 pub const FILE_ATTENTION_MIN_LIMIT: u16 = 1;
 pub const FILE_ATTENTION_DEFAULT_LIMIT: u16 = 50;
-pub const FILE_ATTENTION_DEFAULT_SLA_TARGET_MS: u64 = 600;
-pub const FILE_ATTENTION_BROAD_SLA_TARGET_MS: u64 = 1_200;
 pub const FILE_ATTENTION_DEADLINE_MS: u64 = 4_000;
 /// Minimum number of non-empty, slash-separated segments a path tail must have
 /// before it is treated as specific enough to suffix-match without a
@@ -1031,62 +1024,36 @@ impl From<ContractError> for ToolError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Performance {
     pub elapsed_ms: u64,
-    pub sla_target_ms: u64,
-    pub met_sla: bool,
 }
 
 impl Performance {
-    pub fn from_elapsed_ms(elapsed_ms: u64, sla_target_ms: u64) -> Self {
-        Self {
-            elapsed_ms,
-            sla_target_ms,
-            met_sla: elapsed_ms <= sla_target_ms,
+    pub fn from_elapsed_ms(elapsed_ms: u64) -> Self {
+        Self { elapsed_ms }
+    }
+
+    pub fn from_elapsed(elapsed: Duration) -> Self {
+        Self::from_elapsed_ms(duration_millis_u64(elapsed))
+    }
+
+    pub fn builder() -> PerformanceBuilder {
+        PerformanceBuilder {
+            started_at: Instant::now(),
         }
     }
 
-    pub fn from_elapsed(elapsed: Duration, sla_target_ms: u64) -> Self {
-        Self::from_elapsed_ms(duration_millis_u64(elapsed), sla_target_ms)
-    }
-
-    pub fn builder(sla_target_ms: u64) -> PerformanceBuilder {
-        PerformanceBuilder::new(sla_target_ms)
-    }
-
-    pub(crate) fn builder_from(started_at: Instant, sla_target_ms: u64) -> PerformanceBuilder {
-        PerformanceBuilder::from_started_at(started_at, sla_target_ms)
+    pub(crate) fn builder_from(started_at: Instant) -> PerformanceBuilder {
+        PerformanceBuilder { started_at }
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct PerformanceBuilder {
     started_at: Instant,
-    sla_target_ms: u64,
 }
 
 impl PerformanceBuilder {
-    pub fn new(sla_target_ms: u64) -> Self {
-        Self {
-            started_at: Instant::now(),
-            sla_target_ms,
-        }
-    }
-
-    fn from_started_at(started_at: Instant, sla_target_ms: u64) -> Self {
-        Self {
-            started_at,
-            sla_target_ms,
-        }
-    }
-
     pub fn finish(&self) -> Performance {
-        Performance::from_elapsed(self.started_at.elapsed(), self.sla_target_ms)
-    }
-
-    pub fn with_sla_target(&self, sla_target_ms: u64) -> Self {
-        Self {
-            started_at: self.started_at,
-            sla_target_ms,
-        }
+        Performance::from_elapsed(self.started_at.elapsed())
     }
 }
 
@@ -1771,7 +1738,7 @@ mod tests {
 
     #[test]
     fn success_and_error_envelopes_have_contract_shape() {
-        let performance = Performance::from_elapsed_ms(64, SEARCH_SESSIONS_SLA_TARGET_MS);
+        let performance = Performance::from_elapsed_ms(64);
         let success = ToolEnvelope::success(
             SEARCH_SESSIONS_TOOL,
             json!({
@@ -1808,9 +1775,7 @@ mod tests {
                 },
                 "warnings": [],
                 "performance": {
-                    "elapsed_ms": 64,
-                    "sla_target_ms": 750,
-                    "met_sla": true
+                    "elapsed_ms": 64
                 }
             })
         );
@@ -1824,7 +1789,7 @@ mod tests {
             SEARCH_SESSIONS_TOOL,
             json!({ "query": "   " }),
             error,
-            Performance::from_elapsed_ms(2, SEARCH_SESSIONS_SLA_TARGET_MS),
+            Performance::from_elapsed_ms(2),
         );
 
         assert_eq!(
@@ -1844,9 +1809,7 @@ mod tests {
                 },
                 "warnings": [],
                 "performance": {
-                    "elapsed_ms": 2,
-                    "sla_target_ms": 750,
-                    "met_sla": true
+                    "elapsed_ms": 2
                 }
             })
         );
@@ -1855,14 +1818,9 @@ mod tests {
     #[test]
     fn performance_and_time_helpers_follow_contract() {
         assert_eq!(
-            Performance::from_elapsed_ms(500, OPEN_SLA_TARGET_MS),
-            Performance {
-                elapsed_ms: 500,
-                sla_target_ms: 500,
-                met_sla: true
-            }
+            Performance::from_elapsed_ms(500),
+            Performance { elapsed_ms: 500 }
         );
-        assert!(!Performance::from_elapsed_ms(501, OPEN_SLA_TARGET_MS).met_sla);
         assert_eq!(format_rfc3339_utc_millis(0), "1970-01-01T00:00:00.000Z");
         assert_eq!(
             format_rfc3339_utc_millis(1_777_488_751_125),

--- a/crates/moraine-mcp-core/src/file_attention_v1.rs
+++ b/crates/moraine-mcp-core/src/file_attention_v1.rs
@@ -17,8 +17,7 @@ use super::{
 use crate::contract::{
     format_rfc3339_utc_millis, CanonicalFileAttentionArgs, ContractError, FileAttentionArgs,
     FileAttentionGranularity, FileAttentionScope, McpEventId, McpSessionId, McpTurnId, Performance,
-    ToolEnvelope, ToolErrorCode, ToolErrorEnvelope, FILE_ATTENTION_BROAD_SLA_TARGET_MS,
-    FILE_ATTENTION_DEADLINE_MS, FILE_ATTENTION_DEFAULT_SLA_TARGET_MS,
+    ToolEnvelope, ToolErrorCode, ToolErrorEnvelope, FILE_ATTENTION_DEADLINE_MS,
     FILE_ATTENTION_MIN_TAIL_SEGMENTS, FILE_ATTENTION_TOOL,
 };
 use anyhow::{Context, Result};
@@ -37,7 +36,7 @@ const FILE_ATTENTION_SCAN_CAP: usize = 2_000;
 
 impl AppState {
     pub(crate) async fn file_attention_v1(&self, arguments: Value) -> Result<Value> {
-        let perf = request_performance(FILE_ATTENTION_DEFAULT_SLA_TARGET_MS);
+        let perf = request_performance();
         let raw_request = arguments.clone();
 
         let args = match parse_file_attention_args(arguments, self.cfg.mcp.max_results) {
@@ -45,11 +44,6 @@ impl AppState {
             Err(error) => return encode_error(raw_request, error, perf.finish()),
         };
         let canonical_request = canonical_request_json(&args);
-
-        // The Tier-0 plan still scans `tool_io` by path even when datetime
-        // bounds are present, so report against the broad target until a future
-        // indexed path/time plan can make windowed requests truly narrow.
-        let perf = perf.with_sla_target(FILE_ATTENTION_BROAD_SLA_TARGET_MS);
 
         let mut warnings: Vec<String> = Vec::new();
         let tail = resolve_tail_from(&args.path, self.launch_dir.as_deref());
@@ -911,7 +905,7 @@ mod tests {
                 ToolErrorCode::DeadlineExceeded,
                 "file_attention exceeded its response deadline",
             ),
-            Performance::builder(FILE_ATTENTION_DEFAULT_SLA_TARGET_MS).finish(),
+            Performance::builder().finish(),
         )
         .expect("deadline response");
 

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -273,11 +273,11 @@ tokio::task_local! {
     static REQUEST_ACCEPTED_AT: std::time::Instant;
 }
 
-pub(crate) fn request_performance(sla_target_ms: u64) -> contract::PerformanceBuilder {
+pub(crate) fn request_performance() -> contract::PerformanceBuilder {
     let started_at = REQUEST_ACCEPTED_AT
         .try_with(|started_at| *started_at)
         .unwrap_or_else(|_| std::time::Instant::now());
-    contract::Performance::builder_from(started_at, sla_target_ms)
+    contract::Performance::builder_from(started_at)
 }
 
 pub(crate) fn request_started_at() -> std::time::Instant {
@@ -1269,7 +1269,7 @@ fn admission_error_response(
         tool.name.clone(),
         tool.request.clone(),
         error,
-        contract::Performance::from_elapsed(accepted_at.elapsed(), deadline_ms),
+        contract::Performance::from_elapsed(accepted_at.elapsed()),
     ))
     .expect("MCP admission error envelope is serializable");
     rpc_ok(

--- a/crates/moraine-mcp-core/src/list_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/list_sessions_v1.rs
@@ -5,9 +5,7 @@ use super::{
 use crate::contract::{
     format_rfc3339_utc_millis, CanonicalListSessionsArgs, ContractError, ListSessionsArgs,
     ListSessionsMode, ListSessionsSort, McpSessionId, Performance, ToolEnvelope, ToolErrorCode,
-    ToolErrorEnvelope, LIST_SESSIONS_BROAD_SLA_TARGET_MS, LIST_SESSIONS_DEADLINE_MS,
-    LIST_SESSIONS_DEFAULT_SLA_TARGET_MS, LIST_SESSIONS_FILTERED_BROAD_SLA_TARGET_MS,
-    LIST_SESSIONS_TOOL,
+    ToolErrorEnvelope, LIST_SESSIONS_DEADLINE_MS, LIST_SESSIONS_TOOL,
 };
 use anyhow::{Context, Result};
 use moraine_conversations::{
@@ -18,11 +16,9 @@ use serde_json::{json, Value};
 use tokio::time::{timeout, Duration};
 use tracing::warn;
 
-const LIST_SESSIONS_BROAD_WINDOW_MS: i64 = 30 * 24 * 60 * 60 * 1_000;
-
 impl AppState {
     pub(crate) async fn list_sessions_v1(&self, arguments: Value) -> Result<Value> {
-        let perf = request_performance(LIST_SESSIONS_DEFAULT_SLA_TARGET_MS);
+        let perf = request_performance();
         let raw_request = arguments.clone();
 
         let args = match parse_list_sessions_args(arguments, self.cfg.mcp.max_results) {
@@ -32,8 +28,6 @@ impl AppState {
             }
         };
         let canonical_request = canonical_request_json(&args);
-        let args_perf = perf.with_sla_target(list_sessions_sla_target_ms(&args, false));
-
         let repo_filter = McpSessionListFilter {
             start_unix_ms: args.start_unix_ms,
             end_unix_ms: args.end_unix_ms,
@@ -59,7 +53,7 @@ impl AppState {
                 return encode_list_sessions_error(
                     canonical_request,
                     repo_error_to_contract_error(error),
-                    args_perf.finish(),
+                    perf.finish(),
                 );
             }
             Err(_) => {
@@ -70,17 +64,12 @@ impl AppState {
                         "list_sessions exceeded its response deadline",
                     )
                     .with_details(json!({ "deadline_ms": LIST_SESSIONS_DEADLINE_MS })),
-                    args_perf.finish(),
+                    perf.finish(),
                 );
             }
         };
 
-        let performance = perf
-            .with_sla_target(list_sessions_sla_target_ms(
-                &args,
-                page.next_cursor.is_some(),
-            ))
-            .finish();
+        let performance = perf.finish();
         let data = match list_sessions_data_json(&args, &page) {
             Ok(data) => data,
             Err(error) => {
@@ -176,20 +165,6 @@ fn list_sessions_data_json(
         "sessions": sessions,
         "next_cursor": page.next_cursor.as_deref(),
     }))
-}
-
-fn list_sessions_sla_target_ms(args: &CanonicalListSessionsArgs, has_more: bool) -> u64 {
-    let is_broad_window =
-        args.end_unix_ms.saturating_sub(args.start_unix_ms) >= LIST_SESSIONS_BROAD_WINDOW_MS;
-    if is_broad_window || has_more {
-        if args.mode.is_some() || args.harness.is_some() || args.source.is_some() {
-            LIST_SESSIONS_FILTERED_BROAD_SLA_TARGET_MS
-        } else {
-            LIST_SESSIONS_BROAD_SLA_TARGET_MS
-        }
-    } else {
-        LIST_SESSIONS_DEFAULT_SLA_TARGET_MS
-    }
 }
 
 fn session_json(rank: usize, session: &McpSessionListItem) -> Result<Value, ContractError> {
@@ -333,7 +308,7 @@ mod tests {
                 ToolErrorCode::DeadlineExceeded,
                 "list_sessions exceeded its response deadline",
             ),
-            Performance::builder(LIST_SESSIONS_DEFAULT_SLA_TARGET_MS).finish(),
+            Performance::builder().finish(),
         )
         .expect("deadline response");
 
@@ -611,39 +586,5 @@ mod tests {
         assert_eq!(data["sessions"][0]["rank"], json!(1));
         assert_eq!(data["truncated"], json!(true));
         assert_eq!(data["next_cursor"], json!("opaque-cursor"));
-    }
-
-    #[test]
-    fn selects_list_sessions_sla_for_broad_windows() {
-        let narrow = parse_list_sessions_args(
-            json!({
-                "start_datetime": "2026-04-30T09:00:00-04:00",
-                "end_datetime": "2026-04-30T13:00:00-04:00"
-            }),
-            50,
-        )
-        .expect("valid narrow args");
-        assert_eq!(
-            list_sessions_sla_target_ms(&narrow, false),
-            LIST_SESSIONS_DEFAULT_SLA_TARGET_MS
-        );
-        assert_eq!(
-            list_sessions_sla_target_ms(&narrow, true),
-            LIST_SESSIONS_BROAD_SLA_TARGET_MS
-        );
-
-        let broad_filtered = parse_list_sessions_args(
-            json!({
-                "start_datetime": "2026-01-01T00:00:00Z",
-                "end_datetime": "2026-03-01T00:00:00Z",
-                "mode": "chat"
-            }),
-            50,
-        )
-        .expect("valid broad filtered args");
-        assert_eq!(
-            list_sessions_sla_target_ms(&broad_filtered, false),
-            LIST_SESSIONS_FILTERED_BROAD_SLA_TARGET_MS
-        );
     }
 }

--- a/crates/moraine-mcp-core/src/open_v1.rs
+++ b/crates/moraine-mcp-core/src/open_v1.rs
@@ -11,9 +11,6 @@ use moraine_conversations::{
 use serde_json::{json, Map, Value};
 use std::time::Instant;
 
-const OPEN_EVENT_SLA_TARGET_MS: u64 = 500;
-const OPEN_TURN_SLA_TARGET_MS: u64 = 750;
-const OPEN_SESSION_SLA_TARGET_MS: u64 = 1_000;
 const SUMMARY_PREVIEW_CHARS: usize = 240;
 
 impl AppState {
@@ -32,7 +29,6 @@ impl AppState {
                         details: Some(json!({ "field": "id" })),
                     },
                     started_at,
-                    OPEN_EVENT_SLA_TARGET_MS,
                 );
             }
         };
@@ -40,29 +36,22 @@ impl AppState {
         let canonical = match args.validate() {
             Ok(canonical) => canonical,
             Err(err) => {
-                return contract_error_tool_response(
-                    raw_request,
-                    err,
-                    started_at,
-                    OPEN_EVENT_SLA_TARGET_MS,
-                );
+                return contract_error_tool_response(raw_request, err, started_at);
             }
         };
 
-        let sla_target_ms = open_sla_target_ms(&canonical.id);
         let request = request_for_id(&canonical.id);
 
         match &canonical.id {
             McpId::Session(id) => match self.repo.get_mcp_session(id.raw_session_id()).await {
                 Ok(Some(session)) => match open_session_data(&session) {
                     Ok((data, warnings)) => {
-                        success_tool_response(request, data, warnings, started_at, sla_target_ms)
+                        success_tool_response(request, data, warnings, started_at)
                     }
                     Err(err) => internal_error_tool_response(
                         request,
                         format!("failed to shape session open response: {err:#}"),
                         started_at,
-                        sla_target_ms,
                     ),
                 },
                 Ok(None) => not_found_tool_response(
@@ -70,26 +59,20 @@ impl AppState {
                     McpEntityKind::Session,
                     &canonical.id.to_string(),
                     started_at,
-                    sla_target_ms,
                 ),
-                Err(err) => repo_error_tool_response(request, err, started_at, sla_target_ms),
+                Err(err) => repo_error_tool_response(request, err, started_at),
             },
             McpId::Turn(id) => {
                 let (session_id, turn_seq) = id.decode();
                 match self.repo.get_mcp_turn(session_id, turn_seq).await {
                     Ok(Some(turn)) => match open_turn_data(&turn) {
-                        Ok((data, warnings)) => success_tool_response(
-                            request,
-                            data,
-                            warnings,
-                            started_at,
-                            sla_target_ms,
-                        ),
+                        Ok((data, warnings)) => {
+                            success_tool_response(request, data, warnings, started_at)
+                        }
                         Err(err) => internal_error_tool_response(
                             request,
                             format!("failed to shape turn open response: {err:#}"),
                             started_at,
-                            sla_target_ms,
                         ),
                     },
                     Ok(None) => not_found_tool_response(
@@ -97,21 +80,19 @@ impl AppState {
                         McpEntityKind::Turn,
                         &canonical.id.to_string(),
                         started_at,
-                        sla_target_ms,
                     ),
-                    Err(err) => repo_error_tool_response(request, err, started_at, sla_target_ms),
+                    Err(err) => repo_error_tool_response(request, err, started_at),
                 }
             }
             McpId::Event(id) => match self.repo.get_mcp_event(id.raw_event_uid()).await {
                 Ok(Some(event)) => match open_event_data(&event, None) {
                     Ok((data, warnings)) => {
-                        success_tool_response(request, data, warnings, started_at, sla_target_ms)
+                        success_tool_response(request, data, warnings, started_at)
                     }
                     Err(err) => internal_error_tool_response(
                         request,
                         format!("failed to shape event open response: {err:#}"),
                         started_at,
-                        sla_target_ms,
                     ),
                 },
                 Ok(None) => not_found_tool_response(
@@ -119,19 +100,10 @@ impl AppState {
                     McpEntityKind::Event,
                     &canonical.id.to_string(),
                     started_at,
-                    sla_target_ms,
                 ),
-                Err(err) => repo_error_tool_response(request, err, started_at, sla_target_ms),
+                Err(err) => repo_error_tool_response(request, err, started_at),
             },
         }
-    }
-}
-
-fn open_sla_target_ms(id: &McpId) -> u64 {
-    match id.kind() {
-        McpEntityKind::Session => OPEN_SESSION_SLA_TARGET_MS,
-        McpEntityKind::Turn => OPEN_TURN_SLA_TARGET_MS,
-        McpEntityKind::Event => OPEN_EVENT_SLA_TARGET_MS,
     }
 }
 
@@ -155,9 +127,8 @@ fn success_tool_response(
     data: Value,
     warnings: Vec<String>,
     started_at: Instant,
-    sla_target_ms: u64,
 ) -> Result<Value> {
-    let performance = Performance::from_elapsed(started_at.elapsed(), sla_target_ms);
+    let performance = Performance::from_elapsed(started_at.elapsed());
     let envelope =
         ToolEnvelope::success(OPEN_TOOL, request, data, performance).with_warnings(warnings);
     let payload = serde_json::to_value(envelope).context("failed to encode open envelope")?;
@@ -168,7 +139,6 @@ fn contract_error_tool_response(
     request: Value,
     error: ContractError,
     started_at: Instant,
-    sla_target_ms: u64,
 ) -> Result<Value> {
     let details = error
         .details()
@@ -182,7 +152,6 @@ fn contract_error_tool_response(
             details,
         },
         started_at,
-        sla_target_ms,
     )
 }
 
@@ -191,7 +160,6 @@ fn not_found_tool_response(
     kind: McpEntityKind,
     id: &str,
     started_at: Instant,
-    sla_target_ms: u64,
 ) -> Result<Value> {
     error_tool_response(
         request,
@@ -201,7 +169,6 @@ fn not_found_tool_response(
             details: Some(json!({ "id": id })),
         },
         started_at,
-        sla_target_ms,
     )
 }
 
@@ -209,7 +176,6 @@ fn repo_error_tool_response(
     request: Value,
     error: moraine_conversations::RepoError,
     started_at: Instant,
-    sla_target_ms: u64,
 ) -> Result<Value> {
     error_tool_response(
         request,
@@ -219,7 +185,6 @@ fn repo_error_tool_response(
             details: None,
         },
         started_at,
-        sla_target_ms,
     )
 }
 
@@ -227,7 +192,6 @@ fn internal_error_tool_response(
     request: Value,
     message: String,
     started_at: Instant,
-    sla_target_ms: u64,
 ) -> Result<Value> {
     error_tool_response(
         request,
@@ -237,17 +201,11 @@ fn internal_error_tool_response(
             details: None,
         },
         started_at,
-        sla_target_ms,
     )
 }
 
-fn error_tool_response(
-    request: Value,
-    error: ToolError,
-    started_at: Instant,
-    sla_target_ms: u64,
-) -> Result<Value> {
-    let performance = Performance::from_elapsed(started_at.elapsed(), sla_target_ms);
+fn error_tool_response(request: Value, error: ToolError, started_at: Instant) -> Result<Value> {
+    let performance = Performance::from_elapsed(started_at.elapsed());
     let envelope = ToolErrorEnvelope::error(OPEN_TOOL, request, error, performance);
     let payload = serde_json::to_value(envelope).context("failed to encode open error envelope")?;
     Ok(handled_tool_error_result(
@@ -919,7 +877,6 @@ mod tests {
                 details: Some(json!({ "field": "id" })),
             },
             Instant::now(),
-            OPEN_EVENT_SLA_TARGET_MS,
         )
         .expect("error response");
 

--- a/crates/moraine-mcp-core/src/search_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/search_sessions_v1.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::contract::{
     format_rfc3339_utc_millis, CanonicalSearchSessionsArgs, ContractError, McpEventId, McpId,
     McpSessionId, McpTurnId, Performance, SearchSessionsArgs, ToolEnvelope, ToolErrorCode,
-    ToolErrorEnvelope, SEARCH_SESSIONS_SLA_TARGET_MS, SEARCH_SESSIONS_TOOL,
+    ToolErrorEnvelope, SEARCH_SESSIONS_TOOL,
 };
 use anyhow::{Context, Result};
 use moraine_conversations::{
@@ -18,7 +18,7 @@ const MAX_SNIPPET_CHARS: usize = 600;
 
 impl AppState {
     pub(crate) async fn search_sessions_v1(&self, arguments: Value) -> Result<Value> {
-        let perf = request_performance(SEARCH_SESSIONS_SLA_TARGET_MS);
+        let perf = request_performance();
         let raw_request = arguments.clone();
 
         let args = match parse_search_sessions_args(arguments) {

--- a/docs/agent-mcp-search/interface.md
+++ b/docs/agent-mcp-search/interface.md
@@ -1,7 +1,7 @@
 # MCP Interface
 
 This page explains Moraine's MCP interface as an agent user should understand
-it. For the exhaustive contract, examples, and SLA targets, see the
+it. For the exhaustive contract and examples, see the
 [MCP Search Interface Specification](../mcp-search-interface-spec.md).
 
 ## How MCP Tools Appear
@@ -302,9 +302,7 @@ Successful structured responses share this shape:
   "data": {},
   "warnings": [],
   "performance": {
-    "elapsed_ms": 12,
-    "sla_target_ms": 750,
-    "met_sla": true
+    "elapsed_ms": 12
   }
 }
 ```

--- a/docs/mcp-search-interface-spec.md
+++ b/docs/mcp-search-interface-spec.md
@@ -8,7 +8,7 @@ This document specifies the desired behavior for Moraine's MCP retrieval tools:
 - `file_attention`
 
 The scope of this document is the external interface contract: accepted inputs,
-output shapes, response behavior, errors, performance targets, and success
+output shapes, response behavior, errors, performance reporting, and success
 criteria. It intentionally does not specify storage layout, indexing strategy,
 query planning, or implementation internals.
 
@@ -137,9 +137,7 @@ shape:
   "data": {},
   "warnings": [],
   "performance": {
-    "elapsed_ms": 42,
-    "sla_target_ms": 750,
-    "met_sla": true
+    "elapsed_ms": 42
   }
 }
 ```
@@ -152,8 +150,6 @@ Field rules:
 - `data` contains the tool-specific payload.
 - `warnings` is always present and is an array.
 - `performance.elapsed_ms` is the measured end-to-end tool handling time.
-- `performance.sla_target_ms` is the target that applied to this request.
-- `performance.met_sla` indicates whether the request met its target.
 
 ### Error Envelope
 
@@ -176,9 +172,7 @@ in `structuredContent`.
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 3,
-    "sla_target_ms": 750,
-    "met_sla": true
+    "elapsed_ms": 3
   }
 }
 ```
@@ -392,9 +386,7 @@ should not compare scores across different queries.
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 64,
-    "sla_target_ms": 750,
-    "met_sla": true
+    "elapsed_ms": 64
   }
 }
 ```
@@ -573,9 +565,7 @@ Response:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 64,
-    "sla_target_ms": 750,
-    "met_sla": true
+    "elapsed_ms": 64
   }
 }
 ```
@@ -649,9 +639,7 @@ Response:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 18,
-    "sla_target_ms": 300,
-    "met_sla": true
+    "elapsed_ms": 18
   }
 }
 ```
@@ -687,9 +675,7 @@ Response:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 21,
-    "sla_target_ms": 750,
-    "met_sla": true
+    "elapsed_ms": 21
   }
 }
 ```
@@ -714,9 +700,7 @@ Blank query:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 2,
-    "sla_target_ms": 750,
-    "met_sla": true
+    "elapsed_ms": 2
   }
 }
 ```
@@ -750,9 +734,7 @@ Unsupported event type:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 2,
-    "sla_target_ms": 750,
-    "met_sla": true
+    "elapsed_ms": 2
   }
 }
 ```
@@ -835,9 +817,7 @@ session metadata only:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 42,
-    "sla_target_ms": 300,
-    "met_sla": true
+    "elapsed_ms": 42
   }
 }
 ```
@@ -972,9 +952,7 @@ root buckets, and either session rollups or a flat event timeline:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 90,
-    "sla_target_ms": 1200,
-    "met_sla": true
+    "elapsed_ms": 90
   }
 }
 ```
@@ -1042,9 +1020,7 @@ All successful `open` responses use this envelope:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 32,
-    "sla_target_ms": 500,
-    "met_sla": true
+    "elapsed_ms": 32
   }
 }
 ```
@@ -1207,9 +1183,7 @@ Example:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 32,
-    "sla_target_ms": 500,
-    "met_sla": true
+    "elapsed_ms": 32
   }
 }
 ```
@@ -1374,9 +1348,7 @@ Complete turn example:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 19,
-    "sla_target_ms": 300,
-    "met_sla": true
+    "elapsed_ms": 19
   }
 }
 ```
@@ -1451,9 +1423,7 @@ Incomplete turn example:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 16,
-    "sla_target_ms": 300,
-    "met_sla": true
+    "elapsed_ms": 16
   }
 }
 ```
@@ -1558,9 +1528,7 @@ User input event example:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 9,
-    "sla_target_ms": 200,
-    "met_sla": true
+    "elapsed_ms": 9
   }
 }
 ```
@@ -1619,9 +1587,7 @@ Tool call event example:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 8,
-    "sla_target_ms": 200,
-    "met_sla": true
+    "elapsed_ms": 8
   }
 }
 ```
@@ -1677,9 +1643,7 @@ Tool response event example:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 10,
-    "sla_target_ms": 200,
-    "met_sla": true
+    "elapsed_ms": 10
   }
 }
 ```
@@ -1733,9 +1697,7 @@ Assistant response event example:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 9,
-    "sla_target_ms": 200,
-    "met_sla": true
+    "elapsed_ms": 9
   }
 }
 ```
@@ -1760,9 +1722,7 @@ Malformed ID:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 1,
-    "sla_target_ms": 200,
-    "met_sla": true
+    "elapsed_ms": 1
   }
 }
 ```
@@ -1785,9 +1745,7 @@ Missing object:
   },
   "warnings": [],
   "performance": {
-    "elapsed_ms": 4,
-    "sla_target_ms": 200,
-    "met_sla": true
+    "elapsed_ms": 4
   }
 }
 ```
@@ -1886,96 +1844,19 @@ Required traversal paths:
 
 Null traversal references are valid at boundaries.
 
-## Performance SLA
+## Performance Reporting
 
-These targets define what success looks like for local MCP use. They are
-measured from MCP tool invocation receipt to completed tool response
-serialization.
+Tool responses report the observed end-to-end handling time in
+`performance.elapsed_ms`. Moraine does not advertise a fixed latency target or
+classify individual responses as meeting an SLA: query cost varies with the
+amount of stored session data, request scope, event payload size, hardware, and
+concurrent work.
 
-### Definitions
-
-- `N` is the number of searchable documents visible to the request.
-- One searchable document is one event eligible for `search_sessions`.
-- Warm path means Moraine is already running and the relevant data has been
-  ingested.
-- Cold process startup is outside this SLA.
-- Extremely large event payload serialization is measured separately for
-  `open(event)`.
-
-### `search_sessions` Targets
-
-For default event types and `n_hits <= 10`:
-
-| Searchable documents | P50 | P95 | P99 |
-|---:|---:|---:|---:|
-| 100k | <= 250 ms | <= 750 ms | <= 1500 ms |
-| 500k | <= 500 ms | <= 1500 ms | <= 3000 ms |
-| 1M | <= 800 ms | <= 2500 ms | <= 5000 ms |
-
-For constrained search with `within_id=turn`:
-
-| Scope | P50 | P95 | P99 |
-|---|---:|---:|---:|
-| Any single turn with <= 500 events | <= 50 ms | <= 300 ms | <= 750 ms |
-
-For constrained search with `within_id=session`:
-
-| Scope | P50 | P95 | P99 |
-|---|---:|---:|---:|
-| Any single session with <= 250 turns | <= 100 ms | <= 500 ms | <= 1000 ms |
-
-Deadline:
-
-- `search_sessions` should return a response or `deadline_exceeded` within
-  5 seconds for warm-path requests up to 1M searchable documents.
-
-### `list_sessions` Targets
-
-For metadata-only requests with `limit <= 50`:
-
-| Scenario | P50 | P95 | P99 | Deadline |
-|---|---:|---:|---:|---:|
-| Typical window, <= 5k matching sessions | <= 50 ms | <= 300 ms | <= 750 ms | 2 s |
-| Broad window, <= 100k matching sessions | <= 200 ms | <= 1000 ms | <= 2000 ms | 3 s |
-| Single-mode filtered window, <= 100k matching sessions | <= 250 ms | <= 1200 ms | <= 2500 ms | 3 s |
-
-`list_sessions` should use session metadata or summary tables, avoid event text
-search, always enforce `limit`, and return a normal response or
-`deadline_exceeded` by the applicable deadline.
-
-The response `performance.sla_target_ms` advertises the applicable target:
-300 ms for typical metadata browse requests, 1000 ms for broad unfiltered
-windows, and 1200 ms for broad single-mode filtered windows.
-
-### `file_attention` Targets
-
-For file-attention requests with `limit <= 50`:
-
-| Scenario | P50 | P95 | P99 | Deadline |
-|---|---:|---:|---:|---:|
-| Specific repo-relative tail | <= 150 ms | <= 600 ms | <= 1200 ms | 4 s |
-| Broad or generic tail | <= 300 ms | <= 1200 ms | <= 2500 ms | 4 s |
-
-`file_attention` should bound ClickHouse execution with a per-query execution
-setting and query ID. If the MCP deadline fires, it should return
-`deadline_exceeded` and attempt to cancel the backend query by that ID.
-
-### `open` Targets
-
-| Request | P50 | P95 | P99 |
-|---|---:|---:|---:|
-| `open(event)` with payload <= 64 KiB | <= 25 ms | <= 200 ms | <= 500 ms |
-| `open(turn)` with <= 100 events | <= 50 ms | <= 300 ms | <= 750 ms |
-| `open(session)` with <= 100 turns | <= 100 ms | <= 500 ms | <= 1000 ms |
-| `open(session)` with <= 1000 turns | <= 250 ms | <= 1500 ms | <= 3000 ms |
-
-Large payload note:
-
-- `open(event)` must return full event content.
-- For event payloads over 64 KiB, latency may scale with serialized payload
-  size.
-- Large payload responses should still report `performance.elapsed_ms` and
-  `performance.met_sla` against the applicable target.
+The `list_sessions` and `file_attention` implementations retain bounded
+execution deadlines for resource safety. A deadline failure returns the
+`deadline_exceeded` error code; these safety limits are not latency guarantees.
+`open(event)` always returns full event content, so its elapsed time can scale
+with the serialized payload size.
 
 ## Success Criteria
 
@@ -2000,7 +1881,6 @@ An implementation is successful when:
 - Every hit includes event, turn, and session IDs that can be opened.
 - Snippets are compact and never substitute for full event content.
 - Empty result sets return success with `results: []`.
-- Performance meets the `search_sessions` SLA for the target corpus sizes.
 
 ### `list_sessions`
 
@@ -2018,7 +1898,6 @@ An implementation is successful when:
   or transcript text.
 - Invalid ranges, unknown fields, bad cursors, invalid modes, and invalid sort
   values produce the specified errors.
-- Performance meets the `list_sessions` SLA for target corpus sizes.
 
 ### `file_attention`
 
@@ -2043,7 +1922,6 @@ An implementation is successful when:
   without treating remote URLs or prose mentions as local file touches.
 - Display truncation and scan-cap truncation are visible to generic clients via
   `data.truncated`.
-- Performance meets the `file_attention` SLA for target corpus sizes.
 
 ### `open`
 
@@ -2060,7 +1938,6 @@ An implementation is successful when:
 - Tool names are surfaced for tool call and tool response events.
 - Incomplete turns are represented without inventing final responses.
 - Missing or malformed IDs produce the specified errors.
-- Performance meets the `open` SLA for the target object sizes.
 
 ### End-To-End Discovery
 


### PR DESCRIPTION
## Description

**What.** Removes fixed SLA targets and pass/fail classification from MCP tool response metadata while retaining observed elapsed time.

**Why.** Moraine session databases grow continuously, so a fixed advertised latency guarantee cannot remain valid across user corpus sizes and hardware.

The shared response contract now serializes `performance` with only `elapsed_ms` for all four retrieval tools, including validation, repository, admission, queue, and deadline error envelopes. The change removes request-dependent SLA target selection while preserving queue-inclusive elapsed timing and the operational deadlines that bound `list_sessions`, `file_attention`, and MCP admission work.

The MCP interface documentation and examples now describe elapsed-time reporting without fixed latency promises.

## Usage

No configuration or user action is required. Tool responses now use this shape:

```json
"performance": {
  "elapsed_ms": 1036
}
```

Clients should no longer expect `performance.sla_target_ms` or `performance.met_sla`.

## Bug Evidence

Before this change, every MCP response advertised a fixed SLA target and classified the request with `met_sla`, which produced misleading failures such as the distinct sequential searches reported in #540.

The root cause was the shared `Performance` contract and per-tool builders embedding fixed targets into every success and error response. This PR reduces that shared contract to elapsed time, removes the target-selection paths, and updates the queue-time regression test to require a one-field performance object. A live sandbox request returned exactly `{"elapsed_ms": 0}`.

## Operational Impact

This intentionally removes two fields from the v1 structured response envelope. Resource-safety deadlines and `deadline_exceeded` errors remain unchanged; this is not a relaxation of backend execution limits.

## Changelog

- MCP tool responses report observed elapsed time without advertising a fixed SLA target or per-request SLA result.

## Validation

Validated the rebased commit with `cargo fmt --all -- --check`, `cargo test -p moraine-mcp-core --lib --locked` (109 passed), strict `cargo clippy -p moraine-mcp-core --all-targets --locked -- -D warnings`, `git diff --check`, and `make docs-build`.

In isolated sandbox `sb-6a43ff`, the canonical `bash scripts/ci/e2e-stack.sh` lifecycle passed every MCP smoke path across daemon, named routing, scoped mode, and embedded fallback. A direct live MCP error response contained only `performance.elapsed_ms`, and `http://127.0.0.1:52567/api/v1/health` returned `ok: true`. The sandbox and all owned volumes were removed successfully afterward.

Closes #540.