### PR TITLE
fix(search): deduplicate equivalent MCP events

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo/rows.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/rows.rs
@@ -348,6 +348,8 @@ pub(super) struct SearchMcpCandidateRow {
     pub(super) scope_exists: u8,
     pub(super) projection_ready: u8,
     pub(super) projection_clean: u8,
+    #[serde(default)]
+    pub(super) projection_revision: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -370,6 +372,8 @@ pub(super) struct SearchMcpEventRow {
     pub(super) text_preview: String,
     #[serde(default)]
     pub(super) text_content: String,
+    #[serde(default)]
+    pub(super) text_content_digest: String,
     #[serde(default)]
     pub(super) payload_json: String,
     #[serde(default)]

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -5,6 +5,7 @@ pub(super) const CONVERSATION_CANDIDATE_MULTIPLIER: usize = 80;
 pub(super) const CONVERSATION_CANDIDATE_MAX: usize = 20_000;
 pub(super) const CONVERSATION_RECENT_WINDOW_MS: i64 = 45_000;
 pub(super) const CONVERSATION_RECENT_CANDIDATE_LIMIT: usize = 1024;
+pub(super) const MCP_SEARCH_MAX_CANDIDATE_PAGES: u16 = 16;
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct SearchScoreAccum<'a> {
@@ -429,6 +430,7 @@ FORMAT JSONEachRow",
         min_should_match: u16,
         min_score: f64,
         limit: u16,
+        offset: u64,
     ) -> RepoResult<String> {
         if terms.is_empty() {
             return Err(RepoError::invalid_argument(
@@ -558,7 +560,10 @@ WHERE scope_s.session_id = {session_id}{scope_origin_filter}",
     WHERE state_key = 'global'
   ) AS projection_ready,
   (
-    SELECT toUInt8(count() = 0)
+    SELECT tuple(
+      toUInt8(countIf(dirty.dirty_revision > ifNull(published.dirty_revision, 0)) = 0),
+      toUInt64(ifNull(max(dirty.dirty_revision), 0))
+    )
     FROM (
       SELECT session_id, dirty_revision
       FROM {dirty_sessions_table} FINAL
@@ -567,8 +572,9 @@ WHERE scope_s.session_id = {session_id}{scope_origin_filter}",
       SELECT session_id, dirty_revision
       FROM {sessions_table} FINAL
     ) AS published ON published.session_id = dirty.session_id
-    WHERE dirty.dirty_revision > ifNull(published.dirty_revision, 0)
-  ) AS projection_clean,
+  ) AS projection_status,
+  tupleElement(projection_status, 1) AS projection_clean,
+  tupleElement(projection_status, 2) AS projection_revision,
   ({scope_state_sql}) AS scope_exists,
   term_postings AS (
     SELECT
@@ -617,7 +623,7 @@ WHERE scope_s.session_id = {session_id}{scope_origin_filter}",
     GROUP BY p.doc_id
     HAVING matched_terms >= {min_should_match} AND raw_score >= {min_score:.6}
     ORDER BY raw_score DESC, event_unix_ms DESC, event_uid ASC
-    LIMIT {limit}
+    LIMIT {limit} OFFSET {offset}
   )
 SELECT *
 FROM (
@@ -634,7 +640,8 @@ SELECT
   corpus_total_doc_len AS total_doc_len,
   scope_exists AS scope_exists,
   projection_ready AS projection_ready,
-  projection_clean AS projection_clean
+  projection_clean AS projection_clean,
+  projection_revision AS projection_revision
 FROM ranked
 UNION ALL
 SELECT
@@ -650,7 +657,8 @@ SELECT
   corpus_total_doc_len AS total_doc_len,
   scope_exists AS scope_exists,
   projection_ready AS projection_ready,
-  projection_clean AS projection_clean
+  projection_clean AS projection_clean,
+  projection_revision AS projection_revision
 )
 ORDER BY row_kind ASC, raw_score DESC, event_unix_ms DESC, event_uid ASC
 SETTINGS max_bytes_before_external_group_by = 67108864,
@@ -757,6 +765,7 @@ SELECT
   documents.doc_len AS doc_len,
   documents.text_preview AS text_preview,
   documents.text_content AS text_content,
+  hex(SHA256(projected_events.text_content)) AS text_content_digest,
   documents.payload_json AS payload_json,
   projected_events.event_type AS mcp_event_type,
   toFloat64(0) AS raw_score,
@@ -1414,72 +1423,112 @@ FORMAT JSONEachRow",
         min_score: f64,
         limit: u16,
     ) -> RepoResult<(Vec<SearchMcpEventRow>, u64, u64, bool)> {
-        let sql = self.build_search_mcp_events_sql(
-            terms,
-            event_types,
-            session_id,
-            turn_seq,
-            harness,
-            source_name,
-            min_should_match,
-            min_score,
-            limit,
-        )?;
-        let candidate_rows: Vec<SearchMcpCandidateRow> =
-            self.map_backend(self.query_rows(&sql, None).await)?;
-        let metadata = candidate_rows
-            .iter()
-            .find(|row| row.row_kind == 1)
+        let page_limit = limit.max(1);
+        let target_rows = usize::from(limit);
+        let mut offset = 0_u64;
+        let mut page_count = 0_u16;
+        let mut rows = Vec::<SearchMcpEventRow>::with_capacity(target_rows);
+        let mut snapshot = None::<(u64, u64, bool, u64)>;
+
+        loop {
+            if page_count >= MCP_SEARCH_MAX_CANDIDATE_PAGES {
+                return Err(RepoError::backend(
+                    "MCP search duplicate scan budget exhausted; narrow the query",
+                ));
+            }
+            page_count += 1;
+
+            let sql = self.build_search_mcp_events_sql(
+                terms,
+                event_types,
+                session_id,
+                turn_seq,
+                harness,
+                source_name,
+                min_should_match,
+                min_score,
+                page_limit,
+                offset,
+            )?;
+            let candidate_rows: Vec<SearchMcpCandidateRow> =
+                self.map_backend(self.query_rows(&sql, None).await)?;
+            let metadata = candidate_rows
+                .iter()
+                .find(|row| row.row_kind == 1)
+                .ok_or_else(|| RepoError::backend("MCP search candidate query omitted metadata"))?;
+            if metadata.projection_ready == 0 {
+                return Err(RepoError::backend(
+                    "MCP search read model is not ready; run `moraine db migrate`",
+                ));
+            }
+            if metadata.projection_clean == 0 {
+                return Err(RepoError::backend(
+                    "MCP search read model is catching up with ingest; retry the request",
+                ));
+            }
+
+            let page_snapshot = (
+                metadata.docs,
+                metadata.total_doc_len,
+                metadata.scope_exists != 0,
+                metadata.projection_revision,
+            );
+            match snapshot {
+                None => {
+                    self.cache_corpus_stats(page_snapshot.0, page_snapshot.1, Instant::now())
+                        .await;
+                    snapshot = Some(page_snapshot);
+                }
+                Some(expected) if expected != page_snapshot => {
+                    return Err(RepoError::backend(
+                        "MCP search snapshot changed while paging candidates; retry the request",
+                    ));
+                }
+                Some(_) => {}
+            }
+
+            let candidates = candidate_rows
+                .into_iter()
+                .filter(|row| row.row_kind == 0)
+                .collect::<Vec<_>>();
+            let candidate_count = candidates.len();
+            if candidates.is_empty() {
+                break;
+            }
+
+            let detail_sql = self.build_search_mcp_event_details_sql(&candidates)?;
+            let detail_rows: Vec<SearchMcpEventRow> =
+                self.map_backend(self.query_rows(&detail_sql, None).await)?;
+            let mut details_by_uid = detail_rows
+                .into_iter()
+                .map(|row| (row.event_uid.clone(), row))
+                .collect::<HashMap<_, _>>();
+
+            for candidate in candidates {
+                let Some(mut detail) = details_by_uid.remove(candidate.event_uid.as_str()) else {
+                    return Err(RepoError::backend(format!(
+                        "MCP search projection moved while hydrating event {}; retry the request",
+                        candidate.event_uid
+                    )));
+                };
+                detail.raw_score = candidate.raw_score;
+                detail.matched_terms = candidate.matched_terms;
+                // Ranking is defined by the candidate snapshot. Preserve its
+                // timestamp if the projection publishes between the two reads.
+                detail.event_unix_ms = candidate.event_unix_ms;
+                rows.push(detail);
+            }
+            Self::sort_search_mcp_event_rows(&mut rows);
+            rows = Self::dedupe_mcp_search_rows(rows, limit);
+
+            if rows.len() >= target_rows || candidate_count < usize::from(page_limit) {
+                break;
+            }
+            offset = offset.saturating_add(candidate_count as u64);
+        }
+
+        let (docs, total_doc_len, scope_exists, _) = snapshot
             .ok_or_else(|| RepoError::backend("MCP search candidate query omitted metadata"))?;
-        if metadata.projection_ready == 0 {
-            return Err(RepoError::backend(
-                "MCP search read model is not ready; run `moraine db migrate`",
-            ));
-        }
-        if metadata.projection_clean == 0 {
-            return Err(RepoError::backend(
-                "MCP search read model is catching up with ingest; retry the request",
-            ));
-        }
-
-        let docs = metadata.docs;
-        let total_doc_len = metadata.total_doc_len;
-        let scope_exists = metadata.scope_exists != 0;
-        self.cache_corpus_stats(docs, total_doc_len, Instant::now())
-            .await;
-
-        let candidates = candidate_rows
-            .into_iter()
-            .filter(|row| row.row_kind == 0)
-            .collect::<Vec<_>>();
-        if candidates.is_empty() {
-            return Ok((Vec::new(), docs, total_doc_len, scope_exists));
-        }
-
-        let detail_sql = self.build_search_mcp_event_details_sql(&candidates)?;
-        let detail_rows: Vec<SearchMcpEventRow> =
-            self.map_backend(self.query_rows(&detail_sql, None).await)?;
-        let mut details_by_uid = detail_rows
-            .into_iter()
-            .map(|row| (row.event_uid.clone(), row))
-            .collect::<HashMap<_, _>>();
-
-        let mut rows = Vec::with_capacity(candidates.len());
-        for candidate in candidates {
-            let Some(mut detail) = details_by_uid.remove(candidate.event_uid.as_str()) else {
-                return Err(RepoError::backend(format!(
-                    "MCP search projection moved while hydrating event {}; retry the request",
-                    candidate.event_uid
-                )));
-            };
-            detail.raw_score = candidate.raw_score;
-            detail.matched_terms = candidate.matched_terms;
-            // Ranking is defined by the candidate snapshot. Preserve its
-            // timestamp if the projection publishes between the two reads.
-            detail.event_unix_ms = candidate.event_unix_ms;
-            rows.push(detail);
-        }
-        Self::sort_search_mcp_event_rows(&mut rows);
         Ok((rows, docs, total_doc_len, scope_exists))
     }
 
@@ -1490,6 +1539,56 @@ FORMAT JSONEachRow",
                 .then_with(|| b.event_unix_ms.cmp(&a.event_unix_ms))
                 .then_with(|| a.event_uid.cmp(&b.event_uid))
         });
+    }
+
+    pub(super) fn mcp_search_rows_are_equivalent(
+        a: &SearchMcpEventRow,
+        b: &SearchMcpEventRow,
+    ) -> bool {
+        let a_event_type = if a.mcp_event_type.is_empty() {
+            Self::mcp_event_type_for(&a.event_class, &a.payload_type, &a.actor_role)
+        } else {
+            McpEventType::from_normalized(&a.mcp_event_type)
+        };
+        let b_event_type = if b.mcp_event_type.is_empty() {
+            Self::mcp_event_type_for(&b.event_class, &b.payload_type, &b.actor_role)
+        } else {
+            McpEventType::from_normalized(&b.mcp_event_type)
+        };
+
+        a.session_id == b.session_id
+            && a.turn_seq == b.turn_seq
+            && a.event_unix_ms == b.event_unix_ms
+            && a_event_type == b_event_type
+            && if a.text_content_digest.is_empty() && b.text_content_digest.is_empty() {
+                a.text_content == b.text_content
+            } else {
+                a.text_content_digest == b.text_content_digest
+            }
+    }
+
+    pub(super) fn dedupe_mcp_search_rows(
+        rows: Vec<SearchMcpEventRow>,
+        limit: u16,
+    ) -> Vec<SearchMcpEventRow> {
+        let target = limit as usize;
+        let mut deduped = Vec::<SearchMcpEventRow>::with_capacity(rows.len().min(target));
+
+        for row in rows {
+            if deduped
+                .iter()
+                .any(|existing| Self::mcp_search_rows_are_equivalent(existing, &row))
+            {
+                continue;
+            }
+
+            deduped.push(row);
+            if deduped.len() >= target {
+                break;
+            }
+        }
+
+        deduped
     }
 
     pub(super) fn dedupe_fetch_limit(limit: u16) -> u16 {
@@ -2888,7 +2987,7 @@ FORMAT JSONEachRow",
         let requested_n_hits = query.n_hits.unwrap_or(10).max(1);
         let effective_n_hits = requested_n_hits.min(self.cfg.max_results);
         let limit_capped = requested_n_hits > effective_n_hits;
-        let fetch_limit = effective_n_hits.saturating_add(1);
+        let unique_fetch_limit = effective_n_hits.saturating_add(1);
 
         let min_should_match = query
             .min_should_match
@@ -2930,7 +3029,7 @@ FORMAT JSONEachRow",
                     query.source_name.as_deref(),
                     min_should_match,
                     min_score,
-                    fetch_limit,
+                    unique_fetch_limit,
                 )
                 .await?;
             let avgdl = if docs == 0 {

--- a/crates/moraine-conversations/src/clickhouse_repo/tests.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/tests.rs
@@ -74,6 +74,7 @@ fn sample_mcp_search_row(event_uid: &str, raw_score: f64, event_unix_ms: i64) ->
         doc_len: 42,
         text_preview: "preview".to_string(),
         text_content: "preview".to_string(),
+        text_content_digest: "digest-preview".to_string(),
         payload_json: "{}".to_string(),
         mcp_event_type: "assistant_response".to_string(),
         raw_score,
@@ -525,6 +526,72 @@ fn dedupe_search_rows_reasoning_mirrors_do_not_collapse_with_messages() {
     ];
 
     let deduped = ClickHouseConversationRepository::dedupe_search_rows(rows, 5);
+    assert_eq!(deduped.len(), 2);
+}
+
+#[test]
+fn dedupe_mcp_search_rows_collapses_equivalent_events_and_fills_limit() {
+    let mut duplicate = sample_mcp_search_row("uid-duplicate", 18.0, 1_777_000_000_000);
+    duplicate.turn_seq = 2;
+    duplicate.text_content = "byte-identical response".to_string();
+    let mut canonical = duplicate.clone();
+    canonical.event_uid = "uid-canonical".to_string();
+    let mut second = sample_mcp_search_row("uid-second", 17.0, 1_777_000_001_000);
+    second.turn_seq = 2;
+    second.text_content = "distinct response".to_string();
+    let mut third = sample_mcp_search_row("uid-third", 16.0, 1_777_000_002_000);
+    third.turn_seq = 3;
+    third.text_content = "another distinct response".to_string();
+
+    let deduped = ClickHouseConversationRepository::dedupe_mcp_search_rows(
+        vec![duplicate, canonical, second, third],
+        3,
+    );
+
+    assert_eq!(deduped.len(), 3);
+    assert_eq!(deduped[0].event_uid, "uid-duplicate");
+    assert_eq!(deduped[1].event_uid, "uid-second");
+    assert_eq!(deduped[2].event_uid, "uid-third");
+}
+
+#[test]
+fn dedupe_mcp_search_rows_preserves_distinct_same_turn_events() {
+    let mut base = sample_mcp_search_row("uid-base", 18.0, 1_777_000_000_000);
+    base.turn_seq = 2;
+    base.text_content = "same response".to_string();
+
+    let mut different_timestamp = base.clone();
+    different_timestamp.event_uid = "uid-timestamp".to_string();
+    different_timestamp.event_unix_ms += 1;
+    let mut different_type = base.clone();
+    different_type.event_uid = "uid-type".to_string();
+    different_type.mcp_event_type = "reasoning".to_string();
+    let mut different_content = base.clone();
+    different_content.event_uid = "uid-content".to_string();
+    different_content.text_content = "same response with more".to_string();
+    different_content.text_content_digest = "digest-same-response-with-more".to_string();
+
+    let deduped = ClickHouseConversationRepository::dedupe_mcp_search_rows(
+        vec![base, different_timestamp, different_type, different_content],
+        4,
+    );
+
+    assert_eq!(deduped.len(), 4);
+}
+
+#[test]
+fn dedupe_mcp_search_rows_uses_full_content_digest_beyond_preview() {
+    let shared_prefix = "x".repeat(1_000);
+    let mut first = sample_mcp_search_row("uid-first", 18.0, 1_777_000_000_000);
+    first.turn_seq = 2;
+    first.text_content = shared_prefix.clone();
+    first.text_content_digest = "digest-full-content-a".to_string();
+    let mut second = first.clone();
+    second.event_uid = "uid-second".to_string();
+    second.text_content_digest = "digest-full-content-b".to_string();
+
+    let deduped = ClickHouseConversationRepository::dedupe_mcp_search_rows(vec![first, second], 2);
+
     assert_eq!(deduped.len(), 2);
 }
 

--- a/crates/moraine-conversations/tests/repository_integration/search.rs
+++ b/crates/moraine-conversations/tests/repository_integration/search.rs
@@ -860,7 +860,7 @@ async fn search_mcp_events_event_type_filter_distinguishes_user_and_assistant_me
     }));
 }
 #[tokio::test(flavor = "multi_thread")]
-async fn search_mcp_events_fetches_limit_plus_one_for_truncation() {
+async fn search_mcp_events_deduplicates_before_limit_and_reports_truncation() {
     let (repo, state) = build_repo().await;
 
     let result = repo
@@ -880,17 +880,92 @@ async fn search_mcp_events_fetches_limit_plus_one_for_truncation() {
         .expect("truncated mcp event search");
 
     assert_eq!(result.hits.len(), 2);
+    assert_eq!(result.hits[0].event_uid, "evt-c-42");
+    assert_eq!(result.hits[1].event_uid, "evt-a-11");
     assert!(result.truncated);
     assert!(result.stats.truncated);
     assert_eq!(result.stats.effective_n_hits, 2);
 
     let queries = state.queries.lock().expect("queries lock").clone();
-    let search_query = queries
+    let first_candidate_query = queries
         .iter()
-        .find(|q| q.contains("toUInt8(0) AS row_kind") && q.contains("LIMIT 3"))
-        .expect("search query should fetch limit plus one");
-    assert!(search_query.contains("LIMIT 3"));
+        .find(|query| {
+            query.contains("toUInt8(0) AS row_kind") && query.contains("LIMIT 3 OFFSET 0")
+        })
+        .expect("first bounded candidate page");
+    assert!(!first_candidate_query.contains("text_content"));
+    assert!(!first_candidate_query.contains("SHA256"));
+    assert!(queries.iter().any(|query| {
+        query.contains("toUInt8(0) AS row_kind") && query.contains("LIMIT 3 OFFSET 3")
+    }));
+    assert!(queries.iter().any(|query| {
+        query.contains("hex(SHA256(projected_events.text_content)) AS text_content_digest")
+    }));
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_mcp_events_rejects_projection_changes_between_candidate_pages() {
+    let (repo, state) = build_repo_with_options(
+        100,
+        MockOptions {
+            change_projection_revision_on_second_search_page: true,
+            ..MockOptions::default()
+        },
+    )
+    .await;
+
+    let error = repo
+        .search_mcp_events(SearchMcpEventsQuery {
+            query: "hello world".to_string(),
+            n_hits: Some(2),
+            min_score: Some(0.0),
+            min_should_match: Some(1),
+            ..SearchMcpEventsQuery::default()
+        })
+        .await
+        .expect_err("candidate paging must reject a changed projection revision");
+
+    assert!(error.to_string().contains("snapshot changed"), "{error}");
+    let queries = state.queries.lock().expect("queries lock");
+    assert!(queries
+        .iter()
+        .any(|query| query.contains("LIMIT 3 OFFSET 3")));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_mcp_events_bounds_duplicate_candidate_pages() {
+    let (repo, state) = build_repo_with_options(
+        100,
+        MockOptions {
+            repeat_duplicate_search_pages: true,
+            ..MockOptions::default()
+        },
+    )
+    .await;
+
+    let error = repo
+        .search_mcp_events(SearchMcpEventsQuery {
+            query: "hello world".to_string(),
+            n_hits: Some(2),
+            min_score: Some(0.0),
+            min_should_match: Some(1),
+            ..SearchMcpEventsQuery::default()
+        })
+        .await
+        .expect_err("duplicate paging must stop at the request work budget");
+
+    assert!(
+        error.to_string().contains("scan budget exhausted"),
+        "{error}"
+    );
+    let queries = state.queries.lock().expect("queries lock");
+    let candidate_queries = queries
+        .iter()
+        .filter(|query| query.contains("toUInt8(0) AS row_kind"))
+        .count();
+    assert_eq!(candidate_queries, 16);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn search_mcp_events_reports_event_ordinal_within_turn() {
     let (repo, _state) = build_repo().await;

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -85,6 +85,8 @@ impl ScriptedResponse {
 #[derive(Clone, Default)]
 pub(crate) struct MockOptions {
     pub(crate) omit_second_snippet_row: bool,
+    pub(crate) change_projection_revision_on_second_search_page: bool,
+    pub(crate) repeat_duplicate_search_pages: bool,
     pub(crate) scripted_responses: Vec<ScriptedResponse>,
     pub(crate) query_barrier: Option<QueryBarrier>,
 }
@@ -795,6 +797,15 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
         }
 
         if query.contains("toUInt8(0) AS row_kind") && query.contains("projected_candidates AS") {
+            let projection_revision = if state
+                .options
+                .change_projection_revision_on_second_search_page
+                && query.contains("OFFSET 3")
+            {
+                2_u64
+            } else {
+                1_u64
+            };
             let candidate = |event_uid: &str,
                              raw_score: f64,
                              matched_terms: u64,
@@ -812,7 +823,8 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                     "total_doc_len": 5000_u64,
                     "scope_exists": 1_u8,
                     "projection_ready": 1_u8,
-                    "projection_clean": 1_u8
+                    "projection_clean": 1_u8,
+                    "projection_revision": projection_revision
                 })
             };
             let metadata = json!({
@@ -828,7 +840,8 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                 "total_doc_len": 5000_u64,
                 "scope_exists": 1_u8,
                 "projection_ready": 1_u8,
-                "projection_clean": 1_u8
+                "projection_clean": 1_u8,
+                "projection_revision": projection_revision
             });
             let filter_clause = query
                 .split_once("WHERE ")
@@ -847,11 +860,15 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                 && !filter_clause.contains("lowerUTF8(p.actor_role) = 'user'")
             {
                 vec![candidate("evt-c-42", 12.5, 2, 1_767_434_520_000)]
+            } else if query.contains("LIMIT 3 OFFSET 3")
+                && !state.options.repeat_duplicate_search_pages
+            {
+                vec![candidate("evt-b-9", 6.0, 1, 1_767_348_120_000)]
             } else if query.contains("LIMIT 3") {
                 vec![
                     candidate("evt-c-42", 12.5, 2, 1_767_434_520_000),
+                    candidate("evt-c-duplicate", 12.0, 2, 1_767_434_520_000),
                     candidate("evt-a-11", 7.0, 1, 1_767_261_720_000),
-                    candidate("evt-b-9", 6.0, 1, 1_767_348_120_000),
                 ]
             } else {
                 vec![
@@ -946,6 +963,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                     "doc_len": 19_u32,
                     "text_preview": text,
                     "text_content": text,
+                    "text_content_digest": text,
                     "payload_json": "{}",
                     "mcp_event_type": event_type,
                     "raw_score": 0.0,
@@ -973,6 +991,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                 "evt-c-tool",
                 "evt-c-user",
                 "evt-c-42",
+                "evt-c-duplicate",
                 "evt-a-11",
                 "evt-b-9",
             ]


### PR DESCRIPTION
## Description

**What.** Deduplicates equivalent MCP search events while preserving mainline bounded candidate retrieval.

**Why.** Byte-identical event copies could consume multiple ranked slots, underfill the requested result set, and make truncation reflect raw rows instead of distinct hits.

The candidate query remains narrow and pages deterministic ranked event IDs with `LIMIT`/`OFFSET`. Each bounded page is hydrated from the MCP projection, assigned a SHA-256 digest of its full text, and deduplicated by session, turn, normalized event type, timestamp, and digest. Paging continues only when duplicates leave the unique target underfilled.

Cross-page reads carry the latest ingest dirty revision and fail closed if the projection changes. A 16-page work budget also fails closed rather than allowing duplicate-heavy searches to amplify database work indefinitely. Normal searches still use one candidate query and one bounded detail query.

## Bug Evidence

Before this change, two events with different IDs but identical content and event coordinates could occupy two slots in `search_sessions`, because the result limit was applied before equivalence was known. A fixed overfetch would still underfill on longer duplicate runs and could overstate truncation.

The regression fixture now returns a duplicate-heavy first candidate page and a distinct second page. The test verifies that the duplicate collapses, the later distinct event refills the result set, and the extra unique sentinel reports truncation correctly. Additional tests preserve events that differ by timestamp, type, or full content; reject projection movement between pages; retain the two-read normal path; and enforce the duplicate-page work budget.

## Usage

No user action or configuration change is required. Existing MCP search callers receive distinct hits within the requested limit. A search that encounters concurrent projection movement is retried by the caller, while a pathological duplicate scan returns a narrow-query error instead of partial results.

## Changelog

- Prevent equivalent MCP search events from consuming multiple result slots.
- Refill bounded candidate pages until the requested unique result target is reached or candidates are exhausted.
- Fail closed on projection movement and bound duplicate-heavy paging work.

## Operational Impact

No schema migration, configuration, CLI, or public API change. The common search path remains one narrow candidate query plus one bounded detail query; extra pages occur only when equivalent events collapse result slots.

## Validation

- `cargo fmt --all -- --check` passed.
- The repository pre-commit hook passed formatting and the pinned strict clippy baseline.
- `cargo test -p moraine-conversations -p moraine-mcp-core --locked` passed in sandbox `sb-649707`: 64 conversations unit tests (1 ignored), 6 live-support tests (3 ignored), 89 repository integration tests, and 120 MCP-core tests.
- All 14 `search_mcp_events_` integration tests passed, including duplicate refill, projection-revision rejection, bounded paging, and the one-candidate/one-detail normal path.
- After rebuilding final-base workspace binaries, `MORAINECTL_BIN=/home/moraine/target/debug/moraine MORAINE_SERVICE_BIN_DIR=/home/moraine/target/debug bash scripts/ci/e2e-stack.sh` passed against ClickHouse 25.12.5.44, including MCP search/open/list, bounded query ownership, named routing, and daemon/embedded fallback parity.
- The sandbox monitor health endpoint returned `ok: true`; `sb-649707` was then removed successfully.

Closes #539