### PR TITLE
fix(mcp): restore project identity for Git and directory projects

### DIFF
--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -1452,31 +1452,49 @@ fn parse_repo_backend_ref(path: &Path) -> Option<String> {
     }
 }
 
-/// Stable, opaque identity for one Git repository and all of its linked
-/// worktrees. Identity comes only from Git metadata; the optional repo backend
-/// marker controls routing independently and is not required here.
+/// Stable, opaque identity for a project root.
+///
+/// Git repositories use their common directory so linked worktrees share one
+/// identity. A non-Git directory uses its canonical path and therefore stays
+/// scoped to that exact launch directory. The optional repo backend marker
+/// controls routing independently and is not part of either identity.
 pub fn project_id_for_repo_root(root: impl AsRef<Path>) -> Option<String> {
-    let common_dir = git_common_dir(root.as_ref())?;
-    Some(project_id_for_common_dir(&common_dir))
+    let root = root.as_ref();
+    if let Some(common_dir) = git_common_dir(root) {
+        return Some(project_id_for_common_dir(&common_dir));
+    }
+    let canonical_root = root.canonicalize().ok()?;
+    canonical_root
+        .is_dir()
+        .then(|| project_id_for_directory_root(&canonical_root))
 }
 
 fn project_id_for_common_dir(common_dir: &Path) -> String {
+    project_id_for_path(b"moraine-git-common-dir\0", "git", common_dir)
+}
+
+fn project_id_for_directory_root(root: &Path) -> String {
+    project_id_for_path(b"moraine-directory-root\0", "dir", root)
+}
+
+fn project_id_for_path(domain: &[u8], prefix: &str, path: &Path) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(b"moraine-git-common-dir\0");
+    hasher.update(domain);
     #[cfg(unix)]
-    hasher.update(common_dir.as_os_str().as_bytes());
+    hasher.update(path.as_os_str().as_bytes());
     #[cfg(windows)]
-    for unit in common_dir.as_os_str().encode_wide() {
+    for unit in path.as_os_str().encode_wide() {
         hasher.update(unit.to_le_bytes());
     }
     #[cfg(not(any(unix, windows)))]
-    hasher.update(common_dir.to_string_lossy().as_bytes());
-    format!("git:{:x}", hasher.finalize())
+    hasher.update(path.to_string_lossy().as_bytes());
+    format!("{prefix}:{:x}", hasher.finalize())
 }
 
-/// UTF-8 worktree roots currently registered under this repository's canonical
-/// Git common directory. These roots support a safe transition for normalized
-/// rows written before `project_id` became the common-directory digest.
+/// UTF-8 roots currently associated with this project identity.
+///
+/// Git repositories include registered linked worktrees. Non-Git projects
+/// include only the supplied directory and its canonical spelling.
 pub fn worktree_roots_for_repo_root(root: impl AsRef<Path>) -> Option<Vec<String>> {
     let pwd = std::env::var_os("PWD").map(PathBuf::from);
     worktree_roots_for_repo_root_with_pwd(root.as_ref(), pwd.as_deref())
@@ -1486,47 +1504,52 @@ fn worktree_roots_for_repo_root_with_pwd(
     root: &Path,
     logical_cwd: Option<&Path>,
 ) -> Option<Vec<String>> {
-    let common_dir = git_common_dir(root)?;
+    let common_dir = git_common_dir(root);
+    let canonical_root = root.canonicalize().ok()?;
+    if !canonical_root.is_dir() {
+        return None;
+    }
     let mut roots = vec![root.to_path_buf()];
 
-    if common_dir.file_name().is_some_and(|name| name == ".git") {
-        if let Some(main_root) = common_dir.parent() {
-            roots.push(main_root.to_path_buf());
+    if let Some(common_dir) = common_dir.as_deref() {
+        if common_dir.file_name().is_some_and(|name| name == ".git") {
+            if let Some(main_root) = common_dir.parent() {
+                roots.push(main_root.to_path_buf());
+            }
         }
-    }
 
-    if let Ok(entries) = std::fs::read_dir(common_dir.join("worktrees")) {
-        for entry in entries.flatten() {
-            let gitdir_file = entry.path().join("gitdir");
-            let Ok(content) = std::fs::read_to_string(&gitdir_file) else {
-                continue;
-            };
-            let git_marker = Path::new(content.trim());
-            let git_marker = if git_marker.is_absolute() {
-                git_marker.to_path_buf()
-            } else {
-                entry.path().join(git_marker)
-            };
-            if let Some(worktree_root) = git_marker.parent() {
-                // A stale worktree registration may point at a path that was
-                // deleted and later reused by another repository. Only roots
-                // that still resolve to this common directory are safe to add
-                // to the current mapping; already-durable deleted roots are
-                // handled by the repository layer.
-                if git_common_dir(worktree_root).as_ref() == Some(&common_dir) {
-                    roots.push(worktree_root.to_path_buf());
+        if let Ok(entries) = std::fs::read_dir(common_dir.join("worktrees")) {
+            for entry in entries.flatten() {
+                let gitdir_file = entry.path().join("gitdir");
+                let Ok(content) = std::fs::read_to_string(&gitdir_file) else {
+                    continue;
+                };
+                let git_marker = Path::new(content.trim());
+                let git_marker = if git_marker.is_absolute() {
+                    git_marker.to_path_buf()
+                } else {
+                    entry.path().join(git_marker)
+                };
+                if let Some(worktree_root) = git_marker.parent() {
+                    // A stale worktree registration may point at a path that
+                    // was deleted and later reused by another repository. Only
+                    // roots that still resolve to this common directory are
+                    // safe to add to the current mapping; already-durable
+                    // deleted roots are handled by the repository layer.
+                    if git_common_dir(worktree_root).as_deref() == Some(common_dir) {
+                        roots.push(worktree_root.to_path_buf());
+                    }
                 }
             }
         }
     }
 
-    let canonical_root = root.canonicalize().ok();
-    if let (Some(canonical_root), Some(logical_cwd)) = (&canonical_root, logical_cwd) {
+    if let Some(logical_cwd) = logical_cwd {
         if let Ok(canonical_cwd) = logical_cwd.canonicalize() {
-            if let Ok(relative_cwd) = canonical_cwd.strip_prefix(canonical_root) {
+            if let Ok(relative_cwd) = canonical_cwd.strip_prefix(&canonical_root) {
                 let depth = relative_cwd.components().count();
                 if let Some(logical_root) = logical_cwd.ancestors().nth(depth) {
-                    if logical_root.canonicalize().ok().as_ref() == Some(canonical_root) {
+                    if logical_root.canonicalize().ok().as_ref() == Some(&canonical_root) {
                         roots.push(logical_root.to_path_buf());
                     }
                 }
@@ -1660,6 +1683,75 @@ mod tests {
             assert!(roots.contains(&canonical_linked.to_string_lossy().to_string()));
             assert!(!roots.contains(&canonical_other.to_string_lossy().to_string()));
         }
+
+        std::fs::remove_dir_all(base).ok();
+    }
+
+    #[test]
+    fn project_id_scopes_non_git_projects_to_the_exact_directory() {
+        let base = std::env::temp_dir().join(format!(
+            "moraine-directory-project-id-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time after unix epoch")
+                .as_nanos()
+        ));
+        let root = base.join("project");
+        let nested = root.join("nested");
+        std::fs::create_dir_all(&nested).expect("create non-Git project directories");
+
+        let root_id = project_id_for_repo_root(&root).expect("directory project id");
+        let nested_id = project_id_for_repo_root(&nested).expect("nested directory project id");
+        assert!(root_id.starts_with("dir:"));
+        assert!(nested_id.starts_with("dir:"));
+        assert_ne!(root_id, nested_id);
+
+        let roots = worktree_roots_for_repo_root(&root).expect("directory project roots");
+        assert!(roots.contains(&root.to_string_lossy().to_string()));
+        assert!(roots.contains(
+            &root
+                .canonicalize()
+                .expect("canonical directory project root")
+                .to_string_lossy()
+                .to_string()
+        ));
+        assert_eq!(project_id_for_repo_root(root.join("missing")), None);
+
+        std::fs::remove_dir_all(base).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_project_identity_unifies_logical_aliases() {
+        let base = std::env::temp_dir().join(format!(
+            "moraine-directory-project-alias-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time after unix epoch")
+                .as_nanos()
+        ));
+        let physical_root = base.join("physical");
+        let logical_root = base.join("logical");
+        std::fs::create_dir_all(&physical_root).expect("create physical directory project");
+        std::os::unix::fs::symlink(&physical_root, &logical_root)
+            .expect("create logical directory alias");
+
+        assert_eq!(
+            project_id_for_repo_root(&physical_root),
+            project_id_for_repo_root(&logical_root)
+        );
+        let roots =
+            worktree_roots_for_repo_root(&logical_root).expect("logical directory project roots");
+        assert!(roots.contains(&logical_root.to_string_lossy().to_string()));
+        assert!(roots.contains(
+            &physical_root
+                .canonicalize()
+                .expect("canonical physical directory")
+                .to_string_lossy()
+                .to_string()
+        ));
 
         std::fs::remove_dir_all(base).ok();
     }

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -1453,13 +1453,10 @@ fn parse_repo_backend_ref(path: &Path) -> Option<String> {
 }
 
 /// Stable, opaque identity for one Git repository and all of its linked
-/// worktrees. The repo backend marker is required, but its backend routing name
-/// is deliberately not the identity because multiple projects may share one
-/// backend.
+/// worktrees. Identity comes only from Git metadata; the optional repo backend
+/// marker controls routing independently and is not required here.
 pub fn project_id_for_repo_root(root: impl AsRef<Path>) -> Option<String> {
-    let root = root.as_ref();
-    find_repo_backend_ref(root)?;
-    let common_dir = git_common_dir(root)?;
+    let common_dir = git_common_dir(root.as_ref())?;
     Some(project_id_for_common_dir(&common_dir))
 }
 
@@ -1489,7 +1486,6 @@ fn worktree_roots_for_repo_root_with_pwd(
     root: &Path,
     logical_cwd: Option<&Path>,
 ) -> Option<Vec<String>> {
-    find_repo_backend_ref(root)?;
     let common_dir = git_common_dir(root)?;
     let mut roots = vec![root.to_path_buf()];
 
@@ -1512,7 +1508,14 @@ fn worktree_roots_for_repo_root_with_pwd(
                 entry.path().join(git_marker)
             };
             if let Some(worktree_root) = git_marker.parent() {
-                roots.push(worktree_root.to_path_buf());
+                // A stale worktree registration may point at a path that was
+                // deleted and later reused by another repository. Only roots
+                // that still resolve to this common directory are safe to add
+                // to the current mapping; already-durable deleted roots are
+                // handled by the repository layer.
+                if git_common_dir(worktree_root).as_ref() == Some(&common_dir) {
+                    roots.push(worktree_root.to_path_buf());
+                }
             }
         }
     }
@@ -1613,13 +1616,11 @@ mod tests {
         let linked = base.join("linked");
         let other = base.join("other");
         let linked_git_dir = main.join(".git/worktrees/linked");
+        let stale_git_dir = main.join(".git/worktrees/stale");
         std::fs::create_dir_all(&linked_git_dir).expect("create main git dirs");
+        std::fs::create_dir_all(&stale_git_dir).expect("create stale git dirs");
         std::fs::create_dir_all(&linked).expect("create linked worktree");
         std::fs::create_dir_all(other.join(".git")).expect("create other git dir");
-        for root in [&main, &linked, &other] {
-            std::fs::write(root.join(REPO_BACKEND_FILE), "backend = \"shared\"\n")
-                .expect("write repo backend marker");
-        }
         std::fs::write(linked_git_dir.join("commondir"), "../..\n")
             .expect("write common-dir pointer");
         std::fs::write(
@@ -1632,6 +1633,11 @@ mod tests {
             format!("gitdir: {}\n", linked_git_dir.to_string_lossy()),
         )
         .expect("write linked git pointer");
+        std::fs::write(
+            stale_git_dir.join("gitdir"),
+            format!("{}\n", other.join(".git").to_string_lossy()),
+        )
+        .expect("write stale worktree pointer");
 
         let main_id = project_id_for_repo_root(&main).expect("main project id");
         let linked_id = project_id_for_repo_root(&linked).expect("linked project id");
@@ -1639,15 +1645,20 @@ mod tests {
         assert!(main_id.starts_with("git:"));
         assert_eq!(main_id, linked_id);
         assert_ne!(main_id, other_id);
+        assert_eq!(find_repo_backend_ref(&main), None);
+        assert_eq!(find_repo_backend_ref(&linked), None);
+        assert_eq!(find_repo_backend_ref(&other), None);
         let main_roots =
             worktree_roots_for_repo_root(&main).expect("main registered worktree roots");
         let linked_roots =
             worktree_roots_for_repo_root(&linked).expect("linked registered worktree roots");
         let canonical_main = main.canonicalize().expect("canonical main");
         let canonical_linked = linked.canonicalize().expect("canonical linked");
+        let canonical_other = other.canonicalize().expect("canonical other");
         for roots in [&main_roots, &linked_roots] {
             assert!(roots.contains(&canonical_main.to_string_lossy().to_string()));
             assert!(roots.contains(&canonical_linked.to_string_lossy().to_string()));
+            assert!(!roots.contains(&canonical_other.to_string_lossy().to_string()));
         }
 
         std::fs::remove_dir_all(base).ok();
@@ -1668,11 +1679,6 @@ mod tests {
         let logical_root = base.join("logical-repo");
         std::fs::create_dir_all(physical_root.join(".git")).expect("create physical repository");
         std::fs::create_dir_all(physical_root.join("nested")).expect("create nested launch dir");
-        std::fs::write(
-            physical_root.join(REPO_BACKEND_FILE),
-            "backend = \"shared\"\n",
-        )
-        .expect("write repo backend marker");
         std::os::unix::fs::symlink(&physical_root, &logical_root)
             .expect("create logical repository alias");
 

--- a/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
@@ -300,7 +300,6 @@ SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
             "((JSONHas(input_json, 'command') OR JSONHas(input_json, 'cmd')) AND match({command_expr}, {shell_path_regex}))"
         );
 
-        let matched_path_is_single = single_path_sql("matched_path");
         let normalized_root_is_single = single_path_sql("ti.worktree_root");
         let event_root_expression = if normalized_schema_available {
             "ifNull(e.worktree_root, '')"
@@ -328,27 +327,34 @@ SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
         }
         let match_predicate = inner_clauses.join("\n      AND ");
 
-        let matched_path_arms = PATH_KEYS
+        let scalar_path_values = PATH_KEYS
             .iter()
-            .map(|key| {
-                format!(
-                    "{}, JSONExtractString(ti.input_json, '{key}')",
-                    key_match("ti.input_json", key)
-                )
-            })
+            .map(|key| format!("JSONExtractString(ti.input_json, '{key}')"))
             .collect::<Vec<_>>()
-            .join(",\n      ");
-        let matched_path_expr =
-            format!("multiIf(\n      {matched_path_arms},\n      {nested_path_expr})");
-
-        let verified_event_root_condition = if rel.starts_with('/') {
-            "0".to_string()
-        } else {
+            .join(", ");
+        let legacy_scalar_paths_expr = format!("[{scalar_path_values}]");
+        let legacy_scalar_path_expr = format!(
+            "arrayFirst(path -> endsWith(path, {slash_rel_sql}) OR path = {rel_sql}, legacy_scalar_paths)"
+        );
+        let legacy_scalar_path_is_single = single_path_sql("legacy_scalar_path");
+        let provenance_key_regex = sql_quote(&format!(
+            "\"(?:{path_key_regex}|command|cmd)\"[[:space:]]*:"
+        ));
+        let cwd_is_single = single_path_sql("ifNull(e.cwd, '')");
+        let candidate_root_expr = if query.derive_legacy_roots && !rel.starts_with('/') {
             format!(
-                "{matched_path_is_single}
-      AND {event_root_is_single}
-      AND (matched_path = {rel_sql} OR matched_path = concat({event_root_expression}, '/', {rel_sql}))"
+                "if(
+      countMatches(ti.input_json, {provenance_key_regex}) = 1
+      AND arrayCount(path -> path != '', legacy_scalar_paths) = 1
+      AND {legacy_scalar_path_is_single}
+      AND {cwd_is_single}
+      AND (legacy_scalar_path = {rel_sql}
+           OR legacy_scalar_path = concat(ifNull(e.cwd, ''), '/', {rel_sql})),
+      ifNull(e.cwd, ''),
+      '')"
             )
+        } else {
+            "''".to_string()
         };
         let normalized_root_condition = if normalized_schema_available {
             format!(
@@ -357,16 +363,6 @@ SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
         } else {
             "0".to_string()
         };
-
-        let worktree_root_expr = format!(
-            "multiIf(
-      {normalized_root_condition},
-      ti.worktree_root,
-      {verified_event_root_condition},
-      {event_root_expression},
-      ''
-    )"
-        );
 
         let mut outer_clauses: Vec<String> = Vec::new();
         if let Some(start) = query.start_unix_ms {
@@ -378,36 +374,47 @@ SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
         if let Some(source_name) = query.source_name.as_deref() {
             outer_clauses.push(format!("e.source_name = {}", sql_quote(source_name)));
         }
-        if query.apply_project_scope {
+        let mut project_roots_with = String::new();
+        let verified_project_root_expr = if query.apply_project_scope {
             let project_id = query
                 .normalized_project_id
                 .as_deref()
                 .expect("project scope identity checked before querying");
             let project_id_sql = sql_quote(project_id);
-            let legacy_roots_sql = query
+            let mut registered_roots = query
                 .normalized_project_roots
                 .iter()
                 .filter(|root| !root.is_empty())
+                .cloned()
+                .collect::<Vec<_>>();
+            registered_roots.sort_by_key(|root| std::cmp::Reverse(root.len()));
+            registered_roots.dedup();
+            let legacy_roots_sql = registered_roots
+                .iter()
                 .map(|root| sql_quote(root))
                 .collect::<Vec<_>>()
                 .join(", ");
             let durable_roots = self.table_ref("file_attention_project_roots");
-            let root_membership = |expression: &str| {
-                let mut predicates = Vec::with_capacity(2);
-                if !legacy_roots_sql.is_empty() {
-                    predicates.push(format!("{expression} IN ({legacy_roots_sql})"));
-                }
-                if project_root_mapping_available {
-                    predicates.push(format!(
-                        "{expression} IN (SELECT worktree_root FROM {durable_roots} FINAL WHERE project_id = {project_id_sql})"
-                    ));
-                }
-                if predicates.is_empty() {
-                    "0".to_string()
-                } else {
-                    format!("({})", predicates.join(" OR "))
-                }
+            let registered_roots_array = if legacy_roots_sql.is_empty() {
+                "CAST([], 'Array(String)')".to_string()
+            } else {
+                format!("[{legacy_roots_sql}]")
             };
+            let project_roots_array = if project_root_mapping_available {
+                format!(
+                    "arrayDistinct(arrayConcat(
+      {registered_roots_array},
+      (SELECT groupArray(worktree_root) FROM {durable_roots} FINAL
+       WHERE project_id = {project_id_sql} AND worktree_root != '')
+    ))"
+                )
+            } else {
+                registered_roots_array
+            };
+            project_roots_with = format!("{project_roots_array} AS project_roots,\n  ");
+            let verified_root =
+                "arrayFirst(root -> legacy_candidate_root = root, project_roots)".to_string();
+            let root_membership = |expression: &str| format!("has(project_roots, {expression})");
             let legacy_tool_scope = format!(
                 "(ti.project_id != '' AND NOT startsWith(ti.project_id, 'git:') AND {normalized_root_is_single} AND {})",
                 root_membership("ti.worktree_root")
@@ -419,9 +426,33 @@ SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
             outer_clauses.push(format!(
                 "(ti.project_id = {project_id_sql}
       OR {legacy_tool_scope}
-      OR (ti.project_id = '' AND (e.project_id = {project_id_sql} OR {legacy_event_scope}) AND {verified_event_root_condition}))"
+      OR (ti.project_id = '' AND e.project_id = {project_id_sql})
+      OR (ti.project_id = '' AND legacy_candidate_root != ''
+          AND ({legacy_event_scope} OR (e.project_id = '' AND verified_project_root != ''))))"
             ));
-        }
+            Some(verified_root)
+        } else {
+            None
+        };
+
+        let legacy_root_expr = if verified_project_root_expr.is_some() {
+            "verified_project_root"
+        } else {
+            "legacy_candidate_root"
+        };
+        let worktree_root_expr = format!(
+            "multiIf(
+      {normalized_root_condition},
+      ti.worktree_root,
+      legacy_candidate_root != '',
+      {legacy_root_expr},
+      ''
+    )"
+        );
+        let verified_project_root_column = verified_project_root_expr
+            .as_deref()
+            .map(|expression| format!(",\n    {expression} AS verified_project_root"))
+            .unwrap_or_default();
 
         let outer_where = if outer_clauses.is_empty() {
             "1".to_string()
@@ -449,7 +480,7 @@ SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
         };
 
         let sql = format!(
-            "WITH matched AS (
+            "WITH {project_roots_with}matched AS (
     SELECT session_id, event_uid, tool_call_id, harness, tool_name, tool_phase, input_json, input_preview, output_preview{normalized_tool_columns}
     FROM {tool_io} FINAL
     WHERE {match_predicate}
@@ -462,7 +493,10 @@ SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
     ifNull(e.source_name, '') AS source_name,
     ti.tool_name AS tool_name,
     ti.tool_phase AS tool_phase,
-    {matched_path_expr} AS matched_path,
+    {legacy_scalar_paths_expr} AS legacy_scalar_paths,
+    {legacy_scalar_path_expr} AS legacy_scalar_path,
+    if(legacy_scalar_path != '', legacy_scalar_path, {nested_path_expr}) AS matched_path,
+    {candidate_root_expr} AS legacy_candidate_root{verified_project_root_column},
     if(matched_path != '', 'path_suffix', 'shell_path') AS match_kind,
     {worktree_root_expr} AS worktree_root,
     ifNull(e.cwd, '') AS cwd,

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -85,6 +85,10 @@ pub struct FileAttentionQuery {
     /// admit rows written with the pre-digest project identity during the
     /// transition without widening to another repository sharing the backend.
     pub normalized_project_roots: Vec<String>,
+    /// Whether the request path was proven to be one repository-relative file
+    /// and may therefore use structured legacy path/cwd evidence to recover a
+    /// missing normalized root.
+    pub derive_legacy_roots: bool,
     /// When true normalized request-project identity is enforced in both query
     /// paths. The repository's configured origin scope (`--project-only`) is an
     /// independent hard floor. When false (`scope:"all"`), only request-project

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -72,20 +72,20 @@ pub struct FileAttentionQuery {
     /// Opaque cancellation token assigned by the caller so timed-out requests
     /// can cancel in-flight backend work.
     pub cancellation_token: String,
-    /// Repo-relative tail to suffix-match against captured file paths. The tail
+    /// Project-relative tail to suffix-match against captured file paths. The tail
     /// is what unifies the same logical file across worktree roots.
     pub rel: String,
     /// Canonical request-project identity used by both exact and fallback
-    /// lookup. It is an opaque digest of the Git common directory, so linked
-    /// worktrees agree while unrelated repositories sharing one backend do not.
+    /// lookup. Git projects digest the common directory so linked worktrees
+    /// agree; non-Git projects digest the exact canonical launch directory.
     /// `None` keeps project-scoped queries closed; only an explicit unscoped
     /// query may omit this boundary.
     pub normalized_project_id: Option<String>,
-    /// Canonical registered roots for the request repository. These safely
+    /// Canonical registered roots for the request project. These safely
     /// admit rows written with the pre-digest project identity during the
     /// transition without widening to another repository sharing the backend.
     pub normalized_project_roots: Vec<String>,
-    /// Whether the request path was proven to be one repository-relative file
+    /// Whether the request path was proven to be one project-relative file
     /// and may therefore use structured legacy path/cwd evidence to recover a
     /// missing normalized root.
     pub derive_legacy_roots: bool,

--- a/crates/moraine-conversations/tests/repository_integration/file_attention.rs
+++ b/crates/moraine-conversations/tests/repository_integration/file_attention.rs
@@ -12,6 +12,7 @@ async fn file_attention_clamps_its_query_budget_to_the_request_deadline() {
             rel: "crates/foo.rs".to_string(),
             normalized_project_id: Some("project-a".to_string()),
             normalized_project_roots: vec!["/worktree-a".to_string()],
+            derive_legacy_roots: true,
             apply_project_scope: true,
             start_unix_ms: None,
             end_unix_ms: None,
@@ -51,6 +52,7 @@ async fn file_attention_merges_normalized_exact_lookup_with_suffix_fallback() {
             rel: "crates/foo.rs".to_string(),
             normalized_project_id: Some("project-a".to_string()),
             normalized_project_roots: vec!["/worktree-a".to_string()],
+            derive_legacy_roots: true,
             apply_project_scope: true,
             start_unix_ms: None,
             end_unix_ms: None,
@@ -111,15 +113,30 @@ async fn file_attention_merges_normalized_exact_lookup_with_suffix_fallback() {
             && fallback_query.contains(
                 "ti.project_id != '' AND NOT startsWith(ti.project_id, 'git:')"
             )
-            && fallback_query.contains("ti.worktree_root IN ('/worktree-a')")
-            && fallback_query.contains("ti.project_id = '' AND (e.project_id = 'project-a'")
+            && fallback_query.contains("has(project_roots, ti.worktree_root)")
+            && fallback_query.contains("ti.project_id = '' AND e.project_id = 'project-a'")
+            && fallback_query.contains("legacy_candidate_root")
+            && fallback_query.contains("verified_project_root")
             && fallback_query.contains(
-                "matched_path = concat(ifNull(e.worktree_root, ''), '/', 'crates/foo.rs')"
+                "arrayFirst(root -> legacy_candidate_root = root, project_roots)"
             ),
         "project scope must admit current IDs and root-verified pre-digest rows without widening: {fallback_query}"
     );
     assert!(
-        fallback_query.contains("position(matched_path, ';') = 0"),
+        fallback_query.contains("AS legacy_scalar_paths")
+            && fallback_query.contains("AS legacy_scalar_path")
+            && fallback_query.contains("countMatches(ti.input_json")
+            && fallback_query.contains("|command|cmd)")
+            && fallback_query
+                .contains("arrayCount(path -> path != '', legacy_scalar_paths) = 1")
+            && fallback_query.contains(
+                "= concat(ifNull(e.cwd, ''), '/', 'crates/foo.rs')"
+            ),
+        "legacy root recovery must require exactly one top-level scalar path and no second structured or shell path evidence: {fallback_query}"
+    );
+    assert!(
+        fallback_query.contains("position(legacy_scalar_path")
+            && fallback_query.contains("position(ifNull(e.cwd, ''), ';') = 0"),
         "legacy compound path captures must not become roots: {fallback_query}"
     );
     assert!(
@@ -135,21 +152,25 @@ async fn file_attention_merges_normalized_exact_lookup_with_suffix_fallback() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn file_attention_project_scope_migrates_registered_pre_digest_sibling_root() {
+async fn file_attention_project_scope_recovers_durable_only_deleted_root() {
     let responses = vec![
         ScriptedResponse::rows(&["repo_rel_path = 'crates/foo.rs'"], json!([])),
         ScriptedResponse::raw(
             &[
                 "INSERT INTO `moraine`.`file_attention_project_roots`",
-                "arrayJoin(['/worktree-a', '/worktree-b', '/worktree-''quoted'])",
+                "arrayJoin(['/worktree-a'])",
             ],
             "",
         ),
         ScriptedResponse::rows(
             &[
                 "NOT startsWith(ti.project_id, 'git:')",
-                "ti.worktree_root IN ('/worktree-a', '/worktree-b', '/worktree-''quoted')",
-                "SELECT worktree_root FROM `moraine`.`file_attention_project_roots` FINAL WHERE project_id = 'git:new-project-id'",
+                "has(project_roots, ti.worktree_root)",
+                "'/worktree-a'",
+                "arrayFirst(root -> legacy_candidate_root = root, project_roots)",
+                "e.project_id = '' AND verified_project_root != ''",
+                "SELECT groupArray(worktree_root) FROM `moraine`.`file_attention_project_roots` FINAL",
+                "WHERE project_id = 'git:new-project-id' AND worktree_root != ''",
             ],
             json!([{
                 "session_id": "sess-pre-digest",
@@ -177,11 +198,8 @@ async fn file_attention_project_scope_migrates_registered_pre_digest_sibling_roo
             cancellation_token: "test-file-attention-pre-digest".to_string(),
             rel: "crates/foo.rs".to_string(),
             normalized_project_id: Some("git:new-project-id".to_string()),
-            normalized_project_roots: vec![
-                "/worktree-a".to_string(),
-                "/worktree-b".to_string(),
-                "/worktree-'quoted".to_string(),
-            ],
+            normalized_project_roots: vec!["/worktree-a".to_string()],
+            derive_legacy_roots: true,
             apply_project_scope: true,
             start_unix_ms: None,
             end_unix_ms: None,
@@ -193,7 +211,7 @@ async fn file_attention_project_scope_migrates_registered_pre_digest_sibling_roo
             execution_budget_secs: 3,
         })
         .await
-        .expect("registered pre-digest sibling row remains visible during migration");
+        .expect("durably mapped deleted root remains visible during migration");
 
     assert_eq!(touches.len(), 1);
     assert_eq!(touches[0].session_id, "sess-pre-digest");
@@ -213,8 +231,9 @@ async fn file_attention_project_scope_excludes_unmapped_pruned_legacy_root() {
         ),
         ScriptedResponse::rows(
             &[
-                "ti.worktree_root IN ('/worktree-a')",
-                "SELECT worktree_root FROM `moraine`.`file_attention_project_roots` FINAL WHERE project_id = 'git:new-project-id'",
+                "has(project_roots, ti.worktree_root)",
+                "SELECT groupArray(worktree_root) FROM `moraine`.`file_attention_project_roots` FINAL",
+                "WHERE project_id = 'git:new-project-id' AND worktree_root != ''",
             ],
             json!([]),
         )
@@ -228,6 +247,7 @@ async fn file_attention_project_scope_excludes_unmapped_pruned_legacy_root() {
             rel: "crates/foo.rs".to_string(),
             normalized_project_id: Some("git:new-project-id".to_string()),
             normalized_project_roots: vec!["/worktree-a".to_string()],
+            derive_legacy_roots: true,
             apply_project_scope: true,
             start_unix_ms: None,
             end_unix_ms: None,
@@ -253,6 +273,7 @@ async fn file_attention_all_scope_is_the_only_unscoped_widening_path() {
         rel: "crates/foo.rs".to_string(),
         normalized_project_id: Some("project-a".to_string()),
         normalized_project_roots: vec!["/worktree-a".to_string()],
+        derive_legacy_roots: true,
         apply_project_scope: false,
         start_unix_ms: None,
         end_unix_ms: None,
@@ -293,6 +314,7 @@ async fn file_attention_all_scope_keeps_the_configured_server_floor_only() {
         rel: "crates/foo.rs".to_string(),
         normalized_project_id: Some("project-a".to_string()),
         normalized_project_roots: vec!["/worktree-a".to_string()],
+        derive_legacy_roots: true,
         apply_project_scope: false,
         start_unix_ms: None,
         end_unix_ms: None,
@@ -341,6 +363,7 @@ async fn file_attention_all_scope_preserves_legacy_suffix_fallback_on_schema_ske
             rel: "crates/foo.rs".to_string(),
             normalized_project_id: Some("project-a".to_string()),
             normalized_project_roots: vec!["/worktree-a".to_string()],
+            derive_legacy_roots: true,
             apply_project_scope: false,
             start_unix_ms: None,
             end_unix_ms: None,
@@ -372,6 +395,7 @@ async fn file_attention_project_scope_stays_closed_on_schema_skew() {
             rel: "crates/foo.rs".to_string(),
             normalized_project_id: Some("project-a".to_string()),
             normalized_project_roots: vec!["/worktree-a".to_string()],
+            derive_legacy_roots: true,
             apply_project_scope: true,
             start_unix_ms: None,
             end_unix_ms: None,
@@ -398,6 +422,7 @@ async fn file_attention_project_scope_without_identity_stays_closed() {
         rel: "crates/foo.rs".to_string(),
         normalized_project_id: None,
         normalized_project_roots: Vec::new(),
+        derive_legacy_roots: false,
         apply_project_scope: true,
         start_unix_ms: None,
         end_unix_ms: None,

--- a/crates/moraine-ingest-core/src/sources/shared.rs
+++ b/crates/moraine-ingest-core/src/sources/shared.rs
@@ -1034,17 +1034,20 @@ fn find_file_attention_root(path: &Path) -> Option<String> {
     } else {
         path.parent()
     };
+    let mut backend_root = None;
     while let Some(current) = dir {
-        if current.join(moraine_config::REPO_BACKEND_FILE).exists() || current.join(".git").exists()
-        {
+        if current.join(".git").exists() {
             return Some(current.to_string_lossy().to_string());
+        }
+        if backend_root.is_none() && current.join(moraine_config::REPO_BACKEND_FILE).exists() {
+            backend_root = Some(current.to_string_lossy().to_string());
         }
         if home.as_deref() == Some(current) {
             break;
         }
         dir = current.parent();
     }
-    None
+    backend_root
 }
 
 fn project_id_for_root(root: &str) -> Option<String> {
@@ -1380,11 +1383,6 @@ mod tests {
         ));
         std::fs::create_dir_all(root.join("src")).expect("create repo dirs");
         std::fs::create_dir_all(root.join(".git")).expect("create git dir");
-        std::fs::write(
-            root.join(moraine_config::REPO_BACKEND_FILE),
-            "backend = \"team\"\n",
-        )
-        .expect("write repo backend marker");
         root
     }
 
@@ -1404,6 +1402,8 @@ mod tests {
     fn event_rows_capture_project_and_worktree_from_cwd() {
         let root = make_repo("event-cwd");
         let cwd = root.join("src");
+        std::fs::write(cwd.join(".moraine.toml"), "backend = \"nested\"\n")
+            .expect("write nested backend route");
         let cwd_text = cwd.to_string_lossy().to_string();
         let ctx = test_record_context(&cwd_text);
         let project_id = project_id_for_root(root.to_string_lossy().as_ref()).expect("project id");
@@ -1425,7 +1425,7 @@ mod tests {
     }
 
     #[test]
-    fn event_rows_keep_linked_worktree_root_with_enclosing_project_marker() {
+    fn event_rows_keep_unmarked_linked_worktree_root() {
         let root = make_repo("linked-worktree");
         let linked = root.join("worktrees/linked");
         let linked_git_dir = root.join(".git/worktrees/linked");
@@ -1460,7 +1460,7 @@ mod tests {
     }
 
     #[test]
-    fn event_rows_ignore_git_only_root_without_project_id() {
+    fn event_rows_capture_git_only_root_without_backend_marker() {
         let root = std::env::temp_dir().join(format!(
             "moraine-file-attention-git-only-{}",
             std::process::id()
@@ -1481,8 +1481,11 @@ mod tests {
             "{}",
         ));
 
-        assert_eq!(row["project_id"], "");
-        assert_eq!(row["worktree_root"], "");
+        assert_eq!(
+            row["project_id"],
+            project_id_for_root(root.to_string_lossy().as_ref()).expect("project id")
+        );
+        assert_eq!(row["worktree_root"], root.to_string_lossy().as_ref());
         assert_eq!(row["repo_rel_path"], "");
         std::fs::remove_dir_all(root).ok();
     }

--- a/crates/moraine-ingest-core/src/sources/shared.rs
+++ b/crates/moraine-ingest-core/src/sources/shared.rs
@@ -880,7 +880,8 @@ fn event_file_attention_fields(cwd: &str) -> FileAttentionFields {
         return FileAttentionFields::default();
     }
 
-    let Some(root) = find_file_attention_root(Path::new(&cwd)) else {
+    let Some(root) = find_file_attention_root(Path::new(&cwd)).or_else(|| directory_root(&cwd))
+    else {
         return FileAttentionFields::default();
     };
     let Some(project_id) = project_id_for_root(&root) else {
@@ -927,17 +928,20 @@ fn resolve_tool_path_fields(cwd: &str, raw_path: &str) -> Option<FileAttentionFi
         return None;
     }
 
+    let cwd = normalize_path_text(cwd.trim());
+    if cwd.is_empty() || !cwd.starts_with('/') {
+        return None;
+    }
+
     let absolute = if normalized.starts_with('/') {
         normalized
     } else {
-        let cwd = normalize_path_text(cwd.trim());
-        if cwd.is_empty() || !cwd.starts_with('/') {
-            return None;
-        }
         normalize_path_text(&format!("{}/{}", cwd.trim_end_matches('/'), normalized))
     };
 
-    let root = find_file_attention_root(Path::new(&absolute))?;
+    let root = find_file_attention_root(Path::new(&absolute)).or_else(|| {
+        (Path::new(&cwd).is_dir() && strip_root(&absolute, &cwd).is_some()).then(|| cwd.clone())
+    })?;
     let project_id = project_id_for_root(&root)?;
     let repo_rel_path = strip_root(&absolute, &root)?;
     if repo_rel_path.is_empty() {
@@ -1034,20 +1038,20 @@ fn find_file_attention_root(path: &Path) -> Option<String> {
     } else {
         path.parent()
     };
-    let mut backend_root = None;
     while let Some(current) = dir {
         if current.join(".git").exists() {
             return Some(current.to_string_lossy().to_string());
-        }
-        if backend_root.is_none() && current.join(moraine_config::REPO_BACKEND_FILE).exists() {
-            backend_root = Some(current.to_string_lossy().to_string());
         }
         if home.as_deref() == Some(current) {
             break;
         }
         dir = current.parent();
     }
-    backend_root
+    None
+}
+
+fn directory_root(path: &str) -> Option<String> {
+    Path::new(path).is_dir().then(|| path.to_string())
 }
 
 fn project_id_for_root(root: &str) -> Option<String> {
@@ -1491,6 +1495,41 @@ mod tests {
     }
 
     #[test]
+    fn event_rows_use_exact_cwd_for_non_git_project_identity() {
+        let base = std::env::temp_dir().join(format!(
+            "moraine-file-attention-directory-only-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        let cwd = base.join("project/nested");
+        std::fs::create_dir_all(&cwd).expect("create non-Git cwd");
+        std::fs::write(base.join(".moraine.toml"), "backend = \"default\"\n")
+            .expect("write independent routing marker");
+        let cwd_text = cwd.to_string_lossy().to_string();
+        let ctx = test_record_context(&cwd_text);
+
+        let row = Value::Object(base_event_obj(
+            &ctx,
+            "e1",
+            "message",
+            "message",
+            "assistant",
+            "hello",
+            "{}",
+        ));
+
+        assert!(row["project_id"]
+            .as_str()
+            .is_some_and(|project_id| project_id.starts_with("dir:")));
+        assert_eq!(row["worktree_root"], cwd_text);
+        assert_eq!(row["repo_rel_path"], "");
+        std::fs::remove_dir_all(base).ok();
+    }
+
+    #[test]
     fn tool_rows_capture_absolute_and_relative_structured_paths() {
         let root = make_repo("tool-paths");
         let cwd_text = root.to_string_lossy().to_string();
@@ -1536,6 +1575,58 @@ mod tests {
         );
         assert_eq!(relative_row["repo_rel_path"], "src/lib.rs");
         std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn tool_rows_use_non_git_cwd_and_reject_paths_outside_it() {
+        let base = std::env::temp_dir().join(format!(
+            "moraine-file-attention-directory-tools-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        let cwd = base.join("project");
+        std::fs::create_dir_all(cwd.join("src")).expect("create non-Git project");
+        let cwd_text = cwd.to_string_lossy().to_string();
+        let ctx = test_record_context(&cwd_text);
+
+        let relative = build_tool_row(
+            &ctx,
+            "e1",
+            "call-1",
+            "",
+            "Read",
+            "request",
+            0,
+            r#"{"path":"src/lib.rs"}"#,
+            "",
+            "",
+        );
+        assert!(relative["project_id"]
+            .as_str()
+            .is_some_and(|project_id| project_id.starts_with("dir:")));
+        assert_eq!(relative["worktree_root"], cwd_text);
+        assert_eq!(relative["repo_rel_path"], "src/lib.rs");
+
+        let outside = build_tool_row(
+            &ctx,
+            "e2",
+            "call-2",
+            "",
+            "Read",
+            "request",
+            0,
+            &json!({"path": base.join("outside.rs")}).to_string(),
+            "",
+            "",
+        );
+        assert_eq!(outside["project_id"], "");
+        assert_eq!(outside["worktree_root"], "");
+        assert_eq!(outside["repo_rel_path"], "");
+
+        std::fs::remove_dir_all(base).ok();
     }
 
     #[test]

--- a/crates/moraine-ingest-core/tests/normalize_unit.rs
+++ b/crates/moraine-ingest-core/tests/normalize_unit.rs
@@ -1383,6 +1383,79 @@ fn codex_session_meta_cwd_flows_to_later_records_via_hint() {
 }
 
 #[test]
+fn codex_session_meta_uses_non_git_cwd_as_project_identity() {
+    let root = std::env::temp_dir().join(format!(
+        "moraine-codex-directory-project-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time after unix epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&root).expect("create non-Git project directory");
+    let root_text = root.to_string_lossy().to_string();
+    let meta = json!({
+        "timestamp": "2026-02-15T03:50:40.000Z",
+        "type": "session_meta",
+        "payload": {
+            "id": "019c5f6a-49bd-7920-ac67-1dd8e33b0e96",
+            "cwd": root_text
+        }
+    });
+    let meta_out = normalize_record(
+        &meta,
+        "codex",
+        "codex",
+        "/tmp/non-git-session.jsonl",
+        1,
+        1,
+        1,
+        0,
+        "",
+        "",
+        "",
+    )
+    .expect("non-Git Codex session meta should normalize");
+    assert_eq!(meta_out.cwd_hint, root_text);
+    assert_eq!(meta_out.event_rows[0]["worktree_root"], root_text);
+    assert!(meta_out.event_rows[0]["project_id"]
+        .as_str()
+        .is_some_and(|project_id| project_id.starts_with("dir:")));
+
+    let item = json!({
+        "timestamp": "2026-02-15T03:50:43.000Z",
+        "type": "response_item",
+        "payload": {
+            "type": "function_call",
+            "call_id": "call_directory_project",
+            "name": "Read",
+            "arguments": "{\"path\":\"Cargo.toml\"}"
+        }
+    });
+    let item_out = normalize_record(
+        &item,
+        "codex",
+        "codex",
+        "/tmp/non-git-session.jsonl",
+        1,
+        1,
+        2,
+        100,
+        &meta_out.session_hint,
+        &meta_out.model_hint,
+        &meta_out.cwd_hint,
+    )
+    .expect("non-Git Codex response item should normalize");
+    assert_eq!(item_out.tool_rows[0]["repo_rel_path"], "Cargo.toml");
+    assert_eq!(item_out.tool_rows[0]["worktree_root"], root_text);
+    assert!(item_out.tool_rows[0]["project_id"]
+        .as_str()
+        .is_some_and(|project_id| project_id.starts_with("dir:")));
+
+    std::fs::remove_dir_all(root).ok();
+}
+
+#[test]
 fn cursor_composer_workspace_path_becomes_cwd() {
     // Shape produced by `synthesize_cursor_sqlite_record` for composerData
     // rows: `workspaceIdentifier.uri.fsPath` is surfaced as `workspacePath`.

--- a/crates/moraine-ingest-core/tests/normalize_unit.rs
+++ b/crates/moraine-ingest-core/tests/normalize_unit.rs
@@ -1282,12 +1282,22 @@ fn claude_code_record_level_cwd_wins_over_hint() {
 
 #[test]
 fn codex_session_meta_cwd_flows_to_later_records_via_hint() {
+    let root = std::env::temp_dir().join(format!(
+        "moraine-codex-plain-git-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time after unix epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(root.join(".git")).expect("create plain Git repository");
+    let root_text = root.to_string_lossy().to_string();
     let meta = json!({
         "timestamp": "2026-02-15T03:50:40.000Z",
         "type": "session_meta",
         "payload": {
             "id": "019c5f6a-49bd-7920-ac67-1dd8e33b0e95",
-            "cwd": "/repo",
+            "cwd": root_text,
             "cli_version": "0.5.3"
         }
     });
@@ -1309,9 +1319,19 @@ fn codex_session_meta_cwd_flows_to_later_records_via_hint() {
 
     assert_eq!(
         meta_out.raw_row.get("cwd").and_then(Value::as_str),
-        Some("/repo")
+        Some(root_text.as_str())
     );
-    assert_eq!(meta_out.cwd_hint, "/repo");
+    assert_eq!(meta_out.cwd_hint, root_text);
+    assert_eq!(
+        meta_out.event_rows[0]
+            .get("worktree_root")
+            .and_then(Value::as_str),
+        Some(root_text.as_str())
+    );
+    assert!(meta_out.event_rows[0]
+        .get("project_id")
+        .and_then(Value::as_str)
+        .is_some_and(|project_id| project_id.starts_with("git:")));
 
     // A follow-on record carries no cwd of its own; the chained hint from the
     // session meta record fills it in (mirrors the dispatch loop).
@@ -1319,9 +1339,10 @@ fn codex_session_meta_cwd_flows_to_later_records_via_hint() {
         "timestamp": "2026-02-15T03:50:43.000Z",
         "type": "response_item",
         "payload": {
-            "type": "message",
-            "role": "assistant",
-            "content": [{"type": "output_text", "text": "hi"}]
+            "type": "function_call",
+            "call_id": "call_plain_git",
+            "name": "Read",
+            "arguments": "{\"path\":\"Cargo.toml\"}"
         }
     });
 
@@ -1342,12 +1363,23 @@ fn codex_session_meta_cwd_flows_to_later_records_via_hint() {
 
     assert_eq!(
         item_out.raw_row.get("cwd").and_then(Value::as_str),
-        Some("/repo")
+        Some(root_text.as_str())
     );
     for row in &item_out.event_rows {
-        assert_eq!(row.get("cwd").and_then(Value::as_str), Some("/repo"));
+        assert_eq!(
+            row.get("cwd").and_then(Value::as_str),
+            Some(root_text.as_str())
+        );
     }
-    assert_eq!(item_out.cwd_hint, "/repo");
+    assert_eq!(item_out.cwd_hint, root_text);
+    assert_eq!(item_out.tool_rows.len(), 1);
+    assert_eq!(item_out.tool_rows[0]["repo_rel_path"], "Cargo.toml");
+    assert_eq!(item_out.tool_rows[0]["worktree_root"], root_text);
+    assert!(item_out.tool_rows[0]["project_id"]
+        .as_str()
+        .is_some_and(|project_id| project_id.starts_with("git:")));
+
+    std::fs::remove_dir_all(root).ok();
 }
 
 #[test]

--- a/crates/moraine-mcp-core/src/file_attention_v1.rs
+++ b/crates/moraine-mcp-core/src/file_attention_v1.rs
@@ -109,6 +109,7 @@ impl AppState {
                 .as_deref()
                 .and_then(moraine_config::worktree_roots_for_repo_root)
                 .unwrap_or_default(),
+            derive_legacy_roots: tail.derive_worktree_roots,
             apply_project_scope: args.scope == FileAttentionScope::Project,
             start_unix_ms: args.start_unix_ms,
             end_unix_ms: args.end_unix_ms,
@@ -361,22 +362,26 @@ fn strip_root(path: &str, root: &str) -> Option<String> {
 
 /// Walk up from a file path's parent directory looking for the nearest
 /// repository boundary, bounded at `$HOME` or the filesystem root. A linked
-/// worktree may inherit its `.moraine.toml` route from an enclosing checkout,
-/// but its own `.git` marker still defines the root reported to callers.
+/// worktree may inherit an optional `.moraine.toml` backend route from an
+/// enclosing checkout, but its own `.git` marker still defines the root
+/// reported to callers.
 fn find_project_root(file_path: &Path) -> Option<String> {
     let home = std::env::var_os("HOME").map(PathBuf::from);
     let mut dir = file_path.parent();
+    let mut backend_root = None;
     while let Some(current) = dir {
-        if current.join(moraine_config::REPO_BACKEND_FILE).exists() || current.join(".git").exists()
-        {
+        if current.join(".git").exists() {
             return Some(current.to_string_lossy().to_string());
+        }
+        if backend_root.is_none() && current.join(moraine_config::REPO_BACKEND_FILE).exists() {
+            backend_root = Some(current.to_string_lossy().to_string());
         }
         if home.as_deref() == Some(current) {
             break;
         }
         dir = current.parent();
     }
-    None
+    backend_root
 }
 
 fn project_id_for_root(root: &str) -> Option<String> {
@@ -813,12 +818,22 @@ fn format_text(payload: &Value) -> String {
         "file_attention {tail} — {total} touch(es) across {sessions} session(s) in {roots} worktree root(s) [scope={scope}]."
     )];
 
-    if summary
-        .get("ambiguous")
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
-    {
+    let distinct_known_roots = summary
+        .get("distinct_known_roots")
+        .and_then(Value::as_u64)
+        .unwrap_or(roots);
+    let unknown_root_touches = summary
+        .get("unknown_root_touches")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    if distinct_known_roots > 1 {
         lines.push("Ambiguous tail: matched more than one worktree root (see roots).".to_string());
+    }
+    if unknown_root_touches > 0 {
+        lines.push(
+            "Worktree-root attribution is incomplete; some touches have unknown roots (see roots and matched_path)."
+                .to_string(),
+        );
     }
     for warning in payload
         .get("warnings")
@@ -1034,7 +1049,6 @@ mod tests {
         let root = dir.join("repo");
         std::fs::create_dir_all(&root).expect("mkdir root");
         std::fs::create_dir_all(root.join(".git")).expect("mkdir git dir");
-        std::fs::write(root.join(".moraine.toml"), "backend = \"x\"\n").expect("write marker");
 
         let resolved = resolve_tail_from("crates/new/file.rs", Some(&root));
         assert_eq!(resolved.rel, "crates/new/file.rs");
@@ -1056,7 +1070,8 @@ mod tests {
         let launch = root.join("crates/foo");
         std::fs::create_dir_all(root.join(".git")).expect("mkdir git dir");
         std::fs::create_dir_all(&launch).expect("mkdir launch dir");
-        std::fs::write(root.join(".moraine.toml"), "backend = \"x\"\n").expect("write marker");
+        std::fs::write(launch.join(".moraine.toml"), "backend = \"nested\"\n")
+            .expect("write nested backend route");
 
         let nested = resolve_tail_from("src/lib.rs", Some(&launch));
         assert_eq!(nested.rel, "crates/foo/src/lib.rs");
@@ -1079,7 +1094,6 @@ mod tests {
         let root = dir.join("repo");
         std::fs::create_dir_all(&root).expect("mkdir root");
         std::fs::create_dir_all(root.join(".git")).expect("mkdir git dir");
-        std::fs::write(root.join(".moraine.toml"), "backend = \"x\"\n").expect("write marker");
 
         for delimiter in ["\0", "\n", "\r", ";", "|", "&", "`"] {
             let path = format!("bad{delimiter}command/../src/lib.rs");
@@ -1099,7 +1113,6 @@ mod tests {
         let nested = root.join("crates/foo");
         std::fs::create_dir_all(&nested).expect("mkdir nested");
         std::fs::create_dir_all(root.join(".git")).expect("mkdir git dir");
-        std::fs::write(root.join(".moraine.toml"), "backend = \"x\"\n").expect("write marker");
         let file = nested.join("tee.rs");
         std::fs::write(&file, "// test").expect("write file");
 
@@ -1139,7 +1152,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_tail_keeps_linked_worktree_root_with_enclosing_project_marker() {
+    fn resolve_tail_keeps_unmarked_linked_worktree_root() {
         let dir =
             std::env::temp_dir().join(format!("moraine-fa-linked-worktree-{}", std::process::id()));
         let root = dir.join("repo");
@@ -1153,8 +1166,6 @@ mod tests {
             format!("gitdir: {}\n", linked_git_dir.to_string_lossy()),
         )
         .expect("write linked git marker");
-        std::fs::write(root.join(".moraine.toml"), "backend = \"shared\"\n").expect("write marker");
-
         let resolved = resolve_tail_from("src/lib.rs", Some(&linked));
         assert_eq!(resolved.root.as_deref(), linked.to_str());
         assert_eq!(
@@ -1386,6 +1397,56 @@ mod tests {
             .filter_map(|r| r["root"].as_str())
             .collect();
         assert!(labels.contains(&UNKNOWN_ROOT));
+    }
+
+    #[test]
+    fn format_text_describes_unknown_only_roots_as_incomplete_attribution() {
+        let payload = json!({
+            "warnings": [],
+            "data": {
+                "tail": "crates/foo/tee.rs",
+                "scope": "all",
+                "granularity": "sessions",
+                "summary": {
+                    "total_touches": 2,
+                    "distinct_sessions": 2,
+                    "distinct_roots": 1,
+                    "distinct_known_roots": 0,
+                    "unknown_root_touches": 2,
+                    "ambiguous": true
+                },
+                "sessions": []
+            }
+        });
+
+        let text = format_text(&payload);
+        assert!(text.contains("Worktree-root attribution is incomplete"));
+        assert!(!text.contains("matched more than one worktree root"));
+    }
+
+    #[test]
+    fn format_text_reports_known_root_spread_and_unknown_attribution_separately() {
+        let payload = json!({
+            "warnings": [],
+            "data": {
+                "tail": "crates/foo/tee.rs",
+                "scope": "all",
+                "granularity": "sessions",
+                "summary": {
+                    "total_touches": 3,
+                    "distinct_sessions": 3,
+                    "distinct_roots": 3,
+                    "distinct_known_roots": 2,
+                    "unknown_root_touches": 1,
+                    "ambiguous": true
+                },
+                "sessions": []
+            }
+        });
+
+        let text = format_text(&payload);
+        assert!(text.contains("matched more than one worktree root"));
+        assert!(text.contains("Worktree-root attribution is incomplete"));
     }
 
     #[test]

--- a/crates/moraine-mcp-core/src/file_attention_v1.rs
+++ b/crates/moraine-mcp-core/src/file_attention_v1.rs
@@ -1,7 +1,7 @@
 //! `file_attention` (Phase 0 / Tier 0): every captured session that touched a
 //! file, across every worktree, drillable through `open`.
 //!
-//! Given a path, this suffix-matches the repo-relative tail against the raw
+//! Given a path, this suffix-matches the project-relative tail against the raw
 //! `file_path` (and `notebook_path` / `path`) recorded in `tool_io`, plus a
 //! substring fallback for shell commands. Matching the tail is what unifies the
 //! main checkout, sibling worktrees, and agent-isolation worktrees (which share
@@ -55,30 +55,35 @@ impl AppState {
         }
         if tail.tail_is_absolute {
             warnings.push(format!(
-                "could not reduce {:?} to a repo-relative tail (no .moraine.toml/.git marker found above it); matching the absolute path literally, so other worktrees of the same file will not be unified. Pass a repo-relative path for cross-worktree coverage.",
+                "could not reduce {:?} to a project-relative tail (no Git boundary or launch-directory containment could be proven); matching the absolute path literally, so other roots of the same file will not be unified. Pass a project-relative path for cross-root coverage.",
                 args.path
             ));
         }
         if !tail.derive_worktree_roots {
             warnings.push(
-                "could not prove the path is a repo-relative file in this checkout; roots are derived only from exact relative captures with cwd, otherwise reported as unknown to avoid mislabeling arbitrary suffix matches."
+                "could not prove the path is a project-relative file in this launch scope; roots are derived only from exact relative captures with cwd, otherwise reported as unknown to avoid mislabeling arbitrary suffix matches."
                     .to_string(),
             );
         }
         let depth = tail_segments(&tail.rel);
         if depth < FILE_ATTENTION_MIN_TAIL_SEGMENTS {
             warnings.push(format!(
-                "{:?} is a generic tail (depth {depth}); results may include unrelated files. Pass a longer repo-relative path, and check the surfaced roots.",
+                "{:?} is a generic tail (depth {depth}); results may include unrelated files. Pass a longer project-relative path, and check the surfaced roots.",
                 tail.rel
             ));
         }
         if args.scope == FileAttentionScope::Project && tail.project_id.is_none() {
             warnings.push(
-                "scope=\"project\" could not establish the launch project's normalized identity; the repository query remains closed rather than widening across projects."
+                "scope=\"project\" could not establish the launch project's normalized identity; the project query remains closed rather than widening across projects."
                     .to_string(),
             );
         }
-        if args.scope == FileAttentionScope::Project {
+        if args.scope == FileAttentionScope::Project
+            && tail
+                .project_id
+                .as_deref()
+                .is_some_and(|project_id| project_id.starts_with("git:"))
+        {
             warnings.push(
                 "pre-digest worktree roots pruned before durable project mapping was installed cannot be attributed safely and remain excluded; currently registered roots are migrated and future normalized roots remain durable."
                     .to_string(),
@@ -192,14 +197,14 @@ fn canonical_request_json(args: &CanonicalFileAttentionArgs) -> Value {
     })
 }
 
-/// The repo-relative tail a query path reduces to, plus the launch-side root it
+/// The project-relative tail a query path reduces to, plus the launch-side root it
 /// was stripped against (informational).
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TailResolution {
     rel: String,
     root: Option<String>,
     project_id: Option<String>,
-    /// The path was absolute and could not be reduced to a repo-relative tail,
+    /// The path was absolute and could not be reduced to a project-relative tail,
     /// so `rel` is the absolute path matched literally.
     tail_is_absolute: bool,
     /// Syntactic cleanup changed the path before matching.
@@ -209,7 +214,7 @@ struct TailResolution {
     derive_worktree_roots: bool,
 }
 
-/// Reduce a query `path` to the repo-relative tail used for suffix matching.
+/// Reduce a query `path` to the project-relative tail used for suffix matching.
 ///
 /// Relative paths are resolved lexically against the launch directory, so a
 /// deleted or not-yet-created file still carries the launch project's identity.
@@ -228,7 +233,7 @@ fn resolve_tail_from(path: &str, launch_dir: Option<&Path>) -> TailResolution {
     let normalized_is_single_path = is_single_path_candidate(&normalized);
     let launch_project = launch_dir.and_then(|cwd| {
         let scope_probe = cwd.join(".moraine-project-scope");
-        let root = find_project_root(&scope_probe)?;
+        let root = find_project_root(&scope_probe).or_else(|| directory_root(cwd))?;
         let project_id = project_id_for_root(&root)?;
         Some((root, project_id))
     });
@@ -266,7 +271,14 @@ fn resolve_tail_from(path: &str, launch_dir: Option<&Path>) -> TailResolution {
     }
 
     if raw_is_single_path && normalized_is_single_path {
-        if let Some(root) = find_project_root(Path::new(&normalized)) {
+        let target_root = find_project_root(Path::new(&normalized)).or_else(|| {
+            launch_project.as_ref().and_then(|(root, _)| {
+                strip_root(&normalized, root)
+                    .is_some()
+                    .then(|| root.clone())
+            })
+        });
+        if let Some(root) = target_root {
             if let Some(rel) = strip_root(&normalized, &root) {
                 if !rel.is_empty() {
                     let target_project_id = project_id_for_root(&root);
@@ -354,28 +366,26 @@ fn strip_root(path: &str, root: &str) -> Option<String> {
         .map(|tail| tail.to_string())
 }
 
-/// Walk up from a file path's parent directory looking for the nearest
-/// repository boundary, bounded at `$HOME` or the filesystem root. A linked
-/// worktree may inherit an optional `.moraine.toml` backend route from an
-/// enclosing checkout, but its own `.git` marker still defines the root
-/// reported to callers.
+/// Walk up from a file path's parent directory looking for the nearest Git
+/// boundary, bounded at `$HOME` or the filesystem root. Backend routing markers
+/// are deliberately ignored because they do not define project identity.
 fn find_project_root(file_path: &Path) -> Option<String> {
     let home = std::env::var_os("HOME").map(PathBuf::from);
     let mut dir = file_path.parent();
-    let mut backend_root = None;
     while let Some(current) = dir {
         if current.join(".git").exists() {
             return Some(current.to_string_lossy().to_string());
-        }
-        if backend_root.is_none() && current.join(moraine_config::REPO_BACKEND_FILE).exists() {
-            backend_root = Some(current.to_string_lossy().to_string());
         }
         if home.as_deref() == Some(current) {
             break;
         }
         dir = current.parent();
     }
-    backend_root
+    None
+}
+
+fn directory_root(path: &Path) -> Option<String> {
+    path.is_dir().then(|| path.to_string_lossy().to_string())
 }
 
 fn project_id_for_root(root: &str) -> Option<String> {
@@ -1057,6 +1067,38 @@ mod tests {
     }
 
     #[test]
+    fn resolve_tail_uses_exact_launch_directory_without_git() {
+        let dir = std::env::temp_dir().join(format!(
+            "moraine-fa-directory-project-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time after unix epoch")
+                .as_nanos()
+        ));
+        let launch = dir.join("project/subproject");
+        std::fs::create_dir_all(&launch).expect("create non-Git launch directory");
+        std::fs::write(dir.join(".moraine.toml"), "backend = \"default\"\n")
+            .expect("write routing marker above launch directory");
+
+        let resolved = resolve_tail_from("src/new.rs", Some(&launch));
+        assert_eq!(resolved.rel, "src/new.rs");
+        assert_eq!(resolved.root.as_deref(), launch.to_str());
+        assert!(resolved
+            .project_id
+            .as_deref()
+            .is_some_and(|project_id| project_id.starts_with("dir:")));
+        assert!(resolved.derive_worktree_roots);
+
+        let escaped = resolve_tail_from("../outside.rs", Some(&launch));
+        assert!(escaped.project_id.is_none());
+        assert!(escaped.root.is_none());
+        assert!(!escaped.derive_worktree_roots);
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
     fn resolve_tail_makes_nested_launch_paths_repository_relative() {
         let dir =
             std::env::temp_dir().join(format!("moraine-fa-nested-launch-{}", std::process::id()));
@@ -1143,6 +1185,33 @@ mod tests {
         assert!(resolved.project_id.is_none());
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn resolve_tail_closes_directory_scope_for_absolute_path_outside_launch() {
+        let dir = std::env::temp_dir().join(format!(
+            "moraine-fa-directory-cross-project-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time after unix epoch")
+                .as_nanos()
+        ));
+        let launch = dir.join("launch");
+        let outside = dir.join("outside/file.rs");
+        std::fs::create_dir_all(&launch).expect("create non-Git launch directory");
+        std::fs::create_dir_all(outside.parent().expect("outside parent"))
+            .expect("create outside directory");
+        std::fs::write(&outside, "// outside").expect("write outside file");
+
+        let resolved = resolve_tail_from(outside.to_str().expect("utf8 path"), Some(&launch));
+        assert_eq!(resolved.rel, outside.to_string_lossy());
+        assert!(resolved.tail_is_absolute);
+        assert!(resolved.project_id.is_none());
+        assert!(resolved.root.is_none());
+        assert!(!resolved.derive_worktree_roots);
+
+        std::fs::remove_dir_all(dir).ok();
     }
 
     #[test]

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -2908,8 +2908,6 @@ mod tests {
                 .as_nanos()
         ));
         std::fs::create_dir_all(root.join(".git")).expect("create test git directory");
-        std::fs::write(root.join(".moraine.toml"), "backend = \"default\"\n")
-            .expect("write repository backend marker");
         let expected_project_id =
             moraine_config::project_id_for_repo_root(&root).expect("canonical project id");
 
@@ -2965,6 +2963,7 @@ mod tests {
                 .any(|root| root == &root_text),
             "launch root must be present in registered project roots"
         );
+        assert!(query.derive_legacy_roots);
         assert!(query.apply_project_scope);
 
         shutdown_tx.send(()).expect("shutdown route server");

--- a/docs/agent-mcp-search/interface.md
+++ b/docs/agent-mcp-search/interface.md
@@ -214,7 +214,7 @@ agent-attention history of that file — edits, reads, and aborted attempts —
 across *every* worktree of the project: the main checkout, sibling worktrees,
 and agent-isolation worktrees, including work that never landed in git. Unlike
 `git blame`, it shows the debugging session that only read the file and the edit
-that was tried and reverted. Matching is by the repo-relative path *tail*, which
+that was tried and reverted. Matching is by the project-relative path *tail*, which
 is byte-identical across worktree roots, so the roots unify by construction.
 
 Input:
@@ -234,21 +234,23 @@ Input:
 }
 ```
 
-`path` is required. Absolute paths are reduced to a repo-relative tail by walking
-up to a `.moraine.toml` / `.git` marker. Relative paths are resolved from the
-client's launch directory, including when the client is routed through the
-central MCP server, so deleted or not-yet-created files retain launch-project
-provenance. A plain Git checkout is sufficient: `.moraine.toml` is an optional
-backend-routing file and is not required for project identity. Boundary
-whitespace, `file://` URIs, and directory-style trailing
+`path` is required. Absolute paths are reduced to a project-relative tail using
+the nearest Git boundary or, for a non-Git project, exact containment beneath
+the client's launch directory. Relative paths are resolved from that launch
+directory, including when the client is routed through the central MCP server,
+so deleted or not-yet-created files retain launch-project provenance. Git
+checkouts share one identity across linked worktrees. Without Git metadata, the
+canonical launch directory is the identity and sessions launched from different
+subdirectories remain separate. `.moraine.toml` selects a backend independently
+and is not required for identity. Boundary whitespace, `file://` URIs, and directory-style trailing
 slashes are rejected rather than silently mapped to a different file. Compound
 shell text and multi-path captures are never interpreted as one path or root;
 unprovable roots remain `unknown`.
 
 `scope` is `project` (default) or `all`. `project` restricts both normalized and
-legacy fallback lookup to the launch repository's canonical Git-common-directory
-identity independently of `--project-only`, and fails closed when that identity
-cannot be established. `all` deliberately drops that request-level project
+legacy fallback lookup to the launch project's canonical Git-common-directory
+or exact working-directory identity independently of `--project-only`, and
+fails closed when neither identity can be established. `all` deliberately drops that request-level project
 narrowing. A configured `--project-only` server scope remains a hard floor so
 returned IDs stay openable. Registered pre-digest roots are migrated to a
 durable project mapping, and future normalized roots populate that mapping

--- a/docs/agent-mcp-search/interface.md
+++ b/docs/agent-mcp-search/interface.md
@@ -221,7 +221,9 @@ Input:
 up to a `.moraine.toml` / `.git` marker. Relative paths are resolved from the
 client's launch directory, including when the client is routed through the
 central MCP server, so deleted or not-yet-created files retain launch-project
-provenance. Boundary whitespace, `file://` URIs, and directory-style trailing
+provenance. A plain Git checkout is sufficient: `.moraine.toml` is an optional
+backend-routing file and is not required for project identity. Boundary
+whitespace, `file://` URIs, and directory-style trailing
 slashes are rejected rather than silently mapped to a different file. Compound
 shell text and multi-path captures are never interpreted as one path or root;
 unprovable roots remain `unknown`.
@@ -233,7 +235,11 @@ cannot be established. `all` deliberately drops that request-level project
 narrowing. A configured `--project-only` server scope remains a hard floor so
 returned IDs stay openable. Registered pre-digest roots are migrated to a
 durable project mapping, and future normalized roots populate that mapping
-automatically. A root pruned before this mapping was installed has no stored Git
+automatically. Retained older rows with blank normalized identity can be
+recovered only when one top-level scalar structured path agrees exactly with
+the recorded working directory and that directory is itself a current or
+durable root for this project. A
+root pruned before this mapping was installed has no stored Git
 identity and cannot be attributed safely; project scope excludes it rather than
 widening across projects, and the response warns about this one-time upgrade
 limitation. `granularity` is `sessions` (default, one rollup per session) or

--- a/docs/mcp-search-interface-spec.md
+++ b/docs/mcp-search-interface-spec.md
@@ -861,18 +861,20 @@ Rules:
 
 - `path` is required and must name a file path string. Leading/trailing
   whitespace, `file://` URIs, and directory-style trailing slashes are invalid.
-- Absolute paths are reduced to a repo-relative tail by walking up to
-  `.moraine.toml` or `.git`. Relative paths are resolved from the client's MCP
-  launch directory, including through a central-server route, so missing files
-  still retain launch-project provenance. A plain Git checkout establishes
-  project identity; `.moraine.toml` independently selects a backend and is not
-  required. Compound shell text and multi-path
+- Absolute paths are reduced to a project-relative tail using the nearest Git
+  boundary or exact containment beneath a non-Git launch directory. Relative
+  paths are resolved from the client's MCP launch directory, including through
+  a central-server route, so missing files still retain launch-project
+  provenance. Git common-directory metadata unifies linked worktrees; without
+  Git metadata, the canonical launch directory is the identity and different
+  launch subdirectories remain separate. `.moraine.toml` independently selects
+  a backend and is not required. Compound shell text and multi-path
   captures are not interpreted as one path or root; unprovable roots remain
   `unknown`.
 - `scope` is `project` or `all`. `project` independently restricts normalized
-  and legacy fallback lookup to the launch repository's canonical
-  Git-common-directory identity and fails closed if that identity cannot be
-  established. `all` deliberately drops request-level project narrowing. A
+  and legacy fallback lookup to the launch project's canonical Git-common-
+  directory or exact working-directory identity and fails closed if neither can
+  be established. `all` deliberately drops request-level project narrowing. A
   configured `--project-only` server scope remains a hard floor, so returned IDs
   remain accepted by `open`.
 - Registered pre-digest roots are migrated into a durable project mapping, and

--- a/docs/mcp-search-interface-spec.md
+++ b/docs/mcp-search-interface-spec.md
@@ -884,7 +884,9 @@ Rules:
 - Absolute paths are reduced to a repo-relative tail by walking up to
   `.moraine.toml` or `.git`. Relative paths are resolved from the client's MCP
   launch directory, including through a central-server route, so missing files
-  still retain launch-project provenance. Compound shell text and multi-path
+  still retain launch-project provenance. A plain Git checkout establishes
+  project identity; `.moraine.toml` independently selects a backend and is not
+  required. Compound shell text and multi-path
   captures are not interpreted as one path or root; unprovable roots remain
   `unknown`.
 - `scope` is `project` or `all`. `project` independently restricts normalized
@@ -894,7 +896,11 @@ Rules:
   configured `--project-only` server scope remains a hard floor, so returned IDs
   remain accepted by `open`.
 - Registered pre-digest roots are migrated into a durable project mapping, and
-  future normalized roots populate it automatically. A root pruned before that
+  future normalized roots populate it automatically. Retained older rows with
+  blank identity may be attributed only when exactly one top-level scalar
+  structured path agrees with the recorded cwd and that cwd is itself a current
+  or durable project root. A
+  root pruned before that
   mapping was installed lacks stored Git identity and cannot be attributed
   safely; `project` excludes it rather than widening and emits an upgrade
   limitation warning.

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -541,6 +541,8 @@ main() {
   local codex_session_suffix
   codex_session_suffix="$(printf '%06x%06x' "$RANDOM" "$RANDOM")"
   local codex_session_id="00000000-0000-4000-8000-${codex_session_suffix}"
+  local codex_multi_path_session_id="00000000-0000-4000-8001-${codex_session_suffix}"
+  local codex_nested_path_session_id="00000000-0000-4000-8002-${codex_session_suffix}"
   local claude_session_suffix
   claude_session_suffix="$(printf '%06x%06x' "$RANDOM" "$RANDOM")"
   local claude_session_id="00000000-0000-4000-8000-${claude_session_suffix}"
@@ -629,6 +631,11 @@ main() {
   local pi_fixture_file="$fixtures_root/pi/agent/sessions/--tmp-moraine-e2e--/2026-02-16T12-00-08-000Z_${pi_session_id}.jsonl"
   local hermes_fixture_file="$fixtures_root/hermes/trajectories/001-${run_stamp}.jsonl"
   local hermes_session_fixture_file="$fixtures_root/hermes/sessions/${hermes_session_id}.json"
+  # Codex records the launch cwd in session_meta. Keep this as a plain Git
+  # repository with no .moraine.toml so bundled MCP project identity and ingest
+  # normalization exercise the default, unconfigured repository path.
+  local codex_project_dir="$tmp_root/codex-project"
+  mkdir -p "$codex_project_dir/.git"
   # The directory the claude fixture session "originated from": real Claude
   # Code records a cwd on every message line, and `--project-only` scoping
   # keys off it. Must be a real directory so mcp_smoke.py can launch the
@@ -648,7 +655,7 @@ main() {
   mkdir -p "$runtime_root"
 
   cat > "$codex_fixture_file" <<EOF
-{"timestamp":"2026-02-16T12:00:00.000Z","type":"session_meta","payload":{"id":"${codex_session_id}"}}
+{"timestamp":"2026-02-16T12:00:00.000Z","type":"session_meta","payload":{"id":"${codex_session_id}","cwd":"${codex_project_dir}"}}
 {"timestamp":"2026-02-16T12:00:01.000Z","type":"turn_context","payload":{"turn_id":"1","model":"gpt-5.3-codex"}}
 {"timestamp":"2026-02-16T12:00:02.000Z","type":"response_item","payload":{"type":"message","role":"user","id":"msg-user-${run_stamp}","content":[{"type":"text","text":"local e2e codex user prompt ${codex_keyword}"}],"phase":"completed"}}
 {"timestamp":"2026-02-16T12:00:03.000Z","type":"response_item","parent_id":"msg-user-${run_stamp}","payload":{"type":"message","role":"assistant","id":"msg-assistant-${run_stamp}","content":[{"type":"text","text":"local e2e codex assistant reply ${codex_keyword} ${codex_trace_marker}"}],"phase":"completed"}}
@@ -1111,9 +1118,25 @@ EOF
   assert_clickhouse_count "$clickhouse_url" "codex link rows" "SELECT count() FROM ${clickhouse_database}.event_links FINAL WHERE source_name = 'ci-codex' AND link_type = 'parent_event' AND linked_external_id = 'msg-user-${run_stamp}'" "1"
   assert_clickhouse_count "$clickhouse_url" "codex tool rows" "SELECT count() FROM ${clickhouse_database}.tool_io FINAL WHERE source_name = 'ci-codex' AND tool_call_id = 'codex-tool-${run_stamp}'" "2"
   assert_clickhouse_count "$clickhouse_url" "codex tool request fields" "SELECT count() FROM ${clickhouse_database}.tool_io FINAL WHERE source_name = 'ci-codex' AND tool_call_id = 'codex-tool-${run_stamp}' AND tool_name = 'Read' AND tool_phase = 'request'" "1"
+  assert_clickhouse_count "$clickhouse_url" "codex plain-git event identity" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND event_kind = 'tool_call' AND project_id != '' AND worktree_root = '${codex_project_dir}'" "1"
+  assert_clickhouse_count "$clickhouse_url" "codex plain-git tool identity" "SELECT count() FROM ${clickhouse_database}.tool_io FINAL WHERE source_name = 'ci-codex' AND tool_call_id = 'codex-tool-${run_stamp}' AND tool_phase = 'request' AND project_id != '' AND repo_rel_path = 'Cargo.toml' AND worktree_root = '${codex_project_dir}'" "1"
   assert_clickhouse_count "$clickhouse_url" "codex harness/session fields" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND harness = 'codex' AND session_id = '${codex_session_id}'" "7"
   assert_clickhouse_count "$clickhouse_url" "codex model fields" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND model IN ('gpt-5.3-codex', 'gpt-5.3-codex-spark')" "6"
   assert_clickhouse_count "$clickhouse_url" "codex token buckets" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND payload_type = 'token_count' AND input_tokens = 17 AND output_tokens = 4 AND cache_read_tokens = 3 AND cache_write_tokens = 2 AND token_usage_buckets['input_text'] = 12 AND token_usage_buckets['output_text'] = 3 AND token_usage_buckets['reasoning'] = 1" "1"
+
+  # Simulate rows ingested before normalized project fields existed. The MCP
+  # smoke below must recover only this retained, structured path + cwd evidence
+  # and map it back to the launch repository without resetting checkpoints.
+  clickhouse_scalar "$clickhouse_url" "INSERT INTO ${clickhouse_database}.tool_io SELECT * REPLACE ('' AS project_id, '' AS repo_rel_path, '' AS worktree_root, event_version + 100 AS event_version) FROM ${clickhouse_database}.tool_io FINAL WHERE source_name = 'ci-codex' AND tool_call_id = 'codex-tool-${run_stamp}' AND tool_phase = 'request'" >/dev/null
+  clickhouse_scalar "$clickhouse_url" "INSERT INTO ${clickhouse_database}.events SELECT * REPLACE ('' AS project_id, '' AS repo_rel_path, '' AS worktree_root, event_version + 100 AS event_version) FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND event_kind = 'tool_call' AND tool_call_id = 'codex-tool-${run_stamp}'" >/dev/null
+  assert_clickhouse_count "$clickhouse_url" "codex legacy tool identity fixture" "SELECT count() FROM ${clickhouse_database}.tool_io FINAL WHERE source_name = 'ci-codex' AND tool_call_id = 'codex-tool-${run_stamp}' AND tool_phase = 'request' AND project_id = '' AND repo_rel_path = '' AND worktree_root = ''" "1"
+
+  # Negative legacy fixtures: a top-level path plus nested path evidence, and
+  # a nested-only path, may match the file tail but must never invent a root.
+  clickhouse_scalar "$clickhouse_url" "INSERT INTO ${clickhouse_database}.tool_io SELECT * REPLACE ('${codex_multi_path_session_id}' AS session_id, concat(event_uid, '-multi-path') AS event_uid, 'codex-multi-path-${run_stamp}' AS tool_call_id, '{\"path\":\"Cargo.toml\",\"options\":{\"file_path\":\"other.rs\"}}' AS input_json, '' AS project_id, '' AS repo_rel_path, '' AS worktree_root, event_version + 200 AS event_version) FROM ${clickhouse_database}.tool_io FINAL WHERE source_name = 'ci-codex' AND tool_call_id = 'codex-tool-${run_stamp}' AND tool_phase = 'request'" >/dev/null
+  clickhouse_scalar "$clickhouse_url" "INSERT INTO ${clickhouse_database}.events SELECT * REPLACE ('${codex_multi_path_session_id}' AS session_id, concat(event_uid, '-multi-path') AS event_uid, 'codex-multi-path-${run_stamp}' AS tool_call_id, '' AS project_id, '' AS repo_rel_path, '' AS worktree_root, event_version + 200 AS event_version) FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND event_kind = 'tool_call' AND tool_call_id = 'codex-tool-${run_stamp}'" >/dev/null
+  clickhouse_scalar "$clickhouse_url" "INSERT INTO ${clickhouse_database}.tool_io SELECT * REPLACE ('${codex_nested_path_session_id}' AS session_id, concat(event_uid, '-nested-path') AS event_uid, 'codex-nested-path-${run_stamp}' AS tool_call_id, '{\"options\":{\"path\":\"Cargo.toml\"}}' AS input_json, '' AS project_id, '' AS repo_rel_path, '' AS worktree_root, event_version + 300 AS event_version) FROM ${clickhouse_database}.tool_io FINAL WHERE source_name = 'ci-codex' AND tool_call_id = 'codex-tool-${run_stamp}' AND tool_phase = 'request'" >/dev/null
+  clickhouse_scalar "$clickhouse_url" "INSERT INTO ${clickhouse_database}.events SELECT * REPLACE ('${codex_nested_path_session_id}' AS session_id, concat(event_uid, '-nested-path') AS event_uid, 'codex-nested-path-${run_stamp}' AS tool_call_id, '' AS project_id, '' AS repo_rel_path, '' AS worktree_root, event_version + 300 AS event_version) FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND event_kind = 'tool_call' AND tool_call_id = 'codex-tool-${run_stamp}'" >/dev/null
 
   assert_clickhouse_count "$clickhouse_url" "claude unique raw rows" "SELECT uniqExact(raw_json_hash) FROM ${clickhouse_database}.raw_events WHERE source_name = 'ci-claude'" "3"
   assert_clickhouse_count "$clickhouse_url" "claude event rows" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-claude'" "5"
@@ -1392,24 +1415,34 @@ PY
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
     --moraine "$moraine_bin" \
     --config "$config_path" \
+    --working-dir "$codex_project_dir" \
     --query "$codex_keyword" \
     --expect-session-id "$codex_session_id" \
     --expect-open-text "$codex_trace_marker" \
     --expect-event-count "7" \
     --expect-updated-at "2026-02-16T12:00:03.900Z" \
     --file-attention-path "Cargo.toml" \
+    --file-attention-expect-absent-session-id "$claude_session_id" \
+    --file-attention-expect-absent-session-id "$pi_session_id" \
+    --file-attention-expect-absent-session-id "$codex_multi_path_session_id" \
+    --file-attention-expect-absent-session-id "$codex_nested_path_session_id" \
     --write-tools-snapshot "$daemon_tools_snapshot"
 
   echo "[e2e] checking second fresh stdio MCP process (identical codex cache hit)"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
     --moraine "$moraine_bin" \
     --config "$config_path" \
+    --working-dir "$codex_project_dir" \
     --query "$codex_keyword" \
     --expect-session-id "$codex_session_id" \
     --expect-open-text "$codex_trace_marker" \
     --expect-event-count "7" \
     --expect-updated-at "2026-02-16T12:00:03.900Z" \
     --file-attention-path "Cargo.toml" \
+    --file-attention-expect-absent-session-id "$claude_session_id" \
+    --file-attention-expect-absent-session-id "$pi_session_id" \
+    --file-attention-expect-absent-session-id "$codex_multi_path_session_id" \
+    --file-attention-expect-absent-session-id "$codex_nested_path_session_id" \
     --write-tools-snapshot "$daemon_tools_snapshot"
 
   echo "[e2e] checking shared-daemon MCP cache miss -> hit markers"
@@ -1479,7 +1512,9 @@ PY
   assert_clickhouse_count "$clickhouse_url" "all service SELECTs use the backend UA/PID" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Select' AND (${attributed_service_filter}) AND http_user_agent != '${expected_backend_ua}'" "0"
   assert_clickhouse_count "$clickhouse_url" "named read schema handshake runs once despite MCP/HTTP reuse" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND http_user_agent = '${expected_backend_ua}' AND position(query, 'system.tables') > 0 AND position(query, 'schema_migrations') > 0" "1"
   wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Insert' AND http_user_agent = '${expected_ingest_ua}'" 30
-  assert_clickhouse_count "$clickhouse_url" "all service INSERTs use the ingest UA/PID" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Insert' AND (${attributed_service_filter}) AND http_user_agent != '${expected_ingest_ua}'" "0"
+  local file_attention_root_insert_prefix="INSERT INTO \`${clickhouse_database}\`.\`file_attention_project_roots\`"
+  wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Insert' AND http_user_agent = '${expected_backend_ua}' AND startsWith(query, '${file_attention_root_insert_prefix}')" 30
+  assert_clickhouse_count "$clickhouse_url" "service INSERTs use the ingest UA/PID except backend project-root mappings" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Insert' AND (${attributed_service_filter}) AND http_user_agent != '${expected_ingest_ua}' AND NOT (http_user_agent = '${expected_backend_ua}' AND startsWith(query, '${file_attention_root_insert_prefix}'))" "0"
 
   echo "[e2e] checking MCP initialize/tools/search_sessions/open/list_sessions (claude)"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
@@ -1547,8 +1582,8 @@ PY
 
   # --project-only: launched from the claude fixture's recorded cwd, the MCP
   # server must serve that session normally while sessions from other
-  # directories (pi: cwd=$tmp_root) or with no recorded cwd (codex) are
-  # invisible to search/list and answer not_found on open.
+  # directories (including the separate Codex Git repository) are invisible
+  # to search/list and answer not_found on open.
   echo "[e2e] checking MCP --project-only serves in-scope session and hides others"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
     --moraine "$moraine_bin" \
@@ -1646,12 +1681,17 @@ PY
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \
     --moraine "$moraine_bin" \
     --config "$config_path" \
+    --working-dir "$codex_project_dir" \
     --query "$codex_keyword" \
     --expect-session-id "$codex_session_id" \
     --expect-open-text "$codex_trace_marker" \
     --expect-event-count "7" \
     --expect-updated-at "2026-02-16T12:00:03.900Z" \
     --file-attention-path "Cargo.toml" \
+    --file-attention-expect-absent-session-id "$claude_session_id" \
+    --file-attention-expect-absent-session-id "$pi_session_id" \
+    --file-attention-expect-absent-session-id "$codex_multi_path_session_id" \
+    --file-attention-expect-absent-session-id "$codex_nested_path_session_id" \
     --require-embedded-fallback \
     --write-tools-snapshot "$embedded_tools_snapshot"
 

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -1143,8 +1143,10 @@ EOF
   # Every claude event carries the record-level cwd in the native column;
   # --project-only scoping reads it to resolve the session's origin directory.
   assert_clickhouse_count "$clickhouse_url" "claude cwd column populated" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-claude' AND cwd = '${claude_project_dir}'" "5"
+  assert_clickhouse_count "$clickhouse_url" "claude non-Git directory identity populated" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-claude' AND startsWith(project_id, 'dir:') AND worktree_root = '${claude_project_dir}'" "5"
   assert_clickhouse_count "$clickhouse_url" "claude link rows" "SELECT count() FROM ${clickhouse_database}.event_links FINAL WHERE source_name = 'ci-claude'" "6"
   assert_clickhouse_count "$clickhouse_url" "claude tool rows" "SELECT count() FROM ${clickhouse_database}.tool_io FINAL WHERE source_name = 'ci-claude' AND tool_call_id = 'claude-tool-${run_stamp}'" "2"
+  assert_clickhouse_count "$clickhouse_url" "claude non-Git tool path normalized" "SELECT count() FROM ${clickhouse_database}.tool_io FINAL WHERE source_name = 'ci-claude' AND tool_call_id = 'claude-tool-${run_stamp}' AND tool_phase = 'request' AND startsWith(project_id, 'dir:') AND worktree_root = '${claude_project_dir}' AND repo_rel_path = 'Cargo.toml'" "1"
   assert_clickhouse_count "$clickhouse_url" "claude harness/session fields" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-claude' AND harness = 'claude-code' AND inference_provider = 'anthropic' AND session_id = '${claude_session_id}'" "5"
   assert_clickhouse_count "$clickhouse_url" "claude model fields" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-claude' AND model = 'claude-opus-4-5-20251101'" "3"
   assert_clickhouse_count "$clickhouse_url" "claude token buckets" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-claude' AND actor_kind = 'assistant' AND input_tokens = 9 AND output_tokens = 5 AND token_usage_buckets['input_text'] = 9 AND token_usage_buckets['output_text'] = 5" "3"
@@ -1465,7 +1467,8 @@ PY
     --working-dir "$claude_project_dir" \
     --query "$claude_keyword" \
     --expect-session-id "$claude_session_id" \
-    --expect-open-text "$claude_trace_marker"
+    --expect-open-text "$claude_trace_marker" \
+    --file-attention-path "Cargo.toml"
 
   echo "[e2e] checking named-backend HTTP route through shared daemon router"
   routed_sessions_body="$(curl -fsS \
@@ -1484,7 +1487,8 @@ PY
     --working-dir "$claude_project_dir" \
     --query "$claude_keyword" \
     --expect-session-id "$claude_session_id" \
-    --expect-open-text "$claude_trace_marker"
+    --expect-open-text "$claude_trace_marker" \
+    --file-attention-path "Cargo.toml"
   wait_for_mcp_cache_sequence "$python_bin" "$backend_log" "$routed_cache_log_baseline" 20
 
   echo "[e2e] checking named route excludes default-only content"
@@ -1513,8 +1517,10 @@ PY
   assert_clickhouse_count "$clickhouse_url" "named read schema handshake runs once despite MCP/HTTP reuse" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND http_user_agent = '${expected_backend_ua}' AND position(query, 'system.tables') > 0 AND position(query, 'schema_migrations') > 0" "1"
   wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Insert' AND http_user_agent = '${expected_ingest_ua}'" 30
   local file_attention_root_insert_prefix="INSERT INTO \`${clickhouse_database}\`.\`file_attention_project_roots\`"
-  wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Insert' AND http_user_agent = '${expected_backend_ua}' AND startsWith(query, '${file_attention_root_insert_prefix}')" 30
-  assert_clickhouse_count "$clickhouse_url" "service INSERTs use the ingest UA/PID except backend project-root mappings" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Insert' AND (${attributed_service_filter}) AND http_user_agent != '${expected_ingest_ua}' AND NOT (http_user_agent = '${expected_backend_ua}' AND startsWith(query, '${file_attention_root_insert_prefix}'))" "0"
+  local routed_file_attention_root_insert_prefix="INSERT INTO \`${routed_clickhouse_database}\`.\`file_attention_project_roots\`"
+  local allowed_backend_root_insert="http_user_agent = '${expected_backend_ua}' AND (startsWith(query, '${file_attention_root_insert_prefix}') OR startsWith(query, '${routed_file_attention_root_insert_prefix}'))"
+  wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Insert' AND (${allowed_backend_root_insert})" 30
+  assert_clickhouse_count "$clickhouse_url" "service INSERTs use the ingest UA/PID except backend project-root mappings" "SELECT count() FROM system.query_log WHERE type = 'QueryFinish' AND ${query_log_window} AND query_kind = 'Insert' AND (${attributed_service_filter}) AND http_user_agent != '${expected_ingest_ua}' AND NOT (${allowed_backend_root_insert})" "0"
 
   echo "[e2e] checking MCP initialize/tools/search_sessions/open/list_sessions (claude)"
   "$python_bin" "$repo_root/scripts/ci/mcp_smoke.py" \

--- a/scripts/ci/mcp_smoke.py
+++ b/scripts/ci/mcp_smoke.py
@@ -344,6 +344,8 @@ def open_ids_from_file_attention_item(result: Dict[str, Any]) -> list[str]:
 def select_file_attention_result(
     payload: Dict[str, Any],
     expect_session_id: Optional[str],
+    expect_root: Optional[str] = None,
+    absent_session_ids: Optional[list[str]] = None,
 ) -> Dict[str, Any]:
     data = payload.get("data")
     if not isinstance(data, dict):
@@ -355,13 +357,34 @@ def select_file_attention_result(
         raise AssertionError(f"file_attention returned no events: {payload}")
 
     expected_session = expected_mcp_session_id(expect_session_id)
+    forbidden_sessions = {
+        session_id
+        for raw_session_id in absent_session_ids or []
+        if (session_id := expected_mcp_session_id(raw_session_id)) is not None
+    }
+    selected: Optional[Dict[str, Any]] = None
     for event in events:
         if not isinstance(event, dict):
             continue
         session_id = nested_string(event, "event", "session_id")
         open_session_id = nested_string(event, "open", "session_id")
+        if forbidden_sessions.intersection({session_id, open_session_id}):
+            raise AssertionError(
+                "project-scoped file_attention leaked an excluded session: "
+                f"event={event}, excluded={sorted(forbidden_sessions)}"
+            )
         if expected_session is None or expected_session in {session_id, open_session_id}:
-            return event
+            selected = event
+
+    if selected is not None:
+        if expect_root is not None:
+            actual_root = nested_string(selected, "event", "worktree_root")
+            if actual_root != expect_root:
+                raise AssertionError(
+                    "file_attention returned the expected session with the wrong root: "
+                    f"got={actual_root!r}, wanted={expect_root!r}, event={selected}"
+                )
+        return selected
 
     debug_events = [
         {
@@ -472,6 +495,7 @@ def run_smoke(
     project_dir: Optional[str] = None,
     working_dir: Optional[str] = None,
     absent_session_ids: Optional[list[str]] = None,
+    file_attention_absent_session_ids: Optional[list[str]] = None,
     expect_no_results: bool = False,
     expect_event_count: Optional[int] = None,
     expect_updated_at: Optional[str] = None,
@@ -659,7 +683,7 @@ def run_smoke(
                 "file_attention",
                 {
                     "path": file_attention_path,
-                    "scope": "project" if project_dir is not None else "all",
+                    "scope": "project" if launch_dir is not None else "all",
                     "granularity": "events",
                     "limit": 10,
                 },
@@ -671,6 +695,8 @@ def run_smoke(
             selected_touch = select_file_attention_result(
                 file_attention_payload,
                 expect_session_id,
+                expect_root=launch_dir if launch_dir is not None else None,
+                absent_session_ids=file_attention_absent_session_ids,
             )
             next_id = assert_open_search_ids(
                 proc,
@@ -732,6 +758,15 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--file-attention-expect-absent-session-id",
+        action="append",
+        default=[],
+        help=(
+            "raw session id that must not appear in the file_attention event "
+            "timeline (repeatable)"
+        ),
+    )
+    parser.add_argument(
         "--expect-no-results",
         action="store_true",
         help="assert search_sessions returns zero results for the query",
@@ -774,6 +809,9 @@ def main() -> int:
         project_dir=args.project_dir,
         working_dir=args.working_dir,
         absent_session_ids=args.expect_absent_session_id,
+        file_attention_absent_session_ids=(
+            args.file_attention_expect_absent_session_id
+        ),
         expect_no_results=args.expect_no_results,
         expect_event_count=args.expect_event_count,
         expect_updated_at=args.expect_updated_at,

--- a/sql/021_file_attention_normalization.sql
+++ b/sql/021_file_attention_normalization.sql
@@ -1,9 +1,10 @@
 -- Forward-only normalization columns for file_attention Phase 1.
 --
 -- Existing rows read these as defaults. New ingest rows fill them only when a
--- repo/worktree root and Git common-directory identity can be proven. The
--- optional project backend marker controls routing independently; Tier 0 suffix
--- matching remains the permanent fallback for legacy and unnormalizable rows.
+-- project root and either Git common-directory or exact working-directory
+-- identity can be proven. The optional project backend marker controls routing
+-- independently; Tier 0 suffix matching remains the permanent fallback for
+-- legacy and unnormalizable rows.
 
 ALTER TABLE moraine.events
   ADD COLUMN IF NOT EXISTS project_id LowCardinality(String) DEFAULT '';

--- a/sql/021_file_attention_normalization.sql
+++ b/sql/021_file_attention_normalization.sql
@@ -1,9 +1,9 @@
 -- Forward-only normalization columns for file_attention Phase 1.
 --
 -- Existing rows read these as defaults. New ingest rows fill them only when a
--- repo/worktree root, Git common-directory identity, and project backend marker
--- can be proven; Tier 0 suffix matching remains the permanent fallback for
--- legacy and unnormalizable rows.
+-- repo/worktree root and Git common-directory identity can be proven. The
+-- optional project backend marker controls routing independently; Tier 0 suffix
+-- matching remains the permanent fallback for legacy and unnormalizable rows.
 
 ALTER TABLE moraine.events
   ADD COLUMN IF NOT EXISTS project_id LowCardinality(String) DEFAULT '';


### PR DESCRIPTION
## Description

**What.** Restores project-scoped `file_attention` for ordinary Git checkouts and projects with no Git metadata, while safely recovering older Codex rows whose normalized project identity is blank.

**Why.** Bundled MCP clients already know their launch working directory. Project identity should not require either Git metadata or an unrelated `.moraine.toml` backend-routing file.

Git projects derive identity and linked-worktree membership from the Git common directory. When no Git boundary exists, ingest and MCP use the exact canonical launch working directory as a `dir:` project identity. Launches from different non-Git subdirectories intentionally remain separate projects. `.moraine.toml` continues to control routing independently and never changes identity.

Relative paths are resolved inside that launch scope. Absolute paths are accepted for a non-Git project only when they remain beneath the launch directory; `..` escapes and outside absolute paths fail closed. No Git executable is invoked: existing `.git` metadata is parsed directly when present, and otherwise the working directory is sufficient.

The legacy ClickHouse fallback remains closed by default: it derives a missing root only from exactly one top-level scalar structured path, requires that path to agree with the event cwd, and accepts the cwd only when it exactly matches a current or durable root for the requested project. Nested, array, multi-path, shell, unknown, and cross-project evidence stays excluded.

## Bug Evidence

Before this change, a plain Git checkout without `.moraine.toml` could lose project identity, and a directory with no Git metadata could not establish project identity at all. Project-scoped `file_attention` therefore either failed closed or could not recover retained Codex tool rows with blank normalized identity.

The normalization fixtures now cover both Git-common-directory and exact-working-directory identities. The stack fixture uses a non-Git Claude project, verifies `dir:` identity and project-relative tool paths in ClickHouse, and exercises project-scoped `file_attention` through both daemon routes. The existing legacy fixture deliberately blanks retained Codex tool/event identity and verifies safe recovery without admitting Claude, Pi, unsafe multi-path, nested-path, or cross-project sessions.

## Usage

No configuration change is required:

- In a Git checkout, linked worktrees share the Git common-directory identity.
- Without Git metadata, the MCP client's canonical launch directory is the project identity.
- Launching separately from `/project` and `/project/subdir` creates separate non-Git project scopes.
- `.moraine.toml` remains optional and controls backend routing only.

## Changelog

- Restore Git-based project identity for checkouts without `.moraine.toml`.
- Add exact working-directory identity for projects with no Git metadata.
- Preserve one project identity across valid linked worktrees while rejecting stale reused registrations.
- Reject non-Git relative escapes and absolute paths outside the launch directory.
- Recover safe legacy blank-identity file-attention rows from exact durable root evidence without widening across projects.
- Clarify project-relative matching and document the Git/directory identity contract.

## Operational Impact

No new migration or configuration is required. Git projects retain `git:` identities. Non-Git projects receive stable `dir:` identities derived from the canonical launch directory. Project-scoped requests write their current roots to the existing `file_attention_project_roots` table.

## Validation

The original PR was validated in isolated Moraine sandbox `sb-024dfc`:

- `cargo test --workspace --locked` — passed all workspace tests and doctests.
- `make clippy` — passed the repository's strict clippy baseline.
- `MORAINECTL_BIN=/home/moraine/target/debug/moraine MORAINE_SERVICE_BIN_DIR=/home/moraine/target/debug bash scripts/ci/e2e-stack.sh` — passed the complete managed-stack, ingest, daemon MCP, project isolation, ClickHouse ownership, crash/fallback, and all-down lifecycle smoke.

For the exact-working-directory follow-up, after rebasing onto the remote branch:

- `cargo fmt --all -- --check` — passed.
- `cargo test -p moraine-config -p moraine-ingest-core -p moraine-mcp-core --locked --quiet` — passed 84 config tests, 206 ingest tests across its suites, and 120 MCP tests.
- `make docs-build`, `bash -n scripts/ci/e2e-stack.sh`, and `git diff --check` — passed.

Additional isolated sandbox attempts were cleaned up without reaching the test phase because their private ClickHouse containers failed startup health checks while several unrelated agent sandboxes were starting concurrently. The directory-specific stack regression is therefore awaiting the PR's clean CI runner; no sandbox from this task remains running.

Fixes #541
