### PR TITLE
fix(mcp): remove retrieval admission deadline

### DIFF
--- a/config/moraine.toml
+++ b/config/moraine.toml
@@ -164,8 +164,9 @@ prewarm_on_initialize = false
 async_log_writes = true
 protocol_version = "2024-11-05"
 # Retrievals beyond this process-wide execution limit enter a 16-request FIFO
-# queue. Omit for the default of 8 executing requests. Queue time counts toward
-# the fixed 4-second request deadline; a full queue is rejected immediately.
+# queue. Omit for the default of 8 executing requests. Queued and running
+# retrievals have no fixed admission deadline; a full queue is rejected
+# immediately.
 # max_parallel_requests = 16
 # MCP clients first try the unified backend's Unix socket, then transparently
 # fall back to an embedded server when the socket is absent or unreachable.

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -186,7 +186,8 @@ pub struct McpConfig {
     pub protocol_version: String,
     /// Maximum retrieval requests executed concurrently by each MCP server
     /// process. When omitted, the server executes up to eight. At most sixteen
-    /// additional requests wait in FIFO order, within the fixed wall deadline.
+    /// additional requests wait in FIFO order until capacity becomes available
+    /// or the request is cancelled.
     #[serde(default)]
     pub max_parallel_requests: Option<u16>,
     /// When true, `moraine run mcp` first tries to reach the shared central

--- a/crates/moraine-mcp-core/src/concurrency_tests.rs
+++ b/crates/moraine-mcp-core/src/concurrency_tests.rs
@@ -294,19 +294,13 @@ type ClientReader = BufReader<ReadHalf<tokio::io::DuplexStream>>;
 type ClientWriter = WriteHalf<tokio::io::DuplexStream>;
 
 fn test_state(repository: Arc<BlockingRepository>, max_parallel_requests: usize) -> Arc<AppState> {
-    test_state_with_admission(
-        repository,
-        max_parallel_requests,
-        MAX_QUEUED_REQUESTS,
-        REQUEST_DEADLINE,
-    )
+    test_state_with_admission(repository, max_parallel_requests, MAX_QUEUED_REQUESTS)
 }
 
 fn test_state_with_admission(
     repository: Arc<BlockingRepository>,
     max_parallel_requests: usize,
     max_queued_requests: usize,
-    request_deadline: std::time::Duration,
 ) -> Arc<AppState> {
     AppState::with_repository(
         Arc::new(AppConfig::default()),
@@ -316,7 +310,6 @@ fn test_state_with_admission(
         Arc::new(RequestAdmission::new(
             max_parallel_requests,
             max_queued_requests,
-            request_deadline,
         )),
     )
 }
@@ -437,8 +430,7 @@ where
 #[tokio::test]
 async fn full_queue_returns_structured_overload_within_one_hundred_milliseconds() {
     let repository = Arc::new(BlockingRepository::new(DELAY_SEARCH));
-    let state =
-        test_state_with_admission(repository.clone(), 1, 2, std::time::Duration::from_secs(2));
+    let state = test_state_with_admission(repository.clone(), 1, 2);
     let admission = state.request_admission.clone();
     let (mut reader, mut writer, server) = start_connection_with_state(state);
 
@@ -506,8 +498,7 @@ async fn full_queue_returns_structured_overload_within_one_hundred_milliseconds(
 #[tokio::test]
 async fn queued_success_reports_wall_time_from_frame_acceptance() {
     let repository = Arc::new(BlockingRepository::new(DELAY_SEARCH));
-    let state =
-        test_state_with_admission(repository.clone(), 1, 1, std::time::Duration::from_secs(2));
+    let state = test_state_with_admission(repository.clone(), 1, 1);
     let (mut reader, mut writer, server) = start_connection_with_state(state);
 
     writer
@@ -550,10 +541,9 @@ async fn queued_success_reports_wall_time_from_frame_acceptance() {
 }
 
 #[tokio::test]
-async fn queued_request_deadline_starts_at_frame_acceptance_and_releases_its_slot() {
+async fn queued_request_waits_for_execution_capacity_without_expiring() {
     let repository = Arc::new(BlockingRepository::new(0));
-    let deadline = std::time::Duration::from_millis(60);
-    let state = test_state_with_admission(repository.clone(), 1, 1, deadline);
+    let state = test_state_with_admission(repository.clone(), 1, 1);
     let admission = state.request_admission.clone();
     let held = admission
         .try_register()
@@ -567,32 +557,15 @@ async fn queued_request_deadline_starts_at_frame_acceptance_and_releases_its_slo
         .write_all(search_request(1).as_bytes())
         .await
         .expect("send queued request");
-    let response = read_response(&mut reader).await;
-    assert_eq!(response["id"], json!(1));
-    assert_eq!(
-        response["result"]["structuredContent"]["error"]["code"],
-        json!("deadline_exceeded")
-    );
-    assert_eq!(
-        response["result"]["structuredContent"]["error"]["details"]["reason"],
-        json!("request_deadline")
-    );
-    assert_eq!(
-        response["result"]["structuredContent"]["error"]["details"]["deadline_ms"],
-        json!(60)
-    );
+    tokio::time::sleep(std::time::Duration::from_millis(4_100)).await;
     assert_eq!(repository.started.load(Ordering::Acquire), 0);
     assert!(repository.cancelled_queries.lock().await.is_empty());
-    assert_eq!(admission.slots.available_permits(), 1);
+    assert_eq!(admission.slots.available_permits(), 0);
 
     drop(held);
-    writer
-        .write_all(search_request(2).as_bytes())
-        .await
-        .expect("send recovery request");
-    let recovered = read_response(&mut reader).await;
-    assert_eq!(recovered["id"], json!(2));
-    assert_eq!(recovered["result"]["isError"], json!(false));
+    let response = read_response(&mut reader).await;
+    assert_eq!(response["id"], json!(1));
+    assert_eq!(response["result"]["isError"], json!(false));
 
     writer.shutdown().await.expect("half-close request stream");
     drop(writer);
@@ -606,50 +579,26 @@ async fn queued_request_deadline_starts_at_frame_acceptance_and_releases_its_slo
 }
 
 #[tokio::test]
-async fn running_request_deadline_cancels_query_and_recovers_capacity() {
-    let repository = Arc::new(BlockingRepository::new(BLOCK_SEARCH));
-    repository.block_cancellation.store(true, Ordering::Release);
-    let state = test_state_with_admission(
-        repository.clone(),
-        1,
-        1,
-        std::time::Duration::from_millis(60),
-    );
+async fn running_request_continues_past_four_seconds() {
+    let repository = Arc::new(BlockingRepository::new(DELAY_SEARCH));
+    let state = test_state_with_admission(repository.clone(), 1, 1);
     let admission = state.request_admission.clone();
     let (mut reader, mut writer, server) = start_connection_with_state(state);
 
-    let accepted_at = tokio::time::Instant::now();
     writer
-        .write_all(search_request(1).as_bytes())
+        .write_all(search_request_with_query(json!(1), "slow-deadline").as_bytes())
         .await
-        .expect("send blocked request");
+        .expect("send slow request");
     repository.wait_for_started(1).await;
-    let deadline = read_response(&mut reader).await;
-    assert_eq!(deadline["id"], json!(1));
-    assert_eq!(
-        deadline["result"]["structuredContent"]["error"]["details"]["reason"],
-        json!("request_deadline")
-    );
-    assert!(accepted_at.elapsed() < std::time::Duration::from_millis(150));
-    repository.wait_for_dropped(1).await;
+    tokio::time::sleep(std::time::Duration::from_millis(4_100)).await;
     assert!(repository.cancelled_queries.lock().await.is_empty());
     assert_eq!(admission.execution.available_permits(), 0);
     assert_eq!(admission.slots.available_permits(), 1);
 
-    repository.release_cancellation.notify_one();
-    repository.wait_for_cancelled(1).await;
-    assert!(repository.cancelled_queries.lock().await[0].starts_with("moraine-search-sessions-"));
-    assert_eq!(admission.execution.available_permits(), 1);
-    assert_eq!(admission.slots.available_permits(), 2);
-
-    repository.mode.store(0, Ordering::Release);
-    writer
-        .write_all(search_request(2).as_bytes())
-        .await
-        .expect("send recovery request");
-    let recovered = read_response(&mut reader).await;
-    assert_eq!(recovered["id"], json!(2));
-    assert_eq!(recovered["result"]["isError"], json!(false));
+    repository.release_search.notify_one();
+    let response = read_response(&mut reader).await;
+    assert_eq!(response["id"], json!(1));
+    assert_eq!(response["result"]["isError"], json!(false));
 
     writer.shutdown().await.expect("half-close request stream");
     drop(writer);
@@ -658,13 +607,14 @@ async fn running_request_deadline_cancels_query_and_recovers_capacity() {
         .expect("connection drained")
         .expect("connection task joined")
         .expect("connection succeeded");
+    assert_eq!(admission.execution.available_permits(), 1);
+    assert_eq!(admission.slots.available_permits(), 2);
 }
 
 #[tokio::test]
 async fn queued_requests_acquire_execution_in_frame_acceptance_order() {
     let repository = Arc::new(BlockingRepository::new(DELAY_SEARCH));
-    let state =
-        test_state_with_admission(repository.clone(), 1, 3, std::time::Duration::from_secs(2));
+    let state = test_state_with_admission(repository.clone(), 1, 3);
     let admission = state.request_admission.clone();
     let held = admission
         .try_register()

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, VecDeque};
 use std::future::{pending, Future};
 use std::path::PathBuf;
 use std::sync::{
-    atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
     Arc, Mutex as StdMutex,
 };
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
@@ -45,7 +45,6 @@ impl RequestLimitSource {
 
 const AUTOMATIC_MAX_PARALLEL_REQUESTS: usize = 8;
 const MAX_QUEUED_REQUESTS: usize = 16;
-const REQUEST_DEADLINE: std::time::Duration = std::time::Duration::from_secs(4);
 const SEARCH_PROJECTION_RETRY_AFTER_MS: u64 = 250;
 
 fn effective_max_parallel_requests(configured: Option<u16>) -> (usize, RequestLimitSource) {
@@ -65,14 +64,12 @@ fn build_request_admission(cfg: &AppConfig) -> Arc<RequestAdmission> {
     info!(
         max_parallel_requests,
         max_queued_requests = MAX_QUEUED_REQUESTS,
-        request_deadline_ms = REQUEST_DEADLINE.as_millis(),
         source = source.as_str(),
         "configured bounded MCP retrieval admission"
     );
     Arc::new(RequestAdmission::new(
         max_parallel_requests,
         MAX_QUEUED_REQUESTS,
-        REQUEST_DEADLINE,
     ))
 }
 
@@ -84,14 +81,12 @@ struct RequestAdmission {
     next_ticket: AtomicU64,
     changes: watch::Sender<u64>,
     closed: AtomicBool,
-    cleanup_count: AtomicUsize,
     max_executing: usize,
     max_queued: usize,
-    deadline: std::time::Duration,
 }
 
 impl RequestAdmission {
-    fn new(max_executing: usize, max_queued: usize, deadline: std::time::Duration) -> Self {
+    fn new(max_executing: usize, max_queued: usize) -> Self {
         let max_executing = max_executing.clamp(1, Semaphore::MAX_PERMITS);
         let max_queued = max_queued.min(Semaphore::MAX_PERMITS - max_executing);
         let (changes, _) = watch::channel(0);
@@ -102,10 +97,8 @@ impl RequestAdmission {
             next_ticket: AtomicU64::new(0),
             changes,
             closed: AtomicBool::new(false),
-            cleanup_count: AtomicUsize::new(0),
             max_executing,
             max_queued,
-            deadline,
         }
     }
 
@@ -163,28 +156,6 @@ impl RequestAdmission {
         self.execution.close();
         self.slots.close();
         self.signal_change();
-    }
-
-    fn start_cleanup(self: &Arc<Self>) -> RequestCleanupGuard {
-        self.cleanup_count.fetch_add(1, Ordering::AcqRel);
-        self.signal_change();
-        RequestCleanupGuard {
-            admission: self.clone(),
-        }
-    }
-
-    async fn wait_for_cleanup_until(&self, deadline: tokio::time::Instant) {
-        let mut changes = self.changes.subscribe();
-        while self.cleanup_count.load(Ordering::Acquire) != 0 {
-            tokio::select! {
-                _ = tokio::time::sleep_until(deadline) => break,
-                changed = changes.changed() => {
-                    if changed.is_err() {
-                        break;
-                    }
-                }
-            }
-        }
     }
 }
 
@@ -254,16 +225,6 @@ impl Drop for RequestPermit {
     }
 }
 
-struct RequestCleanupGuard {
-    admission: Arc<RequestAdmission>,
-}
-
-impl Drop for RequestCleanupGuard {
-    fn drop(&mut self) {
-        self.admission.cleanup_count.fetch_sub(1, Ordering::AcqRel);
-        self.admission.signal_change();
-    }
-}
 const QUERY_CANCELLATION_DEADLINE: std::time::Duration = std::time::Duration::from_millis(1_000);
 const SERVICE_DRAIN_GRACE: std::time::Duration = std::time::Duration::from_millis(1_250);
 
@@ -862,8 +823,9 @@ impl QueryCancellationGuard {
 /// Slow repository requests execute concurrently and may complete out of order.
 /// Response encoding and writes stay on this connection task so JSON frames can
 /// never interleave. Admission is shared across socket connections; requests
-/// wait in a finite FIFO queue when execution permits are busy, share one wall
-/// deadline from frame acceptance, and are rejected immediately when it is full.
+/// wait in a finite FIFO queue when execution permits are busy and are rejected
+/// immediately when the queue is full. Admitted requests run until completion
+/// or cancellation.
 async fn serve_connection_with_first_line<R, W>(
     state: Arc<AppState>,
     reader: R,
@@ -1043,10 +1005,6 @@ where
     }
     requests.abort_all();
     while requests.join_next().await.is_some() {}
-    state
-        .request_admission
-        .wait_for_cleanup_until(cancellation_deadline)
-        .await;
 
     if let Some(error) = connection_error {
         Err(error)
@@ -1129,11 +1087,8 @@ async fn dispatch_rpc_line(
                 id,
                 &admitted_tool,
                 accepted_at,
-                state.request_admission.deadline,
-                AdmissionErrorKind::QueueFull {
-                    max_executing: state.request_admission.max_executing,
-                    max_queued: state.request_admission.max_queued,
-                },
+                state.request_admission.max_executing,
+                state.request_admission.max_queued,
             )));
         }
         Err(TryAdmissionError::Closed) => return Ok(None),
@@ -1145,41 +1100,24 @@ async fn dispatch_rpc_line(
     let task_query_cancellation = query_cancellation.clone();
     let request_state = state.clone();
     let task_key = key.clone();
-    let task_id = id.clone();
-    let deadline_duration = request_state.request_admission.deadline;
-    let deadline = accepted_at + deadline_duration;
     let task = requests.spawn(async move {
         enum AdmissionOutcome {
             Admitted(RequestPermit),
             Cancelled,
-            DeadlineExceeded,
         }
 
         let admission = tokio::select! {
             biased;
             _ = &mut cancel_rx => AdmissionOutcome::Cancelled,
             _ = wait_for_connection_shutdown(&mut connection_shutdown) => AdmissionOutcome::Cancelled,
-            _ = tokio::time::sleep_until(deadline) => AdmissionOutcome::DeadlineExceeded,
             permit = admission_ticket.acquire() => match permit {
                 Some(permit) => AdmissionOutcome::Admitted(permit),
                 None => AdmissionOutcome::Cancelled,
             },
         };
-        let permit = match admission {
+        let _permit = match admission {
             AdmissionOutcome::Admitted(permit) => permit,
             AdmissionOutcome::Cancelled => return (task_key, None),
-            AdmissionOutcome::DeadlineExceeded => {
-                return (
-                    task_key,
-                    Some(admission_error_response(
-                        task_id,
-                        &admitted_tool,
-                        accepted_at,
-                        deadline_duration,
-                        AdmissionErrorKind::DeadlineExceeded,
-                    )),
-                );
-            }
         };
         let query_cancellation = task_query_cancellation;
         *query_cancellation
@@ -1189,16 +1127,14 @@ async fn dispatch_rpc_line(
         enum Outcome {
             Completed(Option<Value>),
             Cancelled,
-            DeadlineExceeded,
         }
         let outcome = {
             let request = REQUEST_ACCEPTED_AT.scope(
                 accepted_at.into_std(),
                 REQUEST_QUERY_CANCELLATION.scope(
                     query_cancellation.clone(),
-                    moraine_conversations::with_repository_query_deadline(
+                    moraine_conversations::with_repository_query_id(
                         request_query_id,
-                        deadline,
                         request_state.handle_request(req),
                     ),
                 ),
@@ -1208,7 +1144,6 @@ async fn dispatch_rpc_line(
                 biased;
                 _ = &mut cancel_rx => Outcome::Cancelled,
                 _ = wait_for_connection_shutdown(&mut connection_shutdown) => Outcome::Cancelled,
-                _ = tokio::time::sleep_until(deadline) => Outcome::DeadlineExceeded,
                 response = &mut request => Outcome::Completed(response),
             }
         };
@@ -1217,23 +1152,6 @@ async fn dispatch_rpc_line(
             Outcome::Cancelled => {
                 cancel_registered_query(&request_state, &query_cancellation).await;
                 None
-            }
-            Outcome::DeadlineExceeded => {
-                spawn_deadline_cancellation(
-                    request_state,
-                    query_cancellation,
-                    permit,
-                );
-                return (
-                    task_key,
-                    Some(admission_error_response(
-                        task_id,
-                        &admitted_tool,
-                        accepted_at,
-                        deadline_duration,
-                        AdmissionErrorKind::DeadlineExceeded,
-                    )),
-                );
             }
         };
         (task_key, response)
@@ -1256,44 +1174,22 @@ struct AdmittedToolCall {
     request: Value,
 }
 
-enum AdmissionErrorKind {
-    QueueFull {
-        max_executing: usize,
-        max_queued: usize,
-    },
-    DeadlineExceeded,
-}
-
 fn admission_error_response(
     id: Value,
     tool: &AdmittedToolCall,
     accepted_at: tokio::time::Instant,
-    deadline: std::time::Duration,
-    kind: AdmissionErrorKind,
+    max_executing: usize,
+    max_queued: usize,
 ) -> Value {
-    let deadline_ms = u64::try_from(deadline.as_millis()).unwrap_or(u64::MAX);
-    let error = match kind {
-        AdmissionErrorKind::QueueFull {
-            max_executing,
-            max_queued,
-        } => contract::ContractError::new(
-            contract::ToolErrorCode::DeadlineExceeded,
-            "MCP retrieval queue is full; retry later",
-        )
-        .with_details(json!({
-            "reason": "queue_full",
-            "max_executing": max_executing,
-            "max_queued": max_queued,
-        })),
-        AdmissionErrorKind::DeadlineExceeded => contract::ContractError::new(
-            contract::ToolErrorCode::DeadlineExceeded,
-            "MCP retrieval request exceeded its end-to-end deadline",
-        )
-        .with_details(json!({
-            "reason": "request_deadline",
-            "deadline_ms": deadline_ms,
-        })),
-    };
+    let error = contract::ContractError::new(
+        contract::ToolErrorCode::DeadlineExceeded,
+        "MCP retrieval queue is full; retry later",
+    )
+    .with_details(json!({
+        "reason": "queue_full",
+        "max_executing": max_executing,
+        "max_queued": max_queued,
+    }));
     let payload = serde_json::to_value(contract::ToolErrorEnvelope::error(
         tool.name.clone(),
         tool.request.clone(),
@@ -1325,19 +1221,6 @@ async fn cancel_registered_query(state: &AppState, slot: &QueryCancellationSlot)
         return;
     };
     cancel_query_with_deadline(state, &query_id).await;
-}
-
-fn spawn_deadline_cancellation(
-    state: Arc<AppState>,
-    slot: QueryCancellationSlot,
-    permit: RequestPermit,
-) {
-    let cleanup = state.request_admission.start_cleanup();
-    tokio::spawn(async move {
-        let _cleanup = cleanup;
-        cancel_registered_query(&state, &slot).await;
-        drop(permit);
-    });
 }
 
 pub(crate) async fn cancel_query_with_deadline(state: &AppState, query_id: &str) {
@@ -1682,10 +1565,6 @@ where
     }
     connections.abort_all();
     while connections.join_next().await.is_some() {}
-    state
-        .request_admission
-        .wait_for_cleanup_until(drain_deadline)
-        .await;
     Ok(())
 }
 
@@ -2071,7 +1950,6 @@ mod tests {
         assert_eq!(state.request_admission.execution.available_permits(), 3);
         assert_eq!(state.request_admission.slots.available_permits(), 19);
         assert_eq!(state.request_admission.max_queued, 16);
-        assert_eq!(state.request_admission.deadline, REQUEST_DEADLINE);
     }
 
     #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -622,7 +622,7 @@ central_connect_timeout_ms = 250
 | `prewarm_on_initialize` | `false` | Warms query metadata during MCP initialize, trading startup work for lower first-search latency. |
 | `async_log_writes` | `true` | Writes MCP observability rows asynchronously so tool calls stay responsive. |
 | `protocol_version` | `2024-11-05` | MCP protocol version advertised by the server. |
-| `max_parallel_requests` | `8` | Maximum retrieval requests executed concurrently by each MCP server process. At most 16 additional requests wait in FIFO order. Queue time counts toward the fixed four-second request deadline; a full queue is rejected immediately with a structured retryable error. A configured value must be greater than zero. |
+| `max_parallel_requests` | `8` | Maximum retrieval requests executed concurrently by each MCP server process. At most 16 additional requests wait in FIFO order until capacity is available or the request is cancelled. A full queue is rejected immediately with a structured retryable error. A configured value must be greater than zero. |
 | `use_central_server` | `true` | Makes `moraine run mcp` prefer the shared central server socket, with embedded fallback. |
 | `central_socket_path` | `mcp.sock` | Unix socket path. Bare filenames resolve under `runtime.pids_dir`; absolute paths are used verbatim. |
 | `central_connect_timeout_ms` | `250` | Milliseconds a proxy client waits for the central socket before falling back to embedded mode. |
@@ -635,11 +635,12 @@ first-search latency.
 
 The shared central server applies one parallel-request budget across every MCP
 socket connection and queues at most 16 valid retrievals in FIFO order when that
-budget is busy. Queue time is part of the four-second wall deadline. A full
-queue is rejected immediately with a structured retryable tool error. An
-embedded fallback is a separate process, so its default or configured execution
-budget is process-local. Queued requests remain cancellable while validation and
-control requests continue to run.
+budget is busy. Queued and running retrievals have no fixed admission deadline;
+they continue until completion, client cancellation, disconnect, or service
+shutdown. A full queue is rejected immediately with a structured retryable tool
+error. An embedded fallback is a separate process, so its default or configured
+execution budget is process-local. Validation and control requests continue to
+run while retrievals wait.
 
 ### Shared central MCP server
 

--- a/docs/full-config.toml
+++ b/docs/full-config.toml
@@ -255,8 +255,8 @@ async_log_writes = true
 protocol_version = "2024-11-05"
 # Maximum retrieval requests executed concurrently by this MCP server process.
 # Omit for the default of 8. At most 16 additional requests wait in FIFO order.
-# Queue time counts toward the fixed 4-second request deadline; a full queue is
-# rejected immediately with a structured retryable error.
+# Queued and running retrievals have no fixed admission deadline; a full queue
+# is rejected immediately with a structured retryable error.
 # max_parallel_requests = 16
 
 


### PR DESCRIPTION
## Description

**What.** Removes the fixed four-second end-to-end deadline from central MCP retrieval admission.

**Why.** Ordinary searches can legitimately exceed four seconds as corpora grow and on varied user hardware; bounded execution and queue capacity already constrain backend load.

The MCP request dispatcher now waits for FIFO admission and lets admitted retrievals run until completion, explicit client cancellation, disconnect, or service shutdown. It preserves the process-wide parallel limit, the 16-request queue, immediate structured queue-full rejection, and per-tool deadlines that are separate from admission.

Deadline-only cancellation bookkeeping is removed, while repository query IDs remain scoped so explicit cancellation still reaches ClickHouse. Configuration comments and user documentation now describe the no-fixed-deadline behavior.

## Usage

No configuration change is required. Existing MCP clients continue calling retrieval tools normally; queued and running retrievals are no longer failed automatically after four seconds and remain explicitly cancellable.

## Bug Evidence

Before this change, both queue wait and execution selected against a deadline computed as frame acceptance plus four seconds. Expensive `search_sessions` requests therefore returned `request_deadline` even when the bounded backend could eventually answer them.

The regression suite now holds one running request and one queued request past 4,100 ms. Both complete successfully after their controlled release, proving that neither execution nor queueing retains the former four-second give-up.

## Changelog

- Removes the fixed four-second MCP retrieval admission deadline.
- Keeps bounded parallel execution, finite FIFO queueing, queue-full rejection, and cancellation behavior.
- No config migration or operator action is required.

## Validation

Ran `cargo test -p moraine-mcp-core --lib --locked` after review; all 122 tests passed, including running and queued requests held beyond four seconds. The same 122-test MCP core suite passed in the required Linux dev sandbox, where `scripts/ci/mcp_smoke.py` also passed against the live sandbox stack over raw JSON-RPC. `cargo fmt --all -- --check` passed, and `make docs-build` completed with no issues.

A seven-persona delegated code review covered elegance, idiomatic Rust, correctness, completeness, security, YAGNI, and scope. Two stale Rust comments were corrected, the queued regression was strengthened to cross the former deadline, and all follow-up reviewers confirmed their concerns resolved.

Closes #569