### PR TITLE
fix(mcp): deduplicate equivalent events in search_sessions results

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -1492,6 +1492,29 @@ FORMAT JSONEachRow",
         });
     }
 
+    /// Collapse equivalent MCP search events that the read model can surface
+    /// under several opaque event UIDs (issue #539). Two rows are equivalent
+    /// when they share session, turn, event type, timestamp, and normalized
+    /// content — i.e. only their opaque `event_uid` differs. Without this pass a
+    /// single logical event consumes several ranked slots and starves the
+    /// requested hit budget. Rows arrive in rank order, so the first (highest
+    /// ranked) copy of each equivalence class is kept.
+    pub(super) fn dedupe_mcp_event_rows(rows: &mut Vec<SearchMcpEventRow>) {
+        let mut seen = std::collections::HashSet::new();
+        rows.retain(|row| {
+            seen.insert((
+                row.session_id.clone(),
+                row.turn_seq,
+                row.event_class.clone(),
+                row.payload_type.clone(),
+                row.mcp_event_type.clone(),
+                row.event_unix_ms,
+                Self::compact_preview_for_dedup(&row.text_preview),
+                Self::compact_preview_for_dedup(&row.text_content),
+            ))
+        });
+    }
+
     pub(super) fn dedupe_fetch_limit(limit: u16) -> u16 {
         limit.saturating_mul(3).max(limit)
     }
@@ -2888,7 +2911,10 @@ FORMAT JSONEachRow",
         let requested_n_hits = query.n_hits.unwrap_or(10).max(1);
         let effective_n_hits = requested_n_hits.min(self.cfg.max_results);
         let limit_capped = requested_n_hits > effective_n_hits;
-        let fetch_limit = effective_n_hits.saturating_add(1);
+        // Over-fetch so the dedup pass can drop equivalent duplicate events and
+        // still fill the requested budget with distinct hits (issue #539). The
+        // trailing +1 keeps a sentinel that signals more distinct results exist.
+        let fetch_limit = Self::dedupe_fetch_limit(effective_n_hits).saturating_add(1);
 
         let min_should_match = query
             .min_should_match
@@ -2933,6 +2959,7 @@ FORMAT JSONEachRow",
                     fetch_limit,
                 )
                 .await?;
+            Self::dedupe_mcp_event_rows(&mut rows);
             let avgdl = if docs == 0 {
                 0.0
             } else {

--- a/crates/moraine-conversations/src/clickhouse_repo/tests.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/tests.rs
@@ -528,6 +528,100 @@ fn dedupe_search_rows_reasoning_mirrors_do_not_collapse_with_messages() {
     assert_eq!(deduped.len(), 2);
 }
 
+#[allow(clippy::too_many_arguments)]
+fn mcp_event_row(
+    event_uid: &str,
+    session_id: &str,
+    turn_seq: u32,
+    mcp_event_type: &str,
+    event_unix_ms: i64,
+    text: &str,
+    raw_score: f64,
+) -> SearchMcpEventRow {
+    let mut row = sample_mcp_search_row(event_uid, raw_score, event_unix_ms);
+    row.session_id = session_id.to_string();
+    row.turn_seq = turn_seq;
+    row.mcp_event_type = mcp_event_type.to_string();
+    row.text_preview = text.to_string();
+    row.text_content = text.to_string();
+    row
+}
+
+#[test]
+fn dedupe_mcp_event_rows_collapses_equivalent_events() {
+    // Two byte-identical events (same session/turn/type/timestamp/content,
+    // whitespace-normalized) surfaced under different opaque UIDs, plus two
+    // genuinely distinct hits. The duplicate must free its slot so the budget
+    // is filled with distinct results (issue #539).
+    let mut rows = vec![
+        mcp_event_row(
+            "uid-a1",
+            "sess-a",
+            3,
+            "user_input",
+            1000,
+            "hello world",
+            20.0,
+        ),
+        mcp_event_row(
+            "uid-a2",
+            "sess-a",
+            3,
+            "user_input",
+            1000,
+            "hello   world\n",
+            20.0,
+        ),
+        mcp_event_row(
+            "uid-b",
+            "sess-b",
+            5,
+            "assistant_response",
+            2000,
+            "different answer",
+            18.0,
+        ),
+        mcp_event_row(
+            "uid-c",
+            "sess-c",
+            7,
+            "assistant_response",
+            3000,
+            "another answer",
+            16.0,
+        ),
+    ];
+
+    ClickHouseConversationRepository::dedupe_mcp_event_rows(&mut rows);
+
+    let uids: Vec<&str> = rows.iter().map(|row| row.event_uid.as_str()).collect();
+    assert_eq!(uids, vec!["uid-a1", "uid-b", "uid-c"]);
+}
+
+#[test]
+fn dedupe_mcp_event_rows_keeps_events_that_differ_in_content_turn_or_time() {
+    // Same session/type but different content, or identical content in a
+    // different turn/timestamp, are distinct events and must all survive.
+    let mut rows = vec![
+        mcp_event_row("uid-1", "sess-a", 3, "user_input", 1000, "same text", 10.0),
+        mcp_event_row(
+            "uid-2",
+            "sess-a",
+            3,
+            "user_input",
+            1000,
+            "different text",
+            10.0,
+        ),
+        mcp_event_row("uid-3", "sess-a", 4, "user_input", 2000, "same text", 10.0),
+    ];
+
+    ClickHouseConversationRepository::dedupe_mcp_event_rows(&mut rows);
+
+    let uids: Vec<&str> = rows.iter().map(|row| row.event_uid.as_str()).collect();
+    assert_eq!(uids, vec!["uid-1", "uid-2", "uid-3"]);
+}
+
 #[test]
 fn low_information_system_event_classifier_targets_open_noise() {
     assert!(


### PR DESCRIPTION
## What

`search_sessions` no longer returns byte-identical events from the same session and turn as separate ranked hits. Equivalent events now collapse into a single result slot, and the freed budget is refilled with the next distinct hit.

## Why

The MCP retrieval path (`search_mcp_events_impl`) fetched `n_hits + 1` rows and truncated to `n_hits` with no equivalence pass. The read model can surface one logical event under several opaque `event_uid`s, so a duplicate pair — identical session, turn, type, timestamp, content and score — consumed multiple slots. As reported in #539, five requested hits produced only three distinct snippets, and the documented workaround was to over-request and dedupe client-side.

The sibling `search_events` path already collapses mirror rows via `dedupe_search_rows`; the MCP path had no equivalent step.

## Change

- Add `dedupe_mcp_event_rows`, which keeps the first (highest-ranked) row of each equivalence class. Rows are equivalent when they match on `session_id`, `turn_seq`, `event_class`, `payload_type`, `mcp_event_type`, `event_unix_ms`, and whitespace-normalized `text_preview` + `text_content` — i.e. only the opaque `event_uid` differs.
- Over-fetch through the existing `dedupe_fetch_limit` (instead of `n_hits + 1`) so collapsing duplicates refills the requested budget with distinct hits rather than shrinking the result set. The trailing `+1` keeps the "more results available" sentinel.

Genuinely distinct hits are preserved: different content, or identical content in a different turn/timestamp, do not collapse.

## Tests

New unit tests in `crates/moraine-conversations/src/clickhouse_repo/tests.rs`:

- `dedupe_mcp_event_rows_collapses_equivalent_events` — two byte-identical events (whitespace-normalized) under different UIDs plus two distinct hits collapse to the distinct set. Written first; fails against the pre-fix path (`["uid-a1","uid-a2","uid-b","uid-c"]`) and passes after (`["uid-a1","uid-b","uid-c"]`).
- `dedupe_mcp_event_rows_keeps_events_that_differ_in_content_turn_or_time` — different content, or same content in a different turn/timestamp, all survive.

```
cargo test -p moraine-conversations --lib      # 63 passed, 1 ignored
cargo test -p moraine-mcp-core --lib           # 109 passed
cargo fmt --all -- --check                     # clean
cargo clippy -p moraine-conversations --all-targets --locked -- -Dwarnings <repo baseline flags>  # clean
```

Fixes #539
