### PR TITLE
fix(mcp): normalize open source metadata

### DIFF
--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -811,6 +811,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             name: "027_mcp_open_read_model.sql",
             sql: include_str!("../../../sql/027_mcp_open_read_model.sql"),
         },
+        Migration {
+            version: "028",
+            name: "028_refresh_mcp_open_source_metadata.sql",
+            sql: include_str!("../../../sql/028_refresh_mcp_open_source_metadata.sql"),
+        },
     ]
 }
 

--- a/crates/moraine-clickhouse/src/mcp_open_projection.rs
+++ b/crates/moraine-clickhouse/src/mcp_open_projection.rs
@@ -455,8 +455,7 @@ impl ClickHouseClient {
                  argMax(actor_role, tuple(event_time, event_order, event_uid)) AS last_actor_role,\n\
                  ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'title'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'),\n\
                    ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'name'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'), '')) AS title,\n\
-                 ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'source'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'),\n\
-                   ifNull(argMax(nullIf(source_name, ''), tuple(event_ts, event_uid)), '')) AS source,\n\
+                 ifNull(argMax(nullIf(source_name, ''), tuple(event_ts, event_uid)), '') AS source,\n\
                  ifNull(argMax(nullIf(harness, ''), tuple(event_ts, event_uid)), '') AS harness,\n\
                  ifNull(argMax(nullIf(inference_provider, ''), tuple(event_ts, event_uid)), '') AS inference_provider,\n\
                  ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'slug'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'), '') AS session_slug,\n\

--- a/crates/moraine-conversations/src/clickhouse_repo/open.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/open.rs
@@ -324,6 +324,7 @@ FORMAT JSONEachRow",
             return Ok(Some(McpTurnOpen {
                 metadata: turn.compact.metadata,
                 events: turn.events,
+                parent_session_source: non_empty_string(session.row.source),
                 user_input_summary: turn.compact.user_input_summary,
                 final_response_summary: turn.compact.final_response_summary,
                 user_input_event: turn.compact.user_input_event,

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -428,6 +428,8 @@ pub struct McpSessionListItem {
 pub struct McpTurnOpen {
     pub metadata: TurnSummary,
     pub events: Vec<McpEventSummary>,
+    #[serde(default)]
+    pub parent_session_source: Option<String>,
     pub user_input_summary: Option<String>,
     pub final_response_summary: Option<String>,
     #[serde(default)]

--- a/crates/moraine-conversations/tests/repository_integration/sessions.rs
+++ b/crates/moraine-conversations/tests/repository_integration/sessions.rs
@@ -782,6 +782,7 @@ async fn get_mcp_turn_returns_compact_events_and_incomplete_state() {
 
     assert_eq!(turn.metadata.session_id, "sess-incomplete");
     assert_eq!(turn.metadata.turn_seq, 2);
+    assert_eq!(turn.parent_session_source.as_deref(), Some("fixture"));
     assert_eq!(turn.events.len(), 3);
     assert_eq!(turn.events[0].event_uid, "evt-inc-2");
     assert_eq!(turn.events[0].event_type, "user_input");

--- a/crates/moraine-mcp-core/src/open_v1.rs
+++ b/crates/moraine-mcp-core/src/open_v1.rs
@@ -671,7 +671,7 @@ fn open_turn_data(
         "session": {
             "id": session_id,
             "title": null,
-            "source": null
+            "source": turn.parent_session_source
         },
         "summary": {
             "user_input": user_input,
@@ -1126,6 +1126,7 @@ mod tests {
                 event_summary("event-tool", "tool_call", "", "exec_command", "call-1"),
                 event_summary("event-final", "assistant_response", "assistant", "", ""),
             ],
+            parent_session_source: Some("codex".to_string()),
             user_input_summary: Some("Please check the failing monitor startup.".to_string()),
             final_response_summary: Some("Fixed the startup guard.".to_string()),
             user_input_event: Some(event_ref("event-user", 1)),
@@ -1158,6 +1159,7 @@ mod tests {
         };
         let (data, warnings) = open_turn_data(&turn, Some(&page)).expect("turn data");
         assert_eq!(data["kind"], "turn");
+        assert_eq!(data["session"]["source"], "codex");
         assert_eq!(data["events"][1]["tool_name"], "exec_command");
         assert_eq!(data["events"][2]["terminal"], true);
         assert!(data["events"][0].get("payload").is_none());
@@ -1590,6 +1592,7 @@ mod tests {
                 ..turn_summary()
             },
             events,
+            parent_session_source: Some("codex".to_string()),
             user_input_summary: Some("Please inspect this large turn.".to_string()),
             final_response_summary: Some("The large-turn work is complete.".to_string()),
             user_input_event: Some(event_ref("event-000", 1)),

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -655,7 +655,7 @@ main() {
   mkdir -p "$runtime_root"
 
   cat > "$codex_fixture_file" <<EOF
-{"timestamp":"2026-02-16T12:00:00.000Z","type":"session_meta","payload":{"id":"${codex_session_id}","cwd":"${codex_project_dir}"}}
+{"timestamp":"2026-02-16T12:00:00.000Z","type":"session_meta","payload":{"id":"${codex_session_id}","cwd":"${codex_project_dir}","source":"vscode"}}
 {"timestamp":"2026-02-16T12:00:01.000Z","type":"turn_context","payload":{"turn_id":"1","model":"gpt-5.3-codex"}}
 {"timestamp":"2026-02-16T12:00:02.000Z","type":"response_item","payload":{"type":"message","role":"user","id":"msg-user-${run_stamp}","content":[{"type":"text","text":"local e2e codex user prompt ${codex_keyword}"}],"phase":"completed"}}
 {"timestamp":"2026-02-16T12:00:03.000Z","type":"response_item","parent_id":"msg-user-${run_stamp}","payload":{"type":"message","role":"assistant","id":"msg-assistant-${run_stamp}","content":[{"type":"text","text":"local e2e codex assistant reply ${codex_keyword} ${codex_trace_marker}"}],"phase":"completed"}}

--- a/scripts/ci/mcp_smoke.py
+++ b/scripts/ci/mcp_smoke.py
@@ -413,12 +413,17 @@ def open_payload_session_id(payload: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def open_payload_source(payload: Dict[str, Any]) -> Optional[str]:
+    return nested_string(payload, "data", "session", "source")
+
+
 def assert_open_search_ids(
     proc: subprocess.Popen[str],
     next_id: int,
     open_ids: list[str],
     expect_session_id: Optional[str],
     expect_open_text: Optional[str],
+    expect_source: Optional[str] = None,
 ) -> int:
     expected_session = expected_mcp_session_id(expect_session_id)
     opened_payloads: list[Dict[str, Any]] = []
@@ -437,6 +442,12 @@ def assert_open_search_ids(
             raise AssertionError(
                 "open session mismatch: "
                 f"got={open_session_id} want={expected_session}"
+            )
+        open_source = open_payload_source(open_payload)
+        if expect_source is not None and open_source != expect_source:
+            raise AssertionError(
+                "open source mismatch: "
+                f"id={open_id} got={open_source!r} want={expect_source!r}"
             )
         opened_payloads.append(open_payload)
 
@@ -642,6 +653,7 @@ def run_smoke(
 
         assert_sessions_absent(results, absent_session_ids, "search_sessions")
 
+        selected_result: Optional[Dict[str, Any]] = None
         if expect_no_results:
             if results:
                 raise AssertionError(
@@ -714,12 +726,23 @@ def run_smoke(
                     f"got {session_metadata.get('updated_at')!r}, "
                     f"wanted {expect_updated_at!r}"
                 )
+            listed_source = nested_string(selected_session, "session", "source")
+            if listed_source is None:
+                raise AssertionError(
+                    f"list_sessions result missing configured ingest source: {selected_session}"
+                )
+            listed_open_id = open_id_from_list_sessions_result(selected_session)
+            open_ids = [listed_open_id]
+            if selected_result is not None:
+                open_ids.extend(open_ids_from_search_result(selected_result))
+                open_ids = list(dict.fromkeys(open_ids))
             next_id = assert_open_search_ids(
                 proc,
                 next_id,
-                [open_id_from_list_sessions_result(selected_session)],
+                open_ids,
                 expect_session_id,
                 expect_open_text,
+                listed_source,
             )
         elif not sessions and not expect_no_results:
             raise AssertionError("list_sessions returned no sessions for e2e fixture window")

--- a/sql/028_refresh_mcp_open_source_metadata.sql
+++ b/sql/028_refresh_mcp_open_source_metadata.sql
@@ -1,0 +1,6 @@
+-- Rebuild existing MCP open session heads so `source` is the configured
+-- ingest source name rather than a payload-local value from session metadata.
+INSERT INTO moraine.mcp_open_dirty_sessions (session_id, dirty_revision, observed_at)
+SELECT session_id, generateSnowflakeID(), now64(3)
+FROM moraine.mcp_open_sessions FINAL
+WHERE session_id != '';


### PR DESCRIPTION
## Description

**What.** Normalizes MCP `open` source metadata to the configured ingest source used by `list_sessions`.

**Why.** Codex session payloads can contain an unrelated field also named `source`; treating that payload-local value as the MCP `source` made one session report different values across retrieval tools and entity kinds.

The MCP open projection now derives session `source` from the normalized `source_name` column instead of `payload_json.source`. Turn opens carry the parent session source through the repository/domain boundary, so session, turn, and event responses expose the same semantics. Migration `028` marks existing projected session heads dirty so the normal post-migration backfill rebuilds stale source values.

## Bug Evidence

The issue reproduction returned `codex` from `list_sessions`, `vscode` from session and event opens, and `null` from turn opens for the same session. The root cause was twofold: the MCP open projection preferred the payload-local `source` field, while the turn-open model omitted its parent session source.

The stack fixture deliberately reproduces the conflicting upstream `"source":"vscode"` payload value while configuring the ingest source as `ci-codex`. The MCP smoke opens the list handle plus search-derived session, turn, and event handles and requires every open response source to equal the `list_sessions` source.

## Usage

No configuration or user action is required. After migration, `list_sessions` and all `open` entity responses use the configured ingest source name.

## Operational Impact

Migration `028` queues every existing non-empty MCP open session head for reprojection. The standard migration flow performs the required one-time backfill; work is proportional to the number of projected sessions.

## Changelog

- Fixes inconsistent MCP session `source` values across `list_sessions` and session, turn, and event `open` responses.

## Validation

Ran `cargo test -p moraine-clickhouse -p moraine-conversations -p moraine-mcp-core --locked` successfully: 309 tests passed and 4 live-ClickHouse tests were ignored by their normal opt-in gates. Focused turn-source, repository turn-source, and migration-registry tests passed. `cargo clippy -p moraine-clickhouse -p moraine-conversations -p moraine-mcp-core --all-targets --locked -- -D warnings`, `cargo fmt --all -- --check`, `python3 -m py_compile scripts/ci/mcp_smoke.py`, and `bash -n scripts/ci/e2e-stack.sh` all passed.

Ran `bash scripts/ci/e2e-stack.sh` inside an isolated Moraine sandbox. It applied migrations through `028`, indexed the adversarial Codex fixture, passed the fresh-process, shared-daemon, named-backend, project-scope, and embedded-fallback MCP smoke paths, and completed stack teardown successfully.

Closes #548.
