### PR TITLE
feat(ingest): populate OMP session metadata

### DIFF
--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -848,6 +848,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             name: "029_reset_mcp_open_projection.sql",
             sql: include_str!("../../../sql/029_reset_mcp_open_projection.sql"),
         },
+        Migration {
+            version: "030",
+            name: "030_refresh_omp_session_metadata.sql",
+            sql: include_str!("../../../sql/030_refresh_omp_session_metadata.sql"),
+        },
     ]
 }
 
@@ -1568,7 +1573,7 @@ mod tests {
 
     #[test]
     fn mcp_open_migrations_exclude_blank_session_ids() {
-        for version in ["027", "029"] {
+        for version in ["027", "029", "030"] {
             let migration = bundled_migrations()
                 .into_iter()
                 .find(|migration| migration.version == version)
@@ -1579,6 +1584,17 @@ mod tests {
                 "migration {version} must not enqueue blank session IDs"
             );
         }
+    }
+
+    #[test]
+    fn migration_030_refreshes_only_omp_session_heads() {
+        let migration = bundled_migrations()
+            .into_iter()
+            .find(|migration| migration.version == "030")
+            .expect("migration 030 must be registered");
+
+        assert!(migration.sql.contains("FROM moraine.events FINAL"));
+        assert!(migration.sql.contains("source_name = 'omp'"));
     }
 
     #[test]

--- a/crates/moraine-clickhouse/src/mcp_open_projection.rs
+++ b/crates/moraine-clickhouse/src/mcp_open_projection.rs
@@ -465,15 +465,21 @@ impl ClickHouseClient {
                  argMin(event_uid, tuple(event_time, event_order, event_uid)) AS first_event_uid,\n\
                  argMax(event_uid, tuple(event_time, event_order, event_uid)) AS last_event_uid,\n\
                  argMax(actor_role, tuple(event_time, event_order, event_uid)) AS last_actor_role,\n\
-                 ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'title'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'),\n\
-                   ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'name'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'), '')) AS title,\n\
+                 ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'title'), ''),\n\
+                   tuple(event_ts, event_uid), event_class = 'session_meta'\n\
+                     OR (source_name = 'omp' AND JSONExtractString(payload_json, 'type') IN ('title', 'title_change'))), '') AS latest_metadata_title,\n\
+                 ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'name'), ''),\n\
+                   tuple(event_ts, event_uid), event_class = 'session_meta'), '') AS latest_metadata_name,\n\
+                 ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'summary'), ''),\n\
+                   tuple(event_ts, event_uid), event_class = 'session_meta'), '') AS latest_metadata_summary,\n\
+                 ifNull(argMinIf(nullIf(trimBoth(replaceRegexpOne(arrayElement(splitByChar('/', replaceAll(source_file, '\\\\', '/')), -1), '[.]jsonl$', '')), ''),\n\
+                   tuple(event_ts, event_uid), source_name = 'omp' AND notEmpty(session_id)\n\
+                     AND endsWith(source_file, '.jsonl')\n\
+                     AND NOT endsWith(source_file, concat(session_id, '.jsonl'))), '') AS omp_dispatch_title,\n\
                  ifNull(argMax(nullIf(source_name, ''), tuple(event_ts, event_uid)), '') AS source,\n\
                  ifNull(argMax(nullIf(harness, ''), tuple(event_ts, event_uid)), '') AS harness,\n\
                  ifNull(argMax(nullIf(inference_provider, ''), tuple(event_ts, event_uid)), '') AS inference_provider,\n\
                  ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'slug'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'), '') AS session_slug,\n\
-                 ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'summary'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'),\n\
-                   ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'title'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'),\n\
-                     ifNull(argMaxIf(nullIf(JSONExtractString(payload_json, 'name'), ''), tuple(event_ts, event_uid), event_class = 'session_meta'), ''))) AS session_summary,\n\
                  ifNull(argMinIf(cwd, tuple(event_ts, event_uid), cwd != ''), '') AS origin_cwd\n\
                FROM enriched\n\
                GROUP BY session_id\n\
@@ -495,8 +501,10 @@ impl ClickHouseClient {
                h.session_id, {slot}, {generation}, h.source_revision, {dirty_revision},\n\
                h.first_event_time, h.last_event_time, h.total_turns, h.total_events,\n\
                h.user_messages, h.assistant_messages, h.tool_calls, h.tool_results, h.mode,\n\
-               h.first_event_uid, h.last_event_uid, h.last_actor_role, h.title, h.source,\n\
-               h.harness, h.inference_provider, h.session_slug, h.session_summary,\n\
+               h.first_event_uid, h.last_event_uid, h.last_actor_role,\n\
+               if(h.source = 'omp', coalesce(nullIf(h.latest_metadata_title, ''), nullIf(h.latest_metadata_name, ''), nullIf(h.latest_metadata_summary, ''), nullIf(h.omp_dispatch_title, ''), ''), coalesce(nullIf(h.latest_metadata_title, ''), nullIf(h.latest_metadata_name, ''), '')), h.source,\n\
+               h.harness, h.inference_provider, h.session_slug,\n\
+               if(h.source = 'omp', coalesce(nullIf(h.latest_metadata_summary, ''), nullIf(h.latest_metadata_title, ''), nullIf(h.latest_metadata_name, ''), nullIf(h.omp_dispatch_title, ''), ''), coalesce(nullIf(h.latest_metadata_summary, ''), nullIf(h.latest_metadata_title, ''), nullIf(h.latest_metadata_name, ''), '')),\n\
                ifNull(t.completed, 0), ifNull(t.terminal_event_uid, ''), h.origin_cwd\n\
              FROM header AS h\n\
              CROSS JOIN current_dirty AS d\n\

--- a/crates/moraine-conversations/src/clickhouse_repo/list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/list.rs
@@ -289,17 +289,7 @@ event_rollups AS (
         event_kind = 'session_meta'
       ),
       ''
-    ) AS title,
-    ifNull(argMax(nullIf(e.harness, ''), tuple(event_ts, event_uid)), '') AS latest_harness,
-    ifNull(argMax(nullIf(e.source_name, ''), tuple(event_ts, event_uid)), '') AS latest_source_name,
-    ifNull(
-      argMaxIf(
-        nullIf(JSONExtractString(payload_json, 'slug'), ''),
-        tuple(event_ts, event_uid),
-        event_kind = 'session_meta'
-      ),
-      ''
-    ) AS session_slug,
+    ) AS latest_session_meta_title,
     ifNull(
       argMaxIf(
         coalesce(
@@ -311,7 +301,62 @@ event_rollups AS (
         event_kind = 'session_meta'
       ),
       ''
-    ) AS session_summary
+    ) AS latest_session_meta_summary,
+    ifNull(
+      argMaxIf(
+        nullIf(JSONExtractString(payload_json, 'title'), ''),
+        tuple(event_ts, event_uid),
+        event_kind = 'session_meta'
+          OR (e.source_name = 'omp' AND JSONExtractString(e.payload_json, 'type') IN ('title', 'title_change'))
+      ),
+      ''
+    ) AS latest_metadata_title,
+    ifNull(
+      argMaxIf(
+        nullIf(JSONExtractString(payload_json, 'name'), ''),
+        tuple(event_ts, event_uid),
+        event_kind = 'session_meta'
+      ),
+      ''
+    ) AS latest_metadata_name,
+    ifNull(
+      argMaxIf(
+        nullIf(JSONExtractString(payload_json, 'summary'), ''),
+        tuple(event_ts, event_uid),
+        event_kind = 'session_meta'
+      ),
+      ''
+    ) AS latest_metadata_summary,
+    ifNull(
+      argMinIf(
+        nullIf(
+          trimBoth(
+            replaceRegexpOne(
+              arrayElement(splitByChar('/', replaceAll(e.source_file, '\\\\', '/')), -1),
+              '[.]jsonl$',
+              ''
+            )
+          ),
+          ''
+        ),
+        tuple(event_ts, event_uid),
+        e.source_name = 'omp'
+          AND notEmpty(e.session_id)
+          AND endsWith(e.source_file, '.jsonl')
+          AND NOT endsWith(e.source_file, concat(e.session_id, '.jsonl'))
+      ),
+      ''
+    ) AS omp_dispatch_title,
+    ifNull(argMax(nullIf(e.harness, ''), tuple(event_ts, event_uid)), '') AS latest_harness,
+    ifNull(argMax(nullIf(e.source_name, ''), tuple(event_ts, event_uid)), '') AS latest_source_name,
+    ifNull(
+      argMaxIf(
+        nullIf(JSONExtractString(payload_json, 'slug'), ''),
+        tuple(event_ts, event_uid),
+        event_kind = 'session_meta'
+      ),
+      ''
+    ) AS session_slug
   FROM {events_source} AS e
   WHERE session_id IN (SELECT session_id FROM window_sessions)
   GROUP BY session_id
@@ -330,11 +375,31 @@ candidate_sessions AS (
       ifNull(r.latest_terminal_turn_seq, toUInt32(0)) = w.total_turns
       AND ifNull(r.latest_terminal_payload_type, '') = 'task_complete'
     ) AS completed,
-    ifNull(r.title, '') AS title,
+    if(
+      ifNull(r.latest_source_name, '') = 'omp',
+      coalesce(
+        nullIf(r.latest_metadata_title, ''),
+        nullIf(r.latest_metadata_name, ''),
+        nullIf(r.latest_metadata_summary, ''),
+        nullIf(r.omp_dispatch_title, ''),
+        ''
+      ),
+      ifNull(r.latest_session_meta_title, '')
+    ) AS title,
     ifNull(r.latest_source_name, '') AS source,
     ifNull(r.latest_harness, '') AS harness,
     ifNull(r.session_slug, '') AS session_slug,
-    ifNull(r.session_summary, '') AS session_summary
+    if(
+      ifNull(r.latest_source_name, '') = 'omp',
+      coalesce(
+        nullIf(r.latest_metadata_summary, ''),
+        nullIf(r.latest_metadata_title, ''),
+        nullIf(r.latest_metadata_name, ''),
+        nullIf(r.omp_dispatch_title, ''),
+        ''
+      ),
+      ifNull(r.latest_session_meta_summary, '')
+    ) AS session_summary
   FROM window_sessions AS w
   LEFT JOIN event_rollups AS r ON r.session_id = w.session_id
   {event_filter_sql}ORDER BY w.last_event_unix_ms {order_dir}, w.session_id {order_dir}

--- a/crates/moraine-conversations/tests/live_clickhouse.rs
+++ b/crates/moraine-conversations/tests/live_clickhouse.rs
@@ -3,8 +3,9 @@ use moraine_clickhouse::ClickHouseClient;
 use moraine_config::{AppConfig, ClickHouseConfig, DEFAULT_BACKEND_NAME};
 use moraine_conversations::{
     with_repository_query_id, AnalyticsRange, BackendRepositoryRouter,
-    ClickHouseConversationRepository, ConversationRepository, PageRequest, RepoConfig,
-    SessionAnalyticsQuery, SessionLookback, TurnListFilter,
+    ClickHouseConversationRepository, ConversationListSort, ConversationRepository,
+    McpSessionListFilter, PageRequest, RepoConfig, SessionAnalyticsQuery, SessionLookback,
+    TurnListFilter,
 };
 use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
@@ -346,6 +347,160 @@ VALUES
         .request_text(&commentary_insert, None, Some(database), false, None)
         .await
         .context("failed to insert commentary projection fixture")?;
+    let omp_insert = format!(
+        r#"INSERT INTO `{database}`.`events`
+(
+  ingested_at, event_uid, session_id, session_date, source_name, harness, source_file,
+  source_ref, record_ts, event_ts, event_kind, actor_kind, payload_type, op_kind, request_id,
+  trace_id, turn_index, model, input_tokens, output_tokens, text_content, payload_json,
+  event_version
+)
+VALUES
+(
+  now64(3), 'issue568-explicit-title', 'issue568-explicit-session', today(),
+  'omp', 'pi-coding-agent', '/tmp/omp/ExplicitTask.jsonl', 'issue568-explicit-title',
+  '2026-07-17T01:00:00.000Z', '2026-07-17 01:00:00.000', 'unknown', 'system',
+  'unknown', 'title_change', '', 'issue568-explicit-trace', 1, '', 0, 0,
+  'Explicit OMP Title', '{{"type":"title_change","title":"Explicit OMP Title"}}', 1
+),
+(
+  now64(3), 'issue568-later-name', 'issue568-explicit-session', today(),
+  'omp', 'pi-coding-agent', '/tmp/omp/ExplicitTask.jsonl', 'issue568-later-name',
+  '2026-07-17T01:00:01.000Z', '2026-07-17 01:00:01.000', 'session_meta', 'system',
+  'session_meta', 'session_info', '', 'issue568-explicit-trace', 1, '', 0, 0,
+  '', '{{"name":"Later Lower Priority Name"}}', 1
+),
+(
+  now64(3), 'issue568-windows-fallback', 'issue568-windows-session', today(),
+  'omp', 'pi-coding-agent',
+  'C:\\Users\\alice\\.omp\\agent\\sessions\\project\\ReviewScope-2.jsonl',
+  'issue568-windows-fallback', '2026-07-17T01:01:00.000Z', '2026-07-17 01:01:00.000',
+  'message', 'user', 'user_message', '', '', 'issue568-windows-trace', 1, '', 0, 0,
+  'private prompt', '{{}}', 1
+),
+(
+  now64(3), 'issue568-main-file', '11111111-2222-4333-8444-555555555568', today(),
+  'omp', 'pi-coding-agent',
+  '/tmp/omp/11111111-2222-4333-8444-555555555568.jsonl',
+  'issue568-main-file', '2026-07-17T01:02:00.000Z', '2026-07-17 01:02:00.000',
+  'message', 'user', 'user_message', '', '', 'issue568-main-trace', 1, '', 0, 0,
+  'private main prompt', '{{}}', 1
+),
+(
+  now64(3), 'issue568-pi-title', 'issue568-pi-session', today(),
+  'pi', 'pi-coding-agent', '/tmp/pi/session.jsonl', 'issue568-pi-title',
+  '2026-07-17T01:03:00.000Z', '2026-07-17 01:03:00.000', 'session_meta', 'system',
+  'session_meta', 'session', '', 'issue568-pi-trace', 1, '', 0, 0,
+  'Pi Title', '{{"title":"Pi Title"}}', 1
+),
+(
+  now64(3), 'issue568-pi-name', 'issue568-pi-session', today(),
+  'pi', 'pi-coding-agent', '/tmp/pi/session.jsonl', 'issue568-pi-name',
+  '2026-07-17T01:03:01.000Z', '2026-07-17 01:03:01.000', 'session_meta', 'system',
+  'session_meta', 'session_info', '', 'issue568-pi-trace', 1, '', 0, 0,
+  '', '{{"name":"Later Pi Name"}}', 1
+),
+(
+  now64(3), 'issue568-pi-summary', 'issue568-pi-summary-session', today(),
+  'pi', 'pi-coding-agent', '/tmp/pi/summary-session.jsonl', 'issue568-pi-summary',
+  '2026-07-17T01:04:00.000Z', '2026-07-17 01:04:00.000', 'session_meta', 'system',
+  'session_meta', 'session_info', '', 'issue568-pi-summary-trace', 1, '', 0, 0,
+  '', '{{"summary":"Pi Summary"}}', 1
+)"#
+    );
+    clickhouse
+        .request_text(&omp_insert, None, Some(database), false, None)
+        .await
+        .context("failed to insert OMP session metadata fixtures")?;
+    Ok(())
+}
+
+async fn assert_omp_session_metadata(repository: &ClickHouseConversationRepository) -> Result<()> {
+    let listed = repository
+        .list_mcp_sessions(
+            McpSessionListFilter {
+                start_unix_ms: 0,
+                end_unix_ms: 4_102_444_800_000,
+                mode: None,
+                sort: ConversationListSort::Asc,
+                harness: None,
+                source_name: None,
+            },
+            PageRequest {
+                limit: 100,
+                cursor: None,
+            },
+        )
+        .await
+        .context("failed to list OMP session metadata fixtures")?;
+
+    let explicit = listed
+        .items
+        .iter()
+        .find(|session| session.session_id == "issue568-explicit-session")
+        .context("explicit OMP session missing from listing")?;
+    assert_eq!(explicit.title.as_deref(), Some("Explicit OMP Title"));
+    assert_eq!(
+        explicit.session_summary.as_deref(),
+        Some("Explicit OMP Title")
+    );
+
+    let windows = listed
+        .items
+        .iter()
+        .find(|session| session.session_id == "issue568-windows-session")
+        .context("Windows-path OMP session missing from listing")?;
+    assert_eq!(windows.title.as_deref(), Some("ReviewScope-2"));
+    assert_eq!(windows.session_summary.as_deref(), Some("ReviewScope-2"));
+
+    let main = listed
+        .items
+        .iter()
+        .find(|session| session.session_id == "11111111-2222-4333-8444-555555555568")
+        .context("UUID main-file OMP session missing from listing")?;
+    assert!(main.title.is_none());
+    assert!(main.session_summary.is_none());
+
+    let pi = listed
+        .items
+        .iter()
+        .find(|session| session.session_id == "issue568-pi-session")
+        .context("Pi precedence fixture missing from listing")?;
+    assert_eq!(pi.title.as_deref(), Some("Later Pi Name"));
+    assert_eq!(pi.session_summary.as_deref(), Some("Later Pi Name"));
+
+    let pi_summary = listed
+        .items
+        .iter()
+        .find(|session| session.session_id == "issue568-pi-summary-session")
+        .context("Pi summary-only fixture missing from listing")?;
+    assert_eq!(pi_summary.title.as_deref(), Some("Pi Summary"));
+    assert_eq!(pi_summary.session_summary.as_deref(), Some("Pi Summary"));
+
+    for (session_id, expected_title, expected_summary) in [
+        (
+            "issue568-explicit-session",
+            Some("Explicit OMP Title"),
+            Some("Explicit OMP Title"),
+        ),
+        (
+            "issue568-windows-session",
+            Some("ReviewScope-2"),
+            Some("ReviewScope-2"),
+        ),
+        ("11111111-2222-4333-8444-555555555568", None, None),
+        ("issue568-pi-session", Some("Pi Title"), Some("Pi Title")),
+        ("issue568-pi-summary-session", None, Some("Pi Summary")),
+    ] {
+        let opened = repository
+            .get_mcp_session(session_id)
+            .await
+            .with_context(|| format!("failed to open session metadata fixture {session_id}"))?
+            .with_context(|| format!("session metadata fixture {session_id} missing"))?;
+        assert_eq!(opened.title.as_deref(), expected_title);
+        assert_eq!(opened.session_summary.as_deref(), expected_summary);
+    }
+
     Ok(())
 }
 
@@ -715,6 +870,7 @@ async fn live_schema_semantics_and_teardown() -> Result<()> {
             .backfill_mcp_open_read_model()
             .await
             .context("failed to project live-schema fixtures for bounded MCP open")?;
+        assert_omp_session_metadata(&repository).await?;
         let commentary_turn = repository
             .get_mcp_turn("issue549-commentary-session", 1)
             .await

--- a/crates/moraine-conversations/tests/repository_integration/sessions.rs
+++ b/crates/moraine-conversations/tests/repository_integration/sessions.rs
@@ -223,6 +223,18 @@ async fn list_mcp_sessions_uses_overlap_filter_and_cursor_pagination() {
     assert!(list_query.contains("r.latest_harness = 'codex'"));
     assert!(list_query.contains("r.latest_source_name = 'codex'"));
     assert!(list_query.contains("ifNull(r.latest_source_name, '') AS source"));
+    assert!(list_query.contains(
+        "e.source_name = 'omp' AND JSONExtractString(e.payload_json, 'type') IN ('title', 'title_change')"
+    ));
+    assert!(list_query.contains("replaceRegexpOne("));
+    assert!(list_query.contains("replaceAll(e.source_file, '\\\\', '/')"));
+    assert!(list_query.contains("NOT endsWith(e.source_file, concat(e.session_id, '.jsonl'))"));
+    assert!(list_query.contains("nullIf(r.latest_metadata_title, '')"));
+    assert!(list_query.contains("nullIf(r.latest_metadata_name, '')"));
+    assert!(list_query.contains("nullIf(r.latest_metadata_summary, '')"));
+    assert!(list_query.contains("nullIf(r.omp_dispatch_title, '')"));
+    assert!(list_query.contains("ifNull(r.latest_session_meta_title, '')"));
+    assert!(list_query.contains("ifNull(r.latest_session_meta_summary, '')"));
     assert!(list_query.contains("ORDER BY w.last_event_unix_ms DESC, w.session_id DESC"));
     assert!(list_query.contains("payload_type IN ('task_complete', 'turn_aborted')"));
     // Blank session_id rows are filtered at the source so they never consume a

--- a/crates/moraine-ingest-core/src/sources/pi.rs
+++ b/crates/moraine-ingest-core/src/sources/pi.rs
@@ -96,6 +96,9 @@ fn normalize_pi_record(
         "custom_message" => handle_pi_custom_message(record, base_uid, &mut emitter),
         "label" => handle_pi_label(record, base_uid, &mut emitter),
         "session_info" => handle_pi_session_info(record, base_uid, &mut emitter),
+        "title" | "title_change" if ctx.source_name == "omp" => {
+            handle_omp_title(record, top_type, base_uid, &mut emitter)
+        }
         _ => handle_pi_unknown(record, top_type, base_uid, &mut emitter),
     }
 
@@ -115,6 +118,26 @@ fn handle_pi_session(record: &Value, base_uid: &str, emitter: &mut SourceEmitter
             record,
         )
         .item_id(to_str(record.get("id")));
+    emitter.push_event(event);
+}
+
+fn handle_omp_title(
+    record: &Value,
+    top_type: &str,
+    base_uid: &str,
+    emitter: &mut SourceEmitter<'_>,
+) {
+    let event = emitter
+        .event_for_json(
+            base_uid,
+            "session_meta",
+            "session_meta",
+            "system",
+            &to_str(record.get("title")),
+            record,
+        )
+        .item_id(to_str(record.get("id")))
+        .op_kind(top_type);
     emitter.push_event(event);
 }
 

--- a/crates/moraine-ingest-core/tests/normalize_unit.rs
+++ b/crates/moraine-ingest-core/tests/normalize_unit.rs
@@ -1533,6 +1533,28 @@ fn current_omp_event_types_normalize_with_pi_adapter() {
     let cases = [
         (
             json!({
+                "type": "title",
+                "v": 1,
+                "title": "Review scope changes",
+                "source": "auto",
+                "updatedAt": "2026-07-10T02:43:10.562Z"
+            }),
+            "session_meta",
+        ),
+        (
+            json!({
+                "type": "title_change",
+                "id": "title-change-1",
+                "parentId": "parent-1",
+                "timestamp": "2026-07-10T02:45:40.168Z",
+                "title": "Review scope changes",
+                "source": "auto",
+                "trigger": "replan"
+            }),
+            "session_meta",
+        ),
+        (
+            json!({
                 "type": "custom",
                 "customType": "tool_execution_start",
                 "data": {"toolCallId": "call-1", "toolName": "read"},
@@ -1618,6 +1640,96 @@ fn current_omp_event_types_normalize_with_pi_adapter() {
             Some(expected_event_kind)
         );
     }
+}
+
+#[test]
+fn omp_title_records_preserve_source_metadata() {
+    for top_type in ["title", "title_change"] {
+        let record = json!({
+            "type": top_type,
+            "id": "title-1",
+            "timestamp": "2026-07-10T02:45:40.168Z",
+            "title": "Review scope changes",
+            "source": "auto"
+        });
+
+        let out = normalize_record(
+            &record,
+            "omp",
+            "pi-coding-agent",
+            "/Users/demo/.omp/agent/sessions/project/ReviewScope-2.jsonl",
+            1,
+            1,
+            1,
+            0,
+            "11111111-2222-4333-8444-555555555555",
+            "",
+            "/work/omp-demo",
+        )
+        .expect("OMP title record should normalize");
+
+        let row = &out.event_rows[0];
+        assert_eq!(
+            row.get("event_kind").and_then(Value::as_str),
+            Some("session_meta")
+        );
+        assert_eq!(
+            row.get("payload_type").and_then(Value::as_str),
+            Some("session_meta")
+        );
+        assert_eq!(
+            row.get("text_content").and_then(Value::as_str),
+            Some("Review scope changes")
+        );
+        assert_eq!(row.get("op_kind").and_then(Value::as_str), Some(top_type));
+
+        let payload: Value = serde_json::from_str(
+            row.get("payload_json")
+                .and_then(Value::as_str)
+                .expect("title event payload"),
+        )
+        .expect("valid title event payload");
+        assert_eq!(
+            payload.get("title").and_then(Value::as_str),
+            Some("Review scope changes")
+        );
+    }
+}
+
+#[test]
+fn historical_pi_title_records_remain_unknown() {
+    let record = json!({
+        "type": "title",
+        "v": 1,
+        "title": "Historical Pi title",
+        "updatedAt": "2026-07-10T02:43:10.562Z"
+    });
+
+    let out = normalize_record(
+        &record,
+        "pi",
+        "pi-coding-agent",
+        "/Users/demo/.pi/agent/sessions/project/session.jsonl",
+        1,
+        1,
+        1,
+        0,
+        "11111111-2222-4333-8444-555555555555",
+        "",
+        "/work/pi-demo",
+    )
+    .expect("Pi title record should remain on the generic path");
+
+    assert_eq!(
+        out.event_rows[0].get("event_kind").and_then(Value::as_str),
+        Some("unknown")
+    );
+    assert_eq!(
+        out.event_rows[0]
+            .get("payload_type")
+            .and_then(Value::as_str),
+        Some("unknown")
+    );
 }
 
 #[test]

--- a/sql/030_refresh_omp_session_metadata.sql
+++ b/sql/030_refresh_omp_session_metadata.sql
@@ -1,0 +1,11 @@
+-- Rebuild existing OMP session heads so source titles and privacy-safe
+-- dispatched-session labels are reflected by the MCP open read model.
+INSERT INTO moraine.mcp_open_dirty_sessions
+  (session_id, dirty_revision, observed_at)
+SELECT session_id, generateSnowflakeID(), now64(3)
+FROM (
+  SELECT DISTINCT session_id
+  FROM moraine.events FINAL
+  WHERE notEmpty(session_id)
+    AND source_name = 'omp'
+);


### PR DESCRIPTION
## Description

**What.** Populates `title` and `session_summary` for OMP-sourced sessions from source title records or a privacy-safe dispatched-task filename.

**Why.** OMP sessions were usually indistinguishable in `list_sessions` without opening each transcript.

- Normalizes OMP `title` and `title_change` records as session metadata while retaining compatibility with historical rows stored as unknown events.
- Applies OMP-only metadata precedence in both `list_sessions` and the cached `open` projection.
- Uses a dispatched task/run JSONL basename only when source metadata is absent, normalizing both path separators and excluding UUID-bearing main-session filenames.
- Preserves existing Pi and other non-OMP metadata behavior.
- Adds migration 030 to refresh cached open metadata for existing OMP sessions.

## Bug Evidence

Before this change, issue #568 observed nine of ten OMP sessions with both `title` and `session_summary` set to `null`, including sessions with hundreds of events. OMP uses the Pi adapter, but its `title` and `title_change` records followed the generic unknown-record path, while the list and cached-open projections only recognized canonical session metadata. Titleless dispatched sessions had no safe fallback.

The updated normalization and projections now expose source titles when present and otherwise use only the dispatched JSONL stem. Fixture coverage verifies explicit-title precedence, historical unknown title rows, Windows and POSIX paths, UUID main-file exclusion, and unchanged non-OMP behavior.

Closes #568.

## Usage

No configuration change is required. Existing MCP calls become scannable:

```json
{
  "session": {
    "source": "omp",
    "title": "ReviewScope-2",
    "session_summary": "ReviewScope-2"
  }
}
```

Source-provided OMP titles take precedence over the filename fallback.

## Operational Impact

Migration 030 marks existing OMP sessions dirty so the durable MCP open projection refreshes their metadata. It adds no columns, tables, configuration, or public API fields.

## Changelog

- Populate OMP session titles and summaries from source metadata.
- Add a privacy-safe dispatched-task filename fallback for titleless OMP sessions.
- Refresh cached open metadata for previously ingested OMP sessions.

## Validation

Ran `cargo test --workspace --locked` from the host worktree: 850 tests passed across 26 suites, with four ignored live/benchmark tests. In the dev sandbox, the focused normalization, repository integration, and ClickHouse library suites passed, and the exact owned live ClickHouse test `live_schema_semantics_and_teardown` passed with the new list/open fixtures. `bash scripts/ci/e2e-stack.sh` passed the canonical full-stack lifecycle, migrations through 030, normalized ingest checks, MCP list/search/open smoke, daemon routing, embedded fallback, and teardown.

A dedicated public MCP stdio smoke ingested titleless dispatched, explicitly titled, and UUID main-file OMP sessions; it verified matching `list_sessions` and summary-only `open` metadata, no prompt/task/cwd disclosure, and compatibility after rewriting the title row to the historical unknown-event shape.

The sandbox `make ci-check` run completed dependency policy, formatting, strict clippy, and the locked workspace build before its workspace-test phase hit the known worktree-mount limitation: `/repo/.git` points to host metadata unavailable inside the container, so the unrelated Codex golden lacked project identity. The host workspace run above supplied the real Git metadata and passed the complete test set.