### PR TITLE
fix(setup): refresh Claude plugin during upgrades

### DIFF
--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -3679,14 +3679,14 @@ host = "127.42.0.9"
     }
 
     #[test]
-    fn claude_default_config_installs_plugin_and_cleans_manual_mcp() {
+    fn claude_default_config_installs_updates_and_cleans_manual_mcp() {
         let target = ConfigTarget {
             path: PathBuf::from("/tmp/config.toml"),
             source: ConfigTargetSource::HomeDefault,
         };
         let plan = McpPlan::for_target(SetupMcpTarget::ClaudeCode, &target);
         let commands = plan.commands();
-        assert_eq!(commands.len(), 3);
+        assert_eq!(commands.len(), 5);
         assert_eq!(
             commands[0].args,
             vec![
@@ -3701,12 +3701,93 @@ host = "127.42.0.9"
         );
         assert_eq!(
             commands[1].args,
-            vec!["plugin", "install", "moraine@moraine"]
+            vec!["plugin", "marketplace", "update", "moraine"]
         );
         assert_eq!(
             commands[2].args,
+            vec!["plugin", "install", "moraine@moraine"]
+        );
+        assert_eq!(
+            commands[3].args,
+            vec!["plugin", "update", "moraine@moraine"]
+        );
+        assert_eq!(
+            commands[4].args,
             vec!["mcp", "remove", "moraine", "--scope", "user"]
         );
+    }
+
+    #[test]
+    fn claude_marketplace_add_failure_continues_to_refresh() {
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan = McpPlan::for_target(SetupMcpTarget::ClaudeCode, &target);
+        let commands = plan.commands();
+        let mut runner = FakeRunner::default()
+            .with_existing("claude")
+            .with_response(commands[0].clone(), false, "marketplace already exists")
+            .with_response(commands[1].clone(), true, "")
+            .with_response(commands[2].clone(), true, "")
+            .with_response(commands[3].clone(), true, "")
+            .with_response(commands[4].clone(), true, "");
+
+        let report = execute_mcp_plan(plan, &mut runner).expect("execute Claude plan");
+
+        assert_eq!(report.status, SetupStatus::Ok);
+        assert!(!report.warnings.is_empty());
+        assert_eq!(runner.ran, commands);
+    }
+
+    #[test]
+    fn claude_marketplace_update_failure_stops_setup() {
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan = McpPlan::for_target(SetupMcpTarget::ClaudeCode, &target);
+        let commands = plan.commands();
+        let mut runner = FakeRunner::default()
+            .with_existing("claude")
+            .with_response(commands[0].clone(), true, "")
+            .with_response(commands[1].clone(), false, "marketplace update failed");
+
+        let report = execute_mcp_plan(plan, &mut runner).expect("execute Claude plan");
+
+        assert_eq!(report.status, SetupStatus::Error);
+        assert!(report
+            .error
+            .as_deref()
+            .expect("error")
+            .contains(&commands[1].display()));
+        assert_eq!(runner.ran, commands[..2]);
+    }
+
+    #[test]
+    fn claude_plugin_update_failure_stops_before_cleanup() {
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan = McpPlan::for_target(SetupMcpTarget::ClaudeCode, &target);
+        let commands = plan.commands();
+        let mut runner = FakeRunner::default()
+            .with_existing("claude")
+            .with_response(commands[0].clone(), true, "")
+            .with_response(commands[1].clone(), true, "")
+            .with_response(commands[2].clone(), true, "")
+            .with_response(commands[3].clone(), false, "plugin update failed");
+
+        let report = execute_mcp_plan(plan, &mut runner).expect("execute Claude plan");
+
+        assert_eq!(report.status, SetupStatus::Error);
+        assert!(report
+            .error
+            .as_deref()
+            .expect("error")
+            .contains(&commands[3].display()));
+        assert_eq!(runner.ran, commands[..4]);
     }
 
     #[test]

--- a/apps/moraine/src/commands/setup/harnesses.rs
+++ b/apps/moraine/src/commands/setup/harnesses.rs
@@ -383,6 +383,16 @@ pub(super) fn mcp_plan(
                 ),
                 McpPlanStep::required(CommandSpec::new(
                     "claude",
+                    ["plugin", "marketplace", "update", "moraine"],
+                ))
+                .with_progress(
+                    "Refreshing Claude Code plugin marketplace",
+                    "Claude Code marketplace refreshed",
+                    "Claude Code marketplace refresh warning",
+                    "Claude Code marketplace refresh failed",
+                ),
+                McpPlanStep::required(CommandSpec::new(
+                    "claude",
                     ["plugin", "install", "moraine@moraine"],
                 ))
                 .with_progress(
@@ -390,6 +400,16 @@ pub(super) fn mcp_plan(
                     "Claude Code plugin installed",
                     "Claude Code plugin install warning",
                     "Claude Code plugin install failed",
+                ),
+                McpPlanStep::required(CommandSpec::new(
+                    "claude",
+                    ["plugin", "update", "moraine@moraine"],
+                ))
+                .with_progress(
+                    "Updating Claude Code Moraine plugin",
+                    "Claude Code plugin updated",
+                    "Claude Code plugin update warning",
+                    "Claude Code plugin update failed",
                 ),
                 McpPlanStep::warn_and_continue(
                     CommandSpec::new("claude", ["mcp", "remove", "moraine", "--scope", "user"]),

--- a/docs/agent-mcp-search/install.md
+++ b/docs/agent-mcp-search/install.md
@@ -51,12 +51,23 @@ uv tool upgrade moraine-cli
 moraine up
 ```
 
-Add the marketplace from this repository and install the plugin:
+For a first-time plugin install, add the marketplace and install the plugin:
 
 ```bash
 claude plugin marketplace add eric-tramel/moraine --sparse .claude-plugin plugins
 claude plugin install moraine@moraine
 ```
+
+For an existing plugin installation, refresh the marketplace and update the
+plugin after upgrading the CLI:
+
+```bash
+claude plugin marketplace update moraine
+claude plugin update moraine@moraine
+```
+
+Start a new Claude Code session after installation or update so it loads the
+current plugin version.
 
 The Claude plugin MCP launcher looks for `moraine` on `PATH` and then runs
 `moraine run mcp`. If the CLI is missing, it reports a `binary_missing` message


### PR DESCRIPTION
## Description

**What.** Refreshes Claude Code's Moraine marketplace snapshot and installed plugin whenever `moraine setup` configures the Claude target.

**Why.** Repeating `claude plugin install` is a successful no-op for an existing installation, so users could keep v0.6.1 plugin metadata and a v0.6.1 cache path after upgrading the Moraine CLI/MCP to v0.7.1.

The Claude setup plan now runs marketplace update before install/update, treats both refresh operations as required, and leaves manual MCP cleanup last. Focused executor tests cover the existing-marketplace warning path and both update failure boundaries. The install guide now separates first-time setup from existing-install upgrades.

Closes #584.

## Usage

Existing Claude Code plugin installations can be refreshed with:

```bash
claude plugin marketplace update moraine
claude plugin update moraine@moraine
```

`moraine setup --mcp-target claude-code` now performs that refresh automatically. Start a new Claude Code session afterward so it loads the updated plugin.

## Bug Evidence

Before this change, an isolated Claude state seeded with Moraine plugin v0.6.1 remained at v0.6.1 after repeating `claude plugin install moraine@moraine`. The setup plan did not refresh its marketplace clone or invoke plugin update.

After this change, running the built CLI against the same isolated state:

```bash
moraine setup --yes --skip-config --mcp-target claude-code --output json
```

returned success, and `claude plugin list --json` changed from version `0.6.1` with a cache path ending `/0.6.1` to version `0.7.1` with a path ending `/0.7.1`.

## Changelog

- Refreshes existing Claude Code Moraine plugin installations during `moraine setup`.
- Documents the explicit marketplace and plugin upgrade commands.

## Operational Impact

Claude-target setup now performs two additional Claude CLI update commands. Marketplace or plugin update failures make that target report an error instead of claiming success with stale metadata. No config, schema, service, or launcher behavior changes.

## Validation

Ran `cargo test -p moraine --bin moraine --locked`; all 174 tests passed. `cargo fmt --all -- --check`, `git diff --check`, and `make docs-build` completed successfully, with the documentation build reporting no issues.

An isolated end-to-end smoke check overrode both `HOME` and `CLAUDE_CONFIG_DIR`, seeded a disposable v0.6.1 plugin/cache, executed the built `moraine setup` command, and observed the installed version and cache path advance to v0.7.1. The temporary state was deleted afterward. A seven-persona delegated review completed with no actionable findings.