### PR TITLE
fix(ingest): session attribution is deterministic and thread-truthful

### DIFF
--- a/crates/moraine-ingest-core/src/dispatch.rs
+++ b/crates/moraine-ingest-core/src/dispatch.rs
@@ -610,11 +610,14 @@ struct InitialSourceHints {
     cwd: String,
 }
 
-/// Best-effort session-level identity recovered from the bounded file head.
-/// Resumed files restart after their session header, while OMP subagent files
-/// use descriptive filenames and begin with a title record before the session
-/// header. Priming both hints prevents resumed rows from losing cwd and leading
-/// OMP rows from creating an empty-ID pseudo-session.
+/// File-level identity recovered from the bounded file head, used for every
+/// pass over the file so a resume starting past the session header and a read
+/// starting at byte zero agree on who the file belongs to. The first non-empty
+/// id wins, which is the file's own header — a forked or sub-agent transcript
+/// that replays its parent's header further down never reaches this scan.
+/// Priming cwd from the same head keeps resumed rows from losing it and keeps
+/// leading OMP rows (a title record precedes the session header) out of an
+/// empty-ID pseudo-session.
 fn infer_initial_source_hints(
     source_file: &str,
     source_name: &str,
@@ -1206,12 +1209,15 @@ pub(crate) async fn process_file(
     let mut reader = BufReader::new(file.take(remaining));
     let mut offset = checkpoint.last_offset;
     let mut line_no = checkpoint.last_line_no;
-    let initial_hints = if checkpoint.last_offset > 0 || work.harness == "pi-coding-agent" {
-        infer_initial_source_hints(source_file, &work.source_name, &work.harness)
-    } else {
-        InitialSourceHints::default()
-    };
-    let mut session_hint = kiro_metadata
+    // Priming is unconditional: a resume that primed and a full read that did
+    // not would start the same line from different state, and the resolvers
+    // that fall back to it would attribute that line two different ways.
+    let initial_hints = infer_initial_source_hints(source_file, &work.source_name, &work.harness);
+    // Session identity is fixed for the whole file before the first record is
+    // normalized and never reassigned from a record, so `session_id` is a pure
+    // function of (file, line). A record that names its own session still wins
+    // — this is only what an unnamed record falls back to.
+    let session_identity = kiro_metadata
         .as_ref()
         .map(KiroSessionMetadata::session_id)
         .filter(|value| !value.trim().is_empty())
@@ -1322,13 +1328,12 @@ pub(crate) async fn process_file(
                 checkpoint.source_generation,
                 0,
                 0,
-                &session_hint,
+                &session_identity,
                 &model_hint,
                 &cwd_hint,
                 &record_ts_hint,
             ) {
                 Ok(normalized) => {
-                    session_hint = normalized.session_hint.clone();
                     model_hint = normalized.model_hint.clone();
                     cwd_hint = normalized.cwd_hint.clone();
                     batch.extend_normalized(normalized);
@@ -1474,7 +1479,7 @@ pub(crate) async fn process_file(
             checkpoint.source_generation,
             line_no,
             start_offset,
-            &session_hint,
+            &session_identity,
             &model_hint,
             &cwd_hint,
             &record_ts_hint,
@@ -1563,7 +1568,9 @@ pub(crate) async fn process_file(
             &mut session_cursors,
         );
 
-        session_hint = normalized.session_hint.clone();
+        // `session_identity` is deliberately not reassigned here: chaining it
+        // would carry a record's resolved session forward, and a resume that
+        // began below that record would carry something else.
         model_hint = normalized.model_hint.clone();
         cwd_hint = normalized.cwd_hint.clone();
         // A null `raw_row` means the normalizer deliberately skipped the
@@ -1805,7 +1812,11 @@ async fn process_session_json_file(
     }
 
     let mut batch = RowBatch::default();
-    let mut session_hint = String::new();
+    // Only messages after `already_emitted` are synthesized on a resume, so a
+    // chained identity would start from a different record than a full pass.
+    // Every session-doc record carries its own session, so nothing falls back
+    // to this and it stays empty for the whole file.
+    let session_identity = String::new();
     let mut model_hint = String::new();
     let mut cwd_hint = String::new();
 
@@ -1820,12 +1831,11 @@ async fn process_session_json_file(
             SESSION_JSON_GENERATION,
             line_no,
             0,
-            &session_hint,
+            &session_identity,
             &model_hint,
             &cwd_hint,
         ) {
             Ok(normalized) => {
-                session_hint = normalized.session_hint;
                 model_hint = normalized.model_hint;
                 cwd_hint = normalized.cwd_hint;
                 // A null `raw_row` is the normalizer's "skip this record"
@@ -2237,6 +2247,200 @@ mod tests {
         assert!(error.to_string().contains("shrank"));
 
         let _ = fs::remove_file(&path);
+    }
+
+    /// Own thread of the sub-agent rollout below; also the id in its filename.
+    const CODEX_OWN_THREAD: &str = "019f81a9-8226-7c71-a7de-5a0992207ab6";
+    /// Thread that spawned it, whose `session_meta` Codex replays into the
+    /// child rollout as part of the forked context.
+    const CODEX_PARENT_THREAD: &str = "019f7fe1-3b94-7fa2-856c-79946cb89dd2";
+
+    /// Real Codex sub-agent rollout shape: the file's own header, then the
+    /// PARENT thread's replayed header, then ordinary records, then the parent
+    /// header again further down.
+    fn codex_subagent_rollout_lines() -> Vec<String> {
+        let own_header = json!({
+            "type": "session_meta",
+            "timestamp": "2026-07-20T18:33:17.019Z",
+            "payload": {
+                "id": CODEX_OWN_THREAD,
+                "session_id": CODEX_PARENT_THREAD,
+                "forked_from_id": CODEX_PARENT_THREAD,
+                "parent_thread_id": CODEX_PARENT_THREAD,
+                "thread_source": "subagent",
+                "agent_nickname": "Beauvoir",
+                "cwd": "/repo",
+            }
+        });
+        let replayed_parent_header = json!({
+            "type": "session_meta",
+            "timestamp": "2026-07-20T18:33:18.019Z",
+            "payload": {
+                "id": CODEX_PARENT_THREAD,
+                "session_id": CODEX_PARENT_THREAD,
+                "thread_source": "user",
+                "cwd": "/repo",
+            }
+        });
+        let message = |seq: u64| {
+            json!({
+                "type": "event_msg",
+                "timestamp": format!("2026-07-20T18:33:{:02}.019Z", 20 + seq),
+                "payload": {"type": "agent_message", "message": format!("delegated step {seq}")}
+            })
+        };
+
+        [
+            own_header,
+            replayed_parent_header.clone(),
+            message(1),
+            message(2),
+            replayed_parent_header,
+            message(3),
+        ]
+        .iter()
+        .map(|record| record.to_string() + "\n")
+        .collect()
+    }
+
+    fn unique_rollout_path(name: &str) -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock before unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("moraine-codex-{name}-{suffix}"));
+        fs::create_dir_all(&dir).expect("create rollout directory");
+        dir.join(format!(
+            "rollout-2026-07-20T18-33-17-{CODEX_OWN_THREAD}.jsonl"
+        ))
+    }
+
+    /// One `process_file` pass. Returns the session each source line was
+    /// attributed to, the sub-agent lineage links emitted, and the durable
+    /// checkpoint a following pass would resume from.
+    async fn codex_attribution_pass(
+        path: &Path,
+        resume_from: Option<Checkpoint>,
+    ) -> (
+        std::collections::BTreeMap<u64, String>,
+        Vec<Value>,
+        Option<Checkpoint>,
+    ) {
+        let config = moraine_config::AppConfig::default();
+        let work = WorkItem {
+            source_name: "codex".to_string(),
+            harness: "codex".to_string(),
+            format: SourceFormat::Jsonl,
+            source_glob: String::new(),
+            path: path.to_string_lossy().to_string(),
+        };
+        let checkpoints = Arc::new(RwLock::new(HashMap::<String, Checkpoint>::new()));
+        if let Some(resume_from) = resume_from {
+            checkpoints.write().await.insert(
+                crate::checkpoint::checkpoint_key(&work.source_name, &work.path),
+                resume_from,
+            );
+        }
+        let metrics = Arc::new(Metrics::default());
+        let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(64);
+
+        let (result, messages) = drive_with_barrier_acks(
+            process_file(
+                &config,
+                &work,
+                checkpoints,
+                &VolatilePollMap::new(),
+                sink_tx,
+                &metrics,
+            ),
+            &mut sink_rx,
+        )
+        .await;
+        result.expect("codex rollout ingests");
+
+        let mut by_line = std::collections::BTreeMap::new();
+        let mut links = Vec::new();
+        let mut checkpoint = None;
+        for batch in observed_batches(&messages) {
+            for row in &batch.event_rows {
+                let line = row
+                    .get("source_line_no")
+                    .and_then(Value::as_u64)
+                    .expect("event carries its source line");
+                let session = row
+                    .get("session_id")
+                    .and_then(Value::as_str)
+                    .expect("event carries a session")
+                    .to_string();
+                by_line.insert(line, session);
+            }
+            links.extend(batch.link_rows.iter().cloned());
+            if let Some(batch_checkpoint) = batch.checkpoint.clone() {
+                checkpoint = Some(batch_checkpoint);
+            }
+        }
+
+        (by_line, links, checkpoint)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn codex_subagent_rollout_attribution_is_independent_of_where_the_pass_started() {
+        let lines = codex_subagent_rollout_lines();
+
+        let whole = unique_rollout_path("whole");
+        fs::write(&whole, lines.concat()).expect("write whole rollout");
+        let (fresh, fresh_links, _) = codex_attribution_pass(&whole, None).await;
+
+        // Same bytes, but consumed as a head pass plus an append pass — the
+        // shape that produced one source line under two session ids.
+        let appended = unique_rollout_path("appended");
+        fs::write(&appended, lines[..2].concat()).expect("write rollout head");
+        let (head, head_links, checkpoint) = codex_attribution_pass(&appended, None).await;
+        let checkpoint = checkpoint.expect("head pass persists a checkpoint");
+        assert!(
+            checkpoint.last_offset > 0,
+            "the append must resume mid-file"
+        );
+        fs::write(&appended, lines.concat()).expect("append the rest of the rollout");
+        let (tail, tail_links, _) = codex_attribution_pass(&appended, Some(checkpoint)).await;
+
+        let mut resumed = head;
+        resumed.extend(tail);
+        assert_eq!(
+            fresh, resumed,
+            "a line must resolve to the same session whether the pass started above it or at it"
+        );
+        assert_eq!(fresh.len(), lines.len(), "every line is attributed");
+        for (line, session) in &fresh {
+            assert_eq!(
+                session, CODEX_OWN_THREAD,
+                "line {line} must stay on the rollout's own thread"
+            );
+        }
+
+        let mut resumed_links = head_links;
+        resumed_links.extend(tail_links);
+        for links in [&fresh_links, &resumed_links] {
+            let lineage: Vec<&Value> = links
+                .iter()
+                .filter(|link| {
+                    link.get("link_type").and_then(Value::as_str) == Some("subagent_parent")
+                })
+                .collect();
+            assert_eq!(lineage.len(), 1, "one lineage edge per sub-agent rollout");
+            assert_eq!(
+                lineage[0].get("linked_external_id").and_then(Value::as_str),
+                Some(CODEX_PARENT_THREAD),
+                "the parent thread is preserved as a link, not as the session"
+            );
+            assert_eq!(
+                lineage[0].get("session_id").and_then(Value::as_str),
+                Some(CODEX_OWN_THREAD)
+            );
+        }
+
+        let _ = fs::remove_file(&whole);
+        let _ = fs::remove_file(&appended);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/moraine-ingest-core/src/model.rs
+++ b/crates/moraine-ingest-core/src/model.rs
@@ -152,12 +152,17 @@ pub struct NormalizedRecord {
     pub link_rows: Vec<Value>,
     pub tool_rows: Vec<Value>,
     pub error_rows: Vec<Value>,
+    /// Session this record resolved to. Read it, but never chain it back in as
+    /// the next record's hint: identity is fixed per file from the head so one
+    /// line resolves the same way whatever offset the pass started at, and
+    /// chaining reintroduces exactly the read-position dependence that let a
+    /// replayed parent header rebind a whole sub-agent transcript.
     pub session_hint: String,
     pub model_hint: String,
     /// Resolved working directory for this record (record-level cwd where the
     /// harness carries one, otherwise the caller-supplied session-level hint).
-    /// Callers chain it back in like `session_hint`/`model_hint` so records
-    /// after a harness's session header inherit the session cwd.
+    /// Callers chain it back in like `model_hint` so records after a harness's
+    /// session header inherit the session cwd.
     pub cwd_hint: String,
 }
 

--- a/crates/moraine-ingest-core/src/normalize.rs
+++ b/crates/moraine-ingest-core/src/normalize.rs
@@ -70,7 +70,18 @@ pub(crate) fn normalize_record_with_ts_hint(
 
     let record = match source.preflight(record) {
         Preflight::Keep(record) => record,
-        Preflight::Skip => return Ok(NormalizedRecord::default()),
+        // A skipped record emits nothing (the null `raw_row` is the caller's
+        // skip signal) but must not mutate carried state: returning a default
+        // would blank the session/model/cwd hints mid-file and make every
+        // following record resolve against a cleared chain.
+        Preflight::Skip => {
+            return Ok(NormalizedRecord {
+                session_hint: session_hint.to_string(),
+                model_hint: model_hint.to_string(),
+                cwd_hint: cwd_hint.to_string(),
+                ..Default::default()
+            })
+        }
     };
 
     let harness_name = source.harness();
@@ -144,7 +155,6 @@ pub(crate) fn normalize_record_with_ts_hint(
         harness: harness_name,
         inference_provider: &metadata.inference_provider,
         session_id: &session_id,
-        session_hint,
         session_date: &session_date,
         cwd: &cwd,
         source_file,

--- a/crates/moraine-ingest-core/src/sources/codex.rs
+++ b/crates/moraine-ingest-core/src/sources/codex.rs
@@ -19,19 +19,26 @@ impl IngestSource for Codex {
     }
 
     fn session_id(&self, record: &Value, ctx: &SourceRecordContext<'_>) -> String {
-        if ctx.top_type == "session_meta" {
-            let payload = record.get("payload").cloned().unwrap_or(Value::Null);
-            let payload_id = to_str(payload.get("id"));
+        // A rollout file records exactly one thread and its name carries that
+        // thread's id. Forked and sub-agent rollouts replay the PARENT
+        // thread's `session_meta` further down the same file, so honoring
+        // every header's `payload.id` rebinds the file to its parent from that
+        // line on — and only for a scan that reached it, which makes the same
+        // line resolve differently on a resume than on a full read. Attribution
+        // must be a function of (file, line) alone: the filename wins, and a
+        // header may name the thread only while no identity is established and
+        // the filename carries none.
+        let own_thread_id = infer_session_id_from_file(ctx.source_file);
+        if !own_thread_id.is_empty() {
+            return own_thread_id;
+        }
+        if ctx.session_hint.is_empty() && ctx.top_type == "session_meta" {
+            let payload_id = to_str(record.pointer("/payload/id"));
             if !payload_id.is_empty() {
                 return payload_id;
             }
         }
-
-        if ctx.session_hint.is_empty() {
-            infer_session_id_from_file(ctx.source_file)
-        } else {
-            ctx.session_hint.to_string()
-        }
+        ctx.session_hint.to_string()
     }
 
     fn jsonl_carries_cwd(&self) -> bool {
@@ -72,6 +79,7 @@ fn normalize_codex_event(
     let mut partials = emitter.finish();
     stamp_codex_model_fallbacks(&codex_record, &mut partials.event_rows);
     append_codex_parent_link(&codex_record, ctx, &mut partials);
+    append_codex_thread_lineage(&codex_record, ctx, &mut partials);
     partials
 }
 
@@ -702,7 +710,222 @@ fn append_codex_parent_link(
     }
 }
 
+/// Codex writes a forked or sub-agent thread to its own rollout file, so the
+/// child keeps its own session and the parent relationship travels as an
+/// explicit `subagent_parent` external link (the `kimi-cli` precedent) rather
+/// than by folding the child's records into the parent's transcript. Only the
+/// file's own header describes this file's lineage: a replayed parent header
+/// names a different thread and contributes nothing.
+fn append_codex_thread_lineage(
+    record: &CodexRecord<'_>,
+    ctx: &RecordContext<'_>,
+    partials: &mut NormalizedPartials,
+) {
+    if record.top_type != "session_meta" {
+        return;
+    }
+
+    let own_thread_id = to_str(record.payload_field("id"));
+    if own_thread_id.is_empty() || own_thread_id != ctx.session_id {
+        return;
+    }
+
+    let parent_thread_id = codex_parent_thread_id(record);
+    if parent_thread_id.is_empty() || parent_thread_id == own_thread_id {
+        return;
+    }
+
+    let Some(uid) = partials
+        .event_rows
+        .first()
+        .and_then(|row| row.get("event_uid"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+    else {
+        return;
+    };
+
+    let metadata_json = compact_json(&json!({
+        "thread_source": to_str(record.payload_field("thread_source")),
+        "parent_thread_id": to_str(record.payload_field("parent_thread_id")),
+        "forked_from_id": to_str(record.payload_field("forked_from_id")),
+    }));
+    partials.push_link(build_external_link_row(
+        ctx,
+        &uid,
+        &parent_thread_id,
+        "subagent_parent",
+        &metadata_json,
+    ));
+}
+
+/// `parent_thread_id` is the sub-agent spawn edge and `forked_from_id` the
+/// fork edge; `payload.session_id` names the originating thread on older
+/// rollouts that carry neither, and equals `payload.id` on a plain session.
+fn codex_parent_thread_id(record: &CodexRecord<'_>) -> String {
+    let parent_thread_id = to_str(record.payload_field("parent_thread_id"));
+    if !parent_thread_id.is_empty() {
+        return parent_thread_id;
+    }
+
+    let forked_from_id = to_str(record.payload_field("forked_from_id"));
+    if !forked_from_id.is_empty() {
+        return forked_from_id;
+    }
+
+    to_str(record.payload_field("session_id"))
+}
+
 fn null_value<'a>() -> &'a Value {
     static NULL_VALUE: Value = Value::Null;
     &NULL_VALUE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::normalize::normalize_record;
+
+    const OWN_THREAD: &str = "019f81a9-8226-7c71-a7de-5a0992207ab6";
+    const PARENT_THREAD: &str = "019f7fe1-3b94-7fa2-856c-79946cb89dd2";
+    const ROLLOUT: &str =
+        "/sessions/2026/07/20/rollout-2026-07-20T18-33-17-019f81a9-8226-7c71-a7de-5a0992207ab6.jsonl";
+    /// Older layouts (and hand-copied rollouts) whose name carries no thread id.
+    const UNNAMED_ROLLOUT: &str = "/sessions/2026/07/20/rollout.jsonl";
+
+    fn own_header() -> Value {
+        json!({
+            "type": "session_meta",
+            "timestamp": "2026-07-20T18:33:17.019Z",
+            "payload": {
+                "id": OWN_THREAD,
+                "session_id": PARENT_THREAD,
+                "forked_from_id": PARENT_THREAD,
+                "parent_thread_id": PARENT_THREAD,
+                "thread_source": "subagent",
+                "cwd": "/repo",
+            }
+        })
+    }
+
+    /// Codex replays the spawning thread's own header into the child rollout.
+    fn replayed_parent_header() -> Value {
+        json!({
+            "type": "session_meta",
+            "timestamp": "2026-07-20T18:33:18.019Z",
+            "payload": {
+                "id": PARENT_THREAD,
+                "session_id": PARENT_THREAD,
+                "thread_source": "user",
+                "cwd": "/repo",
+            }
+        })
+    }
+
+    fn normalize(
+        record: &Value,
+        source_file: &str,
+        line_no: u64,
+        session_hint: &str,
+    ) -> crate::model::NormalizedRecord {
+        normalize_record(
+            record,
+            "test-codex",
+            "codex",
+            source_file,
+            1,
+            1,
+            line_no,
+            line_no * 100,
+            session_hint,
+            "",
+            "",
+        )
+        .expect("codex record should normalize")
+    }
+
+    fn lineage_links(record: &crate::model::NormalizedRecord) -> Vec<&Value> {
+        record
+            .link_rows
+            .iter()
+            .filter(|link| link["link_type"] == "subagent_parent")
+            .collect()
+    }
+
+    #[test]
+    fn replayed_parent_header_never_rebinds_the_rollout() {
+        // Whatever identity the pass carried, the answer is the file's own
+        // thread — the property the duplicate-uid defect violated.
+        for hint in ["", OWN_THREAD, PARENT_THREAD] {
+            assert_eq!(
+                normalize(&replayed_parent_header(), ROLLOUT, 2, hint).session_hint,
+                OWN_THREAD
+            );
+        }
+        assert_eq!(
+            normalize(&own_header(), ROLLOUT, 1, "").session_hint,
+            OWN_THREAD
+        );
+        assert_eq!(
+            normalize(
+                &json!({
+                    "type": "event_msg",
+                    "timestamp": "2026-07-20T18:33:21.019Z",
+                    "payload": {"type": "agent_message", "message": "delegated step"}
+                }),
+                ROLLOUT,
+                3,
+                PARENT_THREAD,
+            )
+            .session_hint,
+            OWN_THREAD
+        );
+    }
+
+    #[test]
+    fn an_unnamed_rollout_is_named_by_its_first_header_only() {
+        assert_eq!(
+            normalize(&own_header(), UNNAMED_ROLLOUT, 1, "").session_hint,
+            OWN_THREAD
+        );
+        // Identity established: a later header naming another thread loses.
+        assert_eq!(
+            normalize(&replayed_parent_header(), UNNAMED_ROLLOUT, 2, OWN_THREAD).session_hint,
+            OWN_THREAD
+        );
+    }
+
+    #[test]
+    fn the_own_header_carries_the_parent_relationship() {
+        let normalized = normalize(&own_header(), ROLLOUT, 1, "");
+        let links = lineage_links(&normalized);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0]["linked_external_id"], PARENT_THREAD);
+        assert_eq!(links[0]["session_id"], OWN_THREAD);
+        assert_eq!(links[0]["event_uid"], normalized.event_rows[0]["event_uid"]);
+
+        let metadata: Value = serde_json::from_str(links[0]["metadata_json"].as_str().unwrap())
+            .expect("lineage metadata is JSON");
+        assert_eq!(metadata["thread_source"], "subagent");
+        assert_eq!(metadata["parent_thread_id"], PARENT_THREAD);
+        assert_eq!(metadata["forked_from_id"], PARENT_THREAD);
+    }
+
+    #[test]
+    fn a_replayed_parent_header_contributes_no_lineage() {
+        let normalized = normalize(&replayed_parent_header(), ROLLOUT, 2, OWN_THREAD);
+        assert!(lineage_links(&normalized).is_empty());
+    }
+
+    #[test]
+    fn a_plain_session_has_no_parent() {
+        let plain = json!({
+            "type": "session_meta",
+            "timestamp": "2026-07-20T18:33:17.019Z",
+            "payload": {"id": OWN_THREAD, "session_id": OWN_THREAD, "cwd": "/repo"}
+        });
+        let normalized = normalize(&plain, ROLLOUT, 1, "");
+        assert_eq!(normalized.session_hint, OWN_THREAD);
+        assert!(lineage_links(&normalized).is_empty());
+    }
 }

--- a/crates/moraine-ingest-core/src/sources/emitter.rs
+++ b/crates/moraine-ingest-core/src/sources/emitter.rs
@@ -512,7 +512,6 @@ mod tests {
             harness: "codex",
             inference_provider: "openai",
             session_id: "session-1",
-            session_hint: "",
             session_date: "2026-05-07",
             cwd: "",
             source_file: "/fixtures/codex/session.jsonl",

--- a/crates/moraine-ingest-core/src/sources/kimi_cli.rs
+++ b/crates/moraine-ingest-core/src/sources/kimi_cli.rs
@@ -95,6 +95,9 @@ fn kimi_subagent_parent_session_id(source_file: &str) -> Option<String> {
     Some(format!("kimi-cli:{parent_session_id}"))
 }
 
+/// Whether a TurnBegin already appeared in the bytes before `source_offset`.
+/// Answered from the file itself, so it is a function of (file, offset) alone
+/// and a resume starting mid-file reaches the same verdict as a full pass.
 fn has_prior_kimi_turn_begin(source_file: &str, source_offset: u64) -> bool {
     let Ok(file) = std::fs::File::open(source_file) else {
         return false;
@@ -122,8 +125,10 @@ fn link_kimi_subagent_to_parent(
     // A Kimi wire file can contain multiple turns. Inspect only the already
     // consumed prefix so this relationship is attached to the stream's first
     // TurnBegin across blank lines, skipped records, and incremental resumes.
+    // The prefix scan is the whole gate: session identity is now established
+    // for the file before its first record is normalized, so an emptiness
+    // check on the hint would never hold and would drop the link outright.
     if wire.msg_type() != "TurnBegin"
-        || !ctx.session_hint.is_empty()
         || has_prior_kimi_turn_begin(ctx.source_file, ctx.source_offset)
     {
         return;

--- a/crates/moraine-ingest-core/src/sources/kiro_cli.rs
+++ b/crates/moraine-ingest-core/src/sources/kiro_cli.rs
@@ -810,7 +810,8 @@ mod tests {
         assert_eq!(metadata.model(), "claude-sonnet-4");
         assert_eq!(metadata.created_at(), "2026-05-28T20:26:40Z");
 
-        let mut session_hint = metadata.session_id().to_string();
+        // Sidecar identity is fixed for the file, exactly as dispatch fixes it.
+        let session_identity = metadata.session_id().to_string();
         let mut model_hint = metadata.model().to_string();
         let mut cwd_hint = metadata.cwd().to_string();
         let mut record_ts_hint = metadata.created_at().to_string();
@@ -825,13 +826,12 @@ mod tests {
             1,
             0,
             0,
-            &session_hint,
+            &session_identity,
             &model_hint,
             &cwd_hint,
             &record_ts_hint,
         )
         .expect("normalize Kiro session metadata");
-        session_hint = session_meta.session_hint.clone();
         model_hint = session_meta.model_hint.clone();
         cwd_hint = session_meta.cwd_hint.clone();
         records.push(session_meta);
@@ -852,7 +852,7 @@ mod tests {
                 1,
                 index as u64 + 1,
                 start_offset,
-                &session_hint,
+                &session_identity,
                 &model_hint,
                 &cwd_hint,
                 &record_ts_hint,
@@ -863,7 +863,6 @@ mod tests {
                     record_ts_hint = record_ts.to_string();
                 }
             }
-            session_hint = normalized.session_hint.clone();
             model_hint = normalized.model_hint.clone();
             cwd_hint = normalized.cwd_hint.clone();
             records.push(normalized);

--- a/crates/moraine-ingest-core/src/sources/nac.rs
+++ b/crates/moraine-ingest-core/src/sources/nac.rs
@@ -45,11 +45,17 @@ impl IngestSource for NacSource {
 
     fn session_id(&self, record: &Value, ctx: &SourceRecordContext<'_>) -> String {
         let id = to_str(record.get("session_id"));
-        if id.is_empty() {
-            ctx.session_hint.to_string()
-        } else {
-            id
+        if !id.is_empty() {
+            return id;
         }
+        if !ctx.session_hint.is_empty() {
+            return ctx.session_hint.to_string();
+        }
+        // The poller always supplies an empty hint and the source file is a
+        // SQLite database with no session in its name, so an id-less record
+        // would otherwise land in the empty pseudo-session that migration 020
+        // had to purge. Fall back to the record's own stable UID instead.
+        format!("nac:{}", ctx.base_uid)
     }
 
     fn normalize(

--- a/crates/moraine-ingest-core/src/sources/opencode.rs
+++ b/crates/moraine-ingest-core/src/sources/opencode.rs
@@ -77,7 +77,13 @@ impl IngestSource for Opencode {
 
     fn session_id(&self, record: &Value, ctx: &SourceRecordContext<'_>) -> String {
         let mut session_id = first_text([record.get("session_id"), record.get("sessionID")]);
-        if session_id.is_empty() && ctx.top_type == "opencode_session" {
+        // `opencode_session.id` names a session only while none is
+        // established; a second header inside one stream would otherwise
+        // rebind every following record, and differently per scan start.
+        if session_id.is_empty()
+            && ctx.top_type == "opencode_session"
+            && ctx.session_hint.is_empty()
+        {
             session_id = to_str(record.get("id"));
         }
         if !session_id.is_empty() {

--- a/crates/moraine-ingest-core/src/sources/pi.rs
+++ b/crates/moraine-ingest-core/src/sources/pi.rs
@@ -23,18 +23,21 @@ impl IngestSource for PiCodingAgent {
     }
 
     fn session_id(&self, record: &Value, ctx: &SourceRecordContext<'_>) -> String {
-        if ctx.top_type == "session" {
-            let session_id = to_str(record.get("id"));
-            if !session_id.is_empty() {
-                return session_id;
+        // Same contract as Codex: the `session` header names this file's
+        // thread once, and a later header naming another thread must not
+        // rebind the file — that resolves one line two ways depending on where
+        // the scan began. Established identity therefore outranks any header.
+        if ctx.session_hint.is_empty() {
+            if ctx.top_type == "session" {
+                let session_id = to_str(record.get("id"));
+                if !session_id.is_empty() {
+                    return session_id;
+                }
             }
+            return infer_session_id_from_file(ctx.source_file);
         }
 
-        if ctx.session_hint.is_empty() {
-            infer_session_id_from_file(ctx.source_file)
-        } else {
-            ctx.session_hint.to_string()
-        }
+        ctx.session_hint.to_string()
     }
 
     fn jsonl_carries_cwd(&self) -> bool {
@@ -815,4 +818,71 @@ fn append_pi_parent_links(
 fn null_value<'a>() -> &'a Value {
     static NULL_VALUE: Value = Value::Null;
     &NULL_VALUE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::normalize::normalize_record;
+
+    const SOURCE_FILE: &str = "/sessions/omp-review.jsonl";
+
+    fn normalize(
+        record: Value,
+        line_no: u64,
+        session_hint: &str,
+    ) -> crate::model::NormalizedRecord {
+        normalize_record(
+            &record,
+            "test-pi",
+            "pi-coding-agent",
+            SOURCE_FILE,
+            1,
+            1,
+            line_no,
+            line_no * 100,
+            session_hint,
+            "",
+            "",
+        )
+        .expect("pi record should normalize")
+    }
+
+    fn session_record(id: &str) -> Value {
+        json!({
+            "type": "session",
+            "id": id,
+            "timestamp": "2026-07-20T18:33:17.019Z",
+            "cwd": "/repo",
+        })
+    }
+
+    #[test]
+    fn a_later_session_header_never_rebinds_the_file() {
+        // The head scan names the file; a second `session` record — a forked
+        // or replayed context — must not move the rest of the file onto it,
+        // which would attribute one line two ways across a resume.
+        assert_eq!(
+            normalize(session_record("omp-first"), 2, "").session_hint,
+            "omp-first"
+        );
+        assert_eq!(
+            normalize(session_record("omp-second"), 9, "omp-first").session_hint,
+            "omp-first"
+        );
+        assert_eq!(
+            normalize(
+                json!({
+                    "type": "message",
+                    "timestamp": "2026-07-20T18:33:21.019Z",
+                    "role": "assistant",
+                    "content": "step",
+                }),
+                10,
+                "omp-first",
+            )
+            .session_hint,
+            "omp-first"
+        );
+    }
 }

--- a/crates/moraine-ingest-core/src/sources/record_view.rs
+++ b/crates/moraine-ingest-core/src/sources/record_view.rs
@@ -334,7 +334,6 @@ mod tests {
             harness: "codex",
             inference_provider: "openai",
             session_id: "session-1",
-            session_hint: "",
             session_date: "2026-05-07",
             cwd: "",
             source_file: "/fixtures/dummy/session.jsonl",

--- a/crates/moraine-ingest-core/src/sources/shared.rs
+++ b/crates/moraine-ingest-core/src/sources/shared.rs
@@ -1158,12 +1158,15 @@ fn strip_root(path: &str, root: &str) -> Option<String> {
         .map(|tail| tail.to_string())
 }
 
+/// Per-record normalization context. It deliberately carries the RESOLVED
+/// `session_id` and not the file-level hint it came from: a normalizer able to
+/// branch on "was identity already established?" would emit different rows for
+/// the same line depending on where the pass started.
 pub(crate) struct RecordContext<'a> {
     pub(crate) source_name: &'a str,
     pub(crate) harness: &'a str,
     pub(crate) inference_provider: &'a str,
     pub(crate) session_id: &'a str,
-    pub(crate) session_hint: &'a str,
     pub(crate) session_date: &'a str,
     pub(crate) cwd: &'a str,
     pub(crate) source_file: &'a str,
@@ -1455,7 +1458,6 @@ mod tests {
             harness: "codex",
             inference_provider: "openai",
             session_id: "s1",
-            session_hint: "",
             session_date: "2026-02-15",
             cwd,
             source_file: "/tmp/s1.jsonl",

--- a/crates/moraine-ingest-core/tests/golden_fixtures.rs
+++ b/crates/moraine-ingest-core/tests/golden_fixtures.rs
@@ -167,6 +167,11 @@ fn golden_cases() -> [GoldenCase; 13] {
             source_file: "/fixtures/kiro/11111111-2222-4333-8444-555555555555.jsonl",
             format: GoldenFormat::Jsonl,
         },
+        // `source_file` is synthetic so recorded UIDs stay host-independent,
+        // which means it cannot be opened: the sub-agent link's "is this the
+        // stream's first turn" prefix scan finds nothing and every TurnBegin
+        // anchors a link here. Production reads the real file and links once —
+        // that is pinned by tests/kimi_cli_fixture.rs, not by this snapshot.
         GoldenCase {
             name: "kimi_cli_subagent",
             harness: "kimi-cli",
@@ -257,7 +262,10 @@ fn normalize_jsonl(case: &GoldenCase) -> Vec<NormalizedRecord> {
     let body = std::fs::read_to_string(&path)
         .unwrap_or_else(|err| panic!("read fixture {}: {err}", path.display()));
     let mut offset = 0_u64;
-    let mut session_hint = String::new();
+    // Dispatch fixes session identity from the file head and never reassigns
+    // it from a record, so every pass over a line resolves it the same way.
+    // Mirror that here or the goldens would pin a contract production dropped.
+    let session_identity = prime_session_identity(case, &body);
     let mut model_hint = String::new();
     let mut cwd_hint = String::new();
     let mut records = Vec::new();
@@ -282,18 +290,53 @@ fn normalize_jsonl(case: &GoldenCase) -> Vec<NormalizedRecord> {
             1,
             line_no,
             start_offset,
-            &session_hint,
+            &session_identity,
             &model_hint,
             &cwd_hint,
         )
         .unwrap_or_else(|err| panic!("normalize {} line {line_no}: {err:#}", case.name));
-        session_hint = normalized.session_hint.clone();
         model_hint = normalized.model_hint.clone();
         cwd_hint = normalized.cwd_hint.clone();
         records.push(normalized);
     }
 
     records
+}
+
+/// Stand-in for dispatch's bounded head scan: the first non-empty session a
+/// record resolves to on its own becomes the file's identity for every pass.
+fn prime_session_identity(case: &GoldenCase, body: &str) -> String {
+    const MAX_HEAD_LINES: usize = 25;
+
+    for (idx, raw_line) in body.split_inclusive('\n').take(MAX_HEAD_LINES).enumerate() {
+        let trimmed = raw_line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(record) = serde_json::from_str::<Value>(trimmed) else {
+            continue;
+        };
+        let Ok(normalized) = normalize_record(
+            &record,
+            case.source_name,
+            case.harness,
+            case.source_file,
+            1,
+            1,
+            idx as u64 + 1,
+            0,
+            "",
+            "",
+            "",
+        ) else {
+            continue;
+        };
+        if !normalized.session_hint.trim().is_empty() {
+            return normalized.session_hint;
+        }
+    }
+
+    String::new()
 }
 
 fn normalize_hermes_session_json(case: &GoldenCase) -> Vec<NormalizedRecord> {

--- a/crates/moraine-ingest-core/tests/goldens/source_normalization/kimi_cli.json
+++ b/crates/moraine-ingest-core/tests/goldens/source_normalization/kimi_cli.json
@@ -9,7 +9,7 @@
       "link_rows": [],
       "model_hint": "",
       "raw_rows": [],
-      "session_hint": "",
+      "session_hint": "kimi-cli:kimi-cli",
       "tool_rows": []
     },
     {

--- a/crates/moraine-ingest-core/tests/goldens/source_normalization/kimi_cli_subagent.json
+++ b/crates/moraine-ingest-core/tests/goldens/source_normalization/kimi_cli_subagent.json
@@ -9,7 +9,7 @@
       "link_rows": [],
       "model_hint": "",
       "raw_rows": [],
-      "session_hint": "",
+      "session_hint": "kimi-cli:agent-abcdef01",
       "tool_rows": []
     },
     {
@@ -331,7 +331,21 @@
           "worktree_root": ""
         }
       ],
-      "link_rows": [],
+      "link_rows": [
+        {
+          "event_uid": "f9b588af4094c8a880317e5da1e93d8ad9f683ac0deea498c9eb88570d873ff1",
+          "event_version": "<event_version>",
+          "harness": "kimi-cli",
+          "inference_provider": "moonshot",
+          "link_type": "subagent_parent",
+          "linked_event_uid": "",
+          "linked_external_id": "kimi-cli:11111111-2222-4333-8444-555555555555",
+          "metadata_json": "{}",
+          "session_id": "kimi-cli:agent-abcdef01",
+          "source_event_version": "<event_version>",
+          "source_name": "golden-kimi-cli-subagent"
+        }
+      ],
       "model_hint": "kimi-cli",
       "raw_rows": [
         {

--- a/crates/moraine-ingest-core/tests/kimi_cli_fixture.rs
+++ b/crates/moraine-ingest-core/tests/kimi_cli_fixture.rs
@@ -44,7 +44,10 @@ fn fixture_records(name: &str) -> (PathBuf, Vec<(u64, u64, Value)>) {
 
 fn normalize_lines(name: &str) -> Vec<moraine_ingest_core::model::NormalizedRecord> {
     let (path, records) = fixture_records(name);
-    let mut session_hint = String::new();
+    // Dispatch fixes session identity from the file head and never chains it
+    // forward; Kimi derives its session from the path, so the frozen fallback
+    // is never consulted.
+    let session_identity = String::new();
     let mut model_hint = String::new();
     let mut cwd_hint = String::new();
 
@@ -60,12 +63,11 @@ fn normalize_lines(name: &str) -> Vec<moraine_ingest_core::model::NormalizedReco
                 1,
                 line_no,
                 source_offset,
-                &session_hint,
+                &session_identity,
                 &model_hint,
                 &cwd_hint,
             )
             .expect("kimi fixture normalizes");
-            session_hint = normalized.session_hint.clone();
             model_hint = normalized.model_hint.clone();
             cwd_hint = normalized.cwd_hint.clone();
             normalized

--- a/crates/moraine-ingest-core/tests/qwen_code_fixture.rs
+++ b/crates/moraine-ingest-core/tests/qwen_code_fixture.rs
@@ -18,7 +18,10 @@ fn normalize_fixture() -> Vec<NormalizedRecord> {
     let path = fixture_path();
     let body = std::fs::read_to_string(&path).expect("read Qwen fixture");
     let mut offset = 0_u64;
-    let mut session_hint = String::new();
+    // Dispatch fixes session identity from the file head and never chains it
+    // forward; every fixture record carries its own `sessionId`, so the frozen
+    // fallback stays empty.
+    let session_identity = String::new();
     let mut model_hint = String::new();
     let mut cwd_hint = String::new();
     let mut rows = Vec::new();
@@ -40,12 +43,11 @@ fn normalize_fixture() -> Vec<NormalizedRecord> {
             1,
             index as u64 + 1,
             source_offset,
-            &session_hint,
+            &session_identity,
             &model_hint,
             &cwd_hint,
         )
         .expect("Qwen fixture record normalizes");
-        session_hint = normalized.session_hint.clone();
         model_hint = normalized.model_hint.clone();
         cwd_hint = normalized.cwd_hint.clone();
         rows.push(normalized);

--- a/docs/development/ingest-sources.md
+++ b/docs/development/ingest-sources.md
@@ -56,6 +56,46 @@ the JSONL entry format as internal and unstable. Windows local storage is not
 enabled because no path is verified across installer modes, and remote Cowork
 OpenTelemetry is a separate source surface.
 
+### Session attribution is a function of the line, not of the pass
+
+Every ingest pass over a source line must resolve the same `session_id`. This is
+load-bearing rather than cosmetic: `event_uid` excludes `session_id`, and
+`moraine.events` is a `ReplacingMergeTree` whose sort key LEADS with
+`session_id`, so two passes that disagree write two rows that can never
+collapse — one event with two identities.
+
+Dispatch enforces it structurally. `infer_initial_source_hints` reads the file
+head on EVERY pass (not only on a resume) and takes the first non-empty session
+a record resolves to; that value is the file's identity for the whole pass and
+is never reassigned from a record. A record that names its own session still
+wins — the file identity is only what an unnamed record falls back to. A skipped
+record (`Preflight::Skip`) returns the caller's hints untouched rather than
+blanking them.
+
+`session_id()` implementations must respect the same rule: a header record may
+name the file's thread only while no identity is established, and never a thread
+that is not this file's. `RecordContext` deliberately carries the RESOLVED
+`session_id` and not the hint it came from, so a normalizer cannot branch on
+"was identity already established?" and emit different rows per pass start.
+
+### Codex forks and sub-agent threads
+
+A Codex rollout records exactly one thread, and its filename carries that
+thread's id (`rollout-<ts>-<uuid>.jsonl`). Codex replays the SPAWNING thread's
+`session_meta` into a forked or sub-agent rollout as part of the forked context,
+so such a file contains several `session_meta` records naming different threads.
+`Codex::session_id` therefore trusts the filename first; a header names the
+thread only for a rollout whose name carries none, and only while no identity is
+established.
+
+The child keeps its own session. The relationship is preserved as a
+`subagent_parent` external link on the file's own `session_meta` event — the
+`kimi-cli` precedent — whose `linked_external_id` is the parent thread id
+(`parent_thread_id`, else `forked_from_id`, else the header's `session_id`) and
+whose `metadata_json` carries `thread_source`, `parent_thread_id`, and
+`forked_from_id`. A replayed parent header names another thread and contributes
+no link. A plain session, whose header names only itself, has no parent.
+
 ### Kimi parent and sub-agent streams
 
 Kimi treats every `wire.jsonl` as its own session boundary. A parent stream at
@@ -119,7 +159,7 @@ Each adapter implements `IngestSource` from `sources/mod.rs`:
 | `source_metadata()` | Per-record provider and model hint discovery. Hermes splits `vendor/model` here. |
 | `record_ts()` | Timestamp string consumed by the shared parser. Kimi converts Unix-second wire timestamps here. |
 | `top_type()` | Source-level discriminator used for dispatch inside the adapter. |
-| `session_id()` | Stable session id derived from record fields, file path, prior session hint, or raw UID. |
+| `session_id()` | Stable session id derived from record fields, file path, the file-level session identity, or raw UID. Must resolve one line the same way on every pass. |
 | `normalize()` | Emit `NormalizedPartials`: event rows, event link rows, and tool IO rows. |
 
 `normalize()` receives a `RecordContext`. That context has already been stamped
@@ -207,6 +247,9 @@ Adapters must emit rows that already satisfy the normalized schema domain:
 - `model`, `inference_provider`, and `session_id` must preserve source-specific
   semantics. Hermes model strings are split from provider/model input and are
   not blindly canonicalized through generic helpers.
+- Every column an adapter derives per line must be a pure function of the record
+  and its file. `session_id` in particular must not depend on where the pass
+  started; see "Session attribution is a function of the line, not of the pass".
 - Synthetic timestamp sequencing should only advance for rows that are actually
   emitted. This matters for Hermes trajectory segment parsing.
 


### PR DESCRIPTION
## Description

**What.** Makes ingest session attribution a deterministic function of `(file, line)`, and attributes sub-agent threads to their own session while preserving parent lineage.

**Why.** A Codex sub-agent rollout embeds **more than one** `session_meta`. Line 1 is the thread's own header (`payload.id` = own thread); Codex replays the **parent** thread's header into the child file at line 2 (and again later in the file). The resolver returned `payload.id` for *any* `session_meta`, so line 2 renamed the file's session to the parent, and the carried-forward hint made it stick for every subsequent record — measured at **3,503 of 3,504 lines** on the reference rollout.

Because the hint chain starts from a different place depending on where the pass began, attribution was **read-shape dependent**:

- a full pass from offset 0 saw the line-2 parent header → attributed the **parent**;
- a resumed pass primed from a bounded head scan that stops as soon as it has an id, never reached line 2 → attributed the **own thread**.

The same-generation rewind on a retried replay then read one generation *both* ways. Since `event_uid` hashes `source_file | source_generation | source_line_no | source_offset | record_fingerprint | suffix` and deliberately **excludes** `session_id`, a re-attribution can never dedupe — it can only add a second row.

## Impact on the reference host

| measurement | value |
|---|---|
| `event_uid`s carrying two `session_id`s | 19,846 |
| rows in those groups | 39,692 |
| sub-agent rollouts in the corpus | 1,527 of 2,411 |
| …of those, carrying a replayed parent header | 809 |
| largest "session" (an artifact) | 408,153 rows drawn from 127 files, 95% foreign |

The embedded-header frequency ranking across the corpus is exactly the sink ranking, which is what confirms the mechanism rather than merely fitting it.

This is also what blocked issue #598's `open_v2` cutover: migration 036's overlap audit compares two independently derived indexes and correctly refused readiness on a corpus where one uid maps to two sessions. **The gate worked.**

## Changelog

- Priming is unconditional, so a resume and a full read start from identical state.
- Session identity is fixed for the whole file before the first record is normalized and never reassigned from a record. A record that names its **own** session still wins; identity is only what an unnamed record falls back to.
- Resolvers are header-truthful: for Codex the filename wins, and a `session_meta` may name the thread only when the filename carries none *and* no identity is established.
- `Preflight::Skip` returns the caller's hints instead of blanking session/model/cwd mid-file.
- `RecordContext.session_hint` is deleted, so a normalizer can no longer branch on whether identity was already established — a compile-time property rather than a convention.
- Sub-agent threads keep their own identity **and** their lineage: the parent is recorded as a `subagent_parent` link row rather than merged into the parent's transcript (see the `kimi_cli_subagent` golden).

## Operational Impact

- **No schema change, no migration.** Behavior change is at normalization time only.
- **Newly ingested** sub-agent rollouts land on their own thread with a parent link. Previously ingested rows are untouched — this PR does not rewrite history.
- **Repairing already-ingested corpora is deliberately out of scope.** A first attempt issued hundreds of synchronous `ALTER … DELETE … mutations_sync = 1` statements with a resume cursor derived from state it destroyed first, and search-table deletes that bypassed its own prove-before-delete gate. On a host that filled its disk two days ago that is not acceptable, so it needs its own design and its own review.
- Until a repair lands, hosts with affected history keep failing the 036 overlap audit and stay on the v1 `open` reader — which is the safe outcome.

## Validation

- `cargo test --workspace --locked` — **1,286 passed, 0 failed**
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- New regression test drives the **real** `process_file` over a rollout carrying the real sub-agent header shape (own header, replayed parent header at line 2, third parent header later), once whole and once as head-pass + append-pass, asserting: the two line→session maps are identical, every line is the own thread, the parent id never appears, and exactly one `subagent_parent` link exists in both.
- The mechanism was established empirically by driving the real normalization path over a real rollout from `~/.codex/sessions/`, not by reading alone — an earlier reading of the same code concluded the opposite, because it only considered the first `session_meta`.

## References

Found while deploying #598 to a live host. Unblocks the `open_v2` cutover once affected corpora are repaired.
