### PR TITLE
fix(search): deduplicate Codex final-answer mirrors

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo/rows.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/rows.rs
@@ -367,6 +367,8 @@ pub(super) struct SearchMcpEventRow {
     pub(super) actor_role: String,
     pub(super) name: String,
     pub(super) phase: String,
+    #[serde(default)]
+    pub(super) payload_phase: String,
     pub(super) source_ref: String,
     pub(super) doc_len: u32,
     pub(super) text_preview: String,

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -6,6 +6,7 @@ pub(super) const CONVERSATION_CANDIDATE_MAX: usize = 20_000;
 pub(super) const CONVERSATION_RECENT_WINDOW_MS: i64 = 45_000;
 pub(super) const CONVERSATION_RECENT_CANDIDATE_LIMIT: usize = 1024;
 pub(super) const MCP_SEARCH_MAX_CANDIDATE_PAGES: u16 = 16;
+pub(super) const CODEX_FINAL_ANSWER_MIRROR_MAX_TIMESTAMP_DELTA_MS: u64 = 10;
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct SearchScoreAccum<'a> {
@@ -734,6 +735,7 @@ FORMAT JSONEachRow",
       argMax(document.actor_role, document.doc_version) AS actor_role,
       argMax(document.name, document.doc_version) AS name,
       argMax(document.phase, document.doc_version) AS phase,
+      argMax(JSONExtractString(document.payload_json, 'phase'), document.doc_version) AS payload_phase,
       argMax(document.source_ref, document.doc_version) AS source_ref,
       toUInt32(argMax(document.doc_len, document.doc_version)) AS doc_len,
       argMax(leftUTF8(document.text_content, {preview}), document.doc_version) AS text_preview,
@@ -762,6 +764,7 @@ SELECT
   documents.actor_role AS actor_role,
   documents.name AS name,
   documents.phase AS phase,
+  documents.payload_phase AS payload_phase,
   documents.source_ref AS source_ref,
   documents.doc_len AS doc_len,
   documents.text_preview AS text_preview,
@@ -1557,15 +1560,71 @@ FORMAT JSONEachRow",
             McpEventType::from_normalized(&b.mcp_event_type)
         };
 
-        a.session_id == b.session_id
+        let same_content = if a.text_content_digest.is_empty() && b.text_content_digest.is_empty() {
+            a.text_content == b.text_content
+        } else {
+            a.text_content_digest == b.text_content_digest
+        };
+        let same_logical_coordinates = a.session_id == b.session_id
             && a.turn_seq == b.turn_seq
-            && a.event_unix_ms == b.event_unix_ms
             && a_event_type == b_event_type
-            && if a.text_content_digest.is_empty() && b.text_content_digest.is_empty() {
-                a.text_content == b.text_content
-            } else {
-                a.text_content_digest == b.text_content_digest
-            }
+            && same_content;
+
+        same_logical_coordinates
+            && (a.event_unix_ms == b.event_unix_ms
+                || Self::mcp_search_rows_are_codex_final_answer_mirrors(a, b))
+    }
+
+    fn mcp_search_rows_are_codex_final_answer_mirrors(
+        a: &SearchMcpEventRow,
+        b: &SearchMcpEventRow,
+    ) -> bool {
+        let is_known_representation_pair = matches!(
+            (
+                (a.event_class.as_str(), a.payload_type.as_str()),
+                (b.event_class.as_str(), b.payload_type.as_str()),
+            ),
+            (("message", "message"), ("event_msg", "agent_message"))
+                | (("event_msg", "agent_message"), ("message", "message"))
+        );
+        let is_final_answer = |row: &SearchMcpEventRow| {
+            row.phase == "final_answer" || row.payload_phase == "final_answer"
+        };
+        let Some((a_source_file, a_generation, a_line)) = Self::parse_mcp_source_ref(&a.source_ref)
+        else {
+            return false;
+        };
+        let Some((b_source_file, b_generation, b_line)) = Self::parse_mcp_source_ref(&b.source_ref)
+        else {
+            return false;
+        };
+
+        a.harness == "codex"
+            && b.harness == "codex"
+            && !a.source_name.is_empty()
+            && a.source_name == b.source_name
+            && is_known_representation_pair
+            && is_final_answer(a)
+            && is_final_answer(b)
+            && a_source_file == b_source_file
+            && a_generation == b_generation
+            && a_line.abs_diff(b_line) == 1
+            && a.event_order.abs_diff(b.event_order) == 1
+            && a.event_unix_ms.abs_diff(b.event_unix_ms)
+                <= CODEX_FINAL_ANSWER_MIRROR_MAX_TIMESTAMP_DELTA_MS
+    }
+
+    fn parse_mcp_source_ref(source_ref: &str) -> Option<(&str, u64, u64)> {
+        let (source_and_generation, source_line) = source_ref.rsplit_once(':')?;
+        let (source_file, source_generation) = source_and_generation.rsplit_once(':')?;
+        if source_file.is_empty() {
+            return None;
+        }
+        Some((
+            source_file,
+            source_generation.parse().ok()?,
+            source_line.parse().ok()?,
+        ))
     }
 
     pub(super) fn dedupe_mcp_search_rows(

--- a/crates/moraine-conversations/src/clickhouse_repo/tests.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/tests.rs
@@ -1,5 +1,7 @@
 use super::file_attention::merge_file_attention_touches;
-use super::search::{RankedPosting, SearchScoreAccum};
+use super::search::{
+    RankedPosting, SearchScoreAccum, CODEX_FINAL_ANSWER_MIRROR_MAX_TIMESTAMP_DELTA_MS,
+};
 use super::*;
 
 fn sample_search_doc() -> SearchDocExtraCacheEntry {
@@ -70,6 +72,7 @@ fn sample_mcp_search_row(event_uid: &str, raw_score: f64, event_unix_ms: i64) ->
         actor_role: "assistant".to_string(),
         name: String::new(),
         phase: String::new(),
+        payload_phase: String::new(),
         source_ref: "source-ref".to_string(),
         doc_len: 42,
         text_preview: "preview".to_string(),
@@ -97,6 +100,31 @@ fn sample_mcp_search_row(event_uid: &str, raw_score: f64, event_unix_ms: i64) ->
         session_summary: String::new(),
         session_completed: 0,
     }
+}
+
+fn sample_codex_final_answer_mirror_rows(
+    timestamp_delta_ms: i64,
+) -> (SearchMcpEventRow, SearchMcpEventRow) {
+    let mut response_item = sample_mcp_search_row("uid-response-item", 18.0, 1_777_000_000_000);
+    response_item.harness = "codex".to_string();
+    response_item.phase = "final_answer".to_string();
+    response_item.source_ref = "/tmp/session:with-colon.jsonl:7:41".to_string();
+    response_item.event_order = 41;
+    response_item.turn_seq = 2;
+    response_item.text_content = "byte-identical final answer".to_string();
+    response_item.text_content_digest = "digest-final-answer".to_string();
+
+    let mut event_msg = response_item.clone();
+    event_msg.event_uid = "uid-event-msg".to_string();
+    event_msg.event_class = "event_msg".to_string();
+    event_msg.payload_type = "agent_message".to_string();
+    event_msg.phase = "completed".to_string();
+    event_msg.payload_phase = "final_answer".to_string();
+    event_msg.source_ref = "/tmp/session:with-colon.jsonl:7:42".to_string();
+    event_msg.event_order = 42;
+    event_msg.event_unix_ms += timestamp_delta_ms;
+
+    (response_item, event_msg)
 }
 
 fn sample_file_attention_touch(
@@ -552,6 +580,93 @@ fn dedupe_mcp_search_rows_collapses_equivalent_events_and_fills_limit() {
     assert_eq!(deduped[0].event_uid, "uid-duplicate");
     assert_eq!(deduped[1].event_uid, "uid-second");
     assert_eq!(deduped[2].event_uid, "uid-third");
+}
+
+#[test]
+fn dedupe_mcp_search_rows_collapses_codex_final_answer_mirror_with_near_ms_timestamp() {
+    let (response_item, event_msg) = sample_codex_final_answer_mirror_rows(3);
+    let deduped = ClickHouseConversationRepository::dedupe_mcp_search_rows(
+        vec![response_item.clone(), event_msg.clone()],
+        2,
+    );
+    assert_eq!(deduped.len(), 1);
+
+    let reversed =
+        ClickHouseConversationRepository::dedupe_mcp_search_rows(vec![event_msg, response_item], 2);
+    assert_eq!(reversed.len(), 1);
+
+    let (response_item, event_msg) = sample_codex_final_answer_mirror_rows(
+        CODEX_FINAL_ANSWER_MIRROR_MAX_TIMESTAMP_DELTA_MS as i64,
+    );
+    let at_boundary =
+        ClickHouseConversationRepository::dedupe_mcp_search_rows(vec![response_item, event_msg], 2);
+    assert_eq!(at_boundary.len(), 1);
+}
+
+#[test]
+fn dedupe_mcp_search_rows_preserves_non_mirror_codex_final_answers() {
+    let (response_item, event_msg) = sample_codex_final_answer_mirror_rows(3);
+    let assert_distinct = |candidate: SearchMcpEventRow| {
+        let rows = ClickHouseConversationRepository::dedupe_mcp_search_rows(
+            vec![response_item.clone(), candidate],
+            2,
+        );
+        assert_eq!(rows.len(), 2);
+    };
+
+    let mut same_representation = event_msg.clone();
+    same_representation.event_class = "message".to_string();
+    same_representation.payload_type = "message".to_string();
+    assert_distinct(same_representation);
+
+    let mut different_session = event_msg.clone();
+    different_session.session_id = "session-2".to_string();
+    assert_distinct(different_session);
+
+    let mut different_turn = event_msg.clone();
+    different_turn.turn_seq += 1;
+    assert_distinct(different_turn);
+
+    let mut not_final = event_msg.clone();
+    not_final.payload_phase.clear();
+    assert_distinct(not_final);
+
+    let mut different_source_name = event_msg.clone();
+    different_source_name.source_name = "other-source".to_string();
+    assert_distinct(different_source_name);
+
+    let mut different_source_file = event_msg.clone();
+    different_source_file.source_ref = "/tmp/other.jsonl:7:42".to_string();
+    assert_distinct(different_source_file);
+
+    let mut different_generation = event_msg.clone();
+    different_generation.source_ref = "/tmp/session:with-colon.jsonl:8:42".to_string();
+    assert_distinct(different_generation);
+
+    let mut non_adjacent_source_line = event_msg.clone();
+    non_adjacent_source_line.source_ref = "/tmp/session:with-colon.jsonl:7:43".to_string();
+    assert_distinct(non_adjacent_source_line);
+
+    let mut non_adjacent_event_order = event_msg.clone();
+    non_adjacent_event_order.event_order += 1;
+    assert_distinct(non_adjacent_event_order);
+
+    let mut malformed_source_ref = event_msg.clone();
+    malformed_source_ref.source_ref = "malformed".to_string();
+    assert_distinct(malformed_source_ref);
+
+    let (_, outside_timestamp_bound) = sample_codex_final_answer_mirror_rows(
+        CODEX_FINAL_ANSWER_MIRROR_MAX_TIMESTAMP_DELTA_MS as i64 + 1,
+    );
+    assert_distinct(outside_timestamp_bound);
+
+    let mut different_type = event_msg.clone();
+    different_type.mcp_event_type = "reasoning".to_string();
+    assert_distinct(different_type);
+
+    let mut different_content = event_msg;
+    different_content.text_content_digest = "other-digest".to_string();
+    assert_distinct(different_content);
 }
 
 #[test]

--- a/crates/moraine-conversations/tests/repository_integration/search.rs
+++ b/crates/moraine-conversations/tests/repository_integration/search.rs
@@ -883,6 +883,10 @@ async fn search_mcp_events_deduplicates_before_limit_and_reports_truncation() {
     assert_eq!(result.hits.len(), 2);
     assert_eq!(result.hits[0].event_uid, "evt-c-42");
     assert_eq!(result.hits[1].event_uid, "evt-a-11");
+    assert!(result
+        .hits
+        .iter()
+        .all(|hit| hit.event_uid != "evt-c-duplicate"));
     assert!(result.truncated);
     assert!(result.stats.truncated);
     assert_eq!(result.stats.effective_n_hits, 2);
@@ -902,6 +906,13 @@ async fn search_mcp_events_deduplicates_before_limit_and_reports_truncation() {
     assert!(queries.iter().any(|query| {
         query.contains("hex(SHA256(projected_events.text_content)) AS text_content_digest")
     }));
+    assert!(queries.iter().any(|query| {
+        query.contains("JSONExtractString(document.payload_json, 'phase')")
+            && query.contains("AS payload_phase")
+    }));
+    assert!(queries
+        .iter()
+        .any(|query| { query.contains("documents AS (") && query.contains("'evt-b-9'") }));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -868,7 +868,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
             } else if query.contains("LIMIT 3") {
                 vec![
                     candidate("evt-c-42", 12.5, 2, 1_767_434_520_000),
-                    candidate("evt-c-duplicate", 12.0, 2, 1_767_434_520_000),
+                    candidate("evt-c-duplicate", 12.0, 2, 1_767_434_520_003),
                     candidate("evt-a-11", 7.0, 1, 1_767_261_720_000),
                 ]
             } else {
@@ -917,6 +917,13 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                         41_u64,
                         2_u32,
                     ),
+                    "evt-c-duplicate" => (
+                        "sess_c",
+                        "2026-01-03 10:02:00.003",
+                        1_767_434_520_003_i64,
+                        43_u64,
+                        2_u32,
+                    ),
                     _ => (
                         "sess_c",
                         "2026-01-03 10:02:00",
@@ -927,6 +934,8 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                 };
                 let is_tool = event_uid == "evt-c-tool";
                 let is_user = event_uid == "evt-c-user";
+                let is_duplicate = event_uid == "evt-c-duplicate";
+                let is_canonical_response = event_uid == "evt-c-42";
                 let actor_role = if is_tool {
                     "tool"
                 } else if is_user {
@@ -955,17 +964,18 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                     "harness": "codex",
                     "inference_provider": "openai",
                     "endpoint_kind": "generation",
-                    "event_class": if is_tool { "tool_result" } else { "message" },
-                    "payload_type": if is_tool { "tool_result" } else { "text" },
+                    "event_class": if is_tool { "tool_result" } else if is_duplicate { "event_msg" } else { "message" },
+                    "payload_type": if is_tool { "tool_result" } else if is_duplicate { "agent_message" } else if is_canonical_response { "message" } else { "text" },
                     "actor_role": actor_role,
                     "name": if is_tool { "bash" } else { "" },
-                    "phase": if is_tool { "completed" } else { "" },
+                    "phase": if is_tool || is_duplicate { "completed" } else if is_canonical_response { "final_answer" } else { "" },
+                    "payload_phase": if is_duplicate || is_canonical_response { "final_answer" } else { "" },
                     "source_ref": format!("/tmp/{session_id}.jsonl:1:{event_order}"),
                     "doc_len": 19_u32,
                     "text_preview": text,
                     "text_content": text,
                     "text_content_digest": text,
-                    "payload_json": "{}",
+                    "payload_json": if is_duplicate || is_canonical_response { "{\"phase\":\"final_answer\"}" } else { "{}" },
                     "mcp_event_type": event_type,
                     "raw_score": 0.0,
                     "matched_terms": 0_u64,

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -658,7 +658,8 @@ main() {
 {"timestamp":"2026-02-16T12:00:00.000Z","type":"session_meta","payload":{"id":"${codex_session_id}","cwd":"${codex_project_dir}","source":"vscode"}}
 {"timestamp":"2026-02-16T12:00:01.000Z","type":"turn_context","payload":{"turn_id":"1","model":"gpt-5.3-codex"}}
 {"timestamp":"2026-02-16T12:00:02.000Z","type":"response_item","payload":{"type":"message","role":"user","id":"msg-user-${run_stamp}","content":[{"type":"text","text":"local e2e codex user prompt ${codex_keyword}"}],"phase":"completed"}}
-{"timestamp":"2026-02-16T12:00:03.000Z","type":"response_item","parent_id":"msg-user-${run_stamp}","payload":{"type":"message","role":"assistant","id":"msg-assistant-${run_stamp}","content":[{"type":"text","text":"local e2e codex assistant reply ${codex_keyword} ${codex_trace_marker}"}],"phase":"completed"}}
+{"timestamp":"2026-02-16T12:00:03.000Z","type":"response_item","parent_id":"msg-user-${run_stamp}","payload":{"type":"message","role":"assistant","id":"msg-assistant-${run_stamp}","content":[{"type":"text","text":"local e2e codex assistant reply ${codex_keyword} ${codex_trace_marker}"}],"phase":"final_answer"}}
+{"timestamp":"2026-02-16T12:00:03.003Z","type":"event_msg","payload":{"type":"agent_message","turn_id":"1","message":"local e2e codex assistant reply ${codex_keyword} ${codex_trace_marker}","phase":"final_answer","status":"completed"}}
 {"timestamp":"2026-02-16T12:00:03.500Z","type":"response_item","payload":{"type":"function_call","call_id":"codex-tool-${run_stamp}","name":"Read","arguments":"{\"path\":\"Cargo.toml\"}"}}
 {"timestamp":"2026-02-16T12:00:03.750Z","type":"response_item","payload":{"type":"function_call_output","call_id":"codex-tool-${run_stamp}","output":"workspace = true"}}
 {"timestamp":"2026-02-16T12:00:03.900Z","type":"event_msg","payload":{"type":"token_count","turn_id":"1","info":{"last_token_usage":{"input_tokens":17,"output_tokens":4,"cached_input_tokens":3,"cache_creation_input_tokens":2,"output_tokens_details":{"reasoning_tokens":1}}},"rate_limits":{"limit_name":"GPT-5.3-Codex-Spark","limit_id":"codex_e2e","plan_type":"pro"}}}
@@ -1113,15 +1114,15 @@ EOF
   echo "[e2e] checking ClickHouse normalized ingest rows"
   assert_clickhouse_count "$clickhouse_url" "ingest errors" "SELECT count() FROM ${clickhouse_database}.ingest_errors" "0"
 
-  assert_clickhouse_count "$clickhouse_url" "codex unique raw rows" "SELECT uniqExact(raw_json_hash) FROM ${clickhouse_database}.raw_events WHERE source_name = 'ci-codex'" "7"
-  assert_clickhouse_count "$clickhouse_url" "codex event rows" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex'" "7"
+  assert_clickhouse_count "$clickhouse_url" "codex unique raw rows" "SELECT uniqExact(raw_json_hash) FROM ${clickhouse_database}.raw_events WHERE source_name = 'ci-codex'" "8"
+  assert_clickhouse_count "$clickhouse_url" "codex event rows" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex'" "8"
   assert_clickhouse_count "$clickhouse_url" "codex link rows" "SELECT count() FROM ${clickhouse_database}.event_links FINAL WHERE source_name = 'ci-codex' AND link_type = 'parent_event' AND linked_external_id = 'msg-user-${run_stamp}'" "1"
   assert_clickhouse_count "$clickhouse_url" "codex tool rows" "SELECT count() FROM ${clickhouse_database}.tool_io FINAL WHERE source_name = 'ci-codex' AND tool_call_id = 'codex-tool-${run_stamp}'" "2"
   assert_clickhouse_count "$clickhouse_url" "codex tool request fields" "SELECT count() FROM ${clickhouse_database}.tool_io FINAL WHERE source_name = 'ci-codex' AND tool_call_id = 'codex-tool-${run_stamp}' AND tool_name = 'Read' AND tool_phase = 'request'" "1"
   assert_clickhouse_count "$clickhouse_url" "codex plain-git event identity" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND event_kind = 'tool_call' AND project_id != '' AND worktree_root = '${codex_project_dir}'" "1"
   assert_clickhouse_count "$clickhouse_url" "codex plain-git tool identity" "SELECT count() FROM ${clickhouse_database}.tool_io FINAL WHERE source_name = 'ci-codex' AND tool_call_id = 'codex-tool-${run_stamp}' AND tool_phase = 'request' AND project_id != '' AND repo_rel_path = 'Cargo.toml' AND worktree_root = '${codex_project_dir}'" "1"
-  assert_clickhouse_count "$clickhouse_url" "codex harness/session fields" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND harness = 'codex' AND session_id = '${codex_session_id}'" "7"
-  assert_clickhouse_count "$clickhouse_url" "codex model fields" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND model IN ('gpt-5.3-codex', 'gpt-5.3-codex-spark')" "6"
+  assert_clickhouse_count "$clickhouse_url" "codex harness/session fields" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND harness = 'codex' AND session_id = '${codex_session_id}'" "8"
+  assert_clickhouse_count "$clickhouse_url" "codex model fields" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND model IN ('gpt-5.3-codex', 'gpt-5.3-codex-spark')" "7"
   assert_clickhouse_count "$clickhouse_url" "codex token buckets" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-codex' AND payload_type = 'token_count' AND input_tokens = 17 AND output_tokens = 4 AND cache_read_tokens = 3 AND cache_write_tokens = 2 AND token_usage_buckets['input_text'] = 12 AND token_usage_buckets['output_text'] = 3 AND token_usage_buckets['reasoning'] = 1" "1"
 
   # Simulate rows ingested before normalized project fields existed. The MCP
@@ -1249,7 +1250,7 @@ PY
   assert_clickhouse_count "$clickhouse_url" "hermes session link rows" "SELECT count() FROM ${clickhouse_database}.event_links FINAL WHERE source_name = 'ci-hermes-session'" "0"
   assert_clickhouse_count "$clickhouse_url" "hermes session tool rows" "SELECT count() FROM ${clickhouse_database}.tool_io FINAL WHERE source_name = 'ci-hermes-session' AND tool_call_id = 'hermes-session-tool-${run_stamp}' AND tool_name = 'shell'" "2"
   assert_clickhouse_count "$clickhouse_url" "hermes session domain fields" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-hermes-session' AND harness = 'hermes' AND inference_provider = 'anthropic' AND session_id = '${hermes_raw_session_id}' AND model = 'claude-opus-4-6'" "6"
-  assert_clickhouse_count "$clickhouse_url" "token bucket map keys on all events" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE hasAll(mapKeys(token_usage_buckets), ['input_text', 'output_text', 'input_cache_read', 'input_cache_write', 'reasoning'])" "52"
+  assert_clickhouse_count "$clickhouse_url" "token bucket map keys on all events" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE hasAll(mapKeys(token_usage_buckets), ['input_text', 'output_text', 'input_cache_read', 'input_cache_write', 'reasoning'])" "53"
 
   local hermes_trajectory_session_id
   hermes_trajectory_session_id="$(clickhouse_scalar "$clickhouse_url" "SELECT any(session_id) FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-hermes-trajectory'")"
@@ -1395,7 +1396,7 @@ if not valid:
   printf '%s' "$sessions_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; expected=int(sys.argv[2]); session=next((s for s in data.get("sessions", []) if s.get("id")==sid), None); ok=session is not None and session.get("endedAt")==expected; sys.exit(0 if ok else 1)' "$codex_session_id" "1771243203900"
   local trace_body
   trace_body="$(curl -fsS "http://127.0.0.1:${monitor_port}/api/v1/tables/v_conversation_trace?limit=500")"
-  printf '%s' "$trace_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; expected=int(sys.argv[2]); count=sum(1 for row in data.get("rows", []) if row.get("session_id")==sid); sys.exit(0 if count==expected else 1)' "$codex_session_id" "7"
+  printf '%s' "$trace_body" | "$python_bin" -c 'import json,sys; data=json.load(sys.stdin); sid=sys.argv[1]; expected=int(sys.argv[2]); count=sum(1 for row in data.get("rows", []) if row.get("session_id")==sid); sys.exit(0 if count==expected else 1)' "$codex_session_id" "8"
 
   # Capture a server-clock-bounded query_log window after `moraine up` and its
   # status probe have exited. Direct curl assertions are excluded below by
@@ -1421,7 +1422,8 @@ PY
     --query "$codex_keyword" \
     --expect-session-id "$codex_session_id" \
     --expect-open-text "$codex_trace_marker" \
-    --expect-event-count "7" \
+    --expect-matching-search-hits "1" \
+    --expect-event-count "8" \
     --expect-updated-at "2026-02-16T12:00:03.900Z" \
     --file-attention-path "Cargo.toml" \
     --file-attention-expect-absent-session-id "$claude_session_id" \
@@ -1438,7 +1440,8 @@ PY
     --query "$codex_keyword" \
     --expect-session-id "$codex_session_id" \
     --expect-open-text "$codex_trace_marker" \
-    --expect-event-count "7" \
+    --expect-matching-search-hits "1" \
+    --expect-event-count "8" \
     --expect-updated-at "2026-02-16T12:00:03.900Z" \
     --file-attention-path "Cargo.toml" \
     --file-attention-expect-absent-session-id "$claude_session_id" \
@@ -1691,7 +1694,8 @@ PY
     --query "$codex_keyword" \
     --expect-session-id "$codex_session_id" \
     --expect-open-text "$codex_trace_marker" \
-    --expect-event-count "7" \
+    --expect-matching-search-hits "1" \
+    --expect-event-count "8" \
     --expect-updated-at "2026-02-16T12:00:03.900Z" \
     --file-attention-path "Cargo.toml" \
     --file-attention-expect-absent-session-id "$claude_session_id" \

--- a/scripts/ci/mcp_smoke.py
+++ b/scripts/ci/mcp_smoke.py
@@ -227,14 +227,13 @@ def assert_embedded_fallback(stderr: str) -> None:
 
 
 
-def select_search_sessions_result(
+def matching_search_sessions_results(
     results: list[Any],
     expect_session_id: Optional[str],
     expect_open_text: Optional[str],
-) -> Dict[str, Any]:
+) -> list[Dict[str, Any]]:
     expected_session = expected_mcp_session_id(expect_session_id)
-    candidates: list[Dict[str, Any]] = []
-
+    matches: list[Dict[str, Any]] = []
     for result in results:
         if not isinstance(result, dict):
             continue
@@ -245,7 +244,22 @@ def select_search_sessions_result(
             open_session_id,
         }:
             continue
-        candidates.append(result)
+        if expect_open_text is not None and not contains_text(result, expect_open_text):
+            continue
+        matches.append(result)
+    return matches
+
+
+def select_search_sessions_result(
+    results: list[Any],
+    expect_session_id: Optional[str],
+    expect_open_text: Optional[str],
+) -> Dict[str, Any]:
+    candidates = matching_search_sessions_results(
+        results,
+        expect_session_id,
+        None,
+    )
 
     if not candidates:
         debug_hits = [
@@ -561,6 +575,7 @@ def run_smoke(
     expect_no_results: bool = False,
     expect_event_count: Optional[int] = None,
     expect_updated_at: Optional[str] = None,
+    expect_matching_search_hits: Optional[int] = None,
     require_embedded_fallback: bool = False,
     tools_snapshot: Optional[str] = None,
 ) -> None:
@@ -652,6 +667,18 @@ def run_smoke(
             raise AssertionError(f"search_sessions returned no results array for query={query}")
 
         assert_sessions_absent(results, absent_session_ids, "search_sessions")
+        if expect_matching_search_hits is not None:
+            matching_results = matching_search_sessions_results(
+                results,
+                expect_session_id,
+                expect_open_text,
+            )
+            if len(matching_results) != expect_matching_search_hits:
+                raise AssertionError(
+                    "search_sessions returned an unexpected number of matching hits: "
+                    f"expected={expect_matching_search_hits}, actual={len(matching_results)}, "
+                    f"session_id={expect_session_id}, text={expect_open_text!r}"
+                )
 
         selected_result: Optional[Dict[str, Any]] = None
         if expect_no_results:
@@ -851,6 +878,14 @@ def main() -> int:
         help="expected canonical event_count for the selected list_sessions fixture",
     )
     parser.add_argument(
+        "--expect-matching-search-hits",
+        type=int,
+        help=(
+            "expected search_sessions hit count after filtering by "
+            "--expect-session-id and --expect-open-text"
+        ),
+    )
+    parser.add_argument(
         "--expect-updated-at",
         help="expected RFC3339 updated_at for the selected list_sessions fixture",
     )
@@ -889,6 +924,7 @@ def main() -> int:
         expect_no_results=args.expect_no_results,
         expect_event_count=args.expect_event_count,
         expect_updated_at=args.expect_updated_at,
+        expect_matching_search_hits=args.expect_matching_search_hits,
         require_embedded_fallback=args.require_embedded_fallback,
         tools_snapshot=args.write_tools_snapshot,
     )


### PR DESCRIPTION
## Description

- Deduplicate the known Codex `response_item` / `event_msg` representation pair when both rows are final-answer copies with identical logical coordinates and full content.
- Gate the millisecond tolerance on Codex harness/source identity, parsed source-file generation, adjacent source lines and event order, and a 10 ms maximum timestamp delta.
- Preserve the existing bounded candidate paging/refill behavior so removed mirrors do not reduce the requested distinct hit count.
- Extend unit, repository-integration, and full-stack fixtures to cover the 3 ms mirror, legitimate repeated messages, provenance/phase/type/content boundaries, and one-hit MCP output.

Closes #565

## Usage

No configuration, migration, or public API changes. `search_sessions` automatically collapses qualifying Codex final-answer mirrors while leaving the canonical ingested events intact.

## Changelog

Fixed `search_sessions` returning duplicate final assistant responses when mirrored Codex events had timestamps separated by a few milliseconds.

## Validation

- `cargo test -p moraine-conversations --lib --locked` — 66 passed, 1 ignored.
- `cargo test -p moraine-conversations --test repository_integration --locked` — 89 passed.
- `cargo clippy -p moraine-conversations --all-targets --locked -- -D warnings` — passed in the isolated Linux dev sandbox.
- `cargo build --workspace --locked` — passed in the isolated Linux dev sandbox.
- `MORAINECTL_BIN=/home/moraine/target/debug/moraine MORAINE_SERVICE_BIN_DIR=/home/moraine/target/debug bash scripts/ci/e2e-stack.sh` — passed against ClickHouse 25.12.5.44, including canonical ingest count 8 and exactly one matching Codex search hit through stdio, daemon, cache-hit, named-route, and embedded-fallback paths.
- `cargo fmt --all -- --check`, `bash -n scripts/ci/e2e-stack.sh`, and Python source compilation for `scripts/ci/mcp_smoke.py` — passed.
- Repository pre-commit hook — passed formatting and the workspace strict clippy baseline.