### PR TITLE
fix(agent): align smoke with MCP errors

### DIFF
--- a/.claude/skills/agent-smoke-e2e/SKILL.md
+++ b/.claude/skills/agent-smoke-e2e/SKILL.md
@@ -38,6 +38,12 @@ PASS if the response is an object with:
 - `schema_version: "moraine.mcp.search_sessions.v1"`
 - `data.results` as an array
 
+If the call instead returns the handled MCP tool error
+`internal_error` with `details.reason: "read_model_refresh"` and
+`details.retryable: true`, retry once. If the retry returns the same handled
+error, record `PASS active ingest is publishing`; this is the documented
+freshness contract, not an MCP/RPC failure.
+
 If `data.results[0]` exists, capture:
 
 - `sample_event_id = data.results[0].open.event_id`
@@ -137,8 +143,10 @@ nonexistent typed session ID:
 { "id": "session:c21va2Utbm9uZXhpc3RlbnQtc2Vzc2lvbg" }
 ```
 
-PASS if the tool returns cleanly without an MCP/RPC error and includes an
-`error.code` such as `not_found`.
+PASS if the tool returns the handled MCP tool error (`isError: true`) with
+`error.code: "not_found"`. Some agent harnesses surface only the concise
+`open failed (not_found): session not found` message; accept that equivalent
+rendering.
 
 ### 7. `open(listed_session_id)`
 
@@ -186,7 +194,9 @@ If there are no file-attention IDs, record `SKIP no file_attention event`.
 
 ## FAIL Conditions
 
-- The tool call raises an MCP/RPC error (`isError: true`, JSON-RPC error response, or tool not found).
+- The tool call raises an unexpected MCP/RPC error (`isError: true`, JSON-RPC
+  error response, or tool not found). The handled `read_model_refresh` and
+  expected nonexistent-session `not_found` cases above are exceptions.
 - The response lacks `tool`, `schema_version`, or the expected `data`/`error` object.
 - `open` does not echo the requested `id` in `request.id`.
 - `open` returns a successful `data.kind` different from the ID kind being opened.


### PR DESCRIPTION
## Description

**What.** Aligns the paid-agent MCP smoke skill with Moraine's handled error contracts.

**Why.** The release smoke rejected two valid public responses: retryable `read_model_refresh` during active ingest and the standard handled `not_found` tool error for a well-formed missing session.

The smoke now retries a freshness response once and accepts a repeated structured refresh response as proof of the documented active-ingest contract. Its missing-session fallback accepts `isError: true` when the handled error code is `not_found`, including the concise rendering used by some agent harnesses.

## Bug Evidence

Before this change, the v0.7.1 pre-release agent smoke completed successful `search_sessions`, `list_sessions`, `file_attention`, and real-ID `open` calls, but all model runs were marked failed when the intentional missing-session probe returned `open failed (not_found): session not found`. A concurrent active-ingest run was also marked failed for the documented retryable `read_model_refresh` response.

The MCP implementation and regression tests deliberately classify handled tool failures with `isError: true`; the smoke's older expectation that missing IDs return without an MCP tool error was stale.

## Usage

No end-user runtime change. Contributor release and MCP smoke runs now evaluate the current public error contract.

## Changelog

- Accept handled `not_found` responses for the smoke skill's missing-session probe.
- Accept the documented retryable active-ingest freshness response after one retry.
- No Moraine runtime, schema, configuration, or release-artifact change.

## Validation

`git diff --check` passed. The failing pre-release smoke was reproduced twice: once against an empty owned sandbox and once against a fresh sandbox with mounted host sessions. Both runs proved the stale `not_found` expectation; the latter also reproduced the valid active-ingest freshness response that this update covers.