### PR TITLE
feat(clickhouse): support gzip request compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +355,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +495,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -1124,6 +1149,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1198,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",
+ "flate2",
  "futures-util",
  "moraine-config",
  "reqwest",
@@ -1835,6 +1871,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"

--- a/bindings/python/moraine_conversations/Cargo.lock
+++ b/bindings/python/moraine_conversations/Cargo.lock
@@ -628,6 +628,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
  "url",
 ]
 

--- a/bindings/python/moraine_conversations/Cargo.lock
+++ b/bindings/python/moraine_conversations/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +194,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -572,6 +597,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +622,7 @@ name = "moraine-clickhouse"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "flate2",
  "futures-util",
  "moraine-config",
  "reqwest",
@@ -1060,6 +1096,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"

--- a/bindings/python/moraine_conversations/src/lib.rs
+++ b/bindings/python/moraine_conversations/src/lib.rs
@@ -39,6 +39,7 @@ impl ConversationClient {
             username,
             password,
             timeout_seconds,
+            request_compression: Default::default(),
             async_insert: true,
             wait_for_async_insert: true,
             allow_newer_server: false,

--- a/config/moraine.toml
+++ b/config/moraine.toml
@@ -4,6 +4,7 @@ database = "moraine"
 username = "default"
 password = ""
 timeout_seconds = 30.0
+request_compression = "none"
 async_insert = true
 wait_for_async_insert = true
 
@@ -20,6 +21,7 @@ wait_for_async_insert = true
 # database = "moraine_team"
 # username = "svc-moraine"
 # password = ""
+# request_compression = "gzip"
 # # Accept a server whose migration ledger is ahead of this moraine build.
 # allow_newer_server = false
 

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -11,6 +11,7 @@ flate2 = "1.1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tokio = { version = "1.40", features = ["rt"] }
 url = "2.5"
 moraine-config = { path = "../moraine-config" }
 

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -7,6 +7,7 @@ description = "Shared Moraine ClickHouse client and query helpers"
 [dependencies]
 anyhow = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["async-await", "std"] }
+flate2 = "1.1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -1,12 +1,14 @@
 use anyhow::{anyhow, bail, Context, Result};
-use moraine_config::ClickHouseConfig;
+use flate2::{write::GzEncoder, Compression};
+use moraine_config::{ClickHouseConfig, ClickHouseRequestCompression};
 use reqwest::{
-    header::{HeaderValue, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT},
+    header::{HeaderValue, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT},
     Client, RequestBuilder, Url,
 };
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::Value;
+use std::io::Write;
 
 mod mcp_open_projection;
 
@@ -148,6 +150,19 @@ impl ClickHouseClient {
         }
 
         // ClickHouse HTTP treats GET as readonly, so use POST for both reads and writes.
+        let (body, content_encoding) = match (self.cfg.request_compression, body.is_empty()) {
+            (_, true) | (ClickHouseRequestCompression::None, false) => (body, None),
+            (ClickHouseRequestCompression::Gzip, false) => {
+                let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+                encoder
+                    .write_all(&body)
+                    .context("failed to gzip ClickHouse request body")?;
+                let compressed = encoder
+                    .finish()
+                    .context("failed to finish gzip ClickHouse request body")?;
+                (compressed, Some("gzip"))
+            }
+        };
         let payload_len = body.len();
         let mut req = self
             .http
@@ -156,6 +171,10 @@ impl ClickHouseClient {
             // Some ClickHouse builds require an explicit Content-Length on POST.
             .header(CONTENT_LENGTH, payload_len)
             .body(body);
+
+        if let Some(content_encoding) = content_encoding {
+            req = req.header(CONTENT_ENCODING, content_encoding);
+        }
 
         if let Some(timeout) = options.request_timeout {
             req = req.timeout(timeout);
@@ -1015,10 +1034,12 @@ mod tests {
         routing::{get, post},
         Router,
     };
+    use flate2::read::GzDecoder;
     use moraine_config::ClickHouseConfig;
     use serde::Deserialize;
     use serde_json::json;
     use std::collections::HashMap;
+    use std::io::Read;
     use std::sync::{Arc, Mutex};
 
     fn test_clickhouse_config(url: String) -> ClickHouseConfig {
@@ -1028,6 +1049,7 @@ mod tests {
             username: "default".to_string(),
             password: String::new(),
             timeout_seconds: 5.0,
+            request_compression: ClickHouseRequestCompression::None,
             async_insert: true,
             wait_for_async_insert: true,
             allow_newer_server: false,
@@ -1092,6 +1114,54 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind insert capture listener");
+        let addr = listener.local_addr().expect("listener addr");
+
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        format!("http://{}", addr)
+    }
+
+    #[derive(Clone)]
+    struct RequestCaptureState {
+        requests: Arc<Mutex<Vec<CapturedRequest>>>,
+    }
+
+    struct CapturedRequest {
+        params: HashMap<String, String>,
+        headers: HeaderMap,
+        body: Vec<u8>,
+    }
+
+    async fn spawn_request_capture_server(state: RequestCaptureState) -> String {
+        async fn handler(
+            State(state): State<RequestCaptureState>,
+            Query(params): Query<HashMap<String, String>>,
+            headers: HeaderMap,
+            body: Bytes,
+        ) -> (StatusCode, &'static str) {
+            state
+                .requests
+                .lock()
+                .expect("request capture mutex poisoned")
+                .push(CapturedRequest {
+                    params,
+                    headers,
+                    body: body.to_vec(),
+                });
+            (StatusCode::OK, "ok")
+        }
+
+        let app = Router::new()
+            .route("/", post(handler))
+            .layer(DefaultBodyLimit::max(
+                MAX_INSERT_PAYLOAD_BYTES.saturating_mul(2),
+            ))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind request capture listener");
         let addr = listener.local_addr().expect("listener addr");
 
         tokio::spawn(async move {
@@ -1710,6 +1780,145 @@ mod tests {
         assert!(
             result.is_err(),
             "invalid identity must fail before a request can be built"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn gzip_request_compression_encodes_body_and_preserves_metadata() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let base_url = spawn_request_capture_server(RequestCaptureState {
+            requests: requests.clone(),
+        })
+        .await;
+        let mut config = test_clickhouse_config(base_url);
+        config.database = "moraine_team".to_string();
+        config.username = "svc-moraine".to_string();
+        config.password = "test-password".to_string();
+        config.request_compression = ClickHouseRequestCompression::Gzip;
+        let client = ClickHouseClient::new(config).expect("new client");
+        let payload = br#"{"payload":"synthetic trace payload"}
+"#
+        .to_vec();
+
+        client
+            .request_text_with_params(
+                "INSERT INTO tool_io FORMAT JSONEachRow",
+                Some(payload.clone()),
+                Some("moraine_team"),
+                true,
+                Some("JSONEachRow"),
+                &[("query_id", "gzip-test")],
+            )
+            .await
+            .expect("gzip request");
+
+        let requests = requests.lock().expect("request capture mutex poisoned");
+        assert_eq!(requests.len(), 1);
+        let request = &requests[0];
+        assert_eq!(
+            request
+                .headers
+                .get("content-encoding")
+                .and_then(|value| value.to_str().ok()),
+            Some("gzip")
+        );
+        assert_eq!(
+            request
+                .headers
+                .get("content-type")
+                .and_then(|value| value.to_str().ok()),
+            Some("text/plain; charset=utf-8")
+        );
+        assert_eq!(
+            request
+                .headers
+                .get("content-length")
+                .and_then(|value| value.to_str().ok()),
+            Some(request.body.len().to_string().as_str())
+        );
+        assert!(request.headers.get("authorization").is_some());
+        assert_eq!(
+            request.params.get("query").map(String::as_str),
+            Some("INSERT INTO tool_io FORMAT JSONEachRow")
+        );
+        assert_eq!(
+            request.params.get("database").map(String::as_str),
+            Some("moraine_team")
+        );
+        assert_eq!(
+            request.params.get("default_format").map(String::as_str),
+            Some("JSONEachRow")
+        );
+        assert_eq!(
+            request.params.get("async_insert").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            request
+                .params
+                .get("wait_for_async_insert")
+                .map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            request.params.get("query_id").map(String::as_str),
+            Some("gzip-test")
+        );
+
+        let mut decoded = Vec::new();
+        GzDecoder::new(request.body.as_slice())
+            .read_to_end(&mut decoded)
+            .expect("decode gzip body");
+        assert_eq!(decoded, payload);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn default_request_compression_preserves_plain_body() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let base_url = spawn_request_capture_server(RequestCaptureState {
+            requests: requests.clone(),
+        })
+        .await;
+        let client = ClickHouseClient::new(test_clickhouse_config(base_url)).expect("new client");
+        let payload = b"plain request body".to_vec();
+
+        client
+            .request_text("SELECT 1", Some(payload.clone()), None, false, None)
+            .await
+            .expect("plain request");
+
+        let requests = requests.lock().expect("request capture mutex poisoned");
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].headers.get("content-encoding").is_none());
+        assert_eq!(requests[0].body, payload);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn gzip_request_compression_leaves_empty_body_unencoded() {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let base_url = spawn_request_capture_server(RequestCaptureState {
+            requests: requests.clone(),
+        })
+        .await;
+        let mut config = test_clickhouse_config(base_url);
+        config.request_compression = ClickHouseRequestCompression::Gzip;
+        let client = ClickHouseClient::new(config).expect("new client");
+
+        client
+            .request_text("SELECT 1", None, None, false, None)
+            .await
+            .expect("empty request");
+
+        let requests = requests.lock().expect("request capture mutex poisoned");
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].headers.get("content-encoding").is_none());
+        assert!(requests[0].body.is_empty());
+        assert_eq!(
+            requests[0]
+                .headers
+                .get("content-length")
+                .and_then(|value| value.to_str().ok()),
+            Some("0")
         );
     }
 

--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -122,7 +122,7 @@ impl ClickHouseClient {
         Url::parse(&self.cfg.url).context("invalid ClickHouse URL")
     }
 
-    fn request_builder(
+    async fn request_builder(
         &self,
         query: &str,
         body: Vec<u8>,
@@ -153,13 +153,17 @@ impl ClickHouseClient {
         let (body, content_encoding) = match (self.cfg.request_compression, body.is_empty()) {
             (_, true) | (ClickHouseRequestCompression::None, false) => (body, None),
             (ClickHouseRequestCompression::Gzip, false) => {
-                let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-                encoder
-                    .write_all(&body)
-                    .context("failed to gzip ClickHouse request body")?;
-                let compressed = encoder
-                    .finish()
-                    .context("failed to finish gzip ClickHouse request body")?;
+                let compressed = tokio::task::spawn_blocking(move || {
+                    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+                    encoder
+                        .write_all(&body)
+                        .context("failed to gzip ClickHouse request body")?;
+                    encoder
+                        .finish()
+                        .context("failed to finish gzip ClickHouse request body")
+                })
+                .await
+                .context("ClickHouse request compression task failed")??;
                 (compressed, Some("gzip"))
             }
         };
@@ -224,17 +228,19 @@ impl ClickHouseClient {
         default_format: Option<&str>,
         params: &[(&str, &str)],
     ) -> Result<String> {
-        let req = self.request_builder(
-            query,
-            body.unwrap_or_default(),
-            ClickHouseRequestOptions {
-                database,
-                async_insert,
-                default_format,
-                params,
-                request_timeout: None,
-            },
-        )?;
+        let req = self
+            .request_builder(
+                query,
+                body.unwrap_or_default(),
+                ClickHouseRequestOptions {
+                    database,
+                    async_insert,
+                    default_format,
+                    params,
+                    request_timeout: None,
+                },
+            )
+            .await?;
         let response = self.send_checked_response(req).await?;
         let status = response.status();
         let text = response.text().await.with_context(|| {
@@ -255,17 +261,19 @@ impl ClickHouseClient {
         params: &[(&str, &str)],
         request_timeout: Option<Duration>,
     ) -> Result<ClickHouseByteStream> {
-        let req = self.request_builder(
-            query,
-            Vec::new(),
-            ClickHouseRequestOptions {
-                database,
-                async_insert: false,
-                default_format,
-                params,
-                request_timeout,
-            },
-        )?;
+        let req = self
+            .request_builder(
+                query,
+                Vec::new(),
+                ClickHouseRequestOptions {
+                    database,
+                    async_insert: false,
+                    default_format,
+                    params,
+                    request_timeout,
+                },
+            )
+            .await?;
         let response = self.send_checked_response(req).await?;
 
         Ok(ClickHouseByteStream { response })

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -45,6 +45,14 @@ pub struct IngestSource {
     pub format: String,
 }
 
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ClickHouseRequestCompression {
+    #[default]
+    None,
+    Gzip,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ClickHouseConfig {
@@ -58,6 +66,9 @@ pub struct ClickHouseConfig {
     pub password: String,
     #[serde(default = "default_timeout_seconds")]
     pub timeout_seconds: f64,
+    /// Compression applied to non-empty ClickHouse HTTP request bodies.
+    #[serde(default)]
+    pub request_compression: ClickHouseRequestCompression,
     #[serde(default = "default_true")]
     pub async_insert: bool,
     #[serde(default = "default_true")]
@@ -363,6 +374,7 @@ impl Default for ClickHouseConfig {
             username: default_ch_username(),
             password: String::new(),
             timeout_seconds: default_timeout_seconds(),
+            request_compression: ClickHouseRequestCompression::None,
             async_insert: true,
             wait_for_async_insert: true,
             allow_newer_server: false,
@@ -2091,6 +2103,62 @@ ruleset = "custom"
         assert_eq!(cfg.identity.author, "");
         assert!(!cfg.mcp.prewarm_on_initialize);
         assert!(!cfg.ingest.sources.is_empty());
+    }
+
+    #[test]
+    fn clickhouse_request_compression_defaults_to_none() {
+        let path = write_temp_config("", "clickhouse-request-compression-default");
+        let cfg = load_config(&path).expect("empty config should load with defaults");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(
+            cfg.clickhouse.request_compression,
+            ClickHouseRequestCompression::None
+        );
+        assert_eq!(
+            cfg.backends[DEFAULT_BACKEND_NAME].request_compression,
+            ClickHouseRequestCompression::None
+        );
+    }
+
+    #[test]
+    fn clickhouse_request_compression_parses_gzip() {
+        let path = write_temp_config(
+            r#"
+[clickhouse]
+request_compression = "gzip"
+"#,
+            "clickhouse-request-compression-gzip",
+        );
+        let cfg = load_config(&path).expect("gzip compression should parse");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(
+            cfg.clickhouse.request_compression,
+            ClickHouseRequestCompression::Gzip
+        );
+        assert_eq!(
+            cfg.backends[DEFAULT_BACKEND_NAME].request_compression,
+            ClickHouseRequestCompression::Gzip
+        );
+    }
+
+    #[test]
+    fn clickhouse_request_compression_rejects_unknown_values() {
+        let path = write_temp_config(
+            r#"
+[clickhouse]
+request_compression = "brotli"
+"#,
+            "clickhouse-request-compression-invalid",
+        );
+        let err = load_config(&path).expect_err("unknown compression should fail");
+        std::fs::remove_file(&path).ok();
+
+        assert!(
+            format!("{err:#}").contains("unknown variant `brotli`"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[test]

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -107,6 +107,7 @@ pub(crate) fn test_clickhouse_config(url: String) -> ClickHouseConfig {
         username: "default".to_string(),
         password: String::new(),
         timeout_seconds: 5.0,
+        request_compression: Default::default(),
         async_insert: true,
         wait_for_async_insert: true,
         allow_newer_server: false,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,6 +105,7 @@ database = "moraine"
 username = "default"
 password = ""
 timeout_seconds = 30.0
+request_compression = "none"
 async_insert = true
 wait_for_async_insert = true
 allow_newer_server = false
@@ -126,6 +127,7 @@ projects to additional servers, see
 | `username` | `default` | ClickHouse user for ingest, monitor, MCP, and migrations. |
 | `password` | empty | ClickHouse password. |
 | `timeout_seconds` | `30.0` | Per-request ClickHouse HTTP timeout. |
+| `request_compression` | `none` | Compression for non-empty HTTP request bodies. Supported values are `none` and `gzip`. |
 | `async_insert` | `true` | Enables ClickHouse async insert mode on writes. |
 | `wait_for_async_insert` | `true` | Waits for async insert completion before advancing checkpoints, so write failures are visible. |
 | `allow_newer_server` | `false` | Allows a non-default backend whose migration ledger is ahead of this Moraine build. The default backend is migrated by Moraine itself, so this is only useful on `[backends.<name>]`. |
@@ -142,6 +144,7 @@ url = "https://ch.team.example:8443"
 database = "moraine_team"
 username = "svc-moraine"
 password = "..."
+request_compression = "gzip"
 allow_newer_server = false
 
 [[routes]]

--- a/docs/full-config.toml
+++ b/docs/full-config.toml
@@ -27,6 +27,10 @@ password = ""
 # Per-request ClickHouse HTTP timeout, in seconds.
 timeout_seconds = 30.0
 
+# Compress non-empty ClickHouse HTTP request bodies. Supported values are
+# "none" and "gzip". Gzip can reduce network transfer for trace payloads.
+request_compression = "none"
+
 # Add async_insert=1 to writes so ClickHouse can acknowledge batched inserts
 # before fully flushing them.
 async_insert = true
@@ -50,6 +54,7 @@ allow_newer_server = false
 # username = "svc-moraine"
 # password = ""
 # timeout_seconds = 30.0
+# request_compression = "gzip"
 # async_insert = true
 # wait_for_async_insert = true
 # allow_newer_server = false

--- a/docs/remote-clickhouse.md
+++ b/docs/remote-clickhouse.md
@@ -57,6 +57,7 @@ database = "moraine"
 username = "moraine"
 password = "change-me"
 timeout_seconds = 30.0
+request_compression = "none"
 async_insert = true
 wait_for_async_insert = true
 ```
@@ -85,6 +86,7 @@ database = "moraine"
 username = "moraine"
 password = "replace-with-your-secret"
 timeout_seconds = 30.0
+request_compression = "gzip"
 async_insert = true
 wait_for_async_insert = true
 ```
@@ -105,6 +107,11 @@ password = "replace-with-your-secret"
 ```
 
 Keep the tunnel running before starting Moraine.
+
+`request_compression = "gzip"` applies standard HTTP gzip content encoding to
+non-empty ClickHouse request bodies. It is useful for remote backends where
+trace payloads cross bandwidth-constrained or intermediary-managed links. The
+default is `"none"`.
 
 ## Initialize The Schema
 


### PR DESCRIPTION
## Motivation

Moraine sends trace batches to ClickHouse as HTTP request bodies. When a backend is remote, JSONEachRow payloads may cross a hosted proxy or a bandwidth-constrained link before reaching ClickHouse.

This PR adds client-side gzip request compression using ClickHouse's standard `Content-Encoding` support. It does not change response handling or the ClickHouse query format.

## Configuration

```toml
[backends.team-ch]
url = "https://clickhouse.example.net"
request_compression = "gzip"
```

The setting is available on the default connection and every named backend. It accepts `"none"` or `"gzip"`; `"none"` remains the default, so existing configuration keeps its current request behavior. Unknown values fail config loading.

## Request behavior

With gzip enabled, Moraine compresses each non-empty body before sending it. The request includes `Content-Encoding: gzip`, and `Content-Length` describes the encoded bytes. Authentication and content type are preserved. Database parameters, query parameters, and async-insert settings are also unchanged.

Requests without a body remain unencoded. Compression runs on Tokio's blocking pool so large batches do not occupy async runtime workers. The implementation adds `flate2` to the shared ClickHouse client and updates the separately locked Python binding without changing its public constructor. No schema migration or ClickHouse server change is required.

## Validation

The configuration and ClickHouse client suites passed 125 tests. Formatting, strict Clippy, the locked workspace build, package-isolation checks, the Python binding smoke test, and the documentation build also passed.

After the async offload follow-up, the 38-test ClickHouse suite, strict affected-crate Clippy, ten-package isolation check, standalone Python binding smoke, and a live ClickHouse 25.12 gzip insert all passed.

A live probe used the patched Rust client against the deployed HTTPS ClickHouse 25.12 endpoint. A gzip JSONEachRow insert reached a non-persisting `Null` table function with HTTP 200, and a follow-up query returned `1`.

The workspace run also exposed two existing managed-ClickHouse process-lifecycle races on macOS. Both tests passed when run separately.

