### PR TITLE
feat(search): default session search to message events

### DIFF
--- a/crates/moraine-conversations/tests/repository_integration/search.rs
+++ b/crates/moraine-conversations/tests/repository_integration/search.rs
@@ -594,6 +594,7 @@ async fn search_mcp_events_supports_global_search_with_enriched_hits() {
             n_hits: Some(10),
             event_types: Some(vec![
                 McpEventType::ToolResponse,
+                McpEventType::ToolCall,
                 McpEventType::UserInput,
                 McpEventType::AssistantResponse,
             ]),
@@ -611,6 +612,7 @@ async fn search_mcp_events_supports_global_search_with_enriched_hits() {
         vec![
             McpEventType::UserInput,
             McpEventType::AssistantResponse,
+            McpEventType::ToolCall,
             McpEventType::ToolResponse
         ]
     );
@@ -873,6 +875,63 @@ async fn search_mcp_events_supports_turn_scoped_search() {
     assert!(search_query.contains("ALL INNER JOIN `moraine`.`mcp_open_turns` AS scope_t FINAL"));
 }
 #[tokio::test(flavor = "multi_thread")]
+async fn search_mcp_events_returns_explicit_tool_event_filters() {
+    let (repo, _state) = build_repo().await;
+
+    let tool_call_result = repo
+        .search_mcp_events(SearchMcpEventsQuery {
+            query: "hello world".to_string(),
+            n_hits: Some(5),
+            event_types: Some(vec![McpEventType::ToolCall]),
+            min_score: Some(0.0),
+            min_should_match: Some(1),
+            ..SearchMcpEventsQuery::default()
+        })
+        .await
+        .expect("tool-call search");
+    let tool_response_result = repo
+        .search_mcp_events(SearchMcpEventsQuery {
+            query: "hello world".to_string(),
+            n_hits: Some(5),
+            event_types: Some(vec![McpEventType::ToolResponse]),
+            min_score: Some(0.0),
+            min_should_match: Some(1),
+            ..SearchMcpEventsQuery::default()
+        })
+        .await
+        .expect("tool-response search");
+    let mixed_result = repo
+        .search_mcp_events(SearchMcpEventsQuery {
+            query: "hello world".to_string(),
+            n_hits: Some(5),
+            event_types: Some(vec![McpEventType::UserInput, McpEventType::ToolCall]),
+            min_score: Some(0.0),
+            min_should_match: Some(1),
+            ..SearchMcpEventsQuery::default()
+        })
+        .await
+        .expect("mixed message and tool search");
+
+    assert_eq!(tool_call_result.hits.len(), 1);
+    assert_eq!(tool_call_result.hits[0].event_type, McpEventType::ToolCall);
+    assert_eq!(tool_call_result.hits[0].event_uid, "evt-c-tool-call");
+    assert_eq!(tool_response_result.hits.len(), 1);
+    assert_eq!(
+        tool_response_result.hits[0].event_type,
+        McpEventType::ToolResponse
+    );
+    assert_eq!(tool_response_result.hits[0].event_uid, "evt-c-tool");
+    assert_eq!(
+        mixed_result
+            .hits
+            .iter()
+            .map(|hit| hit.event_type)
+            .collect::<Vec<_>>(),
+        vec![McpEventType::ToolCall, McpEventType::UserInput]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn search_mcp_events_event_type_filter_distinguishes_user_and_assistant_messages() {
     let (repo, state) = build_repo().await;
 
@@ -898,6 +957,20 @@ async fn search_mcp_events_event_type_filter_distinguishes_user_and_assistant_me
         })
         .await
         .expect("assistant response search");
+    let message_result = repo
+        .search_mcp_events(SearchMcpEventsQuery {
+            query: "hello world".to_string(),
+            n_hits: Some(5),
+            event_types: Some(vec![
+                McpEventType::UserInput,
+                McpEventType::AssistantResponse,
+            ]),
+            min_score: Some(0.0),
+            min_should_match: Some(1),
+            ..SearchMcpEventsQuery::default()
+        })
+        .await
+        .expect("message-only search");
 
     assert_eq!(user_result.hits.len(), 1);
     assert_eq!(user_result.hits[0].event_uid, "evt-c-user");
@@ -910,6 +983,14 @@ async fn search_mcp_events_event_type_filter_distinguishes_user_and_assistant_me
         McpEventType::AssistantResponse
     );
     assert_eq!(assistant_result.hits[0].actor_role, "assistant");
+    assert!(message_result.hits.iter().all(|hit| matches!(
+        hit.event_type,
+        McpEventType::UserInput | McpEventType::AssistantResponse
+    )));
+    assert_eq!(
+        message_result.event_types,
+        vec![McpEventType::UserInput, McpEventType::AssistantResponse]
+    );
 
     let queries = state.queries.lock().expect("queries lock").clone();
     assert!(queries.iter().any(|q| {

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -871,18 +871,48 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                 .and_then(|(_, tail)| tail.split_once("GROUP BY p.doc_id"))
                 .map(|(filter, _)| filter)
                 .unwrap_or(query.as_str());
+            let includes_user = filter_clause.contains("lowerUTF8(p.actor_role) = 'user'");
+            let includes_assistant =
+                filter_clause.contains("lowerUTF8(p.actor_role) = 'assistant'");
+            let includes_tool_call = filter_clause.contains("p.event_class = 'tool_call'");
+            let includes_tool_response = filter_clause.contains("p.event_class = 'tool_result'");
             let mut rows = if query.contains("e.session_id = 'sess_c' AND e.turn_seq = 2") {
                 vec![candidate("evt-c-tool", 13.0, 2, 1_767_434_430_000)]
             } else if query.contains("p.session_id = 'sess_a'") {
                 vec![candidate("evt-a-11", 7.0, 1, 1_767_261_720_000)]
-            } else if filter_clause.contains("lowerUTF8(p.actor_role) = 'user'")
-                && !filter_clause.contains("lowerUTF8(p.actor_role) = 'assistant'")
+            } else if includes_user
+                && !includes_assistant
+                && !includes_tool_call
+                && !includes_tool_response
             {
                 vec![candidate("evt-c-user", 11.0, 2, 1_767_434_460_000)]
-            } else if filter_clause.contains("lowerUTF8(p.actor_role) = 'assistant'")
-                && !filter_clause.contains("lowerUTF8(p.actor_role) = 'user'")
+            } else if includes_assistant
+                && !includes_user
+                && !includes_tool_call
+                && !includes_tool_response
             {
                 vec![candidate("evt-c-42", 12.5, 2, 1_767_434_520_000)]
+            } else if includes_tool_call
+                && !includes_user
+                && !includes_assistant
+                && !includes_tool_response
+            {
+                vec![candidate("evt-c-tool-call", 13.5, 2, 1_767_434_400_000)]
+            } else if includes_tool_response
+                && !includes_user
+                && !includes_assistant
+                && !includes_tool_call
+            {
+                vec![candidate("evt-c-tool", 13.0, 2, 1_767_434_430_000)]
+            } else if includes_user
+                && includes_tool_call
+                && !includes_assistant
+                && !includes_tool_response
+            {
+                vec![
+                    candidate("evt-c-tool-call", 13.5, 2, 1_767_434_400_000),
+                    candidate("evt-c-user", 11.0, 2, 1_767_434_460_000),
+                ]
             } else if query.contains("LIMIT 3 OFFSET 3")
                 && !state.options.repeat_duplicate_search_pages
             {
@@ -925,6 +955,13 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                         9_u64,
                         1_u32,
                     ),
+                    "evt-c-tool-call" => (
+                        "sess_c",
+                        "2026-01-03 10:00:00",
+                        1_767_434_400_000_i64,
+                        39_u64,
+                        2_u32,
+                    ),
                     "evt-c-tool" => (
                         "sess_c",
                         "2026-01-03 10:00:30",
@@ -954,18 +991,21 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                         2_u32,
                     ),
                 };
-                let is_tool = event_uid == "evt-c-tool";
+                let is_tool_call = event_uid == "evt-c-tool-call";
+                let is_tool_response = event_uid == "evt-c-tool";
                 let is_user = event_uid == "evt-c-user";
                 let is_duplicate = event_uid == "evt-c-duplicate";
                 let is_canonical_response = event_uid == "evt-c-42";
-                let actor_role = if is_tool {
+                let actor_role = if is_tool_response {
                     "tool"
                 } else if is_user {
                     "user"
                 } else {
                     "assistant"
                 };
-                let event_type = if is_tool {
+                let event_type = if is_tool_call {
+                    "tool_call"
+                } else if is_tool_response {
                     "tool_response"
                 } else if is_user {
                     "user_input"
@@ -973,6 +1013,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                     "assistant_response"
                 };
                 let text = match event_uid {
+                    "evt-c-tool-call" => "assistant invoked bash for hello world",
                     "evt-c-tool" => "cargo test failure output with stack details",
                     "evt-c-user" => "user asked about hello world in a prompt",
                     "evt-a-11" => "weaker assistant event in session a with extra context",
@@ -986,11 +1027,11 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                     "harness": "codex",
                     "inference_provider": "openai",
                     "endpoint_kind": "generation",
-                    "event_class": if is_tool { "tool_result" } else if is_duplicate { "event_msg" } else { "message" },
-                    "payload_type": if is_tool { "tool_result" } else if is_duplicate { "agent_message" } else if is_canonical_response { "message" } else { "text" },
+                    "event_class": if is_tool_call { "tool_call" } else if is_tool_response { "tool_result" } else if is_duplicate { "event_msg" } else { "message" },
+                    "payload_type": if is_tool_call { "tool_use" } else if is_tool_response { "tool_result" } else if is_duplicate { "agent_message" } else if is_canonical_response { "message" } else { "text" },
                     "actor_role": actor_role,
-                    "name": if is_tool { "bash" } else { "" },
-                    "phase": if is_tool || is_duplicate { "completed" } else if is_canonical_response { "final_answer" } else { "" },
+                    "name": if is_tool_call || is_tool_response { "bash" } else { "" },
+                    "phase": if is_tool_call || is_tool_response || is_duplicate { "completed" } else if is_canonical_response { "final_answer" } else { "" },
                     "payload_phase": if is_duplicate || is_canonical_response { "final_answer" } else { "" },
                     "source_ref": format!("/tmp/{session_id}.jsonl:1:{event_order}"),
                     "doc_len": 19_u32,
@@ -1005,11 +1046,11 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                     "event_unix_ms": event_unix_ms,
                     "event_order": event_order,
                     "turn_seq": turn_seq,
-                    "event_ordinal": if is_tool { 1_u32 } else if is_user { 2_u32 } else if session_id == "sess_c" { 3_u32 } else { 1_u32 },
+                    "event_ordinal": if is_tool_call || is_tool_response { 1_u32 } else if is_user { 2_u32 } else if session_id == "sess_c" { 3_u32 } else { 1_u32 },
                     "turn_event_count": if session_id == "sess_c" { 3_u64 } else { 1_u64 },
                     "turn_completed": if session_id == "sess_c" { 1_u8 } else { 0_u8 },
                     "turn_terminal_event_uid": if session_id == "sess_c" { "evt-c-42" } else { "" },
-                    "call_id": if is_tool { "call-bash-1" } else { "" },
+                    "call_id": if is_tool_call || is_tool_response { "call-bash-1" } else { "" },
                     "item_id": format!("item-{event_uid}"),
                     "model": "gpt-5.3-codex",
                     "session_started_at_unix_ms": event_unix_ms - 120_000,
@@ -1021,6 +1062,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                 })
             };
             let event_uids = [
+                "evt-c-tool-call",
                 "evt-c-tool",
                 "evt-c-user",
                 "evt-c-42",

--- a/crates/moraine-mcp-core/src/contract.rs
+++ b/crates/moraine-mcp-core/src/contract.rs
@@ -412,7 +412,7 @@ impl McpEventType {
     }
 
     pub fn search_defaults() -> &'static [McpEventType] {
-        &[Self::UserInput, Self::AssistantResponse, Self::ToolResponse]
+        &[Self::UserInput, Self::AssistantResponse]
     }
 
     pub fn is_searchable(self) -> bool {
@@ -1659,14 +1659,10 @@ mod tests {
     }
 
     #[test]
-    fn default_event_types_are_user_assistant_and_tool_response() {
+    fn default_event_types_are_user_and_assistant_messages() {
         assert_eq!(
             default_search_event_types(),
-            vec![
-                McpEventType::UserInput,
-                McpEventType::AssistantResponse,
-                McpEventType::ToolResponse
-            ]
+            vec![McpEventType::UserInput, McpEventType::AssistantResponse]
         );
 
         let canonical = SearchSessionsArgs {
@@ -1919,7 +1915,7 @@ mod tests {
             json!({
                 "query": "migration",
                 "within_id": null,
-                "event_types": ["user_input", "assistant_response", "tool_response"],
+                "event_types": ["user_input", "assistant_response"],
                 "n_hits": 10
             }),
             json!({
@@ -1939,7 +1935,7 @@ mod tests {
                 "request": {
                     "query": "migration",
                     "within_id": null,
-                    "event_types": ["user_input", "assistant_response", "tool_response"],
+                    "event_types": ["user_input", "assistant_response"],
                     "n_hits": 10
                 },
                 "data": {

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -427,7 +427,7 @@ impl AppState {
             "tools": [
                 {
                     "name": contract::SEARCH_SESSIONS_TOOL,
-                    "description": "Search Moraine session history and return compact event-ranked handles. Use open with the returned event_id, turn_id, or session_id to expand results.",
+                    "description": "Search Moraine session history and return compact event-ranked handles. By default, searches user_input and assistant_response events. Select tool_call or tool_response with event_types for raw tool evidence, then use open on a returned turn_id or session_id for full context.",
                     "inputSchema": {
                         "type": "object",
                         "additionalProperties": false,
@@ -455,7 +455,8 @@ impl AppState {
                                         "runtime"
                                     ]
                                 },
-                                "description": "Optional normalized event type filter. Defaults to user_input, assistant_response, and tool_response."
+                                "default": ["user_input", "assistant_response"],
+                                "description": "Optional normalized event type filter. Defaults to user_input and assistant_response. Select tool_call or tool_response explicitly for raw tool evidence."
                             },
                             "harness": {
                                 "type": ["string", "null"],
@@ -2288,12 +2289,20 @@ mod tests {
             .find(|tool| tool["name"].as_str() == Some("search_sessions"))
             .expect("search_sessions exists");
         assert_eq!(
+            search["description"],
+            json!("Search Moraine session history and return compact event-ranked handles. By default, searches user_input and assistant_response events. Select tool_call or tool_response with event_types for raw tool evidence, then use open on a returned turn_id or session_id for full context.")
+        );
+        assert_eq!(
             search["inputSchema"]["properties"]["query"]["description"],
             json!("Keyword (BM25) search query. Matching is bag-of-words: quotes and punctuation are ignored, and a quoted phrase is matched as independent terms subject to the configured minimum-match threshold, not as an exact phrase.")
         );
         assert_eq!(
             search["inputSchema"]["properties"]["event_types"]["description"],
-            json!("Optional normalized event type filter. Defaults to user_input, assistant_response, and tool_response.")
+            json!("Optional normalized event type filter. Defaults to user_input and assistant_response. Select tool_call or tool_response explicitly for raw tool evidence.")
+        );
+        assert_eq!(
+            search["inputSchema"]["properties"]["event_types"]["default"],
+            json!(["user_input", "assistant_response"])
         );
         assert_eq!(
             search["inputSchema"]["properties"]["n_hits"]["default"],

--- a/crates/moraine-mcp-core/src/search_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/search_sessions_v1.rs
@@ -345,6 +345,9 @@ fn not_found_error(kind: &str, id: String) -> ContractError {
 mod tests {
     use super::*;
     use crate::contract::{McpEventType, OpenV1Args, SearchSessionsArgs};
+    use moraine_config::AppConfig;
+    use moraine_conversations::{InMemoryConversationRepository, RepoConfig};
+    use std::sync::Arc;
 
     #[test]
     fn parses_and_canonicalizes_search_sessions_args() {
@@ -365,6 +368,79 @@ mod tests {
         assert_eq!(args.harness.as_deref(), Some("claude-code"));
         assert_eq!(args.source.as_deref(), Some("claude"));
         assert_eq!(args.n_hits, 3);
+    }
+
+    #[tokio::test]
+    async fn forwards_effective_event_types_and_reports_them_in_canonical_request() {
+        let repository = Arc::new(InMemoryConversationRepository::new(RepoConfig::default()));
+        let state = AppState::embedded(AppConfig::default(), repository.clone());
+        let cases = [
+            (
+                json!({ "query": "migration" }),
+                vec![
+                    RepoMcpEventType::UserInput,
+                    RepoMcpEventType::AssistantResponse,
+                ],
+                json!(["user_input", "assistant_response"]),
+            ),
+            (
+                json!({ "query": "migration", "event_types": null }),
+                vec![
+                    RepoMcpEventType::UserInput,
+                    RepoMcpEventType::AssistantResponse,
+                ],
+                json!(["user_input", "assistant_response"]),
+            ),
+            (
+                json!({ "query": "migration", "event_types": ["tool_call"] }),
+                vec![RepoMcpEventType::ToolCall],
+                json!(["tool_call"]),
+            ),
+            (
+                json!({ "query": "migration", "event_types": ["tool_response"] }),
+                vec![RepoMcpEventType::ToolResponse],
+                json!(["tool_response"]),
+            ),
+            (
+                json!({
+                    "query": "migration",
+                    "event_types": [
+                        "tool_response",
+                        "user_input",
+                        "tool_call",
+                        "tool_response"
+                    ]
+                }),
+                vec![
+                    RepoMcpEventType::UserInput,
+                    RepoMcpEventType::ToolCall,
+                    RepoMcpEventType::ToolResponse,
+                ],
+                json!(["user_input", "tool_call", "tool_response"]),
+            ),
+        ];
+
+        for (arguments, expected_repo_types, expected_request_types) in cases {
+            let result = state
+                .search_sessions_v1(arguments)
+                .await
+                .expect("search sessions");
+            assert_eq!(result["isError"], json!(false));
+            assert_eq!(
+                result["structuredContent"]["request"]["event_types"],
+                expected_request_types
+            );
+
+            let calls = repository.calls();
+            let query = calls
+                .search_mcp_events
+                .last()
+                .expect("repository search call");
+            assert_eq!(
+                query.event_types.as_deref(),
+                Some(expected_repo_types.as_slice())
+            );
+        }
     }
 
     #[test]

--- a/docs/agent-mcp-search/interface.md
+++ b/docs/agent-mcp-search/interface.md
@@ -60,7 +60,7 @@ Input:
 {
   "query": "mcp open tool oneof top-level schema",
   "within_id": null,
-  "event_types": ["user_input", "assistant_response", "tool_response"],
+  "event_types": ["user_input", "assistant_response"],
   "harness": null,
   "source": null,
   "n_hits": 10
@@ -78,10 +78,12 @@ Fields:
 | `source` | Optional exact, case-sensitive ingest source filter. The default configured values are `claude`, `codex`, `cursor`, `cursor-sqlite`, `hermes`, `kimi-cli`, `omp`, `opencode`, and `pi`; each server's MCP tool instructions list its actual configured source names. |
 | `n_hits` | Optional result limit from 1 to 50. Default is 10. |
 
-The default event type filter is `user_input`, `assistant_response`, and
-`tool_response`. That default is intentionally practical: it searches what the
-user asked, what the assistant concluded, and what tools returned, while leaving
-lower-signal operational records out until you request them.
+The default event type filter is `user_input` and `assistant_response`. This
+deterministic, message-first default searches what the user asked and what the
+assistant concluded without returning raw tool evidence. Request `tool_call`
+or `tool_response` explicitly through `event_types` when that evidence is
+needed. To inspect the full context around a hit, pass its returned turn or
+session handle to `open`.
 
 Use `source` when the configured source is the distinction that matters. For
 example, the `pi` and `omp` sources both use the `pi-coding-agent` harness, so
@@ -103,7 +105,7 @@ Each result includes:
 {
   "rank": 1,
   "score": 12.34,
-  "event": { "id": "event:...", "type": "tool_response" },
+  "event": { "id": "event:...", "type": "assistant_response" },
   "turn": { "id": "turn:...", "ordinal": 7 },
   "session": { "id": "session:...", "title": "..." },
   "snippet": { "text": "...", "truncated": false },

--- a/docs/mcp-search-interface-spec.md
+++ b/docs/mcp-search-interface-spec.md
@@ -260,7 +260,7 @@ search_sessions({
 - When omitted or `null`, defaults to:
 
 ```json
-["user_input", "assistant_response", "tool_response"]
+["user_input", "assistant_response"]
 ```
 
 - May contain any supported event type except `unknown`.
@@ -324,7 +324,6 @@ Default behavior searches:
 ```text
 user_input
 assistant_response
-tool_response
 ```
 
 This default intentionally omits:
@@ -332,6 +331,7 @@ This default intentionally omits:
 ```text
 reasoning
 tool_call
+tool_response
 compaction
 system
 runtime
@@ -339,6 +339,9 @@ unknown
 ```
 
 Callers may explicitly include supported omitted types when they need them.
+Raw tool evidence requires `tool_call` or `tool_response` in `event_types`.
+Open a returned turn or session handle to inspect the full context around a
+search hit.
 
 Examples:
 
@@ -378,7 +381,7 @@ should not compare scores across different queries.
   "request": {
     "query": "clickhouse schema migration failure",
     "within_id": null,
-    "event_types": ["user_input", "assistant_response", "tool_response"],
+    "event_types": ["user_input", "assistant_response"],
     "harness": null,
     "source": null,
     "n_hits": 10
@@ -488,7 +491,7 @@ Response:
   "request": {
     "query": "ClickHouse schema migration failure",
     "within_id": null,
-    "event_types": ["user_input", "assistant_response", "tool_response"],
+    "event_types": ["user_input", "assistant_response"],
     "n_hits": 10
   },
   "data": {
@@ -669,7 +672,7 @@ Response:
   "request": {
     "query": "nonexistent exact phrase for this index",
     "within_id": null,
-    "event_types": ["user_input", "assistant_response", "tool_response"],
+    "event_types": ["user_input", "assistant_response"],
     "n_hits": 5
   },
   "data": {

--- a/scripts/ci/mcp_smoke.py
+++ b/scripts/ci/mcp_smoke.py
@@ -661,10 +661,29 @@ def run_smoke(
         )
         next_id += 1
         search_payload = assert_structured_content(search_result, "search_sessions")
+        event_types = search_payload["request"].get("event_types")
+        if event_types != ["user_input", "assistant_response"]:
+            raise AssertionError(
+                "search_sessions default event_types must be "
+                f"['user_input', 'assistant_response'], got: {event_types}"
+            )
 
         results = search_payload["data"].get("results")
         if not isinstance(results, list):
             raise AssertionError(f"search_sessions returned no results array for query={query}")
+        unexpected_event_types = []
+        for result in results:
+            if not isinstance(result, dict) or not isinstance(result.get("event"), dict):
+                unexpected_event_types.append(None)
+                continue
+            event_type = result["event"].get("type")
+            if event_type not in {"user_input", "assistant_response"}:
+                unexpected_event_types.append(event_type)
+        if unexpected_event_types:
+            raise AssertionError(
+                "search_sessions default results must contain only message events, "
+                f"got: {unexpected_event_types}"
+            )
 
         assert_sessions_absent(results, absent_session_ids, "search_sessions")
         if expect_matching_search_hits is not None:


### PR DESCRIPTION
## Description

**What.** Makes `search_sessions` default to `user_input` and `assistant_response` events while keeping raw tool evidence explicitly selectable.

**Why.** Tool responses could dominate default rankings with shell output, logs, and source excerpts when callers were looking for requirements, decisions, or conclusions.

- Applies the two-type default during MCP request canonicalization and reports the effective selection in response request metadata.
- Keeps `tool_call`, `tool_response`, and mixed explicit `event_types` selections working through the repository filter.
- Publishes the default in the MCP input schema and directs callers to explicit tool-event filters plus `open` on returned turn/session handles for full context.
- Extends deterministic repository fixtures and stack smoke assertions so default tool-event leakage fails validation.

## Usage

Omit `event_types` for message-first search:

```json
{
  "query": "search retention decision"
}
```

The canonical response request reports:

```json
{
  "event_types": ["user_input", "assistant_response"]
}
```

Request raw tool evidence explicitly when needed:

```json
{
  "query": "cargo test failure",
  "event_types": ["tool_call", "tool_response"]
}
```

Use a returned `turn_id` or `session_id` with `open` to inspect the full surrounding context.

## Changelog

- Changes default `search_sessions` recall to user and assistant messages only.
- Keeps raw tool calls and responses available through explicit `event_types` selection.
- No data migration, index rebuild, or configuration change is required.

## Operational Impact

Existing callers that rely on errors or command output found only in tool events must now pass `event_types: ["tool_call"]`, `event_types: ["tool_response"]`, or a mixed explicit selection. Stored events, ranking, cache design, and `open` behavior are unchanged.

## Validation

Ran `make ci-check` successfully, including dependency policy, formatting, strict clippy, locked workspace build, and workspace tests. Ran all 92 `moraine-conversations` repository integration tests successfully and `cargo test -p moraine-mcp-core --lib --locked` with 123 passing tests. Ran `python3 -m unittest scripts.ci.test_mcp_smoke` with 5 passing tests and `make docs-build` with no issues. In a fresh repository dev sandbox, ran the supported `bash scripts/ci/e2e-stack.sh` lifecycle against the sandbox-built binaries; it completed with exit 0 and exercised the new canonical-default and message-only result assertions. The sandbox was torn down afterward.

Closes #543
