### PR TITLE
fix(mcp): label untitled session listings

### DIFF
--- a/crates/moraine-conversations/tests/repository_integration/sessions.rs
+++ b/crates/moraine-conversations/tests/repository_integration/sessions.rs
@@ -191,6 +191,10 @@ async fn list_mcp_sessions_uses_overlap_filter_and_cursor_pagination() {
     assert_eq!(first.items[0].title.as_deref(), Some("Session C title"));
     assert_eq!(first.items[0].source.as_deref(), Some("codex"));
     assert_eq!(first.items[0].harness.as_deref(), Some("codex"));
+    let public_items = serde_json::to_string(&first.items).expect("serialize public list items");
+    assert!(!public_items.contains("\"originator\":"));
+    assert!(!public_items.contains("\"project\":"));
+    assert!(!public_items.contains("acme-secret-merger"));
     assert!(first.items[0].completed);
     assert_eq!(first.items[1].session_id, "sess_b");
     assert!(first.next_cursor.is_some());

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -426,6 +426,9 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                         "title": "Session C title",
                         "source": "codex",
                         "harness": "codex",
+                        "originator": "Codex Desktop",
+                        "origin_cwd": "/work/acme-secret-merger",
+                        "project": "acme-secret-merger",
                         "session_slug": "project-c",
                         "session_summary": "Session C summary"
                     },

--- a/crates/moraine-mcp-core/src/list_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/list_sessions_v1.rs
@@ -8,6 +8,7 @@ use crate::contract::{
     ToolErrorEnvelope, LIST_SESSIONS_DEADLINE_MS, LIST_SESSIONS_TOOL,
 };
 use anyhow::{Context, Result};
+use chrono::{Datelike, TimeZone, Timelike, Utc};
 use moraine_conversations::{
     ConversationListSort as RepoListSort, ConversationMode as RepoConversationMode,
     McpSessionListFilter, McpSessionListItem, Page, PageRequest,
@@ -169,6 +170,7 @@ fn list_sessions_data_json(
 
 fn session_json(rank: usize, session: &McpSessionListItem) -> Result<Value, ContractError> {
     let session_id = mcp_session_id(&session.session_id)?;
+    let display_label = session_display_label(session);
 
     Ok(json!({
         "rank": rank,
@@ -176,6 +178,7 @@ fn session_json(rank: usize, session: &McpSessionListItem) -> Result<Value, Cont
         "session": {
             "id": session_id,
             "title": session.title.as_deref(),
+            "display_label": display_label,
             "harness": session.harness.as_deref(),
             "source": session.source.as_deref(),
             "started_at": format_rfc3339_utc_millis(session.first_event_unix_ms),
@@ -191,6 +194,79 @@ fn session_json(rank: usize, session: &McpSessionListItem) -> Result<Value, Cont
             "session_id": session_id,
         }
     }))
+}
+
+fn session_display_label(session: &McpSessionListItem) -> String {
+    if let Some(label) = session
+        .title
+        .as_deref()
+        .filter(|label| !label.trim().is_empty())
+        .or(session.session_summary.as_deref())
+        .filter(|label| !label.trim().is_empty())
+        .or(session.session_slug.as_deref())
+        .filter(|label| !label.trim().is_empty())
+    {
+        return label.to_string();
+    }
+
+    let harness = readable_harness(session.harness.as_deref().unwrap_or("session"));
+    let mode = readable_mode(session.mode.as_str());
+    let updated_at = compact_utc_datetime(session.last_event_unix_ms);
+    let turns = pluralize(session.total_turns as u64, "turn", "turns");
+
+    format!("{harness}, {mode}, {updated_at}, {turns}")
+}
+
+fn readable_harness(harness: &str) -> &str {
+    match harness {
+        "codex" => "Codex",
+        "claude-code" => "Claude Code",
+        "cursor" => "Cursor",
+        "hermes" => "Hermes",
+        "kimi-cli" => "Kimi CLI",
+        "opencode" => "OpenCode",
+        "pi-coding-agent" => "Pi Coding Agent",
+        _ => harness,
+    }
+}
+
+fn readable_mode(mode: &str) -> &'static str {
+    match mode {
+        "web_search" => "web search",
+        "tool_calling" => "tool session",
+        "mcp_internal" => "MCP session",
+        "chat" => "chat",
+        _ => "session",
+    }
+}
+
+fn compact_utc_datetime(unix_ms: i64) -> String {
+    const MONTHS: [&str; 12] = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+
+    let Some(datetime) = Utc.timestamp_millis_opt(unix_ms).single() else {
+        return format_rfc3339_utc_millis(unix_ms);
+    };
+    let month_name = MONTHS
+        .get(datetime.month0() as usize)
+        .copied()
+        .unwrap_or("Jan");
+
+    format!(
+        "{month_name} {} {:02}:{:02} UTC",
+        datetime.day(),
+        datetime.hour(),
+        datetime.minute()
+    )
+}
+
+fn pluralize(count: u64, singular: &str, plural: &str) -> String {
+    if count == 1 {
+        format!("1 {singular}")
+    } else {
+        format!("{count} {plural}")
+    }
 }
 
 fn mcp_session_id(session_id: &str) -> Result<String, ContractError> {
@@ -246,17 +322,23 @@ fn format_list_sessions_text(payload: &Value) -> String {
             let title = session
                 .pointer("/session/title")
                 .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
                 .or_else(|| {
                     session
                         .pointer("/session/session_summary")
                         .and_then(Value::as_str)
+                        .filter(|value| !value.trim().is_empty())
                 })
                 .or_else(|| {
                     session
                         .pointer("/session/session_slug")
                         .and_then(Value::as_str)
-                })
-                .unwrap_or("untitled session");
+                        .filter(|value| !value.trim().is_empty())
+                });
+            let display_label = session
+                .pointer("/session/display_label")
+                .and_then(Value::as_str)
+                .unwrap_or("session");
             let updated_at = session
                 .pointer("/session/updated_at")
                 .and_then(Value::as_str)
@@ -265,9 +347,13 @@ fn format_list_sessions_text(payload: &Value) -> String {
                 .pointer("/session/mode")
                 .and_then(Value::as_str)
                 .unwrap_or("chat");
-            lines.push(format!(
-                "{rank}. {updated_at} {mode} {title} ({session_id})"
-            ));
+            if let Some(title) = title {
+                lines.push(format!(
+                    "{rank}. {updated_at} {mode} {title} ({session_id})"
+                ));
+            } else {
+                lines.push(format!("{rank}. {display_label} ({session_id})"));
+            }
         }
     }
 
@@ -298,6 +384,7 @@ mod tests {
     use moraine_conversations::{
         ConversationMode, InMemoryConversationRepository, InMemoryConversationResponses, RepoConfig,
     };
+    use std::collections::BTreeSet;
     use std::sync::Arc;
 
     #[test]
@@ -459,6 +546,12 @@ mod tests {
         let first = &data["sessions"][0];
         assert_eq!(first["id"], json!("session:c2Vzcy1vcGVu"));
         assert_eq!(first["session"]["harness"], json!("codex"));
+        assert!(first["session"].get("originator").is_none());
+        assert!(first["session"].get("project").is_none());
+        assert_eq!(
+            first["session"]["display_label"],
+            json!("Build failure triage")
+        );
         assert_eq!(first["open"]["session_id"], first["session"]["id"]);
         assert_eq!(first["session"]["turn_count"], json!(3));
         assert_eq!(first["session"]["event_count"], json!(17));
@@ -485,6 +578,130 @@ mod tests {
         assert_eq!(filter.source_name.as_deref(), Some("codex"));
         assert_eq!(page.limit, 1);
         assert_eq!(page.cursor, None);
+    }
+
+    #[test]
+    fn untitled_session_gets_privacy_safe_display_label() {
+        let args = parse_list_sessions_args(
+            json!({
+                "start_datetime": "2026-04-30T09:00:00-04:00",
+                "end_datetime": "2026-04-30T13:00:00-04:00",
+                "limit": 50
+            }),
+            50,
+        )
+        .expect("valid args");
+        let page = Page {
+            items: vec![McpSessionListItem {
+                session_id: "sess-open".to_string(),
+                first_event_time: "2026-04-30 09:00:00".to_string(),
+                first_event_unix_ms: 1_777_554_000_000,
+                last_event_time: "2026-04-30 09:10:00".to_string(),
+                last_event_unix_ms: 1_777_554_600_000,
+                total_turns: 29,
+                total_events: 768,
+                mode: ConversationMode::WebSearch,
+                completed: false,
+                title: None,
+                source: Some("codex".to_string()),
+                harness: Some("codex".to_string()),
+                session_slug: None,
+                session_summary: None,
+            }],
+            next_cursor: None,
+        };
+
+        let data = list_sessions_data_json(&args, &page).expect("page should encode");
+        let session = &data["sessions"][0]["session"];
+        assert_eq!(
+            session["display_label"],
+            json!("Codex, web search, Apr 30 13:10 UTC, 29 turns")
+        );
+        assert!(session.get("originator").is_none());
+        assert!(session.get("project").is_none());
+
+        let payload = json!({
+            "request": canonical_request_json(&args),
+            "data": data,
+        });
+        let text = format_list_sessions_text(&payload);
+        assert!(text.contains("Codex, web search, Apr 30 13:10 UTC, 29 turns"));
+        assert!(!text.contains("untitled session"));
+    }
+
+    #[test]
+    fn blank_title_and_summary_fall_through_to_slug() {
+        let args = parse_list_sessions_args(
+            json!({
+                "start_datetime": "2026-04-30T09:00:00-04:00",
+                "end_datetime": "2026-04-30T13:00:00-04:00",
+                "limit": 50
+            }),
+            50,
+        )
+        .expect("valid args");
+        let page = Page {
+            items: vec![McpSessionListItem {
+                session_id: "sess-open".to_string(),
+                first_event_time: "2026-04-30 09:00:00".to_string(),
+                first_event_unix_ms: 1_777_554_000_000,
+                last_event_time: "2026-04-30 09:10:00".to_string(),
+                last_event_unix_ms: 1_777_554_600_000,
+                total_turns: 29,
+                total_events: 768,
+                mode: ConversationMode::Chat,
+                completed: false,
+                title: Some("   ".to_string()),
+                source: Some("codex".to_string()),
+                harness: Some("codex".to_string()),
+                session_slug: Some("useful-slug".to_string()),
+                session_summary: Some("\t\n".to_string()),
+            }],
+            next_cursor: None,
+        };
+
+        let data = list_sessions_data_json(&args, &page).expect("page should encode");
+        assert_eq!(
+            data["sessions"][0]["session"]["display_label"],
+            json!("useful-slug")
+        );
+
+        let payload = json!({
+            "request": canonical_request_json(&args),
+            "data": data,
+        });
+        let text = format_list_sessions_text(&payload);
+        assert!(text.contains("useful-slug"));
+        assert!(!text.contains("chat     "));
+    }
+
+    #[test]
+    fn readable_harness_covers_canonical_harness_ids() {
+        let cases = [
+            ("codex", "Codex"),
+            ("claude-code", "Claude Code"),
+            ("cursor", "Cursor"),
+            ("hermes", "Hermes"),
+            ("kimi-cli", "Kimi CLI"),
+            ("opencode", "OpenCode"),
+            ("pi-coding-agent", "Pi Coding Agent"),
+            ("future-harness", "future-harness"),
+        ];
+
+        for (raw, expected) in cases {
+            assert_eq!(readable_harness(raw), expected);
+        }
+
+        let covered: BTreeSet<&str> = cases
+            .iter()
+            .map(|(raw, _)| *raw)
+            .filter(|raw| *raw != "future-harness")
+            .collect();
+        let known: BTreeSet<&str> = moraine_config::KNOWN_INGEST_HARNESSES
+            .iter()
+            .copied()
+            .collect();
+        assert_eq!(covered, known);
     }
 
     #[test]

--- a/docs/agent-mcp-search/interface.md
+++ b/docs/agent-mcp-search/interface.md
@@ -196,6 +196,7 @@ Output data includes compact session records:
   "id": "session:...",
   "session": {
     "title": "...",
+    "display_label": "...",
     "harness": "codex",
     "source": "codex",
     "started_at": "2026-05-08T13:00:00.000Z",
@@ -209,7 +210,9 @@ Output data includes compact session records:
 ```
 
 `list_sessions` intentionally does not return transcript text. Open a listed
-session if you need to inspect its turns.
+session if you need to inspect its turns. For untitled sessions,
+`display_label` falls back to already exposed metadata such as harness, mode,
+update time, and turn count.
 
 ## `file_attention`
 

--- a/docs/mcp-search-interface-spec.md
+++ b/docs/mcp-search-interface-spec.md
@@ -805,6 +805,7 @@ session metadata only:
         "session": {
           "id": "session:c2Vzcy0x",
           "title": "Build failure triage",
+          "display_label": "Build failure triage",
           "source": "codex",
           "harness": "codex",
           "started_at": "2026-04-30T13:00:00.000Z",
@@ -834,6 +835,9 @@ session metadata only:
 payloads. To inspect a listed session, pass `open.session_id` to `open`.
 The returned `session.harness` and `session.source` identify the normalized
 harness and configured ingest source that the corresponding filters match.
+When a session has no explicit title, summary, or slug, `session.display_label`
+uses already exposed metadata such as harness, mode, update time, and turn count
+rather than transcript text.
 
 ## Tool: `file_attention`
 


### PR DESCRIPTION
## Summary

Fixes #552 by giving untitled `list_sessions` rows a compact `display_label` instead of falling back to indistinguishable `untitled session` text.

## What changed

- Adds `session.display_label`, preserving explicit title/summary/slug when available.
- Treats blank title/summary/slug values as missing while preserving the original nonblank value.
- Falls back to already exposed list metadata: normalized harness, mode, update time, and turn count.
- Avoids cwd/path-derived project metadata and does not add `originator` or `project` response fields.
- Updates MCP docs for the new display label field.

## Operational impact

No migration required. `list_sessions` remains transcript-safe and path-safe: it does not return event snippets, transcript text, event payloads, cwd paths, or cwd-derived project labels.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p moraine-mcp-core list_sessions_v1 --locked` — 11 passed
- `cargo test -p moraine-conversations list_mcp_sessions --locked` — 4 integration tests passed