### PR TITLE
fix(ingest): policy fingerprints carry the normalization-rules version

### DIFF
--- a/crates/moraine-ingest-core/src/dispatch.rs
+++ b/crates/moraine-ingest-core/src/dispatch.rs
@@ -44,6 +44,24 @@ const ERROR_KIND_SOURCE_LINE_TOO_LARGE: &str = "jsonl_source_line_too_large";
 const ERROR_KIND_NORMALIZED_ROW_TOO_LARGE: &str = "jsonl_normalized_row_too_large";
 const JSONL_PUBLICATION_PROTOCOL_VERSION: &str = "jsonl-publication-v1";
 
+/// Version of the source-adapter normalization rules, i.e. what a given source
+/// line is turned into — session attribution, row shape, derived links.
+///
+/// **Bump this whenever an adapter changes what rows or what attribution a
+/// source line produces.** It feeds the policy fingerprints, so a bump is a
+/// whole-source replacement replay: every source is re-read under a fresh
+/// generation and the atomic publication switches to it, leaving the old
+/// interpretation superseded rather than live alongside the new one. Without
+/// the bump, a corpus keeps rows that the current code would never write, and
+/// the two interpretations disagree forever — precisely the state that
+/// followed the sub-agent attribution fix.
+///
+/// v2: session attribution became deterministic and thread-truthful. A Codex
+/// sub-agent rollout embeds the parent thread's `session_meta`, which used to
+/// re-attribute the rest of the file to the parent, and attribution differed
+/// between a full read and a resumed read.
+pub(crate) const SOURCE_NORMALIZATION_RULES_VERSION: &str = "normalization-v2";
+
 /// Fingerprint the policy inputs that can change which logical rows a file
 /// produces. A changed value is a whole-source replacement, even when the
 /// inode and byte offset are unchanged: rows hidden by an old exclusion or
@@ -54,6 +72,7 @@ fn jsonl_policy_fingerprint(config: &AppConfig, work: &WorkItem) -> String {
     exclusions.sort();
     let payload = serde_json::to_vec(&json!({
         "protocol": JSONL_PUBLICATION_PROTOCOL_VERSION,
+        "normalization_rules": SOURCE_NORMALIZATION_RULES_VERSION,
         "source_format": work.format.to_string(),
         "harness": work.harness,
         "project_exclusions": exclusions,
@@ -2083,16 +2102,19 @@ fn truncate(input: &str, max_chars: usize) -> String {
 mod tests {
     use super::{
         complete_work, compose_hermes_model, enqueue_work, enrich_claude_model_latency,
-        jsonl_source_line_byte_limit, process_file, process_session_json_file, run_work_item,
-        source_inode_for_file, work_item_is_ingestable, work_path_is_canonical, SessionCursor,
-        CLICKHOUSE_JSON_OBJECT_BYTE_LIMIT, ERROR_KIND_NORMALIZED_ROW_TOO_LARGE,
-        ERROR_KIND_SOURCE_LINE_TOO_LARGE, SESSION_JSON_GENERATION, SESSION_JSON_INODE,
+        jsonl_policy_fingerprint, jsonl_source_line_byte_limit, process_file,
+        process_session_json_file, run_work_item, source_inode_for_file, work_item_is_ingestable,
+        work_path_is_canonical, SessionCursor, CLICKHOUSE_JSON_OBJECT_BYTE_LIMIT,
+        ERROR_KIND_NORMALIZED_ROW_TOO_LARGE, ERROR_KIND_SOURCE_LINE_TOO_LARGE,
+        JSONL_PUBLICATION_PROTOCOL_VERSION, SESSION_JSON_GENERATION, SESSION_JSON_INODE,
+        SOURCE_NORMALIZATION_RULES_VERSION,
     };
     use crate::model::{Checkpoint, CheckpointLifecycle};
     use crate::sqlite_poll::VolatilePollMap;
     use crate::{DispatchState, Metrics, SinkMessage, WorkItem};
     use moraine_config::SourceFormat;
     use serde_json::{json, Value};
+    use sha2::{Digest, Sha256};
     use std::collections::HashMap;
     use std::fs;
     use std::future::Future;
@@ -2725,6 +2747,64 @@ mod tests {
         assert_eq!(retried_batch.error_rows.len(), 1);
 
         let _ = fs::remove_file(&path);
+    }
+
+    /// The policy fingerprint must carry the normalization-rules version.
+    ///
+    /// A fingerprint change is what turns an adapter rule change into a
+    /// whole-source replacement replay; without this input, altering what a
+    /// source line normalizes to leaves the old rows live alongside the new
+    /// interpretation forever. Dropping the field from the payload is the
+    /// regression this pins.
+    #[test]
+    fn policy_fingerprints_carry_the_normalization_rules_version() {
+        let config = moraine_config::AppConfig::default();
+        let work = WorkItem {
+            source_name: "codex".to_string(),
+            harness: "codex".to_string(),
+            format: SourceFormat::Jsonl,
+            source_glob: String::new(),
+            path: "/tmp/rollout.jsonl".to_string(),
+        };
+
+        let mut exclusions = config.ingest.exclude_project_dirs.clone();
+        exclusions.sort();
+        let with_rules = serde_json::to_vec(&json!({
+            "protocol": JSONL_PUBLICATION_PROTOCOL_VERSION,
+            "normalization_rules": SOURCE_NORMALIZATION_RULES_VERSION,
+            "source_format": work.format.to_string(),
+            "harness": work.harness,
+            "project_exclusions": exclusions.clone(),
+        }))
+        .expect("policy payload serializes");
+        let expected: String = Sha256::digest(with_rules)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect();
+        assert_eq!(
+            jsonl_policy_fingerprint(&config, &work),
+            expected,
+            "the JSONL fingerprint must hash the normalization-rules version"
+        );
+
+        // A different rules version must be a different fingerprint, or a
+        // future bump would not trigger the replacement replay it exists for.
+        let without_rules = serde_json::to_vec(&json!({
+            "protocol": JSONL_PUBLICATION_PROTOCOL_VERSION,
+            "source_format": work.format.to_string(),
+            "harness": work.harness,
+            "project_exclusions": exclusions,
+        }))
+        .expect("policy payload serializes");
+        let legacy: String = Sha256::digest(without_rules)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect();
+        assert_ne!(
+            jsonl_policy_fingerprint(&config, &work),
+            legacy,
+            "a corpus normalized under the previous rules must not fingerprint equal"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/moraine-ingest-core/src/sqlite_poll.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll.rs
@@ -304,7 +304,11 @@ fn project_exclusions_hash(config: &AppConfig) -> u64 {
 }
 
 fn sqlite_policy_fingerprint(format: &str, exclusions_hash: u64) -> String {
-    format!("sqlite-publication-v1:{format}:{exclusions_hash:016x}")
+    // Carries the normalization-rules version for the same reason the JSONL
+    // fingerprint does: an adapter change that alters attribution or row shape
+    // must replace the source rather than leave both interpretations live.
+    let rules = crate::dispatch::SOURCE_NORMALIZATION_RULES_VERSION;
+    format!("sqlite-publication-v1:{rules}:{format}:{exclusions_hash:016x}")
 }
 
 fn sqlite_data_version(connection: &Connection) -> Result<i64> {


### PR DESCRIPTION
## Description

**What.** Adds `SOURCE_NORMALIZATION_RULES_VERSION` to the JSONL and SQLite policy fingerprints, so an adapter change that alters what a source line normalizes into triggers the whole-source replacement replay the fingerprint mechanism already exists to perform.

**Why.** `jsonl_policy_fingerprint`'s own doc states the contract:

> A changed value is a whole-source replacement, even when the inode and byte offset are unchanged: rows hidden by an old exclusion or **normalized with old adapter rules must not remain live alongside the new interpretation**.

But its inputs were only the protocol version, source format, harness, and project exclusions — nothing describing what a source line normalizes *into*. So the sub-agent attribution fix (#608) changed attribution semantics without changing any fingerprint, and every already-ingested corpus kept rows the current code would never write, live alongside the new interpretation. That is exactly the state the doc says must not happen, and it is why the reference host still fails migration 036's overlap audit after #608 landed.

## Why this is the right repair

The alternative considered was a bespoke repair command. A first attempt at one was reviewed and rejected: it issued hundreds of synchronous `ALTER … DELETE … mutations_sync = 1` statements, derived its resume cursor from state it destroyed first (so an interrupted run silently skipped a half-repaired file), and its search-table deletes bypassed its own prove-before-delete gate.

Bumping the fingerprint instead reuses machinery that already exists and is tested: each source is re-read under a fresh generation, #602's atomic publication switches to it, and the old interpretation becomes superseded rather than deleted. Readers already join published heads, so superseded rows are invisible the moment the switch lands. Physical reclamation is then #603's existing job rather than a new destructive path.

## Changelog

- `SOURCE_NORMALIZATION_RULES_VERSION` (`normalization-v2`) feeds both `jsonl_policy_fingerprint` and `sqlite_policy_fingerprint`, documented as the thing to bump whenever an adapter changes what rows or what attribution a source line produces.
- Regression test pins both halves: the fingerprint must hash the rules version, and a corpus normalized under the previous rules must not fingerprint equal.

## Operational Impact

**This makes the next ingest of an upgraded install replay every JSONL and SQLite source once.** Sources replay independently and resumably, but the corpus transiently holds both generations until superseded rows are reclaimed (#603). On the reference host that is roughly 4.35 GiB of events against 35 GiB free. Operators upgrading a large install should have the reclamation story in hand first.

Once the replay completes, affected corpora carry a single consistent interpretation, migration 036's overlap audit passes, and the #598 `open_v2` cutover unblocks on its own.

## Validation

- `cargo test --workspace --locked` — 1,287 passed, 0 failed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## References

Follow-up to #608. Unblocks the #598 `open_v2` cutover on hosts with pre-fix history.