### PR TITLE
feat(cli): show moraine up startup progress

### DIFF
--- a/apps/moraine/src/commands.rs
+++ b/apps/moraine/src/commands.rs
@@ -7,7 +7,7 @@ mod status;
 mod up;
 
 use anyhow::{bail, Context, Result};
-use moraine_clickhouse::{ClickHouseClient, DoctorReport};
+use moraine_clickhouse::{ClickHouseClient, DoctorReport, MigrationProgress};
 use moraine_config::AppConfig;
 use moraine_conversations::{ClickHouseConversationRepository, RepoConfig};
 use std::path::PathBuf;
@@ -203,26 +203,82 @@ fn conversation_repository(cfg: &AppConfig) -> Result<ClickHouseConversationRepo
 // while `export` owns a versioned row contract and schema-skew gate. Those paths keep
 // direct ClickHouse access; operational status reads go through ConversationRepository.
 
-async fn cmd_db_migrate(cfg: &AppConfig) -> Result<MigrationOutcome> {
+#[derive(Debug, Clone, Copy)]
+pub(super) enum DatabaseProgress {
+    Migration(MigrationProgress),
+    ReconciliationInspecting,
+    ReconciliationStarted { historical: bool },
+    ReconciliationAdvanced { processed: usize },
+    ReconciliationFinished { processed: usize },
+}
+
+async fn migrate_database_with_progress<F>(
+    cfg: &AppConfig,
+    mut on_progress: F,
+) -> Result<MigrationOutcome>
+where
+    F: FnMut(DatabaseProgress),
+{
     let ch = ClickHouseClient::new(cfg.clickhouse.clone())?;
-    let applied = ch.run_migrations().await?;
-    let requires_historical_backfill = !ch.mcp_open_read_model_ready().await?;
-    if requires_historical_backfill {
-        eprintln!(
-            "Building the MCP open read model from existing sessions; this one-time step may take several minutes."
-        );
-    }
+    let applied = ch
+        .run_migrations_with_progress(|event| {
+            on_progress(DatabaseProgress::Migration(event));
+        })
+        .await?;
+    on_progress(DatabaseProgress::ReconciliationInspecting);
+    let historical = !ch.mcp_open_read_model_ready().await?;
+    on_progress(DatabaseProgress::ReconciliationStarted { historical });
+
+    let mut processed = 0;
     ch.backfill_mcp_open_read_model_with_progress(|refreshed_sessions| {
-        if requires_historical_backfill {
-            eprintln!("  projected {refreshed_sessions} sessions");
-        }
+        processed = refreshed_sessions;
+        on_progress(DatabaseProgress::ReconciliationAdvanced {
+            processed: refreshed_sessions,
+        });
     })
     .await
     .context("failed to backfill MCP open read model")?;
-    if requires_historical_backfill {
-        eprintln!("MCP open read model ready.");
-    }
+    on_progress(DatabaseProgress::ReconciliationFinished { processed });
     Ok(MigrationOutcome { applied })
+}
+
+pub(super) async fn migrate_database_for_up<F>(
+    cfg: &AppConfig,
+    on_progress: F,
+) -> Result<MigrationOutcome>
+where
+    F: FnMut(DatabaseProgress),
+{
+    migrate_database_with_progress(cfg, on_progress).await
+}
+
+async fn cmd_db_migrate(cfg: &AppConfig) -> Result<MigrationOutcome> {
+    let mut historical = false;
+    migrate_database_with_progress(cfg, |event| match event {
+        DatabaseProgress::Migration(_) => {}
+        DatabaseProgress::ReconciliationInspecting => {}
+        DatabaseProgress::ReconciliationStarted {
+            historical: required,
+        } => {
+            historical = required;
+            if historical {
+                eprintln!(
+                    "Building the MCP open read model from existing sessions; this one-time step may take several minutes."
+                );
+            }
+        }
+        DatabaseProgress::ReconciliationAdvanced { processed } => {
+            if historical {
+                eprintln!("  projected {processed} sessions");
+            }
+        }
+        DatabaseProgress::ReconciliationFinished { .. } => {
+            if historical {
+                eprintln!("MCP open read model ready.");
+            }
+        }
+    })
+    .await
 }
 
 async fn cmd_db_doctor(cfg: &AppConfig) -> Result<DoctorReport> {
@@ -273,7 +329,7 @@ fn cmd_config_get(cfg: &AppConfig, key: &str) -> Result<String> {
     }
 }
 
-fn doctor_is_healthy(report: &DoctorReport) -> bool {
+pub(super) fn doctor_is_healthy(report: &DoctorReport) -> bool {
     report.clickhouse_healthy
         && report.database_exists
         && report.pending_migrations.is_empty()

--- a/apps/moraine/src/commands/logs.rs
+++ b/apps/moraine/src/commands/logs.rs
@@ -10,7 +10,7 @@ use crate::process::{
 use crate::render::{LogsSnapshot, ServiceLogSection};
 use crate::service::Service;
 
-fn tail_lines(path: &Path, lines: usize) -> Result<Vec<String>> {
+pub(super) fn tail_lines(path: &Path, lines: usize) -> Result<Vec<String>> {
     const TAIL_READ_CHUNK_BYTES: usize = 8 * 1024;
 
     if lines == 0 {

--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -4,7 +4,6 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 use std::collections::BTreeSet;
 use std::env;
-use std::fmt;
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, IsTerminal, Write};
 #[cfg(unix)]
@@ -14,7 +13,7 @@ use std::process::{Command, ExitCode, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::cli::{SetupArgs, SetupMcpTarget};
-use crate::render::{CliOutput, OutputMode};
+use crate::render::CliOutput;
 use toml_edit::{ArrayOfTables, DocumentMut, Item, Table};
 
 mod harnesses;
@@ -1272,18 +1271,14 @@ fn render_setup_selection_summary(selections: &[SetupTargetSelection]) {
 }
 
 struct SetupProgress {
-    enabled: bool,
-    rich: bool,
-    unicode: bool,
+    style: crate::progress::ProgressStyle,
     started: bool,
 }
 
 impl SetupProgress {
     fn from_output(output: &CliOutput) -> Self {
         Self {
-            enabled: !output.is_json() && std::io::stderr().is_terminal(),
-            rich: output.mode == OutputMode::Rich,
-            unicode: output.unicode,
+            style: crate::progress::ProgressStyle::from_output(output),
             started: false,
         }
     }
@@ -1291,125 +1286,124 @@ impl SetupProgress {
     #[cfg(test)]
     fn disabled() -> Self {
         Self {
-            enabled: false,
-            rich: false,
-            unicode: true,
+            style: crate::progress::ProgressStyle::disabled(),
             started: false,
         }
     }
 
     fn finish(&mut self) {
-        if !self.enabled || !self.started {
+        if !self.style.enabled() || !self.started {
             return;
         }
         eprintln!(
             "{} {}",
-            self.progress_line("╰─", "`-", Style::new().bright().black()),
-            self.dim("setup summary follows")
+            self.style.branch("╰─", "`-", Style::new().bright().black()),
+            self.style.dim("setup summary follows")
         );
     }
 
     fn target_start(&mut self, target: SetupMcpTarget, plan: &McpPlan) {
-        if !self.enabled {
+        if !self.style.enabled() {
             return;
         }
         self.ensure_started();
         eprintln!(
             "{} {} {}",
-            self.progress_line("├─", "+-", Style::new().bright().black()),
-            self.bold_label(target.label()),
-            self.dim(plan.target.setup_kind())
+            self.style.branch("├─", "+-", Style::new().bright().black()),
+            self.style.bold_label(target.label()),
+            self.style.dim(plan.target.setup_kind())
         );
     }
 
     fn target_success(&self, target: SetupMcpTarget) {
-        if !self.enabled {
+        if !self.style.enabled() {
             return;
         }
         eprintln!(
             "   {} {}",
-            self.mark("✓", "[ok]", Style::new().green()),
-            self.dim(&format!("{} configured", target.label()))
+            self.style.mark("✓", "[ok]", Style::new().green()),
+            self.style.dim(&format!("{} configured", target.label()))
         );
     }
 
     fn target_error(&self, target: SetupMcpTarget) {
-        if !self.enabled {
+        if !self.style.enabled() {
             return;
         }
         eprintln!(
             "   {} {}",
-            self.mark("✗", "[err]", Style::new().red()),
-            self.dim(&format!("{} needs attention", target.label()))
+            self.style.mark("✗", "[err]", Style::new().red()),
+            self.style
+                .dim(&format!("{} needs attention", target.label()))
         );
     }
 
     fn target_skipped(&self, target: SetupMcpTarget, reason: &str) {
-        if !self.enabled {
+        if !self.style.enabled() {
             return;
         }
         eprintln!(
             "   {} {} {}",
-            self.mark("–", "[-]", Style::new().yellow()),
-            self.dim(target.label()),
-            self.dim(reason)
+            self.style.mark("–", "[-]", Style::new().yellow()),
+            self.style.dim(target.label()),
+            self.style.dim(reason)
         );
     }
 
     fn command_start(&self, step: &McpPlanStep) {
-        if !self.enabled {
+        if !self.style.enabled() {
             return;
         }
         eprintln!(
             "   {} {}",
-            self.mark("→", ">", Style::new().cyan()),
-            self.label(step.progress_label)
+            self.style.mark("→", ">", Style::new().cyan()),
+            self.style.label(step.progress_label)
         );
     }
 
     fn command_success(&self, step: &McpPlanStep) {
-        if !self.enabled {
+        if !self.style.enabled() {
             return;
         }
         eprintln!(
             "   {} {}",
-            self.mark("✓", "[ok]", Style::new().green()),
-            self.dim(step.success_label)
+            self.style.mark("✓", "[ok]", Style::new().green()),
+            self.style.dim(step.success_label)
         );
     }
 
     fn command_warning(&self, step: &McpPlanStep, warning: &str) {
-        if !self.enabled {
+        if !self.style.enabled() {
             return;
         }
         eprintln!(
             "   {} {} {}",
-            self.mark("!", "[warn]", Style::new().yellow()),
-            self.dim(step.warning_label),
-            self.dim(warning)
+            self.style.mark("!", "[warn]", Style::new().yellow()),
+            self.style.dim(step.warning_label),
+            self.style.dim(warning)
         );
     }
 
     fn command_error(&self, step: &McpPlanStep, error: &str) {
-        if !self.enabled {
+        if !self.style.enabled() {
             return;
         }
         eprintln!(
             "   {} {} {}",
-            self.mark("✗", "[err]", Style::new().red()),
-            self.dim(step.error_label),
-            self.dim(error)
+            self.style.mark("✗", "[err]", Style::new().red()),
+            self.style.dim(step.error_label),
+            self.style.dim(error)
         );
     }
 
     fn config_start(&self, write: &McpConfigWrite) {
-        if !self.enabled {
+        if !self.style.enabled() {
             return;
         }
         eprintln!(
             "   {} {}",
-            self.mark("→", ">", Style::new().cyan()),
-            self.label(&format!(
+            self.style.mark("→", ">", Style::new().cyan()),
+            self.style.label(&format!(
                 "Updating {} config at {}",
                 write.label(),
                 write.path().display()
@@ -1418,25 +1412,27 @@ impl SetupProgress {
     }
 
     fn config_success(&self, write: &McpConfigWrite) {
-        if !self.enabled {
+        if !self.style.enabled() {
             return;
         }
         eprintln!(
             "   {} {}",
-            self.mark("✓", "[ok]", Style::new().green()),
-            self.dim(&format!("Updated {}", write.path().display()))
+            self.style.mark("✓", "[ok]", Style::new().green()),
+            self.style
+                .dim(&format!("Updated {}", write.path().display()))
         );
     }
 
     fn config_error(&self, write: &McpConfigWrite, error: &str) {
-        if !self.enabled {
+        if !self.style.enabled() {
             return;
         }
         eprintln!(
             "   {} {} {}",
-            self.mark("✗", "[err]", Style::new().red()),
-            self.dim(&format!("Could not update {}", write.path().display())),
-            self.dim(error)
+            self.style.mark("✗", "[err]", Style::new().red()),
+            self.style
+                .dim(&format!("Could not update {}", write.path().display())),
+            self.style.dim(error)
         );
     }
 
@@ -1445,11 +1441,11 @@ impl SetupProgress {
             return;
         }
         self.started = true;
-        if self.rich {
+        if self.style.rich() {
             eprintln!();
             eprintln!(
                 "{} {}",
-                self.progress_line("╭─", ".-", Style::new().cyan()),
+                self.style.branch("╭─", ".-", Style::new().cyan()),
                 Style::new()
                     .cyan()
                     .bold()
@@ -1458,59 +1454,6 @@ impl SetupProgress {
             );
         } else {
             eprintln!("Installing agent integrations");
-        }
-    }
-
-    fn mark<'a>(&self, unicode: &'a str, ascii: &'a str, style: Style) -> impl fmt::Display + 'a {
-        if self.rich {
-            style
-                .for_stderr()
-                .apply_to(if self.unicode { unicode } else { ascii })
-        } else {
-            Style::new()
-                .for_stderr()
-                .apply_to(if self.unicode { unicode } else { ascii })
-        }
-    }
-
-    fn label<'a>(&self, value: &'a str) -> impl fmt::Display + 'a {
-        if self.rich {
-            Style::new().white().for_stderr().apply_to(value)
-        } else {
-            Style::new().for_stderr().apply_to(value)
-        }
-    }
-
-    fn bold_label<'a>(&self, value: &'a str) -> impl fmt::Display + 'a {
-        if self.rich {
-            Style::new().white().bold().for_stderr().apply_to(value)
-        } else {
-            Style::new().for_stderr().apply_to(value)
-        }
-    }
-
-    fn dim<'a>(&self, value: &'a str) -> impl fmt::Display + 'a {
-        if self.rich {
-            Style::new().bright().black().for_stderr().apply_to(value)
-        } else {
-            Style::new().for_stderr().apply_to(value)
-        }
-    }
-
-    fn progress_line<'a>(
-        &self,
-        unicode: &'a str,
-        ascii: &'a str,
-        style: Style,
-    ) -> impl fmt::Display + 'a {
-        if self.rich {
-            style
-                .for_stderr()
-                .apply_to(if self.unicode { unicode } else { ascii })
-        } else {
-            Style::new()
-                .for_stderr()
-                .apply_to(if self.unicode { unicode } else { ascii })
         }
     }
 }

--- a/apps/moraine/src/commands/up.rs
+++ b/apps/moraine/src/commands/up.rs
@@ -1,15 +1,454 @@
 use anyhow::Result;
+use dialoguer::console::Style;
+use moraine_clickhouse::MigrationProgress;
 use moraine_config::AppConfig;
+use std::future::Future;
+use std::io::Write;
 use std::process::ExitCode;
+use std::sync::mpsc::{self, Receiver};
+use std::time::{Duration, Instant};
+use tokio::time::{interval_at, Instant as TokioInstant, MissedTickBehavior};
 
 use crate::cli::UpArgs;
-use crate::managed_clickhouse::start_clickhouse;
+use crate::managed_clickhouse::{start_clickhouse_with_progress, ClickHouseStartupProgress};
 use crate::paths::{ensure_runtime_dirs, runtime_paths, RuntimePaths};
-use crate::process::{preflight_required_service_binaries, start_background_service};
-use crate::render::{render_up, CliOutput, UpSnapshot};
+use crate::process::{
+    preflight_required_service_binaries, start_background_service, StartOutcome, StartState,
+};
+#[cfg(test)]
+use crate::progress::ProgressStyle;
+use crate::progress::ProgressTree;
+use crate::render::{render_up, CliOutput, MigrationOutcome, StatusSnapshot, UpSnapshot};
 use crate::service::Service;
 
-use super::{cmd_db_migrate, conversation_repository, status::cmd_status};
+use super::{
+    conversation_repository, doctor_is_healthy, migrate_database_for_up, status::cmd_status,
+    DatabaseProgress,
+};
+
+const PROGRESS_REFRESH: Duration = Duration::from_millis(250);
+
+const FAILURE_LOG_LINE_LIMIT: usize = 10;
+
+fn sanitize_log_line(line: &str) -> String {
+    let mut sanitized = String::with_capacity(line.len());
+    for character in line.chars() {
+        if character.is_control() {
+            sanitized.extend(character.escape_default());
+        } else {
+            sanitized.push(character);
+        }
+    }
+    sanitized
+}
+
+enum DatabaseActivity {
+    Inspecting {
+        started: Instant,
+    },
+    Migration {
+        index: usize,
+        total: usize,
+        name: &'static str,
+        started: Instant,
+    },
+    ReconciliationInspection {
+        started: Instant,
+    },
+    Reconciliation {
+        processed: usize,
+        started: Instant,
+    },
+}
+
+struct StartupProgress<W> {
+    tree: ProgressTree<W>,
+    started_at: Instant,
+    database_activity: Option<DatabaseActivity>,
+    launched: Vec<StartOutcome>,
+    verbose: bool,
+}
+
+impl StartupProgress<std::io::Stderr> {
+    fn from_output(output: &CliOutput) -> Self {
+        Self::new(ProgressTree::from_output(output), output.verbose)
+    }
+}
+
+impl<W: Write> StartupProgress<W> {
+    fn new(tree: ProgressTree<W>, verbose: bool) -> Self {
+        Self {
+            tree,
+            started_at: Instant::now(),
+            database_activity: None,
+            launched: Vec::new(),
+            verbose,
+        }
+    }
+
+    fn startup_plan(&mut self, services: &[Service]) {
+        self.tree.start("Starting Moraine");
+        let mut selected = vec!["ClickHouse", "database"];
+        if services.contains(&Service::Ingest) {
+            selected.push("ingest");
+        }
+        if services.contains(&Service::Backend) {
+            selected.push("backend");
+        }
+        let mut detail = selected.join(", ");
+        if !services.contains(&Service::Ingest) {
+            detail.push_str("; ingest skipped by --no-ingest");
+        }
+        if !services.contains(&Service::Backend) {
+            detail.push_str("; backend not selected");
+        }
+        self.tree.phase("Startup plan", Some(&detail));
+    }
+
+    fn phase(&mut self, label: &str, detail: &str) {
+        self.tree.phase(label, Some(detail));
+    }
+
+    fn success_step(&mut self, label: &str, detail: Option<&str>) {
+        self.tree
+            .step("✓", "[ok]", label, detail, Style::new().green());
+    }
+
+    fn info_step(&mut self, label: &str, detail: Option<&str>) {
+        self.tree.step("•", "*", label, detail, Style::new().cyan());
+    }
+
+    fn skipped_step(&mut self, label: &str, detail: Option<&str>) {
+        self.tree
+            .step("–", "[-]", label, detail, Style::new().yellow());
+    }
+
+    fn clickhouse_wait(&mut self, event: ClickHouseStartupProgress) {
+        match event {
+            ClickHouseStartupProgress::ProbingEndpoint { elapsed, timeout } => {
+                self.tree.active(&format!(
+                    "Probing configured ClickHouse endpoint · {:.1}s / {:.1}s",
+                    elapsed.as_secs_f64(),
+                    timeout.as_secs_f64()
+                ));
+            }
+            ClickHouseStartupProgress::EndpointProbeFinished => self.tree.clear_active(),
+            ClickHouseStartupProgress::WaitingForHealth { elapsed, timeout } => {
+                self.tree.active(&format!(
+                    "Waiting for ClickHouse health · {:.1}s / {:.1}s",
+                    elapsed.as_secs_f64(),
+                    timeout.as_secs_f64()
+                ));
+            }
+        }
+    }
+
+    fn clickhouse_outcome(&mut self, outcome: &StartOutcome) {
+        self.tree.clear_active();
+        let pid = outcome.pid.map(|pid| format!("pid {pid}"));
+        match outcome.state {
+            StartState::Started => {
+                self.launched.push(outcome.clone());
+                self.success_step(
+                    "ClickHouse ready",
+                    Some(&format!(
+                        "managed supervisor started{}",
+                        pid.as_deref()
+                            .map(|value| format!(" · {value}"))
+                            .unwrap_or_default()
+                    )),
+                );
+            }
+            StartState::AlreadyRunning => {
+                self.success_step(
+                    "ClickHouse ready",
+                    Some(&format!(
+                        "managed supervisor already running{}",
+                        pid.as_deref()
+                            .map(|value| format!(" · {value}"))
+                            .unwrap_or_default()
+                    )),
+                );
+            }
+            StartState::AlreadyServing => {
+                self.success_step("ClickHouse ready", Some("healthy unmanaged endpoint"));
+            }
+        }
+        if self.verbose {
+            if let Some(path) = &outcome.log_path {
+                self.info_step("ClickHouse log", Some(path));
+            }
+        }
+    }
+
+    fn database_start(&mut self) {
+        self.phase("Database", "inspecting schema and migrations");
+        self.database_activity = Some(DatabaseActivity::Inspecting {
+            started: Instant::now(),
+        });
+        self.database_tick();
+    }
+
+    fn database_event(&mut self, event: DatabaseProgress) {
+        match event {
+            DatabaseProgress::Migration(MigrationProgress::Plan { applied, pending }) => {
+                self.database_activity = None;
+                if pending == 0 {
+                    self.success_step(
+                        "Database schema current",
+                        Some(&format!("{applied} migrations applied")),
+                    );
+                } else {
+                    self.info_step(
+                        "Migration plan",
+                        Some(&format!("{applied} applied · {pending} pending")),
+                    );
+                }
+            }
+            DatabaseProgress::Migration(MigrationProgress::Started {
+                index, total, name, ..
+            }) => {
+                self.database_activity = Some(DatabaseActivity::Migration {
+                    index,
+                    total,
+                    name,
+                    started: Instant::now(),
+                });
+                self.database_tick();
+            }
+            DatabaseProgress::Migration(MigrationProgress::Applied {
+                index, total, name, ..
+            }) => {
+                let elapsed = match self.database_activity.take() {
+                    Some(DatabaseActivity::Migration { started, .. }) => started.elapsed(),
+                    _ => Duration::ZERO,
+                };
+                self.success_step(
+                    name,
+                    Some(&format!(
+                        "migration {index}/{total} applied · {:.1}s",
+                        elapsed.as_secs_f64()
+                    )),
+                );
+            }
+            DatabaseProgress::ReconciliationInspecting => {
+                self.database_activity = Some(DatabaseActivity::ReconciliationInspection {
+                    started: Instant::now(),
+                });
+                self.database_tick();
+            }
+            DatabaseProgress::ReconciliationStarted { historical } => {
+                self.tree.phase(
+                    "MCP read model",
+                    Some(if historical {
+                        "building from existing sessions"
+                    } else {
+                        "reconciling changed sessions"
+                    }),
+                );
+                self.database_activity = Some(DatabaseActivity::Reconciliation {
+                    processed: 0,
+                    started: Instant::now(),
+                });
+                self.database_tick();
+            }
+            DatabaseProgress::ReconciliationAdvanced { processed } => {
+                if let Some(DatabaseActivity::Reconciliation {
+                    processed: current, ..
+                }) = &mut self.database_activity
+                {
+                    *current = processed;
+                }
+                self.database_tick();
+            }
+            DatabaseProgress::ReconciliationFinished { processed } => {
+                let elapsed = match self.database_activity.take() {
+                    Some(DatabaseActivity::Reconciliation { started, .. }) => started.elapsed(),
+                    _ => Duration::ZERO,
+                };
+                self.success_step(
+                    "MCP read model ready",
+                    Some(&format!(
+                        "{processed} sessions processed · {:.1}s",
+                        elapsed.as_secs_f64()
+                    )),
+                );
+            }
+        }
+    }
+
+    fn database_tick(&mut self) {
+        let label = match &self.database_activity {
+            Some(DatabaseActivity::Inspecting { started }) => {
+                format!(
+                    "Reading migration ledger · {:.1}s",
+                    started.elapsed().as_secs_f64()
+                )
+            }
+            Some(DatabaseActivity::Migration {
+                index,
+                total,
+                name,
+                started,
+            }) => format!(
+                "[{index}/{total}] {name} · {:.1}s",
+                started.elapsed().as_secs_f64()
+            ),
+            Some(DatabaseActivity::ReconciliationInspection { started }) => format!(
+                "Inspecting MCP read model · {:.1}s",
+                started.elapsed().as_secs_f64()
+            ),
+            Some(DatabaseActivity::Reconciliation { processed, started }) => format!(
+                "Reconciling sessions · {processed} processed · {:.1}s",
+                started.elapsed().as_secs_f64()
+            ),
+            None => return,
+        };
+        self.tree.active(&label);
+    }
+
+    fn service_outcome(&mut self, outcome: &StartOutcome) {
+        let pid = outcome
+            .pid
+            .map(|pid| format!("pid {pid}"))
+            .unwrap_or_else(|| "unmanaged".to_string());
+        match outcome.state {
+            StartState::Started => {
+                self.launched.push(outcome.clone());
+                self.success_step(&format!("{} launched", outcome.service.name()), Some(&pid));
+            }
+            StartState::AlreadyRunning => self.skipped_step(
+                &format!("{} already running", outcome.service.name()),
+                Some(&pid),
+            ),
+            StartState::AlreadyServing => self.skipped_step(
+                &format!("{} already serving", outcome.service.name()),
+                Some("unmanaged"),
+            ),
+        }
+        if self.verbose {
+            if let Some(path) = &outcome.log_path {
+                self.info_step(&format!("{} log", outcome.service.name()), Some(path));
+            }
+        }
+    }
+
+    fn status_collected(&mut self, status: &StatusSnapshot, elapsed: Duration) {
+        self.tree.clear_active();
+        let healthy = doctor_is_healthy(&status.doctor);
+        let detail = format!(
+            "database {} · {:.1}s",
+            if healthy {
+                "healthy"
+            } else {
+                "needs attention"
+            },
+            elapsed.as_secs_f64()
+        );
+        if healthy {
+            self.success_step("Status collected", Some(&detail));
+        } else {
+            self.tree.step(
+                "!",
+                "[warn]",
+                "Status collected",
+                Some(&detail),
+                Style::new().yellow(),
+            );
+        }
+        if let Some(url) = &status.monitor_url {
+            self.info_step("Monitor", Some(url));
+        }
+    }
+
+    fn finish_success(&mut self) {
+        self.tree.finish(
+            true,
+            &format!(
+                "Moraine startup actions complete · {:.1}s · startup summary follows",
+                self.started_at.elapsed().as_secs_f64()
+            ),
+        );
+    }
+
+    fn finish_error(&mut self, paths: &RuntimePaths) {
+        self.tree.clear_active();
+        if !self.launched.is_empty() {
+            let launched = self
+                .launched
+                .iter()
+                .map(|outcome| outcome.service.name())
+                .collect::<Vec<_>>()
+                .join(", ");
+            self.tree.step(
+                "!",
+                "[warn]",
+                "Services were launched",
+                Some(&format!(
+                    "{launched} may still be running · run `moraine down` to stop them"
+                )),
+                Style::new().yellow(),
+            );
+            let mut remaining_log_lines = FAILURE_LOG_LINE_LIMIT;
+            for outcome in &self.launched {
+                if let Some(path) = &outcome.log_path {
+                    self.tree.step(
+                        "i",
+                        "[info]",
+                        &format!("{} logs", outcome.service.name()),
+                        Some(&format!(
+                            "{path} · `moraine logs {} --lines 200`",
+                            outcome.service.name()
+                        )),
+                        Style::new().cyan(),
+                    );
+                }
+                if !self.verbose || remaining_log_lines == 0 {
+                    continue;
+                }
+                let Ok(snapshot) =
+                    super::logs::collect_logs(paths, Some(outcome.service), remaining_log_lines)
+                else {
+                    continue;
+                };
+                for section in snapshot
+                    .sections
+                    .into_iter()
+                    .rev()
+                    .filter(|section| section.exists && !section.lines.is_empty())
+                {
+                    self.tree.step(
+                        "i",
+                        "[info]",
+                        &format!("{} log source", outcome.service.name()),
+                        Some(&section.path),
+                        Style::new().cyan(),
+                    );
+                    for line in section.lines.into_iter().take(remaining_log_lines) {
+                        let line = sanitize_log_line(&line);
+                        self.tree.step(
+                            "|",
+                            "|",
+                            outcome.service.name(),
+                            Some(&line),
+                            Style::new().bright().black(),
+                        );
+                        remaining_log_lines -= 1;
+                    }
+                    if remaining_log_lines == 0 {
+                        break;
+                    }
+                }
+            }
+        }
+        self.tree.finish(false, "Moraine startup failed");
+    }
+
+    #[cfg(test)]
+    fn into_inner(self) -> W {
+        self.tree.into_inner()
+    }
+}
 
 pub(super) async fn handle_args(
     output: &CliOutput,
@@ -19,43 +458,136 @@ pub(super) async fn handle_args(
 ) -> Result<ExitCode> {
     let paths = runtime_paths(cfg);
     let services_to_start = selected_up_services(args, cfg);
-    start_selected_services(output, config_path, cfg, &paths, services_to_start).await
+    let mut progress = StartupProgress::from_output(output);
+    progress.startup_plan(&services_to_start);
+
+    match start_selected_services(config_path, cfg, &paths, services_to_start, &mut progress).await
+    {
+        Ok(snapshot) => {
+            progress.finish_success();
+            render_up(output, &snapshot)?;
+            Ok(ExitCode::SUCCESS)
+        }
+        Err(error) => {
+            progress.finish_error(&paths);
+            Err(error)
+        }
+    }
 }
 
-async fn start_selected_services(
-    output: &CliOutput,
+async fn start_selected_services<W: Write>(
     config_path: &std::path::Path,
     cfg: &AppConfig,
     paths: &RuntimePaths,
     services_to_start: Vec<Service>,
-) -> Result<ExitCode> {
+    progress: &mut StartupProgress<W>,
+) -> Result<UpSnapshot> {
+    progress.phase(
+        "Preflight",
+        "checking service binaries and runtime directories",
+    );
     preflight_required_service_binaries(&services_to_start, paths)?;
     ensure_runtime_dirs(paths)?;
+    progress.success_step("Preflight complete", None);
 
-    let clickhouse = start_clickhouse(config_path, cfg, paths).await?;
-    let migrations = cmd_db_migrate(cfg).await?;
+    progress.phase("ClickHouse", "inspecting endpoint and managed runtime");
+    let clickhouse = start_clickhouse_with_progress(config_path, cfg, paths, |event| {
+        progress.clickhouse_wait(event);
+    })
+    .await?;
+    progress.clickhouse_outcome(&clickhouse);
 
-    let mut started_services = Vec::new();
+    progress.database_start();
+    let migrations = drive_database_progress(cfg, progress).await?;
+
+    progress.phase("Services", "starting selected Moraine processes");
+    let mut started_services = Vec::with_capacity(services_to_start.len());
     for service in services_to_start {
-        started_services.push(start_background_service(
-            service,
-            config_path,
-            cfg,
-            paths,
-            &[],
-        )?);
+        let outcome = start_background_service(service, config_path, cfg, paths, &[])?;
+        progress.service_outcome(&outcome);
+        started_services.push(outcome);
     }
 
+    progress.phase(
+        "Verification",
+        "collecting final runtime and database status",
+    );
     let repository = conversation_repository(cfg)?;
-    let status = cmd_status(paths, cfg, &repository).await?;
-    let snapshot = UpSnapshot {
+    let status_started = Instant::now();
+    let status = drive_status_progress(
+        cmd_status(paths, cfg, &repository),
+        status_started,
+        progress,
+    )
+    .await?;
+    progress.status_collected(&status, status_started.elapsed());
+
+    Ok(UpSnapshot {
         clickhouse,
         migrations,
         services: started_services,
         status,
-    };
-    render_up(output, &snapshot)?;
-    Ok(ExitCode::SUCCESS)
+    })
+}
+
+async fn drive_database_progress<W: Write>(
+    cfg: &AppConfig,
+    progress: &mut StartupProgress<W>,
+) -> Result<MigrationOutcome> {
+    let (sender, receiver) = mpsc::channel();
+    let migration = migrate_database_for_up(cfg, move |event| {
+        let _ = sender.send(event);
+    });
+    tokio::pin!(migration);
+    let mut ticker = interval_at(TokioInstant::now() + PROGRESS_REFRESH, PROGRESS_REFRESH);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            result = &mut migration => {
+                drain_database_events(&receiver, progress);
+                return result;
+            }
+            _ = ticker.tick() => {
+                drain_database_events(&receiver, progress);
+                progress.database_tick();
+            }
+        }
+    }
+}
+
+fn drain_database_events<W: Write>(
+    receiver: &Receiver<DatabaseProgress>,
+    progress: &mut StartupProgress<W>,
+) {
+    while let Ok(event) = receiver.try_recv() {
+        progress.database_event(event);
+    }
+}
+
+async fn drive_status_progress<F, W>(
+    status: F,
+    started: Instant,
+    progress: &mut StartupProgress<W>,
+) -> Result<StatusSnapshot>
+where
+    F: Future<Output = Result<StatusSnapshot>>,
+    W: Write,
+{
+    tokio::pin!(status);
+    let mut ticker = interval_at(TokioInstant::now() + PROGRESS_REFRESH, PROGRESS_REFRESH);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            result = &mut status => return result,
+            _ = ticker.tick() => {
+                progress.tree.active(&format!(
+                    "Collecting status · {:.1}s",
+                    started.elapsed().as_secs_f64()
+                ));
+            }
+        }
+    }
 }
 
 fn selected_up_services(args: &UpArgs, cfg: &AppConfig) -> Vec<Service> {
@@ -72,6 +604,136 @@ fn selected_up_services(args: &UpArgs, cfg: &AppConfig) -> Vec<Service> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::render::OutputMode;
+
+    fn test_output(mode: OutputMode, unicode: bool) -> CliOutput {
+        CliOutput {
+            mode,
+            verbose: false,
+            unicode,
+            width: 100,
+        }
+    }
+
+    #[test]
+    fn startup_progress_is_stderr_tty_only_and_json_safe() {
+        let rich = ProgressStyle::from_capabilities(&test_output(OutputMode::Rich, true), true);
+        let mut progress = StartupProgress::new(ProgressTree::new(rich, Vec::new()), false);
+        progress.startup_plan(&[Service::Ingest]);
+        progress.phase("Database", "checking");
+        progress.tree.active("Working");
+        progress.success_step("Done", None);
+        progress.finish_success();
+        let rendered = String::from_utf8(progress.into_inner()).expect("progress utf8");
+        assert!(rendered.contains("Starting Moraine"));
+        assert!(rendered.contains("backend not selected"));
+        assert!(rendered.contains("\u{1b}[2K"));
+
+        for mode in [OutputMode::Rich, OutputMode::Json] {
+            let style = ProgressStyle::from_capabilities(
+                &test_output(mode, true),
+                mode == OutputMode::Json,
+            );
+            let mut progress = StartupProgress::new(ProgressTree::new(style, Vec::new()), false);
+            progress.startup_plan(&[]);
+            progress.finish_success();
+            assert!(progress.into_inner().is_empty());
+        }
+    }
+
+    #[test]
+    fn plain_progress_has_no_cursor_control_bytes() {
+        let style = ProgressStyle::from_capabilities(&test_output(OutputMode::Plain, false), true);
+        let mut progress = StartupProgress::new(ProgressTree::new(style, Vec::new()), false);
+        progress.startup_plan(&[]);
+        progress.tree.active("Waiting");
+        progress.tree.active("Waiting longer");
+        progress.finish_success();
+        let rendered = String::from_utf8(progress.into_inner()).expect("progress utf8");
+        assert!(!rendered.contains('\r'));
+        assert!(!rendered.contains("\u{1b}["));
+        assert_eq!(rendered.matches("Waiting").count(), 1);
+    }
+
+    #[test]
+    fn migration_is_applied_only_after_applied_event() {
+        let style = ProgressStyle::from_capabilities(&test_output(OutputMode::Plain, true), true);
+        let mut progress = StartupProgress::new(ProgressTree::new(style, Vec::new()), false);
+        progress.startup_plan(&[]);
+        progress.database_event(DatabaseProgress::Migration(MigrationProgress::Plan {
+            applied: 29,
+            pending: 1,
+        }));
+        progress.database_event(DatabaseProgress::Migration(MigrationProgress::Started {
+            index: 1,
+            total: 1,
+            version: "030",
+            name: "030_refresh_omp_session_metadata.sql",
+        }));
+        let before = String::from_utf8_lossy(progress.tree.bytes());
+        assert!(!before.contains("migration 1/1 applied"));
+        progress.database_event(DatabaseProgress::Migration(MigrationProgress::Applied {
+            index: 1,
+            total: 1,
+            version: "030",
+            name: "030_refresh_omp_session_metadata.sql",
+        }));
+        let rendered = String::from_utf8(progress.into_inner()).expect("progress utf8");
+        assert!(rendered.contains("migration 1/1 applied"));
+    }
+
+    #[test]
+    fn failed_startup_reports_launched_services_and_bounded_safe_logs() {
+        let root = std::env::temp_dir().join(format!("moraine-up-progress-{}", std::process::id()));
+        let mut cfg = AppConfig::default();
+        cfg.runtime.root_dir = root.display().to_string();
+        cfg.runtime.logs_dir = root.join("logs").display().to_string();
+        cfg.runtime.pids_dir = root.join("pids").display().to_string();
+        let paths = runtime_paths(&cfg);
+        ensure_runtime_dirs(&paths).expect("create temporary runtime directories");
+        let ingest_log = crate::process::log_path(&paths, Service::Ingest);
+        let backend_log = crate::process::log_path(&paths, Service::Backend);
+        std::fs::write(
+            &ingest_log,
+            "\u{1b}[2Jdiagnostic-01\ndiagnostic-02\ndiagnostic-03\ndiagnostic-04\ndiagnostic-05\ndiagnostic-06\ndiagnostic-07\ndiagnostic-08\n",
+        )
+        .expect("write temporary ingest log");
+        std::fs::write(
+            &backend_log,
+            "diagnostic-09\ndiagnostic-10\ndiagnostic-11\ndiagnostic-12\ndiagnostic-13\ndiagnostic-14\ndiagnostic-15\ndiagnostic-16\n",
+        )
+        .expect("write temporary backend log");
+        let style = ProgressStyle::from_capabilities(&test_output(OutputMode::Plain, true), true);
+        let mut progress = StartupProgress::new(ProgressTree::new(style, Vec::new()), true);
+        progress.startup_plan(&[Service::Ingest, Service::Backend]);
+        for (service, pid, log_path) in [
+            (Service::Ingest, 42, &ingest_log),
+            (Service::Backend, 43, &backend_log),
+        ] {
+            progress.service_outcome(&StartOutcome {
+                service,
+                state: StartState::Started,
+                pid: Some(pid),
+                log_path: Some(log_path.display().to_string()),
+            });
+        }
+
+        progress.finish_error(&paths);
+        let rendered = String::from_utf8(progress.into_inner()).expect("progress utf8");
+        std::fs::remove_dir_all(&root).expect("remove temporary runtime directories");
+
+        assert!(rendered.contains("Services were launched"));
+        assert!(rendered.contains("may still be running"));
+        assert!(rendered.contains("run `moraine down`"));
+        assert!(rendered.contains("`moraine logs ingest --lines 200`"));
+        assert_eq!(
+            rendered.matches("diagnostic-").count(),
+            FAILURE_LOG_LINE_LIMIT
+        );
+        assert!(rendered.contains(r"\u{1b}[2Jdiagnostic-01"));
+        assert!(!rendered.contains('\u{1b}'));
+        assert!(rendered.contains("Moraine startup failed"));
+    }
 
     #[test]
     fn selected_up_services_uses_only_normalized_backend_switch_and_deduplicates_aliases() {

--- a/apps/moraine/src/main.rs
+++ b/apps/moraine/src/main.rs
@@ -3,6 +3,7 @@ mod commands;
 mod managed_clickhouse;
 mod paths;
 mod process;
+mod progress;
 mod render;
 mod service;
 

--- a/apps/moraine/src/managed_clickhouse.rs
+++ b/apps/moraine/src/managed_clickhouse.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::{Child, Command as TokioCommand};
 use tokio::task::JoinHandle;
-use tokio::time::{sleep, timeout, Instant};
+use tokio::time::{interval_at, sleep, timeout, Instant, MissedTickBehavior};
 
 #[cfg(unix)]
 use std::os::unix::{
@@ -536,12 +536,82 @@ fn prompt_install_clickhouse(version: &str) -> Result<bool> {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ClickHouseStartupProgress {
+    ProbingEndpoint {
+        elapsed: Duration,
+        timeout: Duration,
+    },
+    EndpointProbeFinished,
+    WaitingForHealth {
+        elapsed: Duration,
+        timeout: Duration,
+    },
+}
+
+async fn ping_with_progress<F, E>(
+    client: &ClickHouseClient,
+    started: Instant,
+    deadline: Instant,
+    refresh_interval: Duration,
+    on_progress: &mut F,
+    event: E,
+) -> Result<()>
+where
+    F: FnMut(ClickHouseStartupProgress),
+    E: Fn(Duration, Duration) -> ClickHouseStartupProgress,
+{
+    let progress_timeout = deadline.saturating_duration_since(started);
+    on_progress(event(
+        started.elapsed().min(progress_timeout),
+        progress_timeout,
+    ));
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        bail!(
+            "clickhouse health probe timed out after {:.1}s",
+            progress_timeout.as_secs_f64()
+        );
+    }
+    let ping = timeout(remaining, client.ping());
+    tokio::pin!(ping);
+    let mut ticker = interval_at(Instant::now() + refresh_interval, refresh_interval);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            result = &mut ping => {
+                return match result {
+                    Ok(result) => result,
+                    Err(_) => bail!(
+                        "clickhouse health probe timed out after {:.1}s",
+                        progress_timeout.as_secs_f64()
+                    ),
+                };
+            }
+            _ = ticker.tick() => {
+                on_progress(event(
+                    started.elapsed().min(progress_timeout),
+                    progress_timeout,
+                ));
+            }
+        }
+    }
+}
+
 async fn wait_for_clickhouse(cfg: &AppConfig) -> Result<()> {
+    wait_for_clickhouse_with_progress(cfg, &mut |_| {}).await
+}
+
+async fn wait_for_clickhouse_with_progress<F>(cfg: &AppConfig, on_progress: &mut F) -> Result<()>
+where
+    F: FnMut(ClickHouseStartupProgress),
+{
     let client = ClickHouseClient::new(cfg.clickhouse.clone())?;
     let startup_timeout =
         Duration::from_secs_f64(cfg.runtime.clickhouse_start_timeout_seconds.max(1.0));
     let interval = Duration::from_millis(cfg.runtime.healthcheck_interval_ms.max(100));
-    let deadline = Instant::now() + startup_timeout;
+    let started = Instant::now();
+    let deadline = started + startup_timeout;
 
     loop {
         let remaining = deadline.saturating_duration_since(Instant::now());
@@ -551,8 +621,17 @@ async fn wait_for_clickhouse(cfg: &AppConfig) -> Result<()> {
                 startup_timeout.as_secs_f64()
             );
         }
-
-        if matches!(timeout(remaining, client.ping()).await, Ok(Ok(()))) {
+        if ping_with_progress(
+            &client,
+            started,
+            deadline,
+            interval,
+            on_progress,
+            |elapsed, timeout| ClickHouseStartupProgress::WaitingForHealth { elapsed, timeout },
+        )
+        .await
+        .is_ok()
+        {
             return Ok(());
         }
 
@@ -1301,8 +1380,15 @@ async fn stop_new_supervisor(child: &mut Child, pid_file: &Path, pid: u32) -> Re
     Ok(())
 }
 
-async fn wait_for_supervisor_startup(supervisor: &mut Child, cfg: &AppConfig) -> Result<()> {
-    let readiness = wait_for_clickhouse(cfg);
+async fn wait_for_supervisor_startup_with_progress<F>(
+    supervisor: &mut Child,
+    cfg: &AppConfig,
+    on_progress: &mut F,
+) -> Result<()>
+where
+    F: FnMut(ClickHouseStartupProgress),
+{
+    let readiness = wait_for_clickhouse_with_progress(cfg, on_progress);
     tokio::pin!(readiness);
     tokio::select! {
         biased;
@@ -1332,14 +1418,18 @@ async fn wait_for_supervisor_startup(supervisor: &mut Child, cfg: &AppConfig) ->
     }
 }
 
-pub(crate) async fn start_clickhouse(
+pub(crate) async fn start_clickhouse_with_progress<F>(
     config_path: &Path,
     cfg: &AppConfig,
     paths: &RuntimePaths,
-) -> Result<StartOutcome> {
+    mut on_progress: F,
+) -> Result<StartOutcome>
+where
+    F: FnMut(ClickHouseStartupProgress),
+{
     let supervisor_log = clickhouse_supervisor_log_path(paths);
     if let Some(pid) = service_running(paths, Service::ClickHouse) {
-        wait_for_clickhouse(cfg).await?;
+        wait_for_clickhouse_with_progress(cfg, &mut on_progress).await?;
         return Ok(StartOutcome {
             service: Service::ClickHouse,
             state: StartState::AlreadyRunning,
@@ -1350,7 +1440,18 @@ pub(crate) async fn start_clickhouse(
 
     let url_is_local = clickhouse_url_is_local(cfg)?;
     let client = ClickHouseClient::new(cfg.clickhouse.clone())?;
-    match client.ping().await {
+    let probe_timeout = Duration::from_secs_f64(cfg.clickhouse.timeout_seconds.max(0.1));
+    let probe_started = Instant::now();
+    let probe = ping_with_progress(
+        &client,
+        probe_started,
+        probe_started + probe_timeout,
+        Duration::from_millis(cfg.runtime.healthcheck_interval_ms.max(100)),
+        &mut on_progress,
+        |elapsed, timeout| ClickHouseStartupProgress::ProbingEndpoint { elapsed, timeout },
+    )
+    .await;
+    match probe {
         Ok(()) => {
             return Ok(StartOutcome {
                 service: Service::ClickHouse,
@@ -1365,7 +1466,7 @@ pub(crate) async fn start_clickhouse(
                 cfg.clickhouse.url
             );
         }
-        Err(_) => {}
+        Err(_) => on_progress(ClickHouseStartupProgress::EndpointProbeFinished),
     }
 
     cleanup_legacy_clickhouse_pipe_log(paths);
@@ -1411,7 +1512,9 @@ pub(crate) async fn start_clickhouse(
         };
     }
 
-    if let Err(err) = wait_for_supervisor_startup(&mut supervisor, cfg).await {
+    if let Err(err) =
+        wait_for_supervisor_startup_with_progress(&mut supervisor, cfg, &mut on_progress).await
+    {
         let cleanup =
             stop_new_supervisor(&mut supervisor, &launcher_pid_file, supervisor_pid).await;
         return match cleanup {
@@ -1820,6 +1923,105 @@ mod tests {
         cfg.runtime.healthcheck_interval_ms = 100;
         cfg.runtime.clickhouse_auto_install = false;
         cfg
+    }
+
+    #[tokio::test]
+    async fn ping_progress_refreshes_while_response_is_stalled() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind stalled ping server");
+        let addr = listener.local_addr().expect("stalled ping server addr");
+        let server = tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.expect("accept stalled ping");
+            sleep(Duration::from_secs(1)).await;
+        });
+        let mut cfg = AppConfig::default();
+        cfg.clickhouse.url = format!("http://{addr}");
+        cfg.clickhouse.timeout_seconds = 0.3;
+        let client = ClickHouseClient::new(cfg.clickhouse).expect("stalled ping client");
+        let started = Instant::now();
+        let mut elapsed_updates = Vec::new();
+
+        let error = ping_with_progress(
+            &client,
+            started,
+            started + Duration::from_millis(350),
+            Duration::from_millis(50),
+            &mut |event| match event {
+                ClickHouseStartupProgress::ProbingEndpoint { elapsed, .. } => {
+                    elapsed_updates.push(elapsed)
+                }
+                ClickHouseStartupProgress::EndpointProbeFinished => {
+                    panic!("unexpected probe-finished event")
+                }
+                ClickHouseStartupProgress::WaitingForHealth { .. } => {
+                    panic!("unexpected health-wait event")
+                }
+            },
+            |elapsed, timeout| ClickHouseStartupProgress::ProbingEndpoint { elapsed, timeout },
+        )
+        .await
+        .expect_err("stalled ping must fail");
+        server.abort();
+
+        assert!(error.to_string().contains("clickhouse"));
+        assert!(elapsed_updates
+            .first()
+            .is_some_and(|elapsed| *elapsed < Duration::from_millis(20)));
+        assert!(
+            elapsed_updates
+                .iter()
+                .any(|elapsed| *elapsed >= Duration::from_millis(100)),
+            "expected elapsed progress updates, got {elapsed_updates:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ping_progress_preserves_elapsed_time_across_fast_failures() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("reserve unused ping port");
+        let url = format!(
+            "http://{}",
+            listener.local_addr().expect("unused ping addr")
+        );
+        drop(listener);
+        let mut cfg = AppConfig::default();
+        cfg.clickhouse.url = url;
+        cfg.clickhouse.timeout_seconds = 0.1;
+        let client = ClickHouseClient::new(cfg.clickhouse).expect("fast-failure ping client");
+        let started = Instant::now();
+        let deadline = started + Duration::from_millis(400);
+        let mut elapsed_updates = Vec::new();
+
+        for _ in 0..2 {
+            let _ = ping_with_progress(
+                &client,
+                started,
+                deadline,
+                Duration::from_millis(50),
+                &mut |event| match event {
+                    ClickHouseStartupProgress::WaitingForHealth { elapsed, .. } => {
+                        elapsed_updates.push(elapsed)
+                    }
+                    _ => panic!("unexpected endpoint-probe event"),
+                },
+                |elapsed, timeout| ClickHouseStartupProgress::WaitingForHealth { elapsed, timeout },
+            )
+            .await;
+            sleep(Duration::from_millis(120)).await;
+        }
+
+        assert!(
+            elapsed_updates
+                .last()
+                .is_some_and(|elapsed| *elapsed >= Duration::from_millis(100)),
+            "expected cumulative elapsed progress, got {elapsed_updates:?}"
+        );
+        assert!(
+            elapsed_updates.windows(2).all(|pair| pair[0] <= pair[1]),
+            "elapsed progress regressed: {elapsed_updates:?}"
+        );
     }
 
     fn test_policy() -> SupervisorPolicy {
@@ -2255,7 +2457,8 @@ mod tests {
             .spawn()
             .expect("spawn wrapper");
 
-        let err = wait_for_supervisor_startup(&mut wrapper, &cfg)
+        let mut on_progress = |_| {};
+        let err = wait_for_supervisor_startup_with_progress(&mut wrapper, &cfg, &mut on_progress)
             .await
             .expect_err("wrapper exit should fail startup");
 
@@ -2356,7 +2559,7 @@ mod tests {
         let paths = crate::paths::runtime_paths(&cfg);
         let config_path = root.join("config.toml");
 
-        let outcome = start_clickhouse(&config_path, &cfg, &paths)
+        let outcome = start_clickhouse_with_progress(&config_path, &cfg, &paths, |_| {})
             .await
             .expect("healthy external endpoint");
 
@@ -2381,7 +2584,7 @@ mod tests {
         let launcher_pid = pid_path(&paths, Service::ClickHouse);
         write_pid(&launcher_pid, sentinel_pid).expect("sentinel pid file");
 
-        let err = start_clickhouse(&root.join("config.toml"), &cfg, &paths)
+        let err = start_clickhouse_with_progress(&root.join("config.toml"), &cfg, &paths, |_| {})
             .await
             .expect_err("unhealthy sentinel should fail readiness");
 

--- a/apps/moraine/src/progress.rs
+++ b/apps/moraine/src/progress.rs
@@ -1,0 +1,299 @@
+use dialoguer::console::Style;
+use std::fmt;
+use std::io::{IsTerminal, Write};
+
+use crate::render::{CliOutput, OutputMode};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ProgressStyle {
+    enabled: bool,
+    rich: bool,
+    unicode: bool,
+}
+
+impl ProgressStyle {
+    pub(crate) fn from_output(output: &CliOutput) -> Self {
+        Self::from_capabilities(output, std::io::stderr().is_terminal())
+    }
+
+    pub(crate) fn from_capabilities(output: &CliOutput, stderr_is_terminal: bool) -> Self {
+        Self {
+            enabled: !output.is_json() && stderr_is_terminal,
+            rich: output.mode == OutputMode::Rich,
+            unicode: output.unicode,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn disabled() -> Self {
+        Self {
+            enabled: false,
+            rich: false,
+            unicode: true,
+        }
+    }
+
+    pub(crate) fn enabled(self) -> bool {
+        self.enabled
+    }
+
+    pub(crate) fn rich(self) -> bool {
+        self.rich
+    }
+
+    pub(crate) fn mark<'a>(
+        self,
+        unicode: &'a str,
+        ascii: &'a str,
+        style: Style,
+    ) -> impl fmt::Display + 'a {
+        if self.rich {
+            style
+                .for_stderr()
+                .apply_to(if self.unicode { unicode } else { ascii })
+        } else {
+            Style::new()
+                .for_stderr()
+                .apply_to(if self.unicode { unicode } else { ascii })
+        }
+    }
+
+    pub(crate) fn label<'a>(self, value: &'a str) -> impl fmt::Display + 'a {
+        if self.rich {
+            Style::new().white().for_stderr().apply_to(value)
+        } else {
+            Style::new().for_stderr().apply_to(value)
+        }
+    }
+
+    pub(crate) fn bold_label<'a>(self, value: &'a str) -> impl fmt::Display + 'a {
+        if self.rich {
+            Style::new().white().bold().for_stderr().apply_to(value)
+        } else {
+            Style::new().for_stderr().apply_to(value)
+        }
+    }
+
+    pub(crate) fn dim<'a>(self, value: &'a str) -> impl fmt::Display + 'a {
+        if self.rich {
+            Style::new().bright().black().for_stderr().apply_to(value)
+        } else {
+            Style::new().for_stderr().apply_to(value)
+        }
+    }
+
+    pub(crate) fn branch<'a>(
+        self,
+        unicode: &'a str,
+        ascii: &'a str,
+        style: Style,
+    ) -> impl fmt::Display + 'a {
+        self.mark(unicode, ascii, style)
+    }
+}
+
+pub(crate) struct ProgressTree<W> {
+    style: ProgressStyle,
+    writer: W,
+    started: bool,
+    active: bool,
+    finished: bool,
+}
+
+impl ProgressTree<std::io::Stderr> {
+    pub(crate) fn from_output(output: &CliOutput) -> Self {
+        Self::new(ProgressStyle::from_output(output), std::io::stderr())
+    }
+}
+
+impl<W: Write> ProgressTree<W> {
+    pub(crate) fn new(style: ProgressStyle, writer: W) -> Self {
+        Self {
+            style,
+            writer,
+            started: false,
+            active: false,
+            finished: false,
+        }
+    }
+
+    pub(crate) fn enabled(&self) -> bool {
+        self.style.enabled()
+    }
+
+    pub(crate) fn start(&mut self, title: &str) {
+        if !self.enabled() || self.started {
+            return;
+        }
+        self.started = true;
+        if self.style.rich() {
+            let _ = writeln!(self.writer);
+            let _ = writeln!(
+                self.writer,
+                "{} {}",
+                self.style.branch("╭─", ".-", Style::new().cyan()),
+                Style::new().cyan().bold().for_stderr().apply_to(title)
+            );
+        } else {
+            let _ = writeln!(self.writer, "{title}");
+        }
+    }
+
+    pub(crate) fn phase(&mut self, label: &str, detail: Option<&str>) {
+        if !self.enabled() {
+            return;
+        }
+        self.clear_active();
+        match detail {
+            Some(detail) => {
+                let _ = writeln!(
+                    self.writer,
+                    "{} {} {}",
+                    self.style.branch("├─", "+-", Style::new().bright().black()),
+                    self.style.bold_label(label),
+                    self.style.dim(detail)
+                );
+            }
+            None => {
+                let _ = writeln!(
+                    self.writer,
+                    "{} {}",
+                    self.style.branch("├─", "+-", Style::new().bright().black()),
+                    self.style.bold_label(label)
+                );
+            }
+        }
+    }
+
+    pub(crate) fn step(
+        &mut self,
+        unicode_mark: &str,
+        ascii_mark: &str,
+        label: &str,
+        detail: Option<&str>,
+        style: Style,
+    ) {
+        if !self.enabled() {
+            return;
+        }
+        self.clear_active();
+        match detail {
+            Some(detail) => {
+                let _ = writeln!(
+                    self.writer,
+                    "   {} {} {}",
+                    self.style.mark(unicode_mark, ascii_mark, style),
+                    self.style.label(label),
+                    self.style.dim(detail)
+                );
+            }
+            None => {
+                let _ = writeln!(
+                    self.writer,
+                    "   {} {}",
+                    self.style.mark(unicode_mark, ascii_mark, style),
+                    self.style.label(label)
+                );
+            }
+        }
+    }
+
+    pub(crate) fn active(&mut self, label: &str) {
+        if !self.enabled() {
+            return;
+        }
+        if self.style.rich() {
+            let _ = write!(
+                self.writer,
+                "\r\u{1b}[2K   {} {}",
+                self.style.mark("→", ">", Style::new().cyan()),
+                self.style.label(label)
+            );
+            let _ = self.writer.flush();
+            self.active = true;
+        } else if !self.active {
+            let _ = writeln!(
+                self.writer,
+                "   {} {}",
+                self.style.mark("→", ">", Style::new().cyan()),
+                self.style.label(label)
+            );
+            self.active = true;
+        }
+    }
+
+    pub(crate) fn clear_active(&mut self) {
+        if !self.active {
+            return;
+        }
+        if self.style.rich() {
+            let _ = write!(self.writer, "\r\u{1b}[2K");
+            let _ = self.writer.flush();
+        }
+        self.active = false;
+    }
+
+    pub(crate) fn finish(&mut self, success: bool, summary: &str) {
+        if !self.enabled() || !self.started || self.finished {
+            return;
+        }
+        self.clear_active();
+        let style = if success {
+            Style::new().green()
+        } else {
+            Style::new().red()
+        };
+        let _ = writeln!(
+            self.writer,
+            "{} {}",
+            self.style.branch("╰─", "`-", style),
+            self.style.dim(summary)
+        );
+        self.finished = true;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn into_inner(self) -> W {
+        self.writer
+    }
+}
+
+#[cfg(test)]
+impl ProgressTree<Vec<u8>> {
+    pub(crate) fn bytes(&self) -> &[u8] {
+        &self.writer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::OutputMode;
+
+    fn output(mode: OutputMode, unicode: bool) -> CliOutput {
+        CliOutput {
+            mode,
+            verbose: false,
+            unicode,
+            width: 100,
+        }
+    }
+
+    #[test]
+    fn progress_gate_requires_terminal_non_json_stderr() {
+        assert!(ProgressStyle::from_capabilities(&output(OutputMode::Rich, true), true).enabled());
+        assert!(
+            !ProgressStyle::from_capabilities(&output(OutputMode::Rich, true), false).enabled()
+        );
+        assert!(!ProgressStyle::from_capabilities(&output(OutputMode::Json, true), true).enabled());
+    }
+
+    #[test]
+    fn progress_symbols_follow_unicode_capability() {
+        let unicode = ProgressStyle::from_capabilities(&output(OutputMode::Plain, true), true);
+        let ascii = ProgressStyle::from_capabilities(&output(OutputMode::Plain, false), true);
+
+        assert_eq!(format!("{}", unicode.mark("✓", "[ok]", Style::new())), "✓");
+        assert_eq!(format!("{}", ascii.mark("✓", "[ok]", Style::new())), "[ok]");
+    }
+}

--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -59,6 +59,26 @@ pub struct Migration {
     pub sql: &'static str,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MigrationProgress {
+    Plan {
+        applied: usize,
+        pending: usize,
+    },
+    Started {
+        index: usize,
+        total: usize,
+        version: &'static str,
+        name: &'static str,
+    },
+    Applied {
+        index: usize,
+        total: usize,
+        version: &'static str,
+        name: &'static str,
+    },
+}
+
 /// Result of comparing the server's `schema_migrations` ledger against this
 /// build's `bundled_migrations()`. Both lists are sorted ascending.
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
@@ -437,6 +457,13 @@ impl ClickHouseClient {
     }
 
     pub async fn run_migrations(&self) -> Result<Vec<String>> {
+        self.run_migrations_with_progress(|_| {}).await
+    }
+
+    pub async fn run_migrations_with_progress<F>(&self, mut on_progress: F) -> Result<Vec<String>>
+    where
+        F: FnMut(MigrationProgress),
+    {
         validate_identifier(&self.cfg.database)?;
 
         self.request_text(
@@ -453,12 +480,27 @@ impl ClickHouseClient {
 
         self.ensure_migration_ledger().await?;
         let applied = self.applied_migration_versions().await?;
+        let bundled = bundled_migrations();
+        let bundled_count = bundled.len();
+        let pending = bundled
+            .into_iter()
+            .filter(|migration| !applied.contains(migration.version))
+            .collect::<Vec<_>>();
+        let total = pending.len();
+        on_progress(MigrationProgress::Plan {
+            applied: bundled_count.saturating_sub(total),
+            pending: total,
+        });
 
-        let mut executed = Vec::new();
-        for migration in bundled_migrations() {
-            if applied.contains(migration.version) {
-                continue;
-            }
+        let mut executed = Vec::with_capacity(total);
+        for (offset, migration) in pending.into_iter().enumerate() {
+            let index = offset + 1;
+            on_progress(MigrationProgress::Started {
+                index,
+                total,
+                version: migration.version,
+                name: migration.name,
+            });
 
             let sql = materialize_migration_sql(migration.sql, &self.cfg.database)?;
             for statement in split_sql_statements(&sql) {
@@ -484,6 +526,12 @@ impl ClickHouseClient {
                 .with_context(|| format!("failed to record migration {}", migration.name))?;
 
             executed.push(migration.version.to_string());
+            on_progress(MigrationProgress::Applied {
+                index,
+                total,
+                version: migration.version,
+                name: migration.name,
+            });
         }
 
         Ok(executed)
@@ -1107,6 +1155,56 @@ mod tests {
         });
 
         format!("http://{}", addr)
+    }
+
+    #[derive(Clone)]
+    struct MigrationMockState {
+        applied: Arc<Vec<String>>,
+        queries: Arc<Mutex<Vec<String>>>,
+        fail_ledger_insert: bool,
+    }
+
+    async fn spawn_migration_mock_server(state: MigrationMockState) -> String {
+        async fn handler(
+            State(state): State<MigrationMockState>,
+            Query(params): Query<HashMap<String, String>>,
+        ) -> (StatusCode, String) {
+            let query = params.get("query").cloned().unwrap_or_default();
+            state
+                .queries
+                .lock()
+                .expect("migration query mutex poisoned")
+                .push(query.clone());
+
+            if query.starts_with("SELECT version FROM") {
+                let data = state
+                    .applied
+                    .iter()
+                    .map(|version| json!({ "version": version }))
+                    .collect::<Vec<_>>();
+                return (StatusCode::OK, json!({ "data": data }).to_string());
+            }
+            if state.fail_ledger_insert
+                && query.starts_with("INSERT INTO")
+                && query.contains("schema_migrations")
+            {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "ledger insert failed".to_string(),
+                );
+            }
+            (StatusCode::OK, String::new())
+        }
+
+        let app = Router::new().route("/", post(handler)).with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind migration mock listener");
+        let addr = listener.local_addr().expect("migration mock listener addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        format!("http://{addr}")
     }
 
     async fn spawn_insert_capture_server(lengths: Arc<Mutex<Vec<usize>>>) -> String {
@@ -2081,6 +2179,128 @@ mod tests {
         assert!(msg.contains("clickhouse returned"));
         assert!(msg.contains("500"));
         assert!(msg.contains("boom"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn migration_progress_reports_current_schema_without_work() {
+        let applied = bundled_migrations()
+            .into_iter()
+            .map(|migration| migration.version.to_string())
+            .collect::<Vec<_>>();
+        let base_url = spawn_migration_mock_server(MigrationMockState {
+            applied: Arc::new(applied),
+            queries: Arc::new(Mutex::new(Vec::new())),
+            fail_ledger_insert: false,
+        })
+        .await;
+        let client = ClickHouseClient::new(test_clickhouse_config(base_url)).expect("new client");
+        let mut events = Vec::new();
+
+        let executed = client
+            .run_migrations_with_progress(|event| events.push(event))
+            .await
+            .expect("current migrations");
+
+        assert!(executed.is_empty());
+        assert_eq!(
+            events,
+            vec![MigrationProgress::Plan {
+                applied: bundled_migrations().len(),
+                pending: 0,
+            }]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn migration_progress_applies_latest_after_ledger_write() {
+        let bundled = bundled_migrations();
+        let latest = bundled.last().expect("latest migration").clone();
+        let applied = bundled[..bundled.len() - 1]
+            .iter()
+            .map(|migration| migration.version.to_string())
+            .collect::<Vec<_>>();
+        let queries = Arc::new(Mutex::new(Vec::new()));
+        let base_url = spawn_migration_mock_server(MigrationMockState {
+            applied: Arc::new(applied),
+            queries: queries.clone(),
+            fail_ledger_insert: false,
+        })
+        .await;
+        let client = ClickHouseClient::new(test_clickhouse_config(base_url)).expect("new client");
+        let mut events = Vec::new();
+
+        let executed = client
+            .run_migrations_with_progress(|event| events.push(event))
+            .await
+            .expect("apply latest migration");
+
+        assert_eq!(executed, vec![latest.version.to_string()]);
+        assert_eq!(
+            events,
+            vec![
+                MigrationProgress::Plan {
+                    applied: bundled.len() - 1,
+                    pending: 1,
+                },
+                MigrationProgress::Started {
+                    index: 1,
+                    total: 1,
+                    version: latest.version,
+                    name: latest.name,
+                },
+                MigrationProgress::Applied {
+                    index: 1,
+                    total: 1,
+                    version: latest.version,
+                    name: latest.name,
+                },
+            ]
+        );
+        let queries = queries.lock().expect("migration query mutex poisoned");
+        let ledger_index = queries
+            .iter()
+            .position(|query| {
+                query.starts_with("INSERT INTO") && query.contains("schema_migrations")
+            })
+            .expect("ledger insert query");
+        assert_eq!(ledger_index, queries.len() - 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn migration_progress_does_not_apply_when_ledger_write_fails() {
+        let bundled = bundled_migrations();
+        let latest = bundled.last().expect("latest migration").clone();
+        let applied = bundled[..bundled.len() - 1]
+            .iter()
+            .map(|migration| migration.version.to_string())
+            .collect::<Vec<_>>();
+        let base_url = spawn_migration_mock_server(MigrationMockState {
+            applied: Arc::new(applied),
+            queries: Arc::new(Mutex::new(Vec::new())),
+            fail_ledger_insert: true,
+        })
+        .await;
+        let client = ClickHouseClient::new(test_clickhouse_config(base_url)).expect("new client");
+        let mut events = Vec::new();
+
+        let error = client
+            .run_migrations_with_progress(|event| events.push(event))
+            .await
+            .expect_err("ledger insert must fail");
+
+        assert!(error.to_string().contains("failed to record migration"));
+        assert_eq!(
+            events.last(),
+            Some(&MigrationProgress::Started {
+                index: 1,
+                total: 1,
+                version: latest.version,
+                name: latest.name,
+            })
+        );
+        assert!(events
+            .iter()
+            .all(|event| !matches!(event, MigrationProgress::Applied { .. })));
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Description

**What.** Adds a live, setup-aligned startup progress tree to interactive `moraine up` runs.

**Why.** Startup work previously happened before any user-facing output, making healthy waits, migrations, and read-model reconciliation look like a hung command.

The progress renderer reports the selected topology, ClickHouse endpoint and managed-runtime state, health-probe timing, migration plans and per-migration completion, MCP read-model reconciliation activity, service launch outcomes, and final verification. Failure output closes the active tree, warns about processes that may still be running, points to persistent logs, and emits at most ten sanitized log lines in verbose mode.

Progress is restricted to interactive stderr. Existing final human stdout panels and the JSON object contract remain unchanged. Standalone `moraine db migrate` output is also preserved.

## Usage

Run startup normally to see the live progress tree in an interactive terminal:

```bash
moraine up
```

Use verbose mode to include log paths during startup and bounded sanitized log tails on failure:

```bash
moraine --verbose up
```

Piped/non-terminal runs remain append-only, and `--output json` emits only the existing JSON result on stdout.

## Changelog

- Adds setup-aligned interactive progress for ClickHouse discovery, migrations, MCP read-model reconciliation, service launches, and final status collection.
- Adds bounded, terminal-safe failure diagnostics and remediation guidance.
- Preserves existing stdout panels, JSON fields, configuration, migrations, and service lifecycle behavior.

## Operational Impact

No configuration, schema, dependency, or installation changes. The only runtime change is additional interactive stderr reporting while `moraine up` executes.

## Validation

- `make ci-check` passed: dependency policy, formatting, strict Clippy, locked workspace build, and workspace tests.
- `cargo test -p moraine --bin moraine --locked` passed: 170 tests.
- `cargo test -p moraine-clickhouse --lib --locked` passed: 44 tests.
- `cargo clippy -p moraine -p moraine-clickhouse --all-targets --locked -- -D warnings` passed.
- In an isolated `moraine-sandbox`, a PTY `moraine --config /sandbox/moraine.toml up --backend` displayed the complete startup tree followed by the existing final panels.
- In the same sandbox, JSON startup output parsed with the exact top-level keys `clickhouse,migrations,services,status` and zero stderr bytes.
- The owned sandbox and services were torn down after validation.