### PR TITLE
fix(mcp): skip empty projection sessions

### DIFF
--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -1489,6 +1489,21 @@ mod tests {
     }
 
     #[test]
+    fn mcp_open_migrations_exclude_blank_session_ids() {
+        for version in ["027", "029"] {
+            let migration = bundled_migrations()
+                .into_iter()
+                .find(|migration| migration.version == version)
+                .unwrap_or_else(|| panic!("migration {version} must be registered"));
+
+            assert!(
+                migration.sql.contains("WHERE notEmpty(session_id)"),
+                "migration {version} must not enqueue blank session IDs"
+            );
+        }
+    }
+
+    #[test]
     fn migration_021_adds_file_attention_columns_without_reordering_tables() {
         let migration = bundled_migrations()
             .into_iter()

--- a/crates/moraine-clickhouse/src/mcp_open_projection.rs
+++ b/crates/moraine-clickhouse/src/mcp_open_projection.rs
@@ -40,6 +40,18 @@ struct ProjectionStateRow {
     backfill_cursor: String,
 }
 
+fn projection_session_ids<I, S>(session_ids: I) -> BTreeSet<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    session_ids
+        .into_iter()
+        .map(|session_id| session_id.as_ref().to_string())
+        .filter(|session_id| !session_id.is_empty())
+        .collect()
+}
+
 impl ClickHouseClient {
     /// Rebuild complete canonical snapshots for the affected sessions and
     /// publish each session head only after its inactive children are durable.
@@ -48,11 +60,7 @@ impl ClickHouseClient {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        let session_ids = session_ids
-            .into_iter()
-            .map(|session_id| session_id.as_ref().trim().to_string())
-            .filter(|session_id| !session_id.is_empty())
-            .collect::<BTreeSet<_>>();
+        let session_ids = projection_session_ids(session_ids);
 
         stream::iter(session_ids.into_iter().map(Ok::<_, anyhow::Error>))
             .try_for_each_concurrent(REFRESH_CONCURRENCY, |session_id| async move {
@@ -90,6 +98,7 @@ impl ClickHouseClient {
                        SELECT DISTINCT session_id\n\
                        FROM {}.events FINAL\n\
                        WHERE session_id > {}\n\
+                         AND notEmpty(session_id)\n\
                      )\n\
                      ORDER BY session_id ASC\n\
                      LIMIT {}\n\
@@ -125,7 +134,8 @@ impl ClickHouseClient {
                    SELECT session_id, dirty_revision\n\
                    FROM {}.mcp_open_sessions FINAL\n\
                  ) AS s ON s.session_id = d.session_id\n\
-                 WHERE d.dirty_revision > ifNull(s.dirty_revision, 0)\n\
+                 WHERE notEmpty(d.session_id)\n\
+                   AND d.dirty_revision > ifNull(s.dirty_revision, 0)\n\
                  ORDER BY d.session_id ASC\n\
                  LIMIT {}\n\
                  FORMAT JSONEachRow",
@@ -580,4 +590,20 @@ fn event_type_sql() -> &'static str {
       event_class = 'queue_operation' OR payload_type IN ('task_started', 'task_complete', 'turn_aborted', 'item_completed', 'queue-operation'), 'runtime',\
       lowerUTF8(actor_role) = 'system' OR event_class IN ('system', 'progress', 'file_history_snapshot') OR payload_type IN ('system', 'progress', 'file-history-snapshot', 'file_history_snapshot'), 'system',\
       'unknown')"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::projection_session_ids;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn projection_session_ids_drop_only_the_empty_storage_sentinel() {
+        let ids = projection_session_ids(["", " ", "\u{a0}", "session"]);
+
+        assert_eq!(
+            ids,
+            BTreeSet::from([" ".to_string(), "\u{a0}".to_string(), "session".to_string(),])
+        );
+    }
 }

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -567,6 +567,7 @@ WHERE scope_s.session_id = {session_id}{scope_origin_filter}",
     FROM (
       SELECT session_id, dirty_revision
       FROM {dirty_sessions_table} FINAL
+      WHERE notEmpty(session_id)
     ) AS dirty
     LEFT JOIN (
       SELECT session_id, dirty_revision

--- a/crates/moraine-conversations/tests/live_clickhouse.rs
+++ b/crates/moraine-conversations/tests/live_clickhouse.rs
@@ -734,6 +734,10 @@ async fn live_schema_semantics_and_teardown() -> Result<()> {
             generation: u64,
             dirty_revision: u64,
         }
+        #[derive(Deserialize)]
+        struct CountRow {
+            value: u64,
+        }
         let commentary_head_query = format!(
             "SELECT generation, dirty_revision \
              FROM `{}`.`mcp_open_sessions` FINAL \
@@ -770,6 +774,21 @@ async fn live_schema_semantics_and_teardown() -> Result<()> {
         clickhouse
             .request_text(
                 &format!(
+                    "INSERT INTO `{}`.`mcp_open_dirty_sessions` \
+                     (session_id, dirty_revision, observed_at) \
+                     VALUES ('', generateSnowflakeID(), now64(3))",
+                    database.as_str()
+                ),
+                None,
+                Some(database.as_str()),
+                false,
+                None,
+            )
+            .await
+            .context("failed to seed legacy blank-session dirty row")?;
+        clickhouse
+            .request_text(
+                &format!(
                     "INSERT INTO `{}`.`mcp_open_projection_state` \
                      (state_key, ready, generation, backfill_cursor) \
                      VALUES ('global', 0, generateSnowflakeID(), '')",
@@ -782,10 +801,12 @@ async fn live_schema_semantics_and_teardown() -> Result<()> {
             )
             .await
             .context("failed to reset MCP open projection state")?;
-        clickhouse
-            .backfill_mcp_open_read_model()
-            .await
-            .context("failed to rebuild reset MCP open projections")?;
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            clickhouse.backfill_mcp_open_read_model(),
+        )
+        .await
+        .context("reset MCP open projection did not bypass blank dirty session")??;
         let after_reset = clickhouse
             .query_rows::<ProjectionRevisionRow>(
                 &commentary_head_query,
@@ -799,6 +820,22 @@ async fn live_schema_semantics_and_teardown() -> Result<()> {
         assert!(after_reset.generation > before_reset.generation);
         assert!(after_reset.dirty_revision > before_reset.dirty_revision);
         assert!(clickhouse.mcp_open_read_model_ready().await?);
+        let blank_projection_count = clickhouse
+            .query_rows::<CountRow>(
+                &format!(
+                    "SELECT count() AS value FROM `{}`.`mcp_open_sessions` FINAL \
+                     WHERE session_id = '' FORMAT JSONEachRow",
+                    database.as_str()
+                ),
+                Some(database.as_str()),
+            )
+            .await
+            .context("failed to count blank MCP open projections")?
+            .into_iter()
+            .next()
+            .context("blank MCP open projection count missing")?
+            .value;
+        assert_eq!(blank_projection_count, 0);
         let rebuilt_commentary_turn = repository
             .get_mcp_turn("issue549-commentary-session", 1)
             .await

--- a/crates/moraine-conversations/tests/repository_integration/search.rs
+++ b/crates/moraine-conversations/tests/repository_integration/search.rs
@@ -716,6 +716,7 @@ async fn search_mcp_events_uses_one_candidate_and_one_bounded_detail_query() {
         "scalar corpus metadata must expand exactly once"
     );
     assert!(queries[0].contains("mcp_open_dirty_sessions"));
+    assert!(queries[0].contains("WHERE notEmpty(session_id)"));
     assert!(queries[0].contains("AS projection_clean"));
     assert!(queries[0].contains("projected_candidates AS ("));
     assert!(queries[0].contains("event_uid IN (SELECT event_uid FROM matching_doc_ids)"));

--- a/sql/027_mcp_open_read_model.sql
+++ b/sql/027_mcp_open_read_model.sql
@@ -139,6 +139,7 @@ SELECT
   generateSnowflakeID() AS dirty_revision,
   now64(3) AS observed_at
 FROM moraine.events
+WHERE notEmpty(session_id)
 GROUP BY session_id;
 
 CREATE TABLE IF NOT EXISTS moraine.mcp_open_projection_state (

--- a/sql/029_reset_mcp_open_projection.sql
+++ b/sql/029_reset_mcp_open_projection.sql
@@ -4,6 +4,7 @@ SELECT session_id, generateSnowflakeID(), now64(3)
 FROM (
   SELECT DISTINCT session_id
   FROM moraine.events FINAL
+  WHERE notEmpty(session_id)
 );
 
 INSERT INTO moraine.mcp_open_projection_state


### PR DESCRIPTION
## Description

**What.** Makes MCP open projection backfills ignore the empty session-ID storage sentinel without deleting existing database rows.

**Why.** Migration 029 can enqueue a legacy empty session ID that the Rust refresher rejects, causing the dirty-session drain loop to select and count the same row indefinitely during `moraine up`.

- Excludes empty IDs from fresh dirty-row materialization and the migration 029 reset.
- Ignores legacy empty dirty rows during historical reconciliation and MCP search projection-health checks.
- Preserves every non-empty stored session ID exactly, including ASCII and Unicode whitespace IDs, so Rust and ClickHouse use identical sentinel semantics.
- Leaves existing database rows intact; no cleanup mutation or deletion migration is added.

## Usage

Upgrade to a build containing this fix and rerun `moraine up`. An interrupted projection resumes from its stored cursor, ignores the legacy empty dirty row, and publishes the read model as ready.

No manual database mutation is required.

## Changelog

- Prevents `moraine up` from looping indefinitely while projecting a legacy empty session ID.
- Preserves existing local ClickHouse data and leaves ignored legacy rows stored.

## Bug Evidence

Before this change, migration 029 inserted every distinct event session ID into `mcp_open_dirty_sessions`, including `session_id = empty`. The refresher filtered that ID out, but the drain query kept returning it and incrementing progress forever.

The live regression seeds the legacy empty dirty row, requires the backfill to finish within ten seconds, verifies the global projection becomes ready, and verifies that no empty projection head is published.

## Validation

`cargo fmt --all -- --check` passed. `cargo test -p moraine-clickhouse --lib --locked` passed 37 tests, and `cargo test -p moraine-conversations --test repository_integration --locked` passed all 89 tests. The deterministic `live_clickhouse` target passed six tests with the three owned live cases expectedly ignored. `scripts/dev/sandbox/run-live-test analytics-schema` passed against owned sandbox `sb-e8d5b5`, and teardown completed successfully. The repository pre-commit hook also passed its strict workspace Clippy baseline.