### PR TITLE
feat(backend): start backend with every up

### DIFF
--- a/apps/moraine/src/cli.rs
+++ b/apps/moraine/src/cli.rs
@@ -48,13 +48,13 @@ pub(crate) enum CliCommand {
 pub(crate) struct UpArgs {
     #[arg(long)]
     pub(crate) no_ingest: bool,
-    /// Start the unified MCP socket and monitor HTTP backend.
+    /// Deprecated compatibility flag; the backend now always starts.
     #[arg(long)]
     pub(crate) backend: bool,
-    /// Deprecated compatibility alias for `--backend`.
+    /// Deprecated compatibility flag; the backend now always starts.
     #[arg(long)]
     pub(crate) monitor: bool,
-    /// Deprecated compatibility alias for `--backend`.
+    /// Deprecated compatibility flag; the backend now always starts.
     #[arg(long)]
     pub(crate) mcp: bool,
 }

--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -230,15 +230,9 @@ fn setup_config(
                 "default config written",
             ))
         }
-        ConfigState::Valid {
-            backend_start_on_up,
-            backend_bind,
-        } => migrate_backend_config(
-            &target.path,
-            backend_start_on_up,
-            &backend_bind,
-            args.dry_run,
-        ),
+        ConfigState::Valid { backend_bind } => {
+            migrate_backend_config(&target.path, &backend_bind, args.dry_run)
+        }
         ConfigState::Invalid(message) => {
             if args.dry_run {
                 let action = if args.repair_config {
@@ -286,10 +280,7 @@ fn setup_config(
 
 enum ConfigState {
     Missing,
-    Valid {
-        backend_start_on_up: bool,
-        backend_bind: String,
-    },
+    Valid { backend_bind: String },
     Invalid(String),
     Unreadable(String),
 }
@@ -313,7 +304,6 @@ fn inspect_config(path: &Path) -> ConfigState {
     }
     match moraine_config::load_config(path) {
         Ok(config) => ConfigState::Valid {
-            backend_start_on_up: config.backend.start_on_up,
             backend_bind: config.backend.bind,
         },
         Err(exc) => ConfigState::Invalid(exc.to_string()),
@@ -487,17 +477,18 @@ fn timestamp_suffix() -> String {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct BackendConfigMigration {
     materialized_start_on_up: bool,
+    updated_start_on_up: bool,
     materialized_bind: bool,
     removed_monitor_host: bool,
     removed_monitor_alias: bool,
     removed_mcp_alias: bool,
     removed_central_alias: bool,
-    start_on_up: bool,
 }
 
 impl BackendConfigMigration {
     fn has_changes(&self) -> bool {
         self.materialized_start_on_up
+            || self.updated_start_on_up
             || self.materialized_bind
             || self.removed_monitor_host
             || self.removed_launch_alias_count() > 0
@@ -513,12 +504,21 @@ impl BackendConfigMigration {
         let mut changes = Vec::new();
         if self.materialized_start_on_up {
             changes.push(format!(
-                "backend.start_on_up={} {}",
-                self.start_on_up,
+                "backend.start_on_up=true {}",
                 if dry_run {
                     "would be materialized"
                 } else {
                     "materialized"
+                }
+            ));
+        }
+        if self.updated_start_on_up {
+            changes.push(format!(
+                "backend.start_on_up=true {}",
+                if dry_run {
+                    "would be updated"
+                } else {
+                    "updated"
                 }
             ));
         }
@@ -559,18 +559,9 @@ impl BackendConfigMigration {
     }
 }
 
-fn migrate_backend_config(
-    path: &Path,
-    backend_start_on_up: bool,
-    backend_bind: &str,
-    dry_run: bool,
-) -> Result<ConfigReport> {
+fn migrate_backend_config(path: &Path, backend_bind: &str, dry_run: bool) -> Result<ConfigReport> {
     let mut document = read_config_document(path)?;
-    let migration = apply_backend_config_migration_to_document(
-        &mut document,
-        backend_start_on_up,
-        backend_bind,
-    )?;
+    let migration = apply_backend_config_migration_to_document(&mut document, backend_bind)?;
     if !migration.has_changes() {
         return Ok(ConfigReport::ok(
             path,
@@ -597,15 +588,16 @@ fn migrate_backend_config(
 
 fn apply_backend_config_migration_to_document(
     document: &mut DocumentMut,
-    backend_start_on_up: bool,
     backend_bind: &str,
 ) -> Result<BackendConfigMigration> {
-    let backend_start_explicit = document
+    let backend_start_value = document
         .as_table()
         .get("backend")
         .and_then(Item::as_table_like)
         .and_then(|backend| backend.get("start_on_up"))
-        .is_some();
+        .and_then(Item::as_bool);
+    let backend_start_explicit = backend_start_value.is_some();
+    let updated_start_on_up = backend_start_value == Some(false);
     let backend_bind_explicit = document
         .as_table()
         .get("backend")
@@ -638,8 +630,8 @@ fn apply_backend_config_migration_to_document(
         .get_mut("backend")
         .and_then(Item::as_table_like_mut)
         .ok_or_else(|| anyhow::anyhow!("backend must be a TOML table"))?;
-    if !backend_start_explicit {
-        let _ = backend.insert("start_on_up", toml_edit::value(backend_start_on_up));
+    if !backend_start_explicit || updated_start_on_up {
+        let _ = backend.insert("start_on_up", toml_edit::value(true));
     }
     if !backend_bind_explicit {
         match legacy_monitor_host {
@@ -660,12 +652,12 @@ fn apply_backend_config_migration_to_document(
 
     Ok(BackendConfigMigration {
         materialized_start_on_up: !backend_start_explicit,
+        updated_start_on_up,
         materialized_bind: !backend_bind_explicit,
         removed_monitor_host,
         removed_monitor_alias,
         removed_mcp_alias,
         removed_central_alias,
-        start_on_up: backend_start_on_up,
     })
 }
 
@@ -3360,7 +3352,7 @@ watch_root = "~/custom"
             .expect("parse migrated config");
         assert_eq!(
             config_item(&document, "backend", "start_on_up").and_then(Item::as_bool),
-            Some(false)
+            Some(true)
         );
         assert_eq!(
             config_item(&document, "backend", "bind").and_then(Item::as_str),
@@ -3431,7 +3423,7 @@ watch_root = "~/custom"
     }
 
     #[test]
-    fn setup_materializes_backend_off_without_legacy_keys() {
+    fn setup_materializes_backend_on_without_legacy_keys() {
         let path = temp_path("backend-no-legacy");
         let original =
             "# minimal config\n\n[monitor]\n# preserve host comment\nhost = \"127.0.0.1\"\n";
@@ -3440,7 +3432,7 @@ watch_root = "~/custom"
         let report = setup_config_for_test(&path, false, false);
 
         assert_eq!(report.action, "migrated");
-        assert!(report.message.contains("backend.start_on_up=false"));
+        assert!(report.message.contains("backend.start_on_up=true"));
         assert!(report.message.contains("backend.bind"));
         assert!(report.message.contains("obsolete monitor.host removed"));
         let content = fs::read_to_string(&path).expect("migrated config");
@@ -3451,7 +3443,7 @@ watch_root = "~/custom"
             .expect("parse migrated config");
         assert_eq!(
             config_item(&document, "backend", "start_on_up").and_then(Item::as_bool),
-            Some(false)
+            Some(true)
         );
         assert_eq!(
             config_item(&document, "backend", "bind").and_then(Item::as_str),
@@ -3462,7 +3454,7 @@ watch_root = "~/custom"
     }
 
     #[test]
-    fn setup_materializes_backend_off_when_all_legacy_aliases_are_false() {
+    fn setup_materializes_backend_on_when_all_legacy_aliases_are_false() {
         let path = temp_path("backend-all-aliases-false");
         fs::write(
             &path,
@@ -3476,13 +3468,13 @@ watch_root = "~/custom"
         let document = read_toml_document(&path);
         assert_eq!(
             config_item(&document, "backend", "start_on_up").and_then(Item::as_bool),
-            Some(false)
+            Some(true)
         );
         assert!(config_item(&document, "runtime", "start_monitor_on_up").is_none());
         assert!(config_item(&document, "runtime", "start_mcp_on_up").is_none());
         assert!(config_item(&document, "mcp", "start_central_on_up").is_none());
         assert!(
-            !moraine_config::load_config(&path)
+            moraine_config::load_config(&path)
                 .expect("migrated config loads")
                 .backend
                 .start_on_up
@@ -3491,7 +3483,7 @@ watch_root = "~/custom"
     }
 
     #[test]
-    fn setup_preserves_explicit_backend_and_removes_conflicting_aliases() {
+    fn setup_enables_explicit_backend_and_removes_conflicting_aliases() {
         for explicit in [false, true] {
             let legacy = !explicit;
             let path = temp_path(&format!("backend-explicit-{explicit}"));
@@ -3506,22 +3498,24 @@ watch_root = "~/custom"
             let report = setup_config_for_test(&path, false, false);
 
             assert_eq!(report.action, "migrated");
-            assert!(!report.message.contains("backend.start_on_up"));
+            assert_eq!(
+                report.message.contains("backend.start_on_up=true updated"),
+                !explicit
+            );
             assert!(report.message.contains("3 obsolete launch keys removed"));
             let document = read_toml_document(&path);
             assert_eq!(
                 config_item(&document, "backend", "start_on_up").and_then(Item::as_bool),
-                Some(explicit)
+                Some(true)
             );
             assert!(config_item(&document, "runtime", "start_monitor_on_up").is_none());
             assert!(config_item(&document, "runtime", "start_mcp_on_up").is_none());
             assert!(config_item(&document, "mcp", "start_central_on_up").is_none());
-            assert_eq!(
+            assert!(
                 moraine_config::load_config(&path)
                     .expect("migrated config loads")
                     .backend
-                    .start_on_up,
-                explicit
+                    .start_on_up
             );
             let _ = fs::remove_file(path);
         }
@@ -3534,7 +3528,7 @@ watch_root = "~/custom"
         fs::write(
             &path,
             format!(
-                "[backend]\nbind = \"0.0.0.0\"\nauth_token = \"{secret}\"\n\n[monitor]\nhost = \"127.0.0.1\"\n"
+                "[backend]\nbind = \"0.0.0.0\"\nstart_on_up = true\nauth_token = \"{secret}\"\n\n[monitor]\nhost = \"127.0.0.1\"\n"
             ),
         )
         .expect("write token config");
@@ -3575,7 +3569,7 @@ watch_root = "~/custom"
             .expect("parse migrated config");
         assert_eq!(
             config_item(&document, "backend", "start_on_up").and_then(Item::as_bool),
-            Some(false)
+            Some(true)
         );
         let _ = fs::remove_file(path);
     }
@@ -3661,7 +3655,7 @@ host = "127.42.0.9"
             .expect("parse migrated config");
         assert_eq!(
             config_item(&document, "backend", "start_on_up").and_then(Item::as_bool),
-            Some(false)
+            Some(true)
         );
         assert_eq!(
             config_item(&document, "backend", "bind").and_then(Item::as_str),
@@ -4431,7 +4425,7 @@ watch_root = "~/.codex/sessions"
         assert!(report
             .config
             .message
-            .contains("backend.start_on_up=false would be materialized"));
+            .contains("backend.start_on_up=true would be materialized"));
         assert_eq!(fs::read_to_string(&path).expect("config content"), original);
         assert_eq!(
             report

--- a/apps/moraine/src/commands/up.rs
+++ b/apps/moraine/src/commands/up.rs
@@ -457,7 +457,7 @@ pub(super) async fn handle_args(
     args: &UpArgs,
 ) -> Result<ExitCode> {
     let paths = runtime_paths(cfg);
-    let services_to_start = selected_up_services(args, cfg);
+    let services_to_start = selected_up_services(args);
     let mut progress = StartupProgress::from_output(output);
     progress.startup_plan(&services_to_start);
 
@@ -590,14 +590,12 @@ where
     }
 }
 
-fn selected_up_services(args: &UpArgs, cfg: &AppConfig) -> Vec<Service> {
+fn selected_up_services(args: &UpArgs) -> Vec<Service> {
     let mut services = Vec::new();
     if !args.no_ingest {
         services.push(Service::Ingest);
     }
-    if args.backend || args.monitor || args.mcp || cfg.backend.start_on_up {
-        services.push(Service::Backend);
-    }
+    services.push(Service::Backend);
     services
 }
 
@@ -736,24 +734,15 @@ mod tests {
     }
 
     #[test]
-    fn selected_up_services_uses_only_normalized_backend_switch_and_deduplicates_aliases() {
-        let mut cfg = AppConfig::default();
-        cfg.backend.start_on_up = false;
-        cfg.runtime.start_monitor_on_up = true;
-        cfg.runtime.start_mcp_on_up = true;
-        cfg.mcp.start_central_on_up = true;
-
+    fn selected_up_services_always_includes_backend_and_deduplicates_aliases() {
         assert_eq!(
-            selected_up_services(
-                &UpArgs {
-                    no_ingest: false,
-                    backend: false,
-                    monitor: false,
-                    mcp: false,
-                },
-                &cfg
-            ),
-            vec![Service::Ingest]
+            selected_up_services(&UpArgs {
+                no_ingest: false,
+                backend: false,
+                monitor: false,
+                mcp: false,
+            }),
+            vec![Service::Ingest, Service::Backend]
         );
 
         for (backend, monitor, mcp) in [
@@ -763,32 +752,15 @@ mod tests {
             (true, true, true),
         ] {
             assert_eq!(
-                selected_up_services(
-                    &UpArgs {
-                        no_ingest: true,
-                        backend,
-                        monitor,
-                        mcp,
-                    },
-                    &cfg
-                ),
+                selected_up_services(&UpArgs {
+                    no_ingest: true,
+                    backend,
+                    monitor,
+                    mcp,
+                }),
                 vec![Service::Backend],
                 "backend={backend} monitor={monitor} mcp={mcp}"
             );
         }
-
-        cfg.backend.start_on_up = true;
-        assert_eq!(
-            selected_up_services(
-                &UpArgs {
-                    no_ingest: false,
-                    backend: false,
-                    monitor: false,
-                    mcp: false,
-                },
-                &cfg
-            ),
-            vec![Service::Ingest, Service::Backend]
-        );
     }
 }

--- a/apps/moraine/tests/clickhouse_supervision.rs
+++ b/apps/moraine/tests/clickhouse_supervision.rs
@@ -37,6 +37,7 @@ fn write_executable(path: &Path, contents: &str) {
 
 fn write_config(root: &Path, port: u16) -> PathBuf {
     let runtime = root.join("runtime");
+    write_executable(&root.join("services/moraine-mcp"), "#!/bin/sh\nexit 0\n");
     let config = root.join("config path with spaces.toml");
     fs::write(
         &config,

--- a/bin/moraine
+++ b/bin/moraine
@@ -51,83 +51,6 @@ has_flag() {
   return 1
 }
 
-resolve_config_path() {
-  local config_path=""
-  local skip_next=0
-  local arg
-  for arg in "$@"; do
-    if [[ "$skip_next" == "1" ]]; then
-      config_path="$arg"
-      skip_next=0
-      continue
-    fi
-    case "$arg" in
-      --config)
-        skip_next=1
-        ;;
-      --config=*)
-        config_path="${arg#--config=}"
-        ;;
-    esac
-  done
-
-  if [[ -n "$config_path" ]]; then
-    printf '%s\n' "$config_path"
-    return 0
-  fi
-
-  if [[ -n "${MORAINE_CONFIG:-}" ]]; then
-    printf '%s\n' "$MORAINE_CONFIG"
-    return 0
-  fi
-
-  local home_cfg=""
-  if [[ -n "${HOME:-}" ]]; then
-    home_cfg="${HOME}/.moraine/config.toml"
-    if [[ -f "$home_cfg" ]]; then
-      printf '%s\n' "$home_cfg"
-      return 0
-    fi
-  fi
-
-  if [[ -f "$PROJECT_ROOT/config/moraine.toml" ]]; then
-    printf '%s\n' "$PROJECT_ROOT/config/moraine.toml"
-    return 0
-  fi
-
-  if [[ -n "$home_cfg" ]]; then
-    printf '%s\n' "$home_cfg"
-  else
-    printf '%s\n' "$PROJECT_ROOT/config/moraine.toml"
-  fi
-}
-
-backend_enabled_for_up() {
-  if has_flag "--backend" "$@" || has_flag "--monitor" "$@" || has_flag "--mcp" "$@"; then
-    return 0
-  fi
-
-  local cfg_path
-  cfg_path="$(resolve_config_path "$@")"
-  if [[ ! -f "$cfg_path" ]]; then
-    return 1
-  fi
-
-  local value=""
-  if ! value="$("$BIN_PATH" --output plain --config "$cfg_path" config get backend.start_on_up 2>/dev/null)"; then
-    return 1
-  fi
-
-  case "$value" in
-    true)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
 ensure_monitor_frontend() {
   local dist_dir="$PROJECT_ROOT/web/monitor/dist"
   if ! monitor_frontend_needs_build; then
@@ -222,10 +145,8 @@ export MORAINE_SOURCE_TREE_MODE
 
 command_name="$(first_non_flag_arg "$@" || true)"
 if [[ "$command_name" == "up" ]]; then
-  if backend_enabled_for_up "$@"; then
-    ensure_monitor_frontend
-    build_binary "$PROJECT_ROOT/apps/moraine-mcp/Cargo.toml"
-  fi
+  ensure_monitor_frontend
+  build_binary "$PROJECT_ROOT/apps/moraine-mcp/Cargo.toml"
 fi
 
 if [[ "$command_name" == "run" ]]; then

--- a/config/moraine.toml
+++ b/config/moraine.toml
@@ -202,9 +202,10 @@ bind = "127.0.0.1"
 # A non-loopback bind requires a non-whitespace startup guard token. This does
 # not authenticate HTTP requests.
 # auth_token = "<generate-a-random-guard-token>"
-# Launch the unified MCP socket + monitor HTTP backend from `moraine up`.
-# Keep this opt-in for the first backend-daemon release.
-start_on_up = false
+# Compatibility key retained for upgrades. The unified MCP socket + monitor
+# HTTP backend now starts with every `moraine up`; loopback false values are
+# accepted but ignored. Non-loopback binds require this explicit true value.
+start_on_up = true
 
 [bm25]
 k1 = 1.2

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -3,6 +3,7 @@ use serde::{de::DeserializeOwned, Deserialize};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::fmt;
+use std::net::IpAddr;
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(windows)]
@@ -204,8 +205,8 @@ pub struct McpConfig {
     /// An absolute path is used verbatim.
     #[serde(default = "default_mcp_socket")]
     pub central_socket_path: String,
-    /// Primary deprecated compatibility key. When `[backend].start_on_up` is
-    /// absent, an explicitly configured `true` value maps to the unified backend.
+    /// Deprecated compatibility key. Its value is validated but no longer
+    /// gates the unified backend started by `moraine up`.
     #[serde(default = "default_true")]
     pub start_central_on_up: bool,
     /// Upper bound, in milliseconds, on how long a proxy client waits to
@@ -235,9 +236,9 @@ const REDACTED_AUTH_TOKEN: &str = "[REDACTED]";
 #[derive(Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BackendConfig {
-    /// Launch the unified MCP socket + monitor HTTP daemon from `moraine up`.
-    /// This remains off by default for the first backend-daemon release.
-    #[serde(default = "default_false")]
+    /// Deprecated compatibility input. The unified backend always launches
+    /// from `moraine up`; loaded configurations normalize this value to true.
+    #[serde(default = "default_true")]
     pub start_on_up: bool,
     /// Host or interface for the monitor HTTP listener; `monitor.port`
     /// remains the port configuration.
@@ -280,13 +281,12 @@ pub struct RuntimeConfig {
     pub clickhouse_auto_install: bool,
     #[serde(default = "default_clickhouse_version")]
     pub clickhouse_version: String,
-    /// Primary deprecated compatibility key. When `[backend].start_on_up` is
-    /// absent, an explicitly configured `true` value maps to the unified backend.
+    /// Deprecated compatibility key. Its value is validated but no longer
+    /// gates the unified backend started by `moraine up`.
     #[serde(default = "default_true")]
     pub start_monitor_on_up: bool,
-    /// Tertiary deprecated compatibility alias retained for configs written by
-    /// v0.6.0. It maps to the unified backend only when explicitly set to `true`
-    /// and `[backend].start_on_up` is absent.
+    /// Deprecated compatibility key retained for configs written by v0.6.0.
+    /// Its value is validated but no longer gates backend startup.
     #[serde(default = "default_false")]
     pub start_mcp_on_up: bool,
 }
@@ -400,7 +400,7 @@ impl fmt::Debug for BackendConfig {
 impl Default for BackendConfig {
     fn default() -> Self {
         Self {
-            start_on_up: false,
+            start_on_up: true,
             bind: default_backend_bind(),
             auth_token: None,
         }
@@ -1376,31 +1376,44 @@ fn raw_config_bool(raw: &toml::Value, section: &str, field: &str) -> Option<bool
         .and_then(toml::Value::as_bool)
 }
 
-fn normalize_backend_start_on_up(cfg: &mut AppConfig, raw: &toml::Value) {
-    // The canonical field is authoritative whenever present, including when
-    // explicitly false. AppConfig deserialization has already validated its
-    // type, so presence in the raw document is the distinction that matters.
-    if raw
-        .get("backend")
-        .and_then(|backend| backend.get("start_on_up"))
-        .is_some()
-    {
-        return;
+fn is_explicit_loopback_bind(bind: &str) -> bool {
+    let ip_literal = bind
+        .strip_prefix('[')
+        .and_then(|inner| inner.strip_suffix(']'))
+        .unwrap_or(bind);
+    ip_literal
+        .parse::<IpAddr>()
+        .map(|address| address.is_loopback())
+        .unwrap_or(false)
+}
+
+fn backend_launch_was_explicitly_enabled(raw: &toml::Value) -> bool {
+    match raw_config_bool(raw, "backend", "start_on_up") {
+        Some(enabled) => enabled,
+        None => {
+            raw_config_bool(raw, "runtime", "start_monitor_on_up").unwrap_or(false)
+                || raw_config_bool(raw, "runtime", "start_mcp_on_up").unwrap_or(false)
+                || raw_config_bool(raw, "mcp", "start_central_on_up").unwrap_or(false)
+        }
+    }
+}
+
+fn validate_non_loopback_backend_upgrade(cfg: &AppConfig, raw: &toml::Value) -> Result<()> {
+    if is_explicit_loopback_bind(&cfg.backend.bind) || backend_launch_was_explicitly_enabled(raw) {
+        return Ok(());
     }
 
-    // These two launch keys are the primary compatibility inputs. Inspect the
-    // raw document so their historical serde defaults do not opt in a config
-    // that omitted them.
-    let primary_legacy_start_on_up = raw_config_bool(raw, "runtime", "start_monitor_on_up")
-        .unwrap_or(false)
-        || raw_config_bool(raw, "mcp", "start_central_on_up").unwrap_or(false);
+    Err(anyhow::anyhow!(
+        "refusing to automatically enable the backend on non-loopback bind `{}`: set backend.start_on_up = true to acknowledge startup, or change backend.bind to an explicit loopback IP",
+        cfg.backend.bind
+    ))
+}
 
-    // start_mcp_on_up predates start_central_on_up and remains a separately
-    // named tertiary alias for configs written during that release window.
-    let tertiary_legacy_start_on_up =
-        raw_config_bool(raw, "runtime", "start_mcp_on_up").unwrap_or(false);
-
-    cfg.backend.start_on_up = primary_legacy_start_on_up || tertiary_legacy_start_on_up;
+fn normalize_backend_start_on_up(cfg: &mut AppConfig, _raw: &toml::Value) {
+    // Deserialization above still validates the canonical and legacy launch
+    // keys so existing configuration files remain load-compatible. Their
+    // values no longer gate startup: every `moraine up` includes the backend.
+    cfg.backend.start_on_up = true;
 }
 
 fn normalize_backend_bind(cfg: &mut AppConfig, raw: &toml::Value) {
@@ -1459,8 +1472,9 @@ fn load_config_with_home_path(path: &Path, home_path: Option<PathBuf>) -> Result
             "config declares both [clickhouse] and [backends.default]; they are aliases for the same backend — keep exactly one"
         ));
     }
-    normalize_backend_start_on_up(&mut cfg, &raw);
     normalize_backend_bind(&mut cfg, &raw);
+    validate_non_loopback_backend_upgrade(&cfg, &raw)?;
+    normalize_backend_start_on_up(&mut cfg, &raw);
 
     if cfg.redaction.dangerously_skip_secret_redaction
         && !path_is_home_config(path, home_path.as_deref())
@@ -2317,7 +2331,7 @@ max_parallel_requests = 0
     }
 
     fn assert_backend_defaults(backend: &BackendConfig) {
-        assert!(!backend.start_on_up);
+        assert!(backend.start_on_up);
         assert_eq!(backend.bind, "127.0.0.1");
         assert_eq!(backend.auth_token, None);
     }
@@ -2374,7 +2388,7 @@ auth_token = "  exact token value  "
         assert_eq!(empty_token.auth_token.as_deref(), Some(""));
         assert_eq!(
             format!("{empty_token:?}"),
-            r#"BackendConfig { start_on_up: false, bind: "127.0.0.1", auth_token: Some("[REDACTED]") }"#
+            r#"BackendConfig { start_on_up: true, bind: "127.0.0.1", auth_token: Some("[REDACTED]") }"#
         );
     }
 
@@ -2417,7 +2431,7 @@ auth_token = "  exact token value  "
     #[test]
     fn explicit_legacy_monitor_host_maps_to_backend_bind() {
         let path = write_temp_config(
-            "[monitor]\nhost = \"192.0.2.20\"\n",
+            "[backend]\nstart_on_up = true\n\n[monitor]\nhost = \"192.0.2.20\"\n",
             "backend-legacy-monitor-host",
         );
         let cfg = load_config(&path).expect("legacy monitor host should load");
@@ -2430,7 +2444,7 @@ auth_token = "  exact token value  "
     #[test]
     fn explicit_backend_bind_wins_over_legacy_monitor_host() {
         let path = write_temp_config(
-            "[backend]\nbind = \"0.0.0.0\"\n\n[monitor]\nhost = \"192.0.2.20\"\n",
+            "[backend]\nbind = \"0.0.0.0\"\nstart_on_up = true\n\n[monitor]\nhost = \"192.0.2.20\"\n",
             "backend-bind-precedence",
         );
         let cfg = load_config(&path).expect("canonical and legacy bind config should load");
@@ -2441,9 +2455,9 @@ auth_token = "  exact token value  "
     }
 
     #[test]
-    fn backend_start_on_up_defaults_and_missing_states_are_off() {
-        assert!(!BackendConfig::default().start_on_up);
-        assert!(!AppConfig::default().backend.start_on_up);
+    fn backend_start_on_up_is_effectively_on_for_missing_and_false_states() {
+        assert!(BackendConfig::default().start_on_up);
+        assert!(AppConfig::default().backend.start_on_up);
 
         for (label, contents) in [
             ("backend-empty-config", ""),
@@ -2469,12 +2483,55 @@ auth_token = "  exact token value  "
                 "[runtime]\nstart_monitor_on_up = false\nstart_mcp_on_up = false\n\n[mcp]\nstart_central_on_up = false\n",
             ),
         ] {
-            assert_backend_start_on_up(label, contents, false);
+            assert_backend_start_on_up(label, contents, true);
         }
     }
 
     #[test]
-    fn backend_start_on_up_maps_all_primary_legacy_alias_states() {
+    fn non_loopback_backend_requires_prior_launch_opt_in() {
+        for (label, contents) in [
+            (
+                "missing-launch-switch",
+                "[backend]\nbind = \"0.0.0.0\"\nauth_token = \"guard\"\n",
+            ),
+            (
+                "canonical-false",
+                "[backend]\nbind = \"0.0.0.0\"\nauth_token = \"guard\"\nstart_on_up = false\n",
+            ),
+            (
+                "canonical-false-overrides-legacy-true",
+                "[backend]\nbind = \"0.0.0.0\"\nauth_token = \"guard\"\nstart_on_up = false\n\n[runtime]\nstart_monitor_on_up = true\n",
+            ),
+            (
+                "legacy-false",
+                "[backend]\nbind = \"0.0.0.0\"\nauth_token = \"guard\"\n\n[runtime]\nstart_monitor_on_up = false\n",
+            ),
+        ] {
+            let path = write_temp_config(contents, label);
+            let error = load_config(&path).expect_err("non-loopback auto-enable must fail closed");
+            std::fs::remove_file(path).ok();
+            assert!(
+                error.to_string().contains("set backend.start_on_up = true"),
+                "{label}: {error:#}"
+            );
+        }
+
+        for (label, contents) in [
+            (
+                "canonical-true",
+                "[backend]\nbind = \"0.0.0.0\"\nauth_token = \"guard\"\nstart_on_up = true\n",
+            ),
+            (
+                "legacy-true",
+                "[backend]\nbind = \"0.0.0.0\"\nauth_token = \"guard\"\n\n[mcp]\nstart_central_on_up = true\n",
+            ),
+        ] {
+            assert_backend_start_on_up(label, contents, true);
+        }
+    }
+
+    #[test]
+    fn backend_start_on_up_ignores_all_primary_legacy_alias_states() {
         for monitor in [false, true] {
             for central in [false, true] {
                 let content = format!(
@@ -2483,26 +2540,22 @@ auth_token = "  exact token value  "
                 assert_backend_start_on_up(
                     &format!("backend-primary-{monitor}-{central}"),
                     &content,
-                    monitor || central,
+                    true,
                 );
             }
         }
     }
 
     #[test]
-    fn backend_start_on_up_maps_tertiary_runtime_mcp_alias_only_when_true() {
+    fn backend_start_on_up_ignores_tertiary_runtime_mcp_alias() {
         for start_mcp in [false, true] {
             let content = format!("[runtime]\nstart_mcp_on_up = {start_mcp}\n");
-            assert_backend_start_on_up(
-                &format!("backend-tertiary-{start_mcp}"),
-                &content,
-                start_mcp,
-            );
+            assert_backend_start_on_up(&format!("backend-tertiary-{start_mcp}"), &content, true);
         }
     }
 
     #[test]
-    fn explicit_backend_start_on_up_wins_over_all_legacy_alias_states() {
+    fn explicit_backend_start_on_up_is_accepted_but_effectively_on() {
         for explicit in [false, true] {
             for monitor in [false, true] {
                 for central in [false, true] {
@@ -2515,7 +2568,7 @@ auth_token = "  exact token value  "
                                 "backend-precedence-{explicit}-{monitor}-{central}-{start_mcp}"
                             ),
                             &content,
-                            explicit,
+                            true,
                         );
                     }
                 }
@@ -2934,8 +2987,8 @@ watch_root = "~/.cursor/projects"
 
         assert_eq!(
             raw_config_bool(&raw, "backend", "start_on_up"),
-            Some(false),
-            "template must explicitly opt out of backend launch"
+            Some(true),
+            "template must explicitly enable backend launch"
         );
         assert_eq!(
             raw.get("backend")
@@ -2980,10 +3033,10 @@ watch_root = "~/.cursor/projects"
             "template must not ship the tertiary MCP launch key"
         );
 
-        let path = write_temp_config(contents, "shipped-template-backend-off");
+        let path = write_temp_config(contents, "shipped-template-backend-on");
         let cfg = load_config(&path).expect("shipped template must load");
         std::fs::remove_file(&path).ok();
-        assert!(!cfg.backend.start_on_up);
+        assert!(cfg.backend.start_on_up);
         assert_eq!(cfg.backend.bind, "127.0.0.1");
         assert_eq!(cfg.backend.auth_token, None);
         assert!(cfg.mcp.use_central_server);

--- a/docs/agent-mcp-search/install.md
+++ b/docs/agent-mcp-search/install.md
@@ -6,12 +6,11 @@ Moraine MCP search is a stdio MCP server. Configure your harness to launch:
 moraine run mcp
 ```
 
-Run `moraine up` first so ClickHouse and ingest are available. For this release,
-bare `moraine up` intentionally leaves the unified backend off; use
-`moraine up --backend` or set `backend.start_on_up = true` for the monitor UI
-and shared MCP socket. Without that backend, `moraine run mcp` automatically
-falls back to an embedded server. If you use a non-default Moraine config, pass
-it through the harness's environment support as
+Run `moraine up` first so ClickHouse, ingest, the monitor UI, and the shared MCP
+socket are available. Every `moraine up` includes the unified backend. If that
+backend is unreachable, a new `moraine run mcp` automatically falls back to an
+embedded server. If you use a non-default Moraine config, pass it through the
+harness's environment support as
 `MORAINE_MCP_CONFIG=/path/to/moraine.toml`.
 
 ## Guided setup (recommended)
@@ -147,12 +146,10 @@ Manual Codex MCP registration remains useful for project-scoped setup,
 `--project-only`, and custom environment wiring such as `MORAINE_MCP_CONFIG`.
 
 <a id="shared-central-server-default"></a>
-## Shared central server (opt-in daemon for this release)
+## Shared central server
 
-`moraine run mcp` tries the shared socket by default, but bare `moraine up`
-intentionally leaves the unified backend off in this release. Start it with
-`moraine up --backend`, or set `backend.start_on_up = true` to include it in
-every `moraine up`. When the backend is running, every `moraine run mcp` becomes
+`moraine up` starts the unified backend. When it is running, every
+`moraine run mcp` becomes
 a thin stdio↔socket proxy to its shared repository, ClickHouse client, caches,
 and runtime threads. The same process also serves the monitor HTTP API and
 static UI.
@@ -161,18 +158,16 @@ What this means for you:
 
 - **Registration is unchanged.** Keep registering `moraine run mcp` exactly as
   shown below. The proxy-vs-embedded choice is made internally.
-- **The backend is required for the shared server.** Start it explicitly with
-  `moraine up --backend`, or set `backend.start_on_up = true` before running
-  bare `moraine up`. It listens on a Unix socket at
+- **The backend is required for the shared server.** Start the stack with bare
+  `moraine up`. The backend listens on a Unix socket at
   `~/.moraine/run/mcp.sock` (mode `0o600`, so it is scoped to your user).
   `moraine down` stops it and removes the socket.
-- **Automatic fallback.** If the backend was not started or it crashed,
+- **Automatic fallback.** If the backend is unreachable or crashed, a new
   `moraine run mcp` transparently falls back to an embedded server after
   ~250&nbsp;ms, so retrieval keeps working either way.
 - **Crash blast radius.** A backend crash drops all live sessions' MCP
   connections at once; harnesses re-establish the connection on their next tool
-  use. Restart it with `moraine up --backend` (or bare `moraine up` when
-  `backend.start_on_up = true`). To opt out and return to a server per session,
+  use. Restart it with `moraine up`. To opt out and return to a server per session,
   set `use_central_server = false` (see
   [Configuration → MCP](../configuration.md#shared-central-mcp-server)).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ Most users only need to override paths, ports, or watched sources:
 ```toml
 [backend]
 bind = "127.0.0.1"
-start_on_up = false
+start_on_up = true
 
 [monitor]
 port = 8080
@@ -709,10 +709,9 @@ run while retrievals wait.
 
 When the backend daemon is running, Moraine uses one repository, ClickHouse
 client, and warm cache set for every MCP proxy session and the monitor HTTP
-server. The shipped configuration leaves the daemon off until `moraine up
---backend` is run or `backend.start_on_up` is enabled. `use_central_server`
-controls whether `moraine run mcp` attempts that shared socket before falling
-back to an embedded server:
+server. Every `moraine up` starts the daemon. `use_central_server` controls
+whether `moraine run mcp` attempts that shared socket before falling back to an
+embedded server:
 
 | Field | Default | Purpose |
 | --- | --- | --- |
@@ -740,12 +739,12 @@ See
 
 The up-managed MCP service is the unified backend daemon; the legacy per-`up`
 stdio daemon and standalone monitor service are gone. The old
-`runtime.start_monitor_on_up`, `mcp.start_central_on_up`, and
-`runtime.start_mcp_on_up` keys remain load-only compatibility aliases for one
-release. When `backend.start_on_up` is absent, any explicitly true alias maps
-to true. An explicitly configured canonical value always wins, including
-`false`. `moraine setup` materializes the prior effective value at
-`backend.start_on_up` and atomically removes all three obsolete keys.
+`backend.start_on_up`, `runtime.start_monitor_on_up`,
+`mcp.start_central_on_up`, and `runtime.start_mcp_on_up` launch switches remain
+load-compatible for upgrades, but their values no longer gate startup. Every
+well-typed combination loads with an effective `backend.start_on_up = true`.
+`moraine setup` canonicalizes the value to true and atomically removes the three
+obsolete aliases.
 
 ## Search Ranking
 
@@ -772,25 +771,28 @@ Most installations should keep these defaults.
 
 ## Backend Daemon
 
-`[backend]` controls the unified daemon's startup behavior and HTTP listener:
+`[backend]` controls the unified daemon's HTTP listener:
 
 ```toml
 [backend]
 bind = "127.0.0.1"
 # auth_token = "<generate-a-random-guard-token>"
-start_on_up = false
+start_on_up = true
 ```
 
 | Field | Default | Purpose |
 | --- | --- | --- |
 | `bind` | `127.0.0.1` | Interface for the monitor HTTP listener. Keep the loopback default for local-only access. |
 | `auth_token` | unset | Experimental startup prerequisite for a non-loopback effective bind. It does not authenticate HTTP requests. |
-| `start_on_up` | `false` | Starts one `moraine-mcp --serve socket` backend process that serves the MCP socket, monitor HTTP API, and static UI from one shared repository/cache set. |
+| `start_on_up` | `true` | Deprecated compatibility key. Every `moraine up` starts one unified backend; an existing loopback `false` value is accepted but ignored. |
 
-Use `moraine up --backend` for an explicit one-time start without changing the
-configuration. `moraine up --monitor` and `moraine up --mcp` remain deprecated
-CLI aliases for the same single backend process; they never launch separate
-services.
+`moraine up --backend`, `moraine up --monitor`, and `moraine up --mcp` remain
+deprecated, redundant compatibility forms. They never launch separate services.
+For upgrade safety, a non-loopback `backend.bind` also requires an affirmative
+existing launch setting (`backend.start_on_up = true`, or a legacy true alias);
+otherwise config loading fails rather than unexpectedly exposing the
+unauthenticated monitor API. Loopback configs normalize existing false values
+to true automatically.
 
 ### Experimental HTTP bind guard
 

--- a/docs/full-config.toml
+++ b/docs/full-config.toml
@@ -319,9 +319,10 @@ bind = "127.0.0.1"
 # authentication; requests remain unauthenticated.
 # auth_token = "<generate-a-random-guard-token>"
 
-# Start the unified MCP + monitor backend daemon with "moraine up". This is
-# intentionally off by default for the first compatibility release.
-start_on_up = false
+# Compatibility key retained for upgrades. The unified MCP + monitor backend
+# starts with every "moraine up"; loopback false values are accepted but
+# ignored. Non-loopback binds require this explicit true value.
+start_on_up = true
 
 [monitor]
 # Monitor HTTP port.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -58,25 +58,17 @@ making those changes; for project-scoped or custom harness setup, see
 
 ## Start Moraine
 
-Start ClickHouse and ingest:
+Start ClickHouse, ingest, and the unified MCP/monitor backend:
 
 ```bash
 moraine up
 ```
 
-For this release, bare `moraine up` intentionally leaves the unified backend
-off. To also serve the monitor UI and shared MCP socket, start it explicitly:
-
-```bash
-moraine up --backend
-```
-
-To include the backend in every subsequent `moraine up` instead, set:
-
-```toml
-[backend]
-start_on_up = true
-```
+Every `moraine up` includes the backend. Existing loopback configurations with
+`backend.start_on_up = false` are accepted for upgrade compatibility but no
+longer suppress it. Non-loopback binds require an explicit true value so an
+upgrade cannot unexpectedly expose the unauthenticated monitor API.
+Moraine does not install an OS login service; run `moraine up` after a reboot.
 
 Check service health:
 
@@ -120,10 +112,9 @@ Moraine MCP search uses a local stdio launcher. Each agent harness starts
 `moraine run mcp` when it needs the tools, so keep ClickHouse available with
 `moraine up`.
 
-Bare `moraine up` does not start the shared backend in this release. Run
-`moraine up --backend` or set `backend.start_on_up = true` to let each
-`moraine run mcp` proxy to one shared server instead of booting a full server
-per session. Registration is unchanged; when the shared backend is not running,
+Bare `moraine up` starts the shared backend so each `moraine run mcp` can proxy
+to one shared server instead of booting a full server per session. Registration
+is unchanged; if the shared backend crashes or is otherwise unreachable, a new
 `moraine run mcp` falls back to an embedded server automatically. See
 [Agent MCP Search → Install](agent-mcp-search/install.md#shared-central-server-default).
 
@@ -170,9 +161,8 @@ For manual cleanup, project-scoped setup, and other custom setup, see
 
 | Command | Purpose |
 | --- | --- |
-| `moraine up` | Start ClickHouse and ingest; the backend also starts only when `backend.start_on_up = true`. |
-| `moraine up --backend` | Start ClickHouse, ingest, and the unified MCP/HTTP/static backend for the shared MCP socket and monitor UI. |
-| `moraine up --monitor` / `moraine up --mcp` | Deprecated aliases for `--backend`; both start the same unified backend. |
+| `moraine up` | Start ClickHouse, ingest, and the unified MCP/HTTP/static backend. |
+| `moraine up --backend` / `--monitor` / `--mcp` | Deprecated, redundant compatibility flags; bare `moraine up` starts the same backend. |
 | `moraine setup` | Create or repair config and guide MCP/plugin registration. |
 | `moraine status` | Print service and ingest health. |
 | `moraine logs` | Show recent service logs. |
@@ -190,7 +180,7 @@ Source builds are useful for development and local testing:
 git clone https://github.com/eric-tramel/moraine.git
 cd moraine
 cargo build --workspace --locked
-MORAINE_SOURCE_TREE_MODE=1 cargo run -p moraine -- up --backend
+MORAINE_SOURCE_TREE_MODE=1 cargo run -p moraine -- up
 ```
 
 `MORAINE_SOURCE_TREE_MODE=1` tells the control command to run service binaries

--- a/scripts/ci/e2e-install-artifact.sh
+++ b/scripts/ci/e2e-install-artifact.sh
@@ -59,6 +59,7 @@ main() {
   local bundle_version="ci-e2e-${run_stamp}"
 
   need_cmd curl
+  need_cmd cmp
   need_cmd "$python_bin"
   need_cmd tar
   need_cmd bash
@@ -101,6 +102,28 @@ main() {
     exit 1
   fi
   "$installed_moraine" config get clickhouse.url --config "$installed_config" >/dev/null
+  if [[ "$("$installed_moraine" config get backend.start_on_up --config "$installed_config")" != "true" ]]; then
+    echo "fresh installed config must enable the backend" >&2
+    exit 1
+  fi
+
+  echo "[e2e-install] reinstalling over preserved backend-off config"
+  local preserved_config
+  preserved_config=$'# preserved upgrade config\n\n[backend]\nstart_on_up = false\n'
+  printf '%s' "$preserved_config" > "$installed_config"
+  MORAINE_INSTALL_ASSET_BASE_URL="$asset_base_url" \
+    MORAINE_INSTALL_VERSION="$bundle_version" \
+    MORAINE_INSTALL_SKIP_CLICKHOUSE=1 \
+    MORAINE_INSTALL_DIR="$installed_bin_dir" \
+    bash "$install_script"
+  if ! cmp -s "$installed_config" <(printf '%s' "$preserved_config"); then
+    echo "reinstall must preserve the existing config" >&2
+    exit 1
+  fi
+  if [[ "$("$installed_moraine" config get backend.start_on_up --config "$installed_config")" != "true" ]]; then
+    echo "preserved backend-off config must load as effectively enabled" >&2
+    exit 1
+  fi
 
   echo "[e2e-install] running functional stack + MCP smoke with installed moraine"
   unset MORAINE_SOURCE_TREE_MODE

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -582,6 +582,10 @@ main() {
   need_cmd "$python_bin"
   need_cmd ps
 
+  # Cache assertions below consume info-level events from the managed backend.
+  # Keep the test deterministic when the caller has a stricter global filter.
+  export RUST_LOG=info
+
   if [[ -z "$monitor_port" ]]; then
     monitor_port="$(pick_open_port "$python_bin")"
   fi
@@ -934,7 +938,7 @@ mode = "mirror"
 
 [backend]
 bind = "127.0.0.1"
-start_on_up = true
+start_on_up = false
 
 [monitor]
 port = ${monitor_port}
@@ -1044,6 +1048,9 @@ database = "${routed_clickhouse_database}"
 [backend]
 start_on_up = false
 
+[monitor]
+port = ${monitor_port}
+
 [runtime]
 root_dir = "${runtime_root}"
 logs_dir = "logs"
@@ -1077,6 +1084,7 @@ EOF
 
   echo "[e2e] bootstrapping distinct named-backend schema"
   "$moraine_bin" up --config "$routed_bootstrap_config_path" --no-ingest
+  "$moraine_bin" down --config "$routed_bootstrap_config_path"
 
   echo "[e2e] starting stack"
   "$moraine_bin" up --config "$config_path"

--- a/scripts/dev/sandbox/moraine-sandbox
+++ b/scripts/dev/sandbox/moraine-sandbox
@@ -952,7 +952,7 @@ watch_root = "/sandbox/fixtures/codex/sessions"
 [backend]
 bind = "0.0.0.0"
 auth_token = "${guard_token}"
-start_on_up = false
+start_on_up = true
 
 [monitor]
 port = 8080


### PR DESCRIPTION
## Description

Make the unified backend a fixed member of every `moraine up` invocation, including upgrades whose preserved config still says `backend.start_on_up = false`.

- Always select and prepare the backend from the Rust CLI and source wrapper; the old `--backend`, `--monitor`, and `--mcp` flags remain accepted as redundant compatibility flags.
- Default and normalize loopback backend configs to effective `start_on_up = true`, and have `moraine setup` canonicalize old false values.
- Fail closed for non-loopback binds unless the existing config contains an affirmative launch opt-in, avoiding a silent network-exposure change.
- Exercise both source-stack and packaged reinstall paths with an explicitly preserved false config.
- Update configuration and quickstart docs to distinguish “every `moraine up`” from OS login/boot persistence.

## Bug Evidence

`make install` correctly preserved an existing config from the first backend-daemon release, where `backend.start_on_up` defaulted to false. The `up` service selector then treated that preserved value as authoritative, so a normal post-reboot `moraine up` launched ClickHouse and ingest but left the backend stopped.

The updated stack test keeps `start_on_up = false` and invokes bare `moraine up`; the packaged-install test also reinstalls over a byte-for-byte preserved false config, verifies its effective value is true, and runs the complete stack/MCP smoke test with the installed artifacts.

## Usage

Run the normal command:

```console
moraine up
```

Existing loopback configs with `start_on_up = false` continue to parse but can no longer disable backend startup. A non-loopback `backend.bind` must explicitly acknowledge startup with `backend.start_on_up = true`.

## Operational impact

This does not add an OS login item or crash supervisor; it guarantees backend launch whenever the Moraine stack is brought up. Existing non-loopback configs that never opted into backend launch will fail closed with remediation guidance instead of being exposed automatically.

## Validation

- `cargo test -p moraine-config --lib --locked` — 92 passed on macOS; 90 passed in the Linux sandbox
- `cargo test -p moraine --bin moraine --locked` — 178 passed on macOS and Linux
- `cargo test -p moraine --test clickhouse_supervision --locked` — 2 passed on macOS and Linux
- `cargo test -p moraine --test status_cli --locked` — 5 passed
- `cargo clippy -p moraine-config -p moraine --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `bash -n bin/moraine scripts/ci/e2e-stack.sh scripts/ci/e2e-install-artifact.sh scripts/dev/sandbox/moraine-sandbox`
- `make docs-build`
- Linux isolated sandbox: `bash scripts/ci/e2e-stack.sh` — passed
- macOS packaged artifact: `bash scripts/ci/e2e-install-artifact.sh aarch64-apple-darwin` — passed, including preserved-config reinstall
- Seven-persona review wave (completeness, correctness, elegance, idiomatic, scope, security, YAGNI) — clean after follow-ups
