### PR TITLE
test(clickhouse): stabilize CI synchronization

### DIFF
--- a/apps/moraine/src/managed_clickhouse.rs
+++ b/apps/moraine/src/managed_clickhouse.rs
@@ -1734,7 +1734,9 @@ mod tests {
             let addr = listener.local_addr().expect("ping server addr");
             let stop = Arc::new(AtomicBool::new(false));
             let thread_stop = stop.clone();
+            let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(0);
             let thread = thread::spawn(move || {
+                ready_tx.send(()).expect("signal ping server readiness");
                 let mut request = [0_u8; 8192];
                 while !thread_stop.load(Ordering::Relaxed) {
                     match listener.accept() {
@@ -1753,6 +1755,9 @@ mod tests {
                     }
                 }
             });
+            ready_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("ping server thread did not become ready");
             Self {
                 addr,
                 stop,
@@ -2154,7 +2159,14 @@ mod tests {
         finish_output_forwarders(&mut forwarders, &log)
             .await
             .expect("drain synthetic output");
-        assert_eq!(log.writer_count(), 1, "output tasks retained log handles");
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while log.writer_count() != 1 {
+            assert!(
+                Instant::now() < deadline,
+                "output tasks retained log handles"
+            );
+            sleep(Duration::from_millis(5)).await;
+        }
         log.line("shutdown-marker")
             .await
             .expect("write shutdown marker");


### PR DESCRIPTION
## Description

**What.** Stabilizes two ClickHouse supervisor tests that repeatedly made the functional CI workflow red on main.

**Why.** The tests asserted asynchronous readiness and cleanup before their background work was guaranteed to have reached the corresponding state.

The test-only changes add a rendezvous before the loopback ping helper is returned and wait within the existing one-second bound for cancelled output writers to release their log handles. Runtime behavior is unchanged.

## Usage

No user-facing usage change.

## Changelog

None.

## Bug Evidence

The latest failing main run, https://github.com/eric-tramel/moraine/actions/runs/29470024829, failed `high_volume_child_output_rotates_while_child_remains_live` on x86_64 macOS because the assertion observed three retained writer handles immediately after cancellation instead of one. Earlier main runs failed `healthy_untracked_endpoint_remains_unmanaged` when the test request raced the loopback server thread and fell through to managed ClickHouse installation.

The changed test paths now synchronize those boundaries explicitly while preserving their one-second failure deadlines.

## Validation

Ran `cargo fmt --all -- --check`, `bash scripts/ci/clippy-strict-baseline.sh`, and `cargo test --workspace --locked` successfully. The endpoint synchronization test passed 30 consecutive focused runs, and the high-volume output cleanup test passed 20 consecutive focused runs. The full seven-persona Moraine code review reported no actionable findings.

Sandbox QA was not run because this changes only test synchronization and does not alter ingest, MCP, monitor, schema, or stack behavior.
