### PR TITLE
fix(mcp): omit encrypted reasoning from compact summaries

### DIFF
--- a/crates/moraine-mcp-core/src/open_v1.rs
+++ b/crates/moraine-mcp-core/src/open_v1.rs
@@ -14,6 +14,7 @@ use serde_json::{json, Map, Value};
 use std::time::Instant;
 
 const SUMMARY_PREVIEW_CHARS: usize = 240;
+const ENCRYPTED_REASONING_SUMMARY: &str = "[encrypted reasoning omitted]";
 const SUMMARY_MAX_TOOLS: usize = 25;
 const SUMMARY_TOOL_NAME_CHARS: usize = 120;
 const OPEN_CURSOR_VERSION: u8 = 1;
@@ -702,11 +703,7 @@ fn open_turn_event_summary(
     let id = encode_event_id(&event.event_uid)?;
     let tool_name = tool_name_for(&event.event_type, &event.name, &event.call_id)
         .map(|name| compact_text_line(&name, SUMMARY_TOOL_NAME_CHARS));
-    let summary = event
-        .text_preview
-        .as_deref()
-        .map(|text| compact_text_line(text, SUMMARY_PREVIEW_CHARS))
-        .unwrap_or_default();
+    let (summary, summary_truncated) = compact_event_summary(event);
 
     Ok(json!({
         "id": id,
@@ -717,8 +714,33 @@ fn open_turn_event_summary(
         "tool_name": tool_name,
         "model": null,
         "summary": summary,
-        "truncated": event.text_preview.as_deref().is_some_and(looks_truncated)
+        "truncated": summary_truncated
     }))
+}
+
+fn compact_event_summary(event: &McpEventSummary) -> (String, bool) {
+    let Some(text) = event.text_preview.as_deref() else {
+        return (String::new(), false);
+    };
+    if event.event_type == "reasoning" && has_encrypted_content_field(text) {
+        return (ENCRYPTED_REASONING_SUMMARY.to_string(), false);
+    }
+
+    (
+        compact_text_line(text, SUMMARY_PREVIEW_CHARS),
+        looks_truncated(text),
+    )
+}
+
+fn has_encrypted_content_field(text: &str) -> bool {
+    let text = text.trim_start();
+    if !text.starts_with('{') {
+        return false;
+    }
+
+    const FIELD: &str = "\"encrypted_content\"";
+    text.match_indices(FIELD)
+        .any(|(index, _)| text[index + FIELD.len()..].trim_start().starts_with(':'))
 }
 
 fn open_event_data(
@@ -1225,6 +1247,44 @@ mod tests {
             encode_event_id("event-user").unwrap()
         );
         assert!(warnings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn turn_expansion_omits_encrypted_reasoning_payloads() {
+        let mut turn = large_turn(3, 7);
+        let encrypted_content = format!("encrypted-{}", "x".repeat(1_000));
+        let reasoning = &mut turn.events[1];
+        reasoning.actor_role = "assistant".to_string();
+        reasoning.event_class = "reasoning".to_string();
+        reasoning.payload_type = "reasoning".to_string();
+        reasoning.event_type = "reasoning".to_string();
+        reasoning.text_preview = Some(format!(
+            r#"{{"type":"reasoning","summary":[],"encrypted_content":"{encrypted_content}"}}"#
+        ));
+
+        let repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            InMemoryConversationResponses {
+                get_mcp_turn: Some(Ok(Some(turn))),
+                ..InMemoryConversationResponses::default()
+            },
+        ));
+        let state = AppState::embedded(AppConfig::default(), repository);
+        let turn_id = encode_turn_id("session-a", 1).expect("turn id");
+
+        let result = state
+            .open_v1(json!({ "id": turn_id, "limit": 3 }))
+            .await
+            .expect("expanded turn");
+        let reasoning_summary = &result["structuredContent"]["data"]["events"][1];
+        assert_eq!(
+            reasoning_summary["summary"],
+            json!("[encrypted reasoning omitted]")
+        );
+        assert_eq!(reasoning_summary["truncated"], json!(false));
+        let response = serde_json::to_string(&result).expect("serialized response");
+        assert!(!response.contains("encrypted_content"));
+        assert!(!response.contains(&encrypted_content));
     }
 
     #[tokio::test]

--- a/docs/agent-mcp-search/interface.md
+++ b/docs/agent-mcp-search/interface.md
@@ -145,6 +145,9 @@ Follow `next_cursor` until it is null to recover every compact turn or event
 summary. Then open an individual `event:` ID when exact wording, full tool
 arguments/output, or payload JSON is needed. There is intentionally no
 unbounded one-call transcript mode.
+Encrypted reasoning payloads appear as `[encrypted reasoning omitted]` in
+compact event summaries; open the event directly only when its opaque payload
+is needed.
 
 What comes back depends on the ID kind:
 

--- a/docs/mcp-search-interface-spec.md
+++ b/docs/mcp-search-interface-spec.md
@@ -1301,6 +1301,9 @@ Rules:
   summary exactly once from the pinned snapshot.
 - Event summaries are compact. Full event content is available through
   `open(event_id)`.
+- Encrypted reasoning payloads use the summary placeholder
+  `[encrypted reasoning omitted]`; opening the event directly still returns its
+  full opaque payload.
 - `summary.user_input` may be `null`.
 - `summary.final_response` may be `null`.
 - `summary.tools_called` must contain unique tool names in first-seen order.


### PR DESCRIPTION
## Description

**What.** Replaces encrypted Codex reasoning payloads in bounded `open(turn, limit)` event summaries with `[encrypted reasoning omitted]`.

**Why.** The opaque `encrypted_content` blob is not useful compact context and consumed response budget.

The fix applies at the compact event-summary boundary, preserving each event handle, absolute ordinal, and cursor traversal. Direct `open(event_id)` still returns the full opaque payload when explicitly requested. The interface documentation now states that contract.

This follow-up builds on the bounded-open behavior merged in #547.

## Bug Evidence

Before the change, the focused reproducer failed with a reasoning summary beginning:

```text
{"type":"reasoning","summary":[],"encrypted_content":"encrypted-xxxx..."}
```

`open_turn_event_summary` compacted every projected preview without distinguishing encrypted reasoning payloads. The new regression fixture exercises a bounded turn page and proves neither the `encrypted_content` field nor its value reaches the response.

## Usage

Bounded turn expansion now returns:

```json
{
  "type": "reasoning",
  "summary": "[encrypted reasoning omitted]",
  "truncated": false
}
```

Open the event ID directly only when the opaque payload is needed.

## Changelog

- Omits encrypted reasoning blobs from compact MCP turn summaries.
- Preserves full encrypted payloads for explicit direct event opens.
- No configuration, migration, or service-topology impact.

## Validation

The focused regression test first reproduced the failure, then passed with:

```bash
cargo test -p moraine-mcp-core --lib --locked open_v1::tests::turn_expansion_omits_encrypted_reasoning_payloads -- --exact
```

`cargo test -p moraine-mcp-core --lib --locked` passed all 121 tests. `make ci-check` passed dependency policy, formatting, strict clippy, locked workspace build, and workspace tests. `make docs-build` completed with no issues.

A live isolated sandbox ingested a Codex fixture containing a long `encrypted_content` value. Bounded turn expansion returned `[encrypted reasoning omitted]` without the blob, while direct event open retained `content.payload.encrypted_content`; the sandbox was then removed.

Fixes #550
