### PR TITLE
fix(search): stabilize active-ingest retries

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo/cache.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/cache.rs
@@ -354,15 +354,19 @@ impl ClickHouseConversationRepository {
         );
     }
 
+    pub(super) async fn cached_corpus_stats(&self) -> Option<(u64, u64)> {
+        let now = Instant::now();
+        let cache = self.stats_cache.read().await;
+        cache.corpus_stats.as_ref().and_then(|entry| {
+            (now.duration_since(entry.fetched_at) <= CORPUS_STATS_CACHE_TTL)
+                .then_some((entry.docs, entry.total_doc_len))
+        })
+    }
+
     pub(super) async fn corpus_stats(&self) -> RepoResult<(u64, u64)> {
         let now = Instant::now();
-        {
-            let cache = self.stats_cache.read().await;
-            if let Some(entry) = cache.corpus_stats.as_ref() {
-                if now.duration_since(entry.fetched_at) <= CORPUS_STATS_CACHE_TTL {
-                    return Ok((entry.docs, entry.total_doc_len));
-                }
-            }
+        if let Some(stats) = self.cached_corpus_stats().await {
+            return Ok(stats);
         }
 
         let from_stats_query = format!(

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -429,6 +429,7 @@ FORMAT JSONEachRow",
         source_name: Option<&str>,
         min_should_match: u16,
         min_score: f64,
+        corpus_stats: Option<(u64, u64)>,
         limit: u16,
         offset: u64,
     ) -> RepoResult<String> {
@@ -451,6 +452,14 @@ FORMAT JSONEachRow",
         let events_table = self.table_ref("mcp_open_events");
         let dirty_sessions_table = self.table_ref("mcp_open_dirty_sessions");
         let terms_array_sql = sql_array_strings(terms);
+        let corpus_stats_sql = match corpus_stats {
+            Some((docs, total_doc_len)) => {
+                format!("tuple(toUInt64({docs}), toUInt64({total_doc_len}))")
+            }
+            None => format!(
+                "(\n    SELECT tuple(toUInt64(docs), toUInt64(total_doc_len))\n    FROM {corpus_table}\n  )"
+            ),
+        };
 
         let mut posting_clauses = Vec::new();
         if let Some(session_id) = session_id {
@@ -544,10 +553,7 @@ WHERE scope_s.session_id = {session_id}{scope_origin_filter}",
   {k1:.6} AS k1,
   {b:.6} AS b,
   {terms_array_sql} AS q_terms,
-  (
-    SELECT tuple(toUInt64(docs), toUInt64(total_doc_len))
-    FROM {corpus_table}
-  ) AS corpus_stats,
+  {corpus_stats_sql} AS corpus_stats,
   tupleElement(corpus_stats, 1) AS corpus_docs,
   tupleElement(corpus_stats, 2) AS corpus_total_doc_len,
   greatest(
@@ -666,7 +672,6 @@ SETTINGS max_bytes_before_external_group_by = 67108864,
   max_bytes_before_external_sort = 67108864
 FORMAT JSONEachRow",
             postings_table = postings_table,
-            corpus_table = corpus_table,
             projection_state_table = projection_state_table,
             sessions_table = sessions_table,
             events_table = events_table,
@@ -1429,6 +1434,7 @@ FORMAT JSONEachRow",
         let mut offset = 0_u64;
         let mut page_count = 0_u16;
         let mut rows = Vec::<SearchMcpEventRow>::with_capacity(target_rows);
+        let mut corpus_stats = self.cached_corpus_stats().await;
         let mut snapshot = None::<(u64, u64, bool, u64)>;
 
         loop {
@@ -1439,6 +1445,7 @@ FORMAT JSONEachRow",
             }
             page_count += 1;
 
+            let scanned_corpus_stats = corpus_stats.is_none();
             let sql = self.build_search_mcp_events_sql(
                 terms,
                 event_types,
@@ -1448,6 +1455,7 @@ FORMAT JSONEachRow",
                 source_name,
                 min_should_match,
                 min_score,
+                corpus_stats,
                 page_limit,
                 offset,
             )?;
@@ -1457,15 +1465,19 @@ FORMAT JSONEachRow",
                 .iter()
                 .find(|row| row.row_kind == 1)
                 .ok_or_else(|| RepoError::backend("MCP search candidate query omitted metadata"))?;
+            let page_corpus_stats = (metadata.docs, metadata.total_doc_len);
+            if scanned_corpus_stats {
+                self.cache_corpus_stats(page_corpus_stats.0, page_corpus_stats.1, Instant::now())
+                    .await;
+                corpus_stats = Some(page_corpus_stats);
+            }
             if metadata.projection_ready == 0 {
                 return Err(RepoError::backend(
                     "MCP search read model is not ready; run `moraine db migrate`",
                 ));
             }
             if metadata.projection_clean == 0 {
-                return Err(RepoError::backend(
-                    "MCP search read model is catching up with ingest; retry the request",
-                ));
+                return Err(RepoError::ReadModelChanged);
             }
 
             let page_snapshot = (
@@ -1475,15 +1487,9 @@ FORMAT JSONEachRow",
                 metadata.projection_revision,
             );
             match snapshot {
-                None => {
-                    self.cache_corpus_stats(page_snapshot.0, page_snapshot.1, Instant::now())
-                        .await;
-                    snapshot = Some(page_snapshot);
-                }
+                None => snapshot = Some(page_snapshot),
                 Some(expected) if expected != page_snapshot => {
-                    return Err(RepoError::backend(
-                        "MCP search snapshot changed while paging candidates; retry the request",
-                    ));
+                    return Err(RepoError::ReadModelChanged);
                 }
                 Some(_) => {}
             }
@@ -1507,10 +1513,7 @@ FORMAT JSONEachRow",
 
             for candidate in candidates {
                 let Some(mut detail) = details_by_uid.remove(candidate.event_uid.as_str()) else {
-                    return Err(RepoError::backend(format!(
-                        "MCP search projection moved while hydrating event {}; retry the request",
-                        candidate.event_uid
-                    )));
+                    return Err(RepoError::ReadModelChanged);
                 };
                 detail.raw_score = candidate.raw_score;
                 detail.matched_terms = candidate.matched_terms;

--- a/crates/moraine-conversations/src/error.rs
+++ b/crates/moraine-conversations/src/error.rs
@@ -12,6 +12,8 @@ pub enum RepoError {
     Backend(String),
     #[error("internal error: {0}")]
     Internal(String),
+    #[error("search read model changed during ingest")]
+    ReadModelChanged,
 }
 
 impl RepoError {

--- a/crates/moraine-conversations/tests/repository_integration/search.rs
+++ b/crates/moraine-conversations/tests/repository_integration/search.rs
@@ -1,10 +1,8 @@
 use super::*;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn search_mcp_events_rejects_unready_and_dirty_projection_snapshots() {
-    for (projection_ready, projection_clean, expected) in
-        [(0_u8, 1_u8, "not ready"), (1_u8, 0_u8, "catching up")]
-    {
+async fn search_mcp_events_distinguishes_unready_and_dirty_projection_snapshots() {
+    for (projection_ready, projection_clean) in [(0_u8, 1_u8), (1_u8, 0_u8)] {
         let metadata = json!({
             "row_kind": 1_u8,
             "event_uid": "",
@@ -36,9 +34,70 @@ async fn search_mcp_events_rejects_unready_and_dirty_projection_snapshots() {
             })
             .await
             .expect_err("unhealthy projection must fail closed");
-        assert!(error.to_string().contains(expected), "{error}");
+        if projection_ready == 0 {
+            assert!(error.to_string().contains("not ready"), "{error}");
+        } else {
+            assert!(matches!(error, RepoError::ReadModelChanged));
+        }
         assert_script_consumed(&state, 1);
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_mcp_events_immediate_retry_finishes_within_request_deadline() {
+    let repeated_scan_reached = Arc::new(Notify::new());
+    let repeated_scan_release = Arc::new(Notify::new());
+    let (repo, state) = build_repo_with_options(
+        100,
+        MockOptions {
+            dirty_projection_on_first_candidate: true,
+            repeated_corpus_stats_barrier: Some(ScriptedBarrier {
+                reached: repeated_scan_reached.clone(),
+                release: repeated_scan_release,
+            }),
+            ..MockOptions::default()
+        },
+    )
+    .await;
+    let query = || SearchMcpEventsQuery {
+        query: "active ingest".to_string(),
+        n_hits: Some(10),
+        min_score: Some(0.0),
+        min_should_match: Some(1),
+        ..SearchMcpEventsQuery::default()
+    };
+
+    let first = repo
+        .search_mcp_events(query())
+        .await
+        .expect_err("dirty projection must return retry guidance");
+    assert!(matches!(first, RepoError::ReadModelChanged));
+
+    let retry_deadline = tokio::time::Instant::now() + Duration::from_secs(4);
+    let retry = tokio::time::timeout(
+        Duration::from_secs(4),
+        with_repository_query_deadline(
+            "active-ingest-retry".to_string(),
+            retry_deadline,
+            repo.search_mcp_events(query()),
+        ),
+    )
+    .await
+    .expect("published retry must finish inside the request deadline")
+    .expect("published retry must succeed");
+    assert_eq!(retry.hits.len(), 2);
+
+    let queries = state.queries.lock().expect("queries lock");
+    let candidate_queries = queries
+        .iter()
+        .filter(|query| {
+            query.contains("toUInt8(0) AS row_kind") && query.contains("projected_candidates AS")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(candidate_queries.len(), 2);
+    assert!(candidate_queries[0].contains("search_corpus_stats"));
+    assert!(!candidate_queries[1].contains("search_corpus_stats"));
+    assert!(candidate_queries[1].contains("tuple(toUInt64(100), toUInt64(5000)) AS corpus_stats"));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -926,11 +985,36 @@ async fn search_mcp_events_rejects_projection_changes_between_candidate_pages() 
         .await
         .expect_err("candidate paging must reject a changed projection revision");
 
-    assert!(error.to_string().contains("snapshot changed"), "{error}");
+    assert!(matches!(error, RepoError::ReadModelChanged));
     let queries = state.queries.lock().expect("queries lock");
     assert!(queries
         .iter()
         .any(|query| query.contains("LIMIT 3 OFFSET 3")));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_mcp_events_classifies_hydration_projection_movement() {
+    let (repo, _state) = build_repo_with_options(
+        100,
+        MockOptions {
+            omit_first_mcp_detail_row: true,
+            ..MockOptions::default()
+        },
+    )
+    .await;
+
+    let error = repo
+        .search_mcp_events(SearchMcpEventsQuery {
+            query: "hello world".to_string(),
+            n_hits: Some(2),
+            min_score: Some(0.0),
+            min_should_match: Some(1),
+            ..SearchMcpEventsQuery::default()
+        })
+        .await
+        .expect_err("missing pinned detail must report projection movement");
+
+    assert!(matches!(error, RepoError::ReadModelChanged));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -85,6 +85,9 @@ impl ScriptedResponse {
 #[derive(Clone, Default)]
 pub(crate) struct MockOptions {
     pub(crate) omit_second_snippet_row: bool,
+    pub(crate) dirty_projection_on_first_candidate: bool,
+    pub(crate) omit_first_mcp_detail_row: bool,
+    pub(crate) repeated_corpus_stats_barrier: Option<ScriptedBarrier>,
     pub(crate) change_projection_revision_on_second_search_page: bool,
     pub(crate) repeat_duplicate_search_pages: bool,
     pub(crate) scripted_responses: Vec<ScriptedResponse>,
@@ -798,6 +801,25 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
         }
 
         if query.contains("toUInt8(0) AS row_kind") && query.contains("projected_candidates AS") {
+            let candidate_query_count = state
+                .queries
+                .lock()
+                .expect("query lock")
+                .iter()
+                .filter(|candidate_query| {
+                    candidate_query.contains("toUInt8(0) AS row_kind")
+                        && candidate_query.contains("projected_candidates AS")
+                })
+                .count();
+            if candidate_query_count == 2 && query.contains("search_corpus_stats") {
+                if let Some(barrier) = state.options.repeated_corpus_stats_barrier.clone() {
+                    barrier.reached.notify_one();
+                    barrier.release.notified().await;
+                }
+            }
+            let projection_clean = u8::from(
+                !state.options.dirty_projection_on_first_candidate || candidate_query_count != 1,
+            );
             let projection_revision = if state
                 .options
                 .change_projection_revision_on_second_search_page
@@ -824,7 +846,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                     "total_doc_len": 5000_u64,
                     "scope_exists": 1_u8,
                     "projection_ready": 1_u8,
-                    "projection_clean": 1_u8,
+                    "projection_clean": projection_clean,
                     "projection_revision": projection_revision
                 })
             };
@@ -841,7 +863,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                 "total_doc_len": 5000_u64,
                 "scope_exists": 1_u8,
                 "projection_ready": 1_u8,
-                "projection_clean": 1_u8,
+                "projection_clean": projection_clean,
                 "projection_revision": projection_revision
             });
             let filter_clause = query
@@ -998,6 +1020,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
             ]
             .into_iter()
             .filter(|event_uid| query.contains(&format!("'{event_uid}'")))
+            .skip(usize::from(state.options.omit_first_mcp_detail_row))
             .map(detail)
             .collect::<Vec<_>>();
             return (StatusCode::OK, json_each_row(json!(event_uids)));

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -46,6 +46,7 @@ impl RequestLimitSource {
 const AUTOMATIC_MAX_PARALLEL_REQUESTS: usize = 8;
 const MAX_QUEUED_REQUESTS: usize = 16;
 const REQUEST_DEADLINE: std::time::Duration = std::time::Duration::from_secs(4);
+const SEARCH_PROJECTION_RETRY_AFTER_MS: u64 = 250;
 
 fn effective_max_parallel_requests(configured: Option<u16>) -> (usize, RequestLimitSource) {
     let (requested, source) = match configured {
@@ -773,6 +774,18 @@ pub(crate) fn repo_error_to_contract_error(error: RepoError) -> contract::Contra
         RepoError::InvalidArgument(message) | RepoError::InvalidCursor(message) => {
             contract::ContractError::new(contract::ToolErrorCode::InvalidRequest, message)
         }
+        RepoError::ReadModelChanged => contract::ContractError::new(
+            contract::ToolErrorCode::InternalError,
+            format!(
+                "MCP search read model is refreshing; retry after {} ms",
+                SEARCH_PROJECTION_RETRY_AFTER_MS
+            ),
+        )
+        .with_details(json!({
+            "reason": "read_model_refresh",
+            "retryable": true,
+            "retry_after_ms": SEARCH_PROJECTION_RETRY_AFTER_MS,
+        })),
         RepoError::Backend(message) | RepoError::Internal(message) => {
             contract::ContractError::new(contract::ToolErrorCode::InternalError, message)
         }
@@ -2122,6 +2135,17 @@ mod tests {
         AppState::embedded(AppConfig::default(), repository)
     }
 
+    fn read_model_changed_test_state() -> Arc<AppState> {
+        let repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            InMemoryConversationResponses {
+                search_mcp_events: Some(Err(RepoError::ReadModelChanged)),
+                ..InMemoryConversationResponses::default()
+            },
+        ));
+        AppState::embedded(AppConfig::default(), repository)
+    }
+
     async fn call_tool_rpc(state: &AppState, id: u64, tool: &str, arguments: Value) -> Value {
         state
             .handle_request(RpcRequest {
@@ -2500,7 +2524,39 @@ mod tests {
         for (index, (tool, arguments)) in cases.into_iter().enumerate() {
             let response = call_tool_rpc(&state, index as u64 + 1, tool, arguments).await;
             assert_handled_tool_error_exchange(&response, tool, "internal_error");
+            assert!(response["result"]["structuredContent"]["error"]
+                .get("details")
+                .is_none());
         }
+    }
+
+    #[tokio::test]
+    async fn search_projection_changes_are_structured_retryable_errors() {
+        let state = read_model_changed_test_state();
+        let response = call_tool_rpc(
+            &state,
+            1,
+            contract::SEARCH_SESSIONS_TOOL,
+            json!({ "query": "active ingest" }),
+        )
+        .await;
+
+        assert_handled_tool_error_exchange(
+            &response,
+            contract::SEARCH_SESSIONS_TOOL,
+            "internal_error",
+        );
+        let error = &response["result"]["structuredContent"]["error"];
+        assert_eq!(error["details"]["reason"], json!("read_model_refresh"));
+        assert_eq!(error["details"]["retryable"], json!(true));
+        assert_eq!(
+            error["details"]["retry_after_ms"],
+            json!(SEARCH_PROJECTION_RETRY_AFTER_MS)
+        );
+        assert!(error["message"]
+            .as_str()
+            .expect("freshness error message")
+            .contains("retry after 250 ms"));
     }
 
     #[tokio::test]

--- a/docs/agent-mcp-search/interface.md
+++ b/docs/agent-mcp-search/interface.md
@@ -340,6 +340,11 @@ Tool-level errors return `schema_version: "moraine.mcp.error.v1"` with an
 `not_found`, `unsupported_event_type`, `deadline_exceeded`, and
 `internal_error`.
 
+While the search read model is publishing an active-ingest update,
+`search_sessions` returns `internal_error` with
+`error.details.reason = "read_model_refresh"`, `retryable = true`, and a
+positive `retry_after_ms`. Wait for that interval, then retry the same request.
+
 ## How Agents Should Read Results
 
 The agent should treat Moraine records as a navigable evidence graph:

--- a/docs/mcp-search-interface-spec.md
+++ b/docs/mcp-search-interface-spec.md
@@ -198,6 +198,11 @@ Error behavior:
 - Malformed IDs must return `invalid_id`.
 - Unknown event type filters must return `unsupported_event_type`.
 - Runtime failures must return `internal_error` with a concise message.
+- While the search read model is publishing an active-ingest update,
+  `search_sessions` returns `internal_error` with
+  `error.details.reason = "read_model_refresh"`, `retryable = true`, and a
+  positive `retry_after_ms`; clients should wait for that interval and retry the
+  same request.
 
 ## Tool: `search_sessions`
 


### PR DESCRIPTION
## Description

**What.** Makes `search_sessions` active-ingest freshness failures prompt and retryable, then reuses the authoritative corpus statistics from the failed dirty read on the immediate post-publication retry.

**Why.** A dirty candidate read already paid for the corpus-stat scan before rejecting the projection snapshot; discarding that result made the immediate retry repeat the scan and sometimes consume the fixed four-second MCP request deadline.

The repository now classifies dirty candidate pages, page-to-page projection movement, and candidate-to-hydration movement with a typed `ReadModelChanged` error. The MCP boundary maps that variant to `internal_error` details containing `reason=read_model_refresh`, `retryable=true`, and `retry_after_ms=250`. Corpus statistics are cached only after an authoritative scan, preserving the existing absolute 30-second TTL instead of turning it into sliding expiration.

No request-deadline, admission, queueing, schema, migration, projection-publication, result-cache, or unrelated retrieval-tool policy changes are included.

Closes #564.

## Usage

No configuration or operator action changes. During an active projection publication, clients can distinguish freshness from backend failures:

```json
{
  "code": "internal_error",
  "details": {
    "reason": "read_model_refresh",
    "retryable": true,
    "retry_after_ms": 250
  }
}
```

Wait for the indicated interval, then retry the same `search_sessions` request.

## Bug Evidence

Before this change, the dirty candidate query returned a catch-up error after scanning `search_corpus_stats`; the immediate retry discarded those statistics, repeated the scan, and could end as `request_deadline`.

The final owned-stack reproduction kept one MCP process alive, forced a published session dirty, published through `moraine db migrate`, and retried the exact query. The dirty response returned structured freshness guidance in 85 ms. The immediate retry succeeded with one result in 65 ms. Owned ClickHouse query-log evidence showed the dirty candidate scanning corpus stats and the retry candidate omitting them (`scans_corpus_stats: 1 -> 0`).

## Performance

The unchanged documented native central burst benchmark ran on arm64 macOS against an owned, non-default 100,000-document full fixture. All 2,600 requests, query-log inventory checks, tool-surface checks, and existing latency gates passed.

Concurrency-1 results:

| Mode | Cold p95 | Warm p95 | Max |
| --- | ---: | ---: | ---: |
| hydration | 202.48 ms | 0.31 ms | 240.17 ms |
| ranking tie | 215.79 ms | 0.28 ms | 274.44 ms |
| rare | 251.58 ms | 0.14 ms | 286.69 ms |
| session scope | 256.54 ms | 0.14 ms | 302.08 ms |

## Changelog

- Returns structured retry guidance when active ingest is publishing the search projection.
- Prevents immediate post-publication retries from repeating the authoritative corpus-stat scan.
- Preserves the existing four-second deadline and cache TTL policies.

## Validation

In an owned Linux dev sandbox, `cargo test -p moraine-conversations --test repository_integration --locked` passed 91 tests, `cargo test -p moraine-conversations --lib --locked` passed 65 tests, and `cargo test -p moraine-mcp-core --lib --locked` passed 122 tests. The deterministic dirty-to-published regression runs the retry through the four-second repository/MCP deadline context and fails if a second corpus-stat scan is attempted.

`cargo fmt --all -- --check`, the repository strict Clippy baseline via `make clippy`, and `make docs-build` passed. The final owned-stack MCP smoke and query-log assertions passed as described above.

The unchanged native benchmark passed with:

```bash
python3 scripts/bench/performance_suite.py native-central-burst \
  --mcp-binary ./target/release/moraine-mcp \
  --config /tmp/moraine-issue564-native/config.toml \
  --profile full --split research \
  --cold-repetitions 100 --minimum-cold-samples 100 \
  --bursts-per-case 25 \
  --warm-p95-limit-ms 750 --cold-p95-limit-ms 2000 \
  --max-latency-ms 5000 --collect-query-log \
  --output /tmp/moraine-issue564-native/native-central-burst-rerun.json
```

All owned sandboxes, ClickHouse data, volumes, sockets, processes, and temporary configs were removed after validation.