### PR TITLE
fix(mcp): exclude commentary from final responses

### DIFF
--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -816,6 +816,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             name: "028_refresh_mcp_open_source_metadata.sql",
             sql: include_str!("../../../sql/028_refresh_mcp_open_source_metadata.sql"),
         },
+        Migration {
+            version: "029",
+            name: "029_reset_mcp_open_projection.sql",
+            sql: include_str!("../../../sql/029_reset_mcp_open_projection.sql"),
+        },
     ]
 }
 

--- a/crates/moraine-clickhouse/src/mcp_open_projection.rs
+++ b/crates/moraine-clickhouse/src/mcp_open_projection.rs
@@ -341,6 +341,8 @@ impl ClickHouseClient {
         let message = "(event_class = 'message' OR (event_class = 'event_msg' AND payload_type IN ('user_message', 'agent_message', 'message', 'text')))";
         let user_message = format!("(lowerUTF8(actor_role) = 'user' AND {message})");
         let assistant_message = format!("(lowerUTF8(actor_role) = 'assistant' AND {message})");
+        let final_response_message =
+            format!("({assistant_message} AND lowerUTF8(phase) != 'commentary')");
         let statement = format!(
             "INSERT INTO {database}.mcp_open_turns\n\
              (session_id, slot, generation, turn_seq, turn_id, started_at, ended_at,\n\
@@ -363,17 +365,17 @@ impl ClickHouseClient {
                  countIf(event_class = 'tool_call') AS tool_calls, countIf(event_class = 'tool_result') AS tool_results,\n\
                  countIf(event_class = 'reasoning') AS reasoning_items,\n\
                  argMinIf(summary_source, tuple(event_order, event_uid), {user_message}) AS user_input_summary_source,\n\
-                 argMaxIf(summary_source, tuple(event_order, event_uid), {assistant_message}) AS final_response_summary_source,\n\
+                 argMaxIf(summary_source, tuple(event_order, event_uid), {final_response_message}) AS final_response_summary_source,\n\
                  argMinIf(toUInt8(summary_is_payload), tuple(event_order, event_uid), {user_message}) AS user_input_summary_is_payload,\n\
-                 argMaxIf(toUInt8(summary_is_payload), tuple(event_order, event_uid), {assistant_message}) AS final_response_summary_is_payload,\n\
+                 argMaxIf(toUInt8(summary_is_payload), tuple(event_order, event_uid), {final_response_message}) AS final_response_summary_is_payload,\n\
                  argMinIf(event_uid, tuple(event_order, event_uid), {user_message}) AS user_input_event_uid,\n\
                  argMinIf(event_order, tuple(event_order, event_uid), {user_message}) AS user_input_event_order,\n\
                  argMinIf(event_time, tuple(event_order, event_uid), {user_message}) AS user_input_event_time,\n\
                  argMinIf(event_type, tuple(event_order, event_uid), {user_message}) AS user_input_event_type,\n\
-                 argMaxIf(event_uid, tuple(event_order, event_uid), {assistant_message}) AS final_response_event_uid,\n\
-                 argMaxIf(event_order, tuple(event_order, event_uid), {assistant_message}) AS final_response_event_order,\n\
-                 argMaxIf(event_time, tuple(event_order, event_uid), {assistant_message}) AS final_response_event_time,\n\
-                 argMaxIf(event_type, tuple(event_order, event_uid), {assistant_message}) AS final_response_event_type,\n\
+                 argMaxIf(event_uid, tuple(event_order, event_uid), {final_response_message}) AS final_response_event_uid,\n\
+                 argMaxIf(event_order, tuple(event_order, event_uid), {final_response_message}) AS final_response_event_order,\n\
+                 argMaxIf(event_time, tuple(event_order, event_uid), {final_response_message}) AS final_response_event_time,\n\
+                 argMaxIf(event_type, tuple(event_order, event_uid), {final_response_message}) AS final_response_event_type,\n\
                  arrayDistinct(arrayMap(x -> x.2, arraySort(groupArrayIf(tuple(event_order, tool_label), event_type = 'tool_call' AND tool_label != '')))) AS tools_called,\n\
                  arrayDistinct(arrayMap(x -> x.2, arraySort(groupArray(tuple(event_order, event_type))))) AS normalized_event_types,\n\
                  argMaxIf(toUInt8(payload_type = 'task_complete'), tuple(event_order, event_uid), payload_type IN ('task_complete', 'turn_aborted')) AS completed,\n\

--- a/crates/moraine-conversations/tests/live_clickhouse.rs
+++ b/crates/moraine-conversations/tests/live_clickhouse.rs
@@ -320,6 +320,32 @@ VALUES
         .request_text(&insert, None, Some(database), false, None)
         .await
         .context("failed to insert live-schema fixtures")?;
+    let commentary_insert = format!(
+        r#"INSERT INTO `{database}`.`events`
+(
+  ingested_at, event_uid, session_id, session_date, source_name, harness, source_file,
+  source_ref, record_ts, event_ts, event_kind, actor_kind, payload_type, op_kind, op_status,
+  request_id, trace_id, turn_index, model, input_tokens, output_tokens, text_content,
+  payload_json, event_version
+)
+VALUES
+(
+  now64(3), 'issue549-user', 'issue549-commentary-session', today(), 'fixture', 'codex',
+  'fixture-commentary', 'issue549-user', '2026-07-15T20:00:00.000Z', now64(3),
+  'message', 'user', 'message', '', '', 'issue549-request', 'issue549-trace', 1,
+  '', 0, 0, 'Check the repository.', '{{}}', 1
+),
+(
+  now64(3), 'issue549-commentary', 'issue549-commentary-session', today(), 'fixture',
+  'codex', 'fixture-commentary', 'issue549-commentary', '2026-07-15T20:00:01.000Z',
+  now64(3), 'message', 'assistant', 'message', '', 'commentary', 'issue549-request',
+  'issue549-trace', 1, '', 0, 0, 'I am still checking the repository.', '{{}}', 1
+)"#
+    );
+    clickhouse
+        .request_text(&commentary_insert, None, Some(database), false, None)
+        .await
+        .context("failed to insert commentary projection fixture")?;
     Ok(())
 }
 
@@ -689,6 +715,96 @@ async fn live_schema_semantics_and_teardown() -> Result<()> {
             .backfill_mcp_open_read_model()
             .await
             .context("failed to project live-schema fixtures for bounded MCP open")?;
+        let commentary_turn = repository
+            .get_mcp_turn("issue549-commentary-session", 1)
+            .await
+            .context("commentary turn projection failed")?
+            .context("commentary turn missing")?;
+        assert!(!commentary_turn.completed);
+        assert!(commentary_turn.terminal_event_uid.is_none());
+        assert!(commentary_turn.final_response_summary.is_none());
+        assert!(commentary_turn.events.iter().any(|event| {
+            event.event_uid == "issue549-commentary"
+                && event.event_type == "assistant_response"
+                && event.phase == "commentary"
+        }));
+
+        #[derive(Deserialize)]
+        struct ProjectionRevisionRow {
+            generation: u64,
+            dirty_revision: u64,
+        }
+        let commentary_head_query = format!(
+            "SELECT generation, dirty_revision \
+             FROM `{}`.`mcp_open_sessions` FINAL \
+             WHERE session_id = 'issue549-commentary-session' \
+             FORMAT JSONEachRow",
+            database.as_str()
+        );
+        let before_reset = clickhouse
+            .query_rows::<ProjectionRevisionRow>(
+                &commentary_head_query,
+                Some(database.as_str()),
+            )
+            .await
+            .context("failed to read commentary projection before reset")?
+            .into_iter()
+            .next()
+            .context("commentary projection head missing before reset")?;
+        clickhouse
+            .request_text(
+                &format!(
+                    "INSERT INTO `{0}`.`mcp_open_dirty_sessions` \
+                     (session_id, dirty_revision, observed_at) \
+                     SELECT session_id, generateSnowflakeID(), now64(3) \
+                     FROM (SELECT DISTINCT session_id FROM `{0}`.`events` FINAL)",
+                    database.as_str()
+                ),
+                None,
+                Some(database.as_str()),
+                false,
+                None,
+            )
+            .await
+            .context("failed to invalidate existing MCP open projections")?;
+        clickhouse
+            .request_text(
+                &format!(
+                    "INSERT INTO `{}`.`mcp_open_projection_state` \
+                     (state_key, ready, generation, backfill_cursor) \
+                     VALUES ('global', 0, generateSnowflakeID(), '')",
+                    database.as_str()
+                ),
+                None,
+                Some(database.as_str()),
+                false,
+                None,
+            )
+            .await
+            .context("failed to reset MCP open projection state")?;
+        clickhouse
+            .backfill_mcp_open_read_model()
+            .await
+            .context("failed to rebuild reset MCP open projections")?;
+        let after_reset = clickhouse
+            .query_rows::<ProjectionRevisionRow>(
+                &commentary_head_query,
+                Some(database.as_str()),
+            )
+            .await
+            .context("failed to read commentary projection after reset")?
+            .into_iter()
+            .next()
+            .context("commentary projection head missing after reset")?;
+        assert!(after_reset.generation > before_reset.generation);
+        assert!(after_reset.dirty_revision > before_reset.dirty_revision);
+        assert!(clickhouse.mcp_open_read_model_ready().await?);
+        let rebuilt_commentary_turn = repository
+            .get_mcp_turn("issue549-commentary-session", 1)
+            .await
+            .context("rebuilt commentary turn projection failed")?
+            .context("rebuilt commentary turn missing")?;
+        assert!(rebuilt_commentary_turn.final_response_summary.is_none());
 
         #[derive(Deserialize)]
         struct TurnTimestampTypeRow {

--- a/sql/029_reset_mcp_open_projection.sql
+++ b/sql/029_reset_mcp_open_projection.sql
@@ -1,0 +1,11 @@
+INSERT INTO moraine.mcp_open_dirty_sessions
+  (session_id, dirty_revision, observed_at)
+SELECT session_id, generateSnowflakeID(), now64(3)
+FROM (
+  SELECT DISTINCT session_id
+  FROM moraine.events FINAL
+);
+
+INSERT INTO moraine.mcp_open_projection_state
+  (state_key, ready, generation, backfill_cursor)
+VALUES ('global', 0, generateSnowflakeID(), '');


### PR DESCRIPTION
## Description

**What.** Prevents commentary-phase assistant messages from being exposed as MCP turn `final_response` values.

**Why.** The MCP open projection selected the latest assistant message without distinguishing Codex commentary from an actual final answer.

The projection now excludes `commentary` messages from every final-response field while preserving those messages as ordinary assistant events. Migration 029 marks every existing session projection dirty before resetting the global projection state, so upgrades rebuild persisted rows with the corrected semantics.

## Usage

No operator action is required beyond the normal database migration during upgrade. Commentary remains available in the turn's ordinary `events`; `summary.final_response` is `null` until an eligible assistant response exists.

## Bug Evidence

Before this change, a commentary-only Codex turn could report `completed: false` and `terminal_event_id: null` while exposing the commentary text as `final_response`.

The live fixture now projects an incomplete turn containing a user message and a commentary-phase assistant message. It verifies that the assistant message remains an `assistant_response` event with phase `commentary`, while `final_response_summary` is absent. The upgrade regression also starts from an existing unchanged projection head, invalidates it through the migration path, and proves that both the generation and dirty revision advance before the corrected turn is reopened.

## Operational Impact

Migration 029 triggers a one-time rebuild of all existing MCP open projections. The existing bounded paging and refresh concurrency controls apply; large corpora may take several minutes during the normal migration step.

## Changelog

- Keeps nonterminal Codex commentary out of MCP turn `final_response` fields.
- Rebuilds existing MCP open projections on upgrade so persisted summaries adopt the corrected semantics.

## Validation

Ran `cargo test -p moraine-clickhouse --lib --locked`; all 35 tests passed. Ran `scripts/dev/sandbox/run-live-test analytics-schema` against an isolated ClickHouse sandbox; the live schema and projection regression passed after rebasing onto current `main`, including the in-place dirty-revision rebuild assertions. The repository pre-commit hook also passed for the committed four-file change.

Closes #549