### PR TITLE
chore(release): cut v0.7.1

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.7.0)"
+        description: "Tag to release (for example v0.7.1)"
         required: true
         type: string
       target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "moraine"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "glob",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1310,11 +1310,11 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "moraine-monitor-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/moraine-ingest/Cargo.toml
+++ b/apps/moraine-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Moraine ingest service binary"
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Moraine MCP stdio entry and unified backend daemon"
 

--- a/apps/moraine-monitor/Cargo.toml
+++ b/apps/moraine-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Deprecated alias for the unified Moraine backend"
 

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Unified runtime control plane for Moraine services"
 

--- a/bindings/python/moraine_conversations/Cargo.lock
+++ b/bindings/python/moraine_conversations/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "flate2",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "glob",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-clickhouse"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Shared Moraine ClickHouse client and query helpers"
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-config"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Shared Moraine configuration schema and loaders"
 

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-conversations"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "High-level read/query APIs for Moraine conversations"
 

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest-core"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Core ingestion pipeline internals for Moraine"
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp-core"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "MCP protocol and tool routing core for Moraine"
 

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor-core"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Analytics and query logic for Moraine monitor service"
 

--- a/plugins/hermes-moraine/plugin.yaml
+++ b/plugins/hermes-moraine/plugin.yaml
@@ -1,6 +1,6 @@
 manifest_version: 1
 name: moraine
-version: "0.7.0"
+version: "0.7.1"
 description: "Hermes integration for Moraine MCP session search, realtime agent awareness, sanitized bug reports, and setup diagnostics."
 author: "Moraine maintainers"
 provides_tools:

--- a/plugins/moraine-dev/skills/release/SKILL.md
+++ b/plugins/moraine-dev/skills/release/SKILL.md
@@ -82,6 +82,7 @@ python3 plugins/moraine-dev/skills/release/scripts/bump-version.py "$VERSION"
 Then inspect the diff. Expected version-only files are normally:
 
 - `Cargo.lock`
+- `bindings/python/moraine_conversations/Cargo.lock` path-dependency entries
 - release-managed `apps/*/Cargo.toml`
 - release-managed `crates/*/Cargo.toml`
 - `.github/workflows/release-moraine.yml` example tag, if it still contains
@@ -91,8 +92,10 @@ Then inspect the diff. Expected version-only files are normally:
 - install docs only if they contain an explicit `MORAINE_INSTALL_VERSION`
   example for the old tag
 
-Do not bump `bindings/python/moraine_conversations`; it is a separate internal
-Python extension package.
+Do not bump the package version in
+`bindings/python/moraine_conversations/Cargo.toml`; it is a separate internal
+Python extension package. Its lockfile must still track the release-managed
+path dependencies.
 
 ## Validation
 

--- a/plugins/moraine-dev/skills/release/scripts/bump-version.py
+++ b/plugins/moraine-dev/skills/release/scripts/bump-version.py
@@ -36,6 +36,12 @@ MANAGED_PACKAGE_NAMES = {
     "moraine-monitor-core",
 }
 
+BINDING_LOCK_PACKAGES = {
+    "moraine-clickhouse",
+    "moraine-config",
+    "moraine-conversations",
+}
+
 RUNTIME_PLUGIN_JSON_MANIFESTS = [
     ("Claude", "plugins/moraine/.claude-plugin/plugin.json"),
     ("Codex", "plugins/moraine/.codex-plugin/plugin.json"),
@@ -148,9 +154,15 @@ def bump_cargo_tomls(repo_root: Path, target_version: str, *, dry_run: bool) -> 
 
 
 def bump_lockfile(
-    repo_root: Path, current_version: str, target_version: str, *, dry_run: bool
+    repo_root: Path,
+    relpath: str,
+    package_names: set[str],
+    current_version: str,
+    target_version: str,
+    *,
+    dry_run: bool,
 ) -> None:
-    path = repo_root / "Cargo.lock"
+    path = repo_root / relpath
     text = read_text(path)
     blocks = re.split(r"(?=^\[\[package\]\]\n)", text, flags=re.MULTILINE)
     changed_names: set[str] = set()
@@ -158,7 +170,7 @@ def bump_lockfile(
 
     for block in blocks:
         name_match = re.search(r'(?m)^name = "([^"]+)"$', block)
-        if name_match and name_match.group(1) in MANAGED_PACKAGE_NAMES:
+        if name_match and name_match.group(1) in package_names:
             version_match = re.search(r'(?m)^version = "([^"]+)"$', block)
             if not version_match:
                 raise SystemExit(f"lockfile package has no version: {name_match.group(1)}")
@@ -176,15 +188,15 @@ def bump_lockfile(
             changed_names.add(name_match.group(1))
         new_blocks.append(block)
 
-    missing = MANAGED_PACKAGE_NAMES - changed_names
+    missing = package_names - changed_names
     if missing:
         raise SystemExit(
-            "lockfile did not contain managed packages: " + ", ".join(sorted(missing))
+            f"{relpath} did not contain managed packages: " + ", ".join(sorted(missing))
         )
 
     new_text = "".join(new_blocks)
     write_text(path, new_text, dry_run=dry_run)
-    print(f"Cargo.lock: updated {len(changed_names)} managed package entries")
+    print(f"{relpath}: updated {len(changed_names)} managed package entries")
 
 
 def replace_optional_file(
@@ -290,7 +302,20 @@ def main() -> int:
         repo_root, target_version, dry_run=args.dry_run
     )
     bump_lockfile(
-        repo_root, current_version, target_version, dry_run=args.dry_run
+        repo_root,
+        "Cargo.lock",
+        MANAGED_PACKAGE_NAMES,
+        current_version,
+        target_version,
+        dry_run=args.dry_run,
+    )
+    bump_lockfile(
+        repo_root,
+        "bindings/python/moraine_conversations/Cargo.lock",
+        BINDING_LOCK_PACKAGES,
+        current_version,
+        target_version,
+        dry_run=args.dry_run,
     )
     bump_release_examples(
         repo_root, current_version, target_version, dry_run=args.dry_run

--- a/plugins/moraine/.claude-plugin/plugin.json
+++ b/plugins/moraine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "displayName": "Moraine",
   "description": "Claude Code plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {

--- a/plugins/moraine/.codex-plugin/plugin.json
+++ b/plugins/moraine/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Codex plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {
     "name": "Moraine maintainers",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ install directory precedence:
 
 examples:
   scripts/install.sh
-  MORAINE_INSTALL_VERSION=v0.7.0 scripts/install.sh
+  MORAINE_INSTALL_VERSION=v0.7.1 scripts/install.sh
   MORAINE_INSTALL_ASSET_BASE_URL=http://127.0.0.1:8080 \
     MORAINE_INSTALL_VERSION=ci-e2e scripts/install.sh
   MORAINE_INSTALL_DIR="$HOME/bin" MORAINE_INSTALL_SKIP_CLICKHOUSE=1 scripts/install.sh


### PR DESCRIPTION
## Description

**What.** Bumps all release-managed Moraine packages, runtime plugin manifests, install examples, and workflow examples from `0.7.0` to `0.7.1`.

**Why.** Publishes the user-facing ingest, startup, MCP retrieval, and search improvements merged since v0.7.0.

### User-facing summary

- `moraine up` now shows live interactive progress for ClickHouse discovery, migrations, MCP read-model reconciliation, service launches, and final verification ([#579](https://github.com/eric-tramel/moraine/pull/579)).
- Moraine now discovers and ingests local Claude Cowork sessions on macOS while excluding audit records and sensitive sidecar metadata ([#578](https://github.com/eric-tramel/moraine/pull/578)).
- OMP sessions receive useful source titles or privacy-safe dispatched-task labels, including a refresh for existing projected sessions ([#574](https://github.com/eric-tramel/moraine/pull/574)).
- MCP `open` is summary-first and cursor-paginated for large turns and sessions ([#547](https://github.com/eric-tramel/moraine/pull/547)); `search_sessions` now defaults to user and assistant messages while retaining explicit tool-event search ([#571](https://github.com/eric-tramel/moraine/pull/571)).
- Search performs bounded candidate hydration, avoids duplicate equivalent and mirrored Codex final-answer hits, returns retry guidance during active ingest, and no longer abandons legitimate queued or running retrieval after four seconds ([#538](https://github.com/eric-tramel/moraine/pull/538), [#554](https://github.com/eric-tramel/moraine/pull/554), [#566](https://github.com/eric-tramel/moraine/pull/566), [#567](https://github.com/eric-tramel/moraine/pull/567), [#572](https://github.com/eric-tramel/moraine/pull/572)).
- Project-scoped file attention again works for ordinary Git checkouts and non-Git directories, and untitled session listings now carry safe display labels ([#546](https://github.com/eric-tramel/moraine/pull/546), [#556](https://github.com/eric-tramel/moraine/pull/556)).

## Usage

After the tag-triggered release workflow publishes:

```bash
uv tool upgrade moraine-cli
moraine up && moraine status
```

No configuration change is required. Callers that need raw tool evidence from `search_sessions` should now pass explicit `event_types` containing `tool_call` and/or `tool_response`. Use `open` with an explicit `limit`, then continue with the returned cursor, when compact child expansion is needed.

## Changelog

- Bumps ten release-managed Rust packages and `Cargo.lock` to `0.7.1`.
- Bumps the Claude, Codex, and Hermes runtime plugin manifests to `0.7.1`.
- Updates the pinned installer and release workflow examples to `v0.7.1`.
- Leaves the separately versioned `bindings/python/moraine_conversations` package manifest unchanged while refreshing its lockfile's three release-managed path dependencies.

## Operational Impact

Pushing annotated tag `v0.7.1` after merge triggers `.github/workflows/release-moraine.yml`, which builds four platform bundles, uploads release assets, builds four wheels plus the stub sdist, and publishes `moraine-cli==0.7.1` to PyPI.

Normal startup applies migrations 028 through 030. They refresh MCP open projections and existing OMP session metadata; they add no tables, columns, or configuration keys. The refresh is resumable through the existing read-model reconciliation path.

## Validation

`git diff --check` and `cargo fmt --all -- --check` passed. `cargo test --workspace --locked` passed 875 tests across 26 suites, with four expected ignored live/benchmark tests. In owned sandbox `sb-bbb934`, the canonical `scripts/ci/e2e-stack.sh` passed migrations through 030, multi-harness ingest, monitor routes, MCP search/list/open/file-attention across daemon and embedded paths, named routing, process topology, crash fallback, and all-down teardown; the sandbox was removed afterward.

The first PR CI run caught that binding-local lockfile drift under `maturin develop --locked`. The release script now updates that lockfile automatically, and `cargo metadata --format-version 1 --locked --no-deps` passes from the binding package.

The paid-agent smoke exposed a stale verifier expectation for handled `not_found` and active-ingest freshness responses. That contributor-only contract was corrected and merged separately in [#581](https://github.com/eric-tramel/moraine/pull/581) before this release branch was rebased.