### PR TITLE
feat(599): directory-backed session discovery (WI-01, WI-02)

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo/canonical_list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/canonical_list.rs
@@ -1,0 +1,762 @@
+//! Batched, content-free session DISCOVERY over the migration-036 indexes
+//! (issue-599 WI-01).
+//!
+//! [`canonical_open`](super::canonical_open) is session-scoped: every builder
+//! there pins `WHERE n.session_id = '<one literal>'`. Session listing needs the
+//! K-session forms of the same statements, so this module supplies them:
+//!
+//! * **Phase A** — [`ClickHouseConversationRepository::build_session_directory_page_sql`]:
+//!   one content-free `GROUP BY session_id` over `mcp_session_directory`,
+//!   tuple-`IN`-joined to the #602 published source generations, producing the
+//!   candidate keyset page. No wide column, no `events` scan, no session-origin
+//!   subquery. **Exactly one such statement runs per page request** — see
+//!   [`candidate_fetch_size`].
+//! * **Phase B** — the three batched hydration builders
+//!   ([`build_session_totals_batch_sql`](ClickHouseConversationRepository::build_session_totals_batch_sql),
+//!   [`build_session_metadata_batch_sql`](ClickHouseConversationRepository::build_session_metadata_batch_sql),
+//!   [`build_session_terminal_batch_sql`](ClickHouseConversationRepository::build_session_terminal_batch_sql)),
+//!   each PK-pruned to the bounded hydration chunk. Only the metadata statement
+//!   decompresses `payload_json`, and only for `is_metadata_bearing = 1` rows.
+//!   **No statement here reads `text_content`.**
+//!
+//! Every builder is a pure method so the SQL-shape tests can assert the query
+//! contract without a backend. Orchestration (Phase C: exact re-filter, title
+//! fold, trim, cursor mint) lives in [`list`](super::list).
+
+use super::canonical_open::{metadata_precedence, MetaRow, MetadataPrecedence};
+use super::*;
+use moraine_clickhouse::canonical_derivations::{self as cd, DerivationColumns};
+
+/// The migration-036 indexes carry the physical `events` column names.
+const COLS: DerivationColumns = DerivationColumns::EVENTS;
+
+/// How many candidate chunks one page request may HYDRATE before it returns
+/// what survived with a continuation cursor.
+///
+/// Only hydration is chunked. Phase A is *not* re-run per chunk: its keyset
+/// predicate lives in `HAVING` (post-aggregation) and `mcp_session_directory`
+/// leads its sort key with `session_id` (`sql/036:49`), so advancing the keyset
+/// prunes nothing at the storage layer and every extra pass would re-aggregate
+/// the ENTIRE directory — the corpus-scaling cost issue #599 exists to remove.
+/// The single pass instead over-fetches the whole budget up front
+/// ([`candidate_fetch_size`]), so the worst case per page is
+/// `1 directory + MAX_HYDRATION_CHUNKS × 3 hydration = 13` statements against
+/// the Interactive `statement_cap = 256` — and against the naive per-session
+/// alternative of `3 × 25 = 75` sequential round trips inside a 3 s deadline.
+/// Tunable against the issue-599 §5.3 `filtered` boundedness phase, not a
+/// design invariant.
+pub(super) const MAX_HYDRATION_CHUNKS: usize = 4;
+
+/// Ceiling on one hydration chunk, bounding a single batched statement's cost.
+const MAX_HYDRATION_CHUNK_ROWS: u32 = 256;
+
+/// Ceiling on the single Phase-A over-fetch, bounding the candidate page's
+/// deserialization cost independently of `limit`.
+const MAX_CANDIDATE_FETCH_ROWS: u32 = 1024;
+
+/// Sessions hydrated per batched round trip:
+/// `clamp(2 × (limit + 1), limit + 1, 256)`. Over-fetching absorbs the recall
+/// filters' false positives without a second round trip; the floor keeps a
+/// `limit + 1` "is there more" probe possible in one chunk.
+pub(super) fn hydration_chunk_size(limit: u16) -> u32 {
+    let floor = u32::from(limit).saturating_add(1);
+    floor
+        .saturating_mul(2)
+        .min(MAX_HYDRATION_CHUNK_ROWS)
+        .max(floor)
+}
+
+/// Candidates the SINGLE Phase-A pass fetches: the page's whole hydration
+/// budget, capped.
+///
+/// Fetching the full budget in one statement is what keeps Phase A to one
+/// pass (see [`MAX_HYDRATION_CHUNKS`]). The result never exceeds
+/// `MAX_HYDRATION_CHUNKS × hydration_chunk_size`, so slicing the candidate
+/// vector into hydration chunks is bounded by construction and needs no
+/// separate counter.
+pub(super) fn candidate_fetch_size(limit: u16) -> u32 {
+    let chunk = hydration_chunk_size(limit);
+    chunk
+        .saturating_mul(MAX_HYDRATION_CHUNKS as u32)
+        .min(MAX_CANDIDATE_FETCH_ROWS)
+        .max(chunk)
+}
+
+/// The `mcp_session_directory.mode_hint` LOWER BOUND a mode filter may push,
+/// or `None` when no predicate is safe (issue-599 §2.3).
+///
+/// `mode_hint` is `max(cd::mode_rank_expr)` — `3 = web_search`,
+/// `2 = mcp_internal`, `1 = tool_calling`, `0 = chat`. The internal-tool-name
+/// allowlist is FROZEN in the migration-036 MV body (`sql/036:156`), so a
+/// session using an MCP tool added after that migration stores a hint BELOW its
+/// live rank. Pushing `mode_hint = 2` would silently drop it; pushing nothing
+/// keeps it a candidate and the exact `cd::mode_aggregate_expr` re-filter in
+/// Phase C decides. `chat` (rank 0) has a vacuous bound.
+fn mode_hint_lower_bound(mode: ConversationMode) -> Option<u8> {
+    match mode {
+        ConversationMode::WebSearch => Some(3),
+        ConversationMode::ToolCalling => Some(1),
+        ConversationMode::McpInternal | ConversationMode::Chat => None,
+    }
+}
+
+/// One Phase-A candidate-page request. `after` is the keyset anchor
+/// `(cand_last_ms, session_id)` the page resumes strictly after — always the
+/// directory value, never a hydrated one (see
+/// [`DirectoryCandidateRow::cand_last_ms`]).
+pub(super) struct DirectoryPageParams<'a> {
+    pub(super) start_unix_ms: i64,
+    pub(super) end_unix_ms: i64,
+    pub(super) mode: Option<ConversationMode>,
+    pub(super) harness: Option<&'a str>,
+    pub(super) source_name: Option<&'a str>,
+    pub(super) sort: ConversationListSort,
+    pub(super) after: Option<(i64, &'a str)>,
+    pub(super) limit: u32,
+}
+
+impl ClickHouseConversationRepository {
+    /// Phase A (issue-599 §1.3): the content-free candidate page.
+    ///
+    /// Load-bearing properties, each of which a shape test pins:
+    ///
+    /// * **No `FINAL`.** `mcp_session_directory` is an `AggregatingMergeTree`;
+    ///   its `SimpleAggregateFunction` columns re-aggregate with their own
+    ///   functions and `origin_cwd_state` merges with `argMinIfMerge`. Same
+    ///   pattern as [`Self::build_session_signal_sql`].
+    /// * **Published generations as a tuple-`IN`, never `ALL INNER JOIN`** — a
+    ///   join defeats KeyCondition pruning. Unlike the session-scoped signal
+    ///   read, this statement MUST apply the filter: an unpublished
+    ///   (replay-in-progress) generation would otherwise inflate `cand_last_ms`
+    ///   and leak an incomplete generation into the page, violating #602's
+    ///   "previous complete generation until the atomic switch". It is also the
+    ///   canonical replacement for the retired `tombstone` column: a session
+    ///   whose only source generation is unpublished has zero live rows and
+    ///   drops out of the `GROUP BY` entirely (issue-599 §2.7).
+    /// * **`notEmpty(trimBoth(session_id))`.** The 036 MVs guard only
+    ///   `notEmpty` (`sql/036:162,181,218`), so whitespace-only ids reach the
+    ///   directory. Without the trim they would consume LIMIT slots and anchor
+    ///   cursors while mcp-core drops them, breaking the contiguous-`rank`
+    ///   invariant.
+    /// * **`argMinIfMerge(origin_cwd_state)` is exact**, not a heuristic:
+    ///   `argMinIfState(cwd, tuple(event_ts, event_uid), cwd != '')` merged
+    ///   across a session's directory rows IS
+    ///   `argMin(cwd, (event_ts, event_uid)) WHERE cwd != ''` — the identical
+    ///   rule as [`Self::session_origin_scope_subquery`]. Project scope is
+    ///   therefore applied here and NOT re-applied after hydration, which
+    ///   deletes a corpus-sized `events FINAL` scan from every scoped page.
+    /// * `harness` / `source` / `mode_hint` are RECALL filters only; the exact
+    ///   values are re-checked in Phase C against the hydrated aggregates.
+    /// * **`cand_last_ms` is the operation's single keyset time source.** It is
+    ///   the only time value this statement can filter on, so it is also what
+    ///   Phase C orders survivors by and mints the cursor from
+    ///   ([`DirectoryCandidateRow::cand_last_ms`]).
+    pub(super) fn build_session_directory_page_sql(&self, params: &DirectoryPageParams) -> String {
+        let directory = self.table_ref("mcp_session_directory");
+        let published = self.published_generations_subquery();
+
+        let mut having = vec![
+            format!("cand_last_ms >= {}", params.start_unix_ms),
+            format!("cand_first_ms < {}", params.end_unix_ms),
+        ];
+        if let Some((last_ms, session_id)) = params.after {
+            let (time_cmp, session_cmp) = match params.sort {
+                ConversationListSort::Desc => ("<", "<"),
+                ConversationListSort::Asc => (">", ">"),
+            };
+            having.push(format!(
+                "(cand_last_ms {time_cmp} {last_ms} OR (cand_last_ms = {last_ms} AND session_id {session_cmp} {}))",
+                sql_quote(session_id)
+            ));
+        }
+        if let Some(rank) = params.mode.and_then(mode_hint_lower_bound) {
+            having.push(format!("mode_hint >= {rank}"));
+        }
+        if let Some(harness) = params.harness {
+            having.push(format!("has(harnesses, {})", sql_quote(harness)));
+        }
+        if let Some(source_name) = params.source_name {
+            having.push(format!("has(sources, {})", sql_quote(source_name)));
+        }
+        if let Some(scope) = self.cfg.session_scope.as_ref() {
+            let roots = scope
+                .roots
+                .iter()
+                .map(|root| {
+                    format!(
+                        "origin_cwd = {root} OR startsWith(origin_cwd, {prefix})",
+                        root = sql_quote(root),
+                        prefix = sql_quote(&format!("{root}/")),
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(" OR ");
+            having.push(format!("({roots})"));
+        }
+
+        let order_dir = match params.sort {
+            ConversationListSort::Desc => "DESC",
+            ConversationListSort::Asc => "ASC",
+        };
+        format!(
+            "SELECT\n  d.session_id AS session_id,\n  toInt64(toUnixTimestamp64Milli(max(d.max_observed_event_time))) AS cand_last_ms,\n  toInt64(toUnixTimestamp64Milli(min(d.min_observed_event_time))) AS cand_first_ms,\n  toUInt8(max(d.mode_hint)) AS mode_hint,\n  argMinIfMerge(d.origin_cwd_state) AS origin_cwd,\n  groupUniqArray(d.harness) AS harnesses,\n  groupUniqArray(d.source_name) AS sources\nFROM {directory} AS d\nWHERE notEmpty(trimBoth(d.session_id))\n  AND (d.source_host, d.source_name, d.source_file, d.source_generation) IN {published}\nGROUP BY d.session_id\nHAVING {having}\nORDER BY cand_last_ms {order_dir}, session_id {order_dir}\nLIMIT {limit}\nFORMAT JSONEachRow",
+            having = having.join("\n   AND "),
+            limit = params.limit,
+        )
+    }
+
+    /// Phase B1 (issue-599 §1.4): the K-session form of
+    /// [`Self::build_session_totals_sql`]. Content-free; `ALL INNER JOIN
+    /// published` is correct here because the statement consumes whole
+    /// session-pruned ranges anyway (see [`Self::navigation_live_from`]).
+    ///
+    /// The projection list is the single-session builder's minus the three
+    /// OPEN-only columns that need the display tuple (`first_event_uid`,
+    /// `last_event_uid`, `last_actor_role`), plus `session_id` for the Rust
+    /// bucketing. `user_messages` / `assistant_messages` / `tool_results` stay
+    /// even though no `McpSessionListItem` field reads them: they are `countIf`s
+    /// folded into the same aggregate pass, and they are what
+    /// `totals_batch_reproduces_the_single_session_aggregates` compares to prove
+    /// the transcription stayed mechanical.
+    ///
+    /// `counter_user_messages` is the one non-mechanical column. The
+    /// single-session builder uses a correlated scalar subquery; emitting K of
+    /// those would be a per-session loop in disguise, so this uses one windowed
+    /// pass: `running_u` (the prefix user-message count in navigation-tuple
+    /// order) sampled at the LAST `turn_index = 0` row is exactly the same
+    /// value (design VERIFIER ADDENDUM item 1). With no counter row,
+    /// `argMaxIf` yields its `UInt64` default `0` — the same answer the
+    /// single-session `countIf(… <= <default tuple>)` produces.
+    pub(super) fn build_session_totals_batch_sql(&self, session_ids: &[String]) -> String {
+        let from = self.navigation_live_from();
+        let ids = sql_array_strings(session_ids);
+        let sort_tuple = Self::navigation_sort_tuple("n");
+        let umsg = cd::user_message_count_predicate(COLS);
+        let assistant_msg = "nav.actor_kind = 'assistant' AND nav.event_kind = 'message'";
+        let mode = cd::mode_aggregate_expr(COLS);
+        let event_ts_tuple = "tuple(nav.event_ts, nav.event_uid)";
+        // The inner scan republishes the physical navigation columns the outer
+        // aggregates read, so `cd::*` fragments (which name the raw `events`
+        // columns) resolve against the single derived relation unqualified.
+        let inner = format!(
+            "SELECT\n    n.session_id AS session_id,\n    n.turn_index AS turn_index,\n    n.is_user_message AS is_user_message,\n    n.actor_kind AS actor_kind,\n    n.event_kind AS event_kind,\n    n.payload_type AS payload_type,\n    n.tool_name AS tool_name,\n    n.source_name AS source_name,\n    n.source_file AS source_file,\n    n.harness AS harness,\n    n.inference_provider AS inference_provider,\n    n.display_time AS display_time,\n    n.event_ts AS event_ts,\n    n.event_uid AS event_uid,\n    {sort_tuple} AS sort_key,\n    sum(if(n.is_user_message = 1, 1, 0)) OVER counter_window AS running_u\n  {from}\n  WHERE n.session_id IN {ids}\n  WINDOW counter_window AS (PARTITION BY n.session_id ORDER BY {sort_tuple} ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"
+        );
+        format!(
+            "SELECT\n  nav.session_id AS session_id,\n  toUInt64(count()) AS total_events,\n  toUInt64(countIf({umsg})) AS user_messages,\n  toUInt64(countIf({assistant_msg})) AS assistant_messages,\n  toUInt64(countIf(nav.event_kind = 'tool_call')) AS tool_calls,\n  toUInt64(countIf(nav.event_kind = 'tool_result')) AS tool_results,\n  toUInt32(max(nav.turn_index)) AS max_override,\n  toUInt64(argMaxIf(nav.running_u, nav.sort_key, nav.turn_index = 0)) AS counter_user_messages,\n  toString(min(nav.display_time)) AS first_event_time,\n  toInt64(toUnixTimestamp64Milli(min(nav.display_time))) AS first_event_unix_ms,\n  toString(max(nav.display_time)) AS last_event_time,\n  toInt64(toUnixTimestamp64Milli(max(nav.display_time))) AS last_event_unix_ms,\n  ifNull(argMax(nullIf(nav.source_name, ''), {event_ts_tuple}), '') AS source,\n  ifNull(argMax(nullIf(nav.harness, ''), {event_ts_tuple}), '') AS harness,\n  ifNull(argMax(nullIf(nav.inference_provider, ''), {event_ts_tuple}), '') AS inference_provider,\n  ifNull(argMinIf(nullIf(trimBoth(replaceRegexpOne(arrayElement(splitByChar('/', replaceAll(nav.source_file, '\\\\', '/')), -1), '[.]jsonl$', '')), ''), {event_ts_tuple}, nav.source_name = 'omp' AND notEmpty(nav.session_id) AND endsWith(nav.source_file, '.jsonl') AND NOT endsWith(nav.source_file, concat(nav.session_id, '.jsonl'))), '') AS omp_dispatch_title,\n  {mode} AS mode\nFROM (\n  {inner}\n) AS nav\nGROUP BY nav.session_id\nFORMAT JSONEachRow"
+        )
+    }
+
+    /// Phase B2 (issue-599 §1.4): the K-session form of
+    /// [`Self::build_session_metadata_sql`] — the ONLY list statement that
+    /// decompresses `payload_json`, and only for `is_metadata_bearing = 1`
+    /// rows (typically 0-3 per session).
+    ///
+    /// `moraine.events` is `ORDER BY (session_id, event_ts, …)`
+    /// (`sql/001_schema.sql:125`), so the K-element `IN` on the leading key
+    /// column prunes the `FINAL` scan to K key ranges — but only because
+    /// [`Self::live_events_source_sessions`] emits it INSIDE the derived table.
+    /// The same predicate in this statement's outer `WHERE` sits above the
+    /// publication join and prunes nothing (issue-598 C2-R0 "no optimizer
+    /// trust"), which is a whole-corpus `events FINAL` scan on the discovery
+    /// path. No time bound is applied: the directory's bounds are on
+    /// `display_time` while the events primary key is on `event_ts` — different
+    /// expressions that must not be conflated.
+    pub(super) fn build_session_metadata_batch_sql(&self, session_ids: &[String]) -> String {
+        let events = self.live_events_source_sessions(session_ids);
+        let nav = self.table_ref("mcp_event_navigation");
+        let published = self.published_generations_subquery();
+        let ids = sql_array_strings(session_ids);
+        format!(
+            "SELECT\n  e.session_id AS session_id,\n  toString(e.event_ts) AS event_ts,\n  e.event_uid AS event_uid,\n  e.event_kind AS event_kind,\n  e.payload_json AS payload_json\nFROM {events} AS e\nWHERE e.event_uid IN (\n  SELECT n.event_uid\n  FROM {nav} AS n FINAL\n  ALL INNER JOIN {published} AS published\n    ON published.source_host = n.source_host AND published.source_name = n.source_name AND published.source_file = n.source_file AND published.source_generation = n.source_generation\n  WHERE n.session_id IN {ids} AND n.is_metadata_bearing = 1\n)\nFORMAT JSONEachRow"
+        )
+    }
+
+    /// Phase B3 (issue-599 §1.4): the K-session form of
+    /// [`Self::build_session_terminal_sql`]. Content-free.
+    ///
+    /// The two-level rule is preserved exactly: per-TURN `completed` is the
+    /// turn's latest terminal event being `task_complete`, then the SESSION
+    /// takes `argMax(completed, turn_seq)` — the LAST turn's flag. A
+    /// session-wide latest-terminal `argMax` diverges when the terminal event
+    /// sits in a middle turn (the WI-10 terminal-mid parity fixture). The only
+    /// batch change is `PARTITION BY n.session_id` on the turn window plus the
+    /// two `session_id` group keys.
+    pub(super) fn build_session_terminal_batch_sql(&self, session_ids: &[String]) -> String {
+        let from = self.navigation_live_from();
+        let tuple = Self::navigation_sort_tuple("n");
+        let ids = sql_array_strings(session_ids);
+        format!(
+            "SELECT\n  session_id,\n  toUInt8(argMax(turn_completed, turn_seq)) AS completed\nFROM (\n  SELECT\n    session_id,\n    turn_seq,\n    argMaxIf(toUInt8(payload_type = 'task_complete'), sort_key, payload_type IN ('task_complete', 'turn_aborted')) AS turn_completed\n  FROM (\n    SELECT\n      n.session_id AS session_id,\n      n.payload_type AS payload_type,\n      {tuple} AS sort_key,\n      if(toUInt32(n.turn_index) > 0, toUInt32(n.turn_index), greatest(toUInt32(1), toUInt32(sum(if(n.is_user_message = 1, 1, 0)) OVER turn_window))) AS turn_seq\n    {from}\n    WHERE n.session_id IN {ids}\n    WINDOW turn_window AS (PARTITION BY n.session_id ORDER BY {tuple} ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\n  )\n  GROUP BY session_id, turn_seq\n)\nGROUP BY session_id\nFORMAT JSONEachRow"
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deserialization rows.
+// ---------------------------------------------------------------------------
+
+/// One Phase-A candidate. The recall columns (`mode_hint`, `origin_cwd`,
+/// `harnesses`, `sources`) are consumed by the statement's own `HAVING` and
+/// deliberately not deserialized.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct DirectoryCandidateRow {
+    pub(super) session_id: String,
+    /// **The operation's one keyset time source.** Phase A orders by it, its
+    /// `HAVING` keyset resumes strictly after it, Phase C sorts survivors by
+    /// it, and the continuation cursor is minted from it. Candidate filtering,
+    /// result ordering and cursor minting must all read this same value or a
+    /// page can skip sessions.
+    ///
+    /// It is authoritative because it is the ONLY time value Phase A can filter
+    /// on: `mcp_session_directory` is the only relation the candidate pass
+    /// reads, and `max(max_observed_event_time)` is its only upper time bound.
+    ///
+    /// The hydrated `SessionTotalsBatchRow::last_event_unix_ms` is a DIFFERENT
+    /// number. The directory is an `AggregatingMergeTree` whose
+    /// `SimpleAggregateFunction(max)` accumulates every physically inserted
+    /// event version and can never retract a superseded one, while
+    /// `mcp_event_navigation` is `ReplacingMergeTree(event_version)` read with
+    /// `FINAL`, so hydration sees only the winning version. Hence
+    /// `cand_last_ms >= last_event_unix_ms`, with equality in the common
+    /// never-re-ingested case. Minting the cursor from the hydrated value and
+    /// then comparing it against `cand_last_ms` on the next page silently skips
+    /// every session whose directory aggregate falls between the two.
+    ///
+    /// The hydrated value is what the item REPORTS as `last_event_unix_ms`
+    /// (response fidelity — it is the same exact aggregate the projected-header
+    /// path served) and is never an ordering or cursor input.
+    pub(super) cand_last_ms: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct SessionTotalsBatchRow {
+    pub(super) session_id: String,
+    pub(super) total_events: u64,
+    pub(super) tool_calls: u64,
+    pub(super) max_override: u32,
+    pub(super) counter_user_messages: u64,
+    pub(super) first_event_time: String,
+    pub(super) first_event_unix_ms: i64,
+    pub(super) last_event_time: String,
+    pub(super) last_event_unix_ms: i64,
+    pub(super) source: String,
+    pub(super) harness: String,
+    pub(super) inference_provider: String,
+    pub(super) omp_dispatch_title: String,
+    pub(super) mode: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct SessionMetaBatchRow {
+    pub(super) session_id: String,
+    pub(super) event_ts: String,
+    pub(super) event_uid: String,
+    pub(super) event_kind: String,
+    pub(super) payload_json: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct SessionTerminalBatchRow {
+    pub(super) session_id: String,
+    pub(super) completed: u8,
+}
+
+/// One candidate session's hydrated exact state (Phase B output, Phase C
+/// input).
+pub(super) struct HydratedSession {
+    pub(super) totals: SessionTotalsBatchRow,
+    pub(super) metadata: Vec<MetaRow>,
+    pub(super) completed: bool,
+}
+
+impl HydratedSession {
+    /// The metadata-precedence inputs for this session: the bounded
+    /// metadata-bearing fold, seeded with the omp dispatch-title fallback the
+    /// fold cannot see (v1 derives it over ALL canonical rows, so the totals
+    /// pass supplies it).
+    pub(super) fn precedence(&self) -> MetadataPrecedence {
+        let mut precedence = metadata_precedence(&self.metadata);
+        precedence
+            .omp_dispatch_title
+            .clone_from(&self.totals.omp_dispatch_title);
+        precedence
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repo() -> ClickHouseConversationRepository {
+        let client = ClickHouseClient::new(moraine_config::ClickHouseConfig::default())
+            .expect("build ClickHouse client");
+        ClickHouseConversationRepository::new(client, RepoConfig::default())
+    }
+
+    fn scoped_repo(roots: &[&str]) -> ClickHouseConversationRepository {
+        let client = ClickHouseClient::new(moraine_config::ClickHouseConfig::default())
+            .expect("build ClickHouse client");
+        ClickHouseConversationRepository::new(
+            client,
+            RepoConfig {
+                session_scope: SessionOriginScope::from_roots(roots.iter().copied()),
+                ..RepoConfig::default()
+            },
+        )
+    }
+
+    async fn build<F: FnOnce(&ClickHouseConversationRepository) -> String>(
+        repo: ClickHouseConversationRepository,
+        f: F,
+    ) -> String {
+        with_test_publication_snapshot(TestPublicationSnapshot::idle_local(11, 1), async move {
+            f(&repo)
+        })
+        .await
+    }
+
+    fn params<'a>(mode: Option<ConversationMode>) -> DirectoryPageParams<'a> {
+        DirectoryPageParams {
+            start_unix_ms: 1_767_261_600_000,
+            end_unix_ms: 1_767_500_000_000,
+            mode,
+            harness: None,
+            source_name: None,
+            sort: ConversationListSort::Desc,
+            after: None,
+            limit: 52,
+        }
+    }
+
+    fn ids() -> Vec<String> {
+        vec!["sess-a".to_string(), "sess-b".to_string()]
+    }
+
+    /// No discovery statement may read transcript content, and none may open
+    /// the `events` relation unpruned.
+    ///
+    /// The name grep alone cannot see the second failure: the live-events
+    /// derived table projects `SELECT e.*`, which republishes every wide column
+    /// — including `text_content` — without ever naming one. The guard that
+    /// actually bounds it is the leading-primary-key filter INSIDE that derived
+    /// table, so assert on the filter, not on the column names.
+    fn assert_content_free(sql: &str) {
+        assert!(
+            !sql.contains("text_content"),
+            "discovery statement leaked text_content:\n{sql}"
+        );
+        assert_events_scan_is_key_pruned(sql);
+    }
+
+    /// Every `SELECT e.*` derived table must carry a `session_id` predicate in
+    /// its own body (issue-598 C2-R0): an outer `WHERE` sits above the
+    /// publication join and prunes nothing, so the statement would scan the
+    /// whole `events` table with `FINAL`.
+    fn assert_events_scan_is_key_pruned(sql: &str) {
+        let Some(start) = sql.find("(SELECT e.*") else {
+            return;
+        };
+        let body = &sql[start..];
+        let end = body
+            .find(") AS e")
+            .unwrap_or_else(|| panic!("unterminated live-events derived table in:\n{sql}"));
+        let body = &body[..end];
+        assert!(
+            body.contains("\nWHERE e.session_id"),
+            "the events FINAL scan is not key-pruned inside its derived table:\n{sql}"
+        );
+    }
+
+    /// No discovery statement may read or gate on the retired projection.
+    fn assert_no_projection(sql: &str) {
+        assert!(
+            !sql.contains("mcp_open_"),
+            "discovery statement touched mcp_open_*:\n{sql}"
+        );
+        assert!(
+            !sql.contains("v_session_summary") && !sql.contains("v_conversation_trace"),
+            "discovery statement touched a legacy view chain:\n{sql}"
+        );
+    }
+
+    // --- chunk sizing ------------------------------------------------------
+
+    #[test]
+    fn hydration_chunk_over_fetches_within_the_ceiling() {
+        assert_eq!(hydration_chunk_size(25), 52);
+        assert_eq!(hydration_chunk_size(1), 4);
+        // Ceiling holds …
+        assert_eq!(hydration_chunk_size(200), 256);
+        // … but never below `limit + 1`, so a K+1 probe is always possible.
+        assert_eq!(hydration_chunk_size(400), 401);
+    }
+
+    #[test]
+    fn one_phase_a_pass_fetches_the_whole_hydration_budget() {
+        // The invariant the single-pass design rests on: the over-fetch never
+        // exceeds what the chunk loop is allowed to hydrate, so a page can
+        // never need a second directory aggregation.
+        for limit in [1_u16, 2, 25, 50, 200, 400, u16::MAX] {
+            let chunk = hydration_chunk_size(limit);
+            let fetch = candidate_fetch_size(limit);
+            assert!(fetch >= chunk, "limit {limit} cannot fill one chunk");
+            assert!(
+                fetch <= chunk.saturating_mul(MAX_HYDRATION_CHUNKS as u32),
+                "limit {limit} over-fetches beyond the hydration budget"
+            );
+            assert!(fetch <= MAX_CANDIDATE_FETCH_ROWS.max(chunk));
+        }
+        assert_eq!(candidate_fetch_size(25), 208);
+        assert_eq!(candidate_fetch_size(1), 16);
+        // The absolute ceiling clamps before the budget multiple does.
+        assert_eq!(candidate_fetch_size(200), 1024);
+    }
+
+    // --- Phase A shape -----------------------------------------------------
+
+    #[tokio::test]
+    async fn directory_page_is_content_free_and_publication_pinned() {
+        let sql = build(repo(), |r| {
+            r.build_session_directory_page_sql(&params(None))
+        })
+        .await;
+        assert_content_free(&sql);
+        assert_no_projection(&sql);
+        assert!(
+            !sql.contains("payload_json"),
+            "directory read is scalar-only"
+        );
+        assert!(sql.contains("`moraine`.`mcp_session_directory` AS d"));
+        // AggregatingMergeTree re-aggregates through its own functions.
+        assert!(
+            !sql.contains("FINAL"),
+            "directory read must not use FINAL:\n{sql}"
+        );
+        // Published heads are a tuple-IN, never a join (KeyCondition pruning),
+        // and they are the canonical `tombstone` replacement.
+        assert!(
+            !sql.contains("ALL INNER JOIN"),
+            "directory read must not join the published heads:\n{sql}"
+        );
+        assert!(sql.contains(
+            "(d.source_host, d.source_name, d.source_file, d.source_generation) IN (SELECT"
+        ));
+        // Whitespace-only ids never consume a LIMIT slot or anchor a cursor.
+        assert!(sql.contains("WHERE notEmpty(trimBoth(d.session_id))"));
+        // The exact origin-cwd rule, merged from the directory state.
+        assert!(sql.contains("argMinIfMerge(d.origin_cwd_state) AS origin_cwd"));
+        // Overlap, not containment.
+        assert!(sql.contains("cand_last_ms >= 1767261600000"));
+        assert!(sql.contains("cand_first_ms < 1767500000000"));
+        assert!(sql.contains("ORDER BY cand_last_ms DESC, session_id DESC"));
+        assert!(sql.contains("LIMIT 52"));
+    }
+
+    #[tokio::test]
+    async fn directory_page_never_runs_the_corpus_wide_scope_subquery() {
+        let sql = build(scoped_repo(&["/work/project"]), |r| {
+            r.build_session_directory_page_sql(&params(None))
+        })
+        .await;
+        assert!(sql.contains("origin_cwd = '/work/project'"));
+        assert!(sql.contains("startsWith(origin_cwd, '/work/project/')"));
+        // The corpus-sized `argMin(cwd, …) GROUP BY session_id` over
+        // `events FINAL` is exactly what the directory state replaces.
+        assert!(
+            !sql.contains("argMin(cwd"),
+            "scoped page must not re-run the session-origin subquery:\n{sql}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mode_prefilter_is_a_lower_bound_and_absent_for_mcp_internal() {
+        for (mode, rank) in [
+            (ConversationMode::WebSearch, 3_u8),
+            (ConversationMode::ToolCalling, 1),
+        ] {
+            let sql = build(repo(), move |r| {
+                r.build_session_directory_page_sql(&params(Some(mode)))
+            })
+            .await;
+            assert!(
+                sql.contains(&format!("mode_hint >= {rank}")),
+                "expected a lower-bound prefilter for {mode:?}:\n{sql}"
+            );
+            assert!(
+                !sql.contains("mode_hint ="),
+                "mode_hint must never be precision-filtered (sql/036:156 freezes the allowlist):\n{sql}"
+            );
+        }
+        // rank 2 (frozen allowlist) and rank 0 (vacuous) push nothing.
+        for mode in [ConversationMode::McpInternal, ConversationMode::Chat] {
+            let sql = build(repo(), move |r| {
+                r.build_session_directory_page_sql(&params(Some(mode)))
+            })
+            .await;
+            assert!(
+                !sql.contains("mode_hint >="),
+                "{mode:?} must not push a mode_hint predicate:\n{sql}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn recall_filters_and_keyset_flip_with_sort() {
+        let sql = build(repo(), |r| {
+            r.build_session_directory_page_sql(&DirectoryPageParams {
+                harness: Some("codex"),
+                source_name: Some("codex-jsonl"),
+                sort: ConversationListSort::Asc,
+                after: Some((1_767_348_600_000, "sess_b")),
+                ..params(None)
+            })
+        })
+        .await;
+        assert!(sql.contains("has(harnesses, 'codex')"));
+        assert!(sql.contains("has(sources, 'codex-jsonl')"));
+        assert!(sql.contains(
+            "(cand_last_ms > 1767348600000 OR (cand_last_ms = 1767348600000 AND session_id > 'sess_b'))"
+        ));
+        assert!(sql.contains("ORDER BY cand_last_ms ASC, session_id ASC"));
+    }
+
+    // --- Phase B shape -----------------------------------------------------
+
+    #[tokio::test]
+    async fn totals_batch_groups_by_session_and_is_content_free() {
+        let sql = build(repo(), |r| r.build_session_totals_batch_sql(&ids())).await;
+        assert_content_free(&sql);
+        assert_no_projection(&sql);
+        assert!(!sql.contains("payload_json"));
+        assert!(sql.contains("`moraine`.`mcp_event_navigation` AS n FINAL"));
+        assert!(sql.contains("WHERE n.session_id IN ['sess-a','sess-b']"));
+        assert!(sql.contains("GROUP BY nav.session_id"));
+        assert!(sql.contains("AS inference_provider"));
+        assert!(sql.contains("AS tool_calls"));
+        // One windowed pass, never K correlated subqueries.
+        assert!(sql.contains(
+            "WINDOW counter_window AS (PARTITION BY n.session_id ORDER BY tuple(n.sort_time"
+        ));
+        assert!(sql.contains("argMaxIf(nav.running_u, nav.sort_key, nav.turn_index = 0)"));
+        assert!(
+            !sql.contains("SELECT maxIf("),
+            "the batch must not emit the single-session correlated subquery:\n{sql}"
+        );
+    }
+
+    #[tokio::test]
+    async fn totals_batch_reproduces_the_single_session_aggregates() {
+        // Mechanical-transcription guard: for every column both builders
+        // project, the aggregate expression must be identical once the table
+        // alias is normalized away.
+        let batch = build(repo(), |r| r.build_session_totals_batch_sql(&ids())).await;
+        let single = build(repo(), |r| r.build_session_totals_sql("sess-a")).await;
+        for alias in [
+            "total_events",
+            "user_messages",
+            "assistant_messages",
+            "tool_calls",
+            "tool_results",
+            "max_override",
+            "first_event_time",
+            "first_event_unix_ms",
+            "last_event_time",
+            "last_event_unix_ms",
+            "source",
+            "harness",
+            "inference_provider",
+            "omp_dispatch_title",
+        ] {
+            assert_eq!(
+                projection_for(&batch, alias),
+                projection_for(&single, alias),
+                "batched `{alias}` diverged from the single-session builder"
+            );
+        }
+        // `mode` spans lines; assert both embed the shared authority verbatim.
+        let mode = cd::mode_aggregate_expr(COLS);
+        assert!(batch.contains(&mode) && single.contains(&mode));
+        // `counter_user_messages` is the deliberate divergence (windowed pass
+        // vs correlated subquery), asserted separately above.
+    }
+
+    /// The single projection line ending in `AS {alias}`, alias-normalized.
+    fn projection_for(sql: &str, alias: &str) -> String {
+        let needle = format!(" AS {alias},");
+        let line = sql
+            .lines()
+            .find(|line| line.ends_with(&needle) || line.ends_with(&format!(" AS {alias}")))
+            .unwrap_or_else(|| panic!("no `AS {alias}` projection in:\n{sql}"));
+        line.trim().replace("nav.", "").replace("n.", "")
+    }
+
+    #[tokio::test]
+    async fn metadata_batch_reads_payload_only_for_metadata_bearing_rows() {
+        let sql = build(repo(), |r| r.build_session_metadata_batch_sql(&ids())).await;
+        assert_content_free(&sql);
+        assert_no_projection(&sql);
+        assert!(sql.contains("n.is_metadata_bearing = 1"));
+        assert!(sql.contains("e.payload_json AS payload_json"));
+        assert!(sql.contains("e.session_id AS session_id"));
+        // Leading-primary-key prune, emitted INSIDE the live-events derived
+        // table so it survives the publication join (C2-R0). The same predicate
+        // in the outer WHERE would prune nothing and scan the whole corpus.
+        assert!(sql.contains(
+            "AND published.source_generation = e.source_generation\nWHERE e.session_id IN ['sess-a','sess-b'])"
+        ));
+        // The uid set is the exact filter and stays outside.
+        assert!(sql.contains(") AS e\nWHERE e.event_uid IN ("));
+        // The directory's display-time bounds must never be applied to the
+        // events `event_ts` primary key.
+        assert!(!sql.contains("BETWEEN"));
+    }
+
+    /// Regression pin for [`assert_content_free`] itself. This is the exact
+    /// shape the metadata builder had before the C2-R0 fix: an outer-only
+    /// `session_id` filter over an unpruned `SELECT e.*` derived table. The
+    /// `text_content` grep passes it, so only the key-prune check can fail it.
+    #[tokio::test]
+    #[should_panic(expected = "not key-pruned inside its derived table")]
+    async fn unpruned_events_scan_fails_the_content_free_guard() {
+        let sql = build(repo(), |r| {
+            format!(
+                "SELECT e.session_id\nFROM {} AS e\nWHERE e.session_id IN ['sess-a']\nFORMAT JSONEachRow",
+                r.live_events_source()
+            )
+        })
+        .await;
+        assert!(
+            !sql.contains("text_content"),
+            "the name grep alone must pass this shape"
+        );
+        assert_content_free(&sql);
+    }
+
+    #[tokio::test]
+    async fn terminal_batch_keeps_the_two_level_last_turn_rule() {
+        let sql = build(repo(), |r| r.build_session_terminal_batch_sql(&ids())).await;
+        assert_content_free(&sql);
+        assert_no_projection(&sql);
+        assert!(sql.contains("argMax(turn_completed, turn_seq)"));
+        assert!(sql.contains("GROUP BY session_id, turn_seq"));
+        assert!(sql.contains("GROUP BY session_id\nFORMAT"));
+        assert!(sql.contains(
+            "WINDOW turn_window AS (PARTITION BY n.session_id ORDER BY tuple(n.sort_time"
+        ));
+        assert!(sql.contains("WHERE n.session_id IN ['sess-a','sess-b']"));
+    }
+
+    #[tokio::test]
+    async fn terminal_batch_matches_the_single_session_turn_rule() {
+        let batch = build(repo(), |r| r.build_session_terminal_batch_sql(&ids())).await;
+        let single = build(repo(), |r| r.build_session_terminal_sql("sess-a")).await;
+        for fragment in [
+            "argMax(turn_completed, turn_seq)",
+            "argMaxIf(toUInt8(payload_type = 'task_complete'), sort_key, payload_type IN ('task_complete', 'turn_aborted'))",
+            "if(toUInt32(n.turn_index) > 0, toUInt32(n.turn_index), greatest(toUInt32(1), toUInt32(sum(if(n.is_user_message = 1, 1, 0)) OVER turn_window)))",
+        ] {
+            assert!(batch.contains(fragment), "batch lost `{fragment}`:\n{batch}");
+            assert!(single.contains(fragment));
+        }
+    }
+}

--- a/crates/moraine-conversations/src/clickhouse_repo/canonical_list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/canonical_list.rs
@@ -248,7 +248,7 @@ impl ClickHouseConversationRepository {
         // aggregates read, so `cd::*` fragments (which name the raw `events`
         // columns) resolve against the single derived relation unqualified.
         let inner = format!(
-            "SELECT\n    n.session_id AS session_id,\n    n.turn_index AS turn_index,\n    n.is_user_message AS is_user_message,\n    n.actor_kind AS actor_kind,\n    n.event_kind AS event_kind,\n    n.payload_type AS payload_type,\n    n.tool_name AS tool_name,\n    n.source_name AS source_name,\n    n.source_file AS source_file,\n    n.harness AS harness,\n    n.inference_provider AS inference_provider,\n    n.display_time AS display_time,\n    n.event_ts AS event_ts,\n    n.event_uid AS event_uid,\n    {sort_tuple} AS sort_key,\n    sum(if(n.is_user_message = 1, 1, 0)) OVER counter_window AS running_u\n  {from}\n  WHERE n.session_id IN {ids}\n  WINDOW counter_window AS (PARTITION BY n.session_id ORDER BY {sort_tuple} ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"
+            "SELECT\n    n.session_id AS session_id,\n    n.turn_index AS turn_index,\n    n.is_user_message AS is_user_message,\n    n.actor_kind AS actor_kind,\n    n.event_kind AS event_kind,\n    n.payload_type AS payload_type,\n    n.tool_name AS tool_name,\n    n.source_name AS source_name,\n    n.source_file AS source_file,\n    n.harness AS harness,\n    n.inference_provider AS inference_provider,\n    n.cwd AS cwd,\n    n.display_time AS display_time,\n    n.event_ts AS event_ts,\n    n.event_uid AS event_uid,\n    {sort_tuple} AS sort_key,\n    sum(if(n.is_user_message = 1, 1, 0)) OVER counter_window AS running_u\n  {from}\n  WHERE n.session_id IN {ids}\n  WINDOW counter_window AS (PARTITION BY n.session_id ORDER BY {sort_tuple} ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"
         );
         format!(
             "SELECT\n  nav.session_id AS session_id,\n  toUInt64(count()) AS total_events,\n  toUInt64(countIf({umsg})) AS user_messages,\n  toUInt64(countIf({assistant_msg})) AS assistant_messages,\n  toUInt64(countIf(nav.event_kind = 'tool_call')) AS tool_calls,\n  toUInt64(countIf(nav.event_kind = 'tool_result')) AS tool_results,\n  toUInt32(max(nav.turn_index)) AS max_override,\n  toUInt64(argMaxIf(nav.running_u, nav.sort_key, nav.turn_index = 0)) AS counter_user_messages,\n  toString(min(nav.display_time)) AS first_event_time,\n  toInt64(toUnixTimestamp64Milli(min(nav.display_time))) AS first_event_unix_ms,\n  toInt64(toUnixTimestamp64Milli(max(nav.display_time))) AS last_event_unix_ms,\n  ifNull(argMinIf(nav.cwd, {event_ts_tuple}, nav.cwd != ''), '') AS origin_cwd,\n  ifNull(argMax(nullIf(nav.source_name, ''), {event_ts_tuple}), '') AS source,\n  ifNull(argMax(nullIf(nav.harness, ''), {event_ts_tuple}), '') AS harness,\n  ifNull(argMax(nullIf(nav.inference_provider, ''), {event_ts_tuple}), '') AS inference_provider,\n  ifNull(argMinIf(nullIf(trimBoth(replaceRegexpOne(arrayElement(splitByChar('/', replaceAll(nav.source_file, '\\\\', '/')), -1), '[.]jsonl$', '')), ''), {event_ts_tuple}, nav.source_name = 'omp' AND notEmpty(nav.session_id) AND endsWith(nav.source_file, '.jsonl') AND NOT endsWith(nav.source_file, concat(nav.session_id, '.jsonl'))), '') AS omp_dispatch_title,\n  {mode} AS mode\nFROM (\n  {inner}\n) AS nav\nGROUP BY nav.session_id\nFORMAT JSONEachRow"
@@ -474,6 +474,47 @@ mod tests {
     /// its own body (issue-598 C2-R0): an outer `WHERE` sits above the
     /// publication join and prunes nothing, so the statement would scan the
     /// whole `events` table with `FINAL`.
+    /// Every `nav.<column>` the OUTER query references must be projected by
+    /// the inner derived table it selects from.
+    ///
+    /// ClickHouse resolves this only at execution time, so a missing
+    /// projection passes every text-matching shape assertion and fails in the
+    /// functional stack. That has now happened twice — `ev.event_ts` in the
+    /// #598 navigation window and `nav.cwd` here — which is why this is a
+    /// structural check rather than another literal.
+    fn assert_outer_columns_are_projected_by_inner(sql: &str, alias: &str) {
+        let Some(inner_start) = sql.find("FROM (") else {
+            panic!("no derived table to check in:\n{sql}");
+        };
+        let (outer, inner) = sql.split_at(inner_start);
+
+        let needle = format!("{alias}.");
+        let mut referenced: Vec<String> = Vec::new();
+        let mut rest = outer;
+        while let Some(at) = rest.find(&needle) {
+            let tail = &rest[at + needle.len()..];
+            let end = tail
+                .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+                .unwrap_or(tail.len());
+            let column = &tail[..end];
+            if !column.is_empty() && !referenced.iter().any(|seen| seen == column) {
+                referenced.push(column.to_string());
+            }
+            rest = &tail[end..];
+        }
+        assert!(
+            !referenced.is_empty(),
+            "found no {alias}.<column> references to check in:\n{sql}"
+        );
+        for column in referenced {
+            assert!(
+                inner.contains(&format!("AS {column}")),
+                "outer references {alias}.{column} but the inner derived table does not project it \
+                 — ClickHouse would fail this at execution time:\n{sql}"
+            );
+        }
+    }
+
     fn assert_events_scan_is_key_pruned(sql: &str) {
         // Only statements that actually open `events` are in scope…
         if !sql.contains("`events`") {
@@ -657,6 +698,7 @@ mod tests {
         let sql = build(repo(), |r| r.build_session_totals_batch_sql(&ids())).await;
         assert_content_free(&sql);
         assert_no_projection(&sql);
+        assert_outer_columns_are_projected_by_inner(&sql, "nav");
         assert!(!sql.contains("payload_json"));
         assert!(sql.contains("`moraine`.`mcp_event_navigation` AS n FINAL"));
         assert!(sql.contains("WHERE n.session_id IN ['sess-a','sess-b']"));

--- a/crates/moraine-conversations/src/clickhouse_repo/canonical_list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/canonical_list.rs
@@ -199,7 +199,7 @@ impl ClickHouseConversationRepository {
             ConversationListSort::Asc => "ASC",
         };
         format!(
-            "SELECT\n  d.session_id AS session_id,\n  toInt64(toUnixTimestamp64Milli(max(d.max_observed_event_time))) AS cand_last_ms,\n  toInt64(toUnixTimestamp64Milli(min(d.min_observed_event_time))) AS cand_first_ms,\n  toUInt8(max(d.mode_hint)) AS mode_hint,\n  argMinIfMerge(d.origin_cwd_state) AS origin_cwd,\n  groupUniqArray(d.harness) AS harnesses,\n  groupUniqArray(d.source_name) AS sources\nFROM {directory} AS d\nWHERE notEmpty(trimBoth(d.session_id))\n  AND (d.source_host, d.source_name, d.source_file, d.source_generation) IN {published}\nGROUP BY d.session_id\nHAVING {having}\nORDER BY cand_last_ms {order_dir}, session_id {order_dir}\nLIMIT {limit}\nFORMAT JSONEachRow",
+            "SELECT\n  d.session_id AS session_id,\n  toInt64(toUnixTimestamp64Milli(max(d.max_observed_event_time))) AS cand_last_ms,\n  toString(max(d.max_observed_event_time)) AS cand_last_time,\n  toInt64(toUnixTimestamp64Milli(min(d.min_observed_event_time))) AS cand_first_ms,\n  toUInt8(max(d.mode_hint)) AS mode_hint,\n  argMinIfMerge(d.origin_cwd_state) AS origin_cwd,\n  groupUniqArray(d.harness) AS harnesses,\n  groupUniqArray(d.source_name) AS sources\nFROM {directory} AS d\nWHERE notEmpty(trimBoth(d.session_id))\n  AND (d.source_host, d.source_name, d.source_file, d.source_generation) IN {published}\nGROUP BY d.session_id\nHAVING {having}\nORDER BY cand_last_ms {order_dir}, session_id {order_dir}\nLIMIT {limit}\nFORMAT JSONEachRow",
             having = having.join("\n   AND "),
             limit = params.limit,
         )
@@ -242,7 +242,7 @@ impl ClickHouseConversationRepository {
             "SELECT\n    n.session_id AS session_id,\n    n.turn_index AS turn_index,\n    n.is_user_message AS is_user_message,\n    n.actor_kind AS actor_kind,\n    n.event_kind AS event_kind,\n    n.payload_type AS payload_type,\n    n.tool_name AS tool_name,\n    n.source_name AS source_name,\n    n.source_file AS source_file,\n    n.harness AS harness,\n    n.inference_provider AS inference_provider,\n    n.display_time AS display_time,\n    n.event_ts AS event_ts,\n    n.event_uid AS event_uid,\n    {sort_tuple} AS sort_key,\n    sum(if(n.is_user_message = 1, 1, 0)) OVER counter_window AS running_u\n  {from}\n  WHERE n.session_id IN {ids}\n  WINDOW counter_window AS (PARTITION BY n.session_id ORDER BY {sort_tuple} ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"
         );
         format!(
-            "SELECT\n  nav.session_id AS session_id,\n  toUInt64(count()) AS total_events,\n  toUInt64(countIf({umsg})) AS user_messages,\n  toUInt64(countIf({assistant_msg})) AS assistant_messages,\n  toUInt64(countIf(nav.event_kind = 'tool_call')) AS tool_calls,\n  toUInt64(countIf(nav.event_kind = 'tool_result')) AS tool_results,\n  toUInt32(max(nav.turn_index)) AS max_override,\n  toUInt64(argMaxIf(nav.running_u, nav.sort_key, nav.turn_index = 0)) AS counter_user_messages,\n  toString(min(nav.display_time)) AS first_event_time,\n  toInt64(toUnixTimestamp64Milli(min(nav.display_time))) AS first_event_unix_ms,\n  toString(max(nav.display_time)) AS last_event_time,\n  toInt64(toUnixTimestamp64Milli(max(nav.display_time))) AS last_event_unix_ms,\n  ifNull(argMax(nullIf(nav.source_name, ''), {event_ts_tuple}), '') AS source,\n  ifNull(argMax(nullIf(nav.harness, ''), {event_ts_tuple}), '') AS harness,\n  ifNull(argMax(nullIf(nav.inference_provider, ''), {event_ts_tuple}), '') AS inference_provider,\n  ifNull(argMinIf(nullIf(trimBoth(replaceRegexpOne(arrayElement(splitByChar('/', replaceAll(nav.source_file, '\\\\', '/')), -1), '[.]jsonl$', '')), ''), {event_ts_tuple}, nav.source_name = 'omp' AND notEmpty(nav.session_id) AND endsWith(nav.source_file, '.jsonl') AND NOT endsWith(nav.source_file, concat(nav.session_id, '.jsonl'))), '') AS omp_dispatch_title,\n  {mode} AS mode\nFROM (\n  {inner}\n) AS nav\nGROUP BY nav.session_id\nFORMAT JSONEachRow"
+            "SELECT\n  nav.session_id AS session_id,\n  toUInt64(count()) AS total_events,\n  toUInt64(countIf({umsg})) AS user_messages,\n  toUInt64(countIf({assistant_msg})) AS assistant_messages,\n  toUInt64(countIf(nav.event_kind = 'tool_call')) AS tool_calls,\n  toUInt64(countIf(nav.event_kind = 'tool_result')) AS tool_results,\n  toUInt32(max(nav.turn_index)) AS max_override,\n  toUInt64(argMaxIf(nav.running_u, nav.sort_key, nav.turn_index = 0)) AS counter_user_messages,\n  toString(min(nav.display_time)) AS first_event_time,\n  toInt64(toUnixTimestamp64Milli(min(nav.display_time))) AS first_event_unix_ms,\n  toInt64(toUnixTimestamp64Milli(max(nav.display_time))) AS last_event_unix_ms,\n  ifNull(argMax(nullIf(nav.source_name, ''), {event_ts_tuple}), '') AS source,\n  ifNull(argMax(nullIf(nav.harness, ''), {event_ts_tuple}), '') AS harness,\n  ifNull(argMax(nullIf(nav.inference_provider, ''), {event_ts_tuple}), '') AS inference_provider,\n  ifNull(argMinIf(nullIf(trimBoth(replaceRegexpOne(arrayElement(splitByChar('/', replaceAll(nav.source_file, '\\\\', '/')), -1), '[.]jsonl$', '')), ''), {event_ts_tuple}, nav.source_name = 'omp' AND notEmpty(nav.session_id) AND endsWith(nav.source_file, '.jsonl') AND NOT endsWith(nav.source_file, concat(nav.session_id, '.jsonl'))), '') AS omp_dispatch_title,\n  {mode} AS mode\nFROM (\n  {inner}\n) AS nav\nGROUP BY nav.session_id\nFORMAT JSONEachRow"
         )
     }
 
@@ -301,6 +301,11 @@ impl ClickHouseConversationRepository {
 #[derive(Debug, Clone, Deserialize)]
 pub(super) struct DirectoryCandidateRow {
     pub(super) session_id: String,
+    /// Display form of [`Self::cand_last_ms`], reported as the item's
+    /// `last_event_time` so the response's timestamp is the value the page was
+    /// ordered and keyset by (issue-599 B1). Reporting the hydrated exact value
+    /// instead would leave the page sorted by a field it does not return.
+    pub(super) cand_last_time: String,
     /// **The operation's one keyset time source.** Phase A orders by it, its
     /// `HAVING` keyset resumes strictly after it, Phase C sorts survivors by
     /// it, and the continuation cursor is minted from it. Candidate filtering,
@@ -337,7 +342,6 @@ pub(super) struct SessionTotalsBatchRow {
     pub(super) counter_user_messages: u64,
     pub(super) first_event_time: String,
     pub(super) first_event_unix_ms: i64,
-    pub(super) last_event_time: String,
     pub(super) last_event_unix_ms: i64,
     pub(super) source: String,
     pub(super) harness: String,
@@ -660,7 +664,9 @@ mod tests {
             "max_override",
             "first_event_time",
             "first_event_unix_ms",
-            "last_event_time",
+            // `last_event_time` is deliberately absent: the directory path
+            // reports the value it orders by (`cand_last_time`), so hydrating
+            // the display string here would transfer bytes that are discarded.
             "last_event_unix_ms",
             "source",
             "harness",

--- a/crates/moraine-conversations/src/clickhouse_repo/canonical_list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/canonical_list.rs
@@ -47,11 +47,20 @@ const COLS: DerivationColumns = DerivationColumns::EVENTS;
 /// design invariant.
 pub(super) const MAX_HYDRATION_CHUNKS: usize = 4;
 
-/// Ceiling on one hydration chunk, bounding a single batched statement's cost.
+/// Ceiling on one hydration chunk — but the caller's page size WINS when it is
+/// larger. `hydration_chunk_size` floors the chunk at `limit + 1` so a single
+/// chunk can always answer "is there more", so a request for a page bigger than
+/// this constant is hydrated in `limit + 1` rows, not clamped to 256. The
+/// effective bound is therefore `max(256, limit + 1)`, and `limit` is itself
+/// bounded by the configured `max_results`.
 const MAX_HYDRATION_CHUNK_ROWS: u32 = 256;
 
-/// Ceiling on the single Phase-A over-fetch, bounding the candidate page's
-/// deserialization cost independently of `limit`.
+/// Ceiling on the single Phase-A over-fetch. Same caveat as
+/// [`MAX_HYDRATION_CHUNK_ROWS`]: `candidate_fetch_size` floors the fetch at one
+/// chunk, so the effective bound is `max(1024, chunk)`. It bounds the candidate
+/// page independently of `limit` only while `limit + 1 <= 1024`; past that the
+/// caller's page size governs, which is the intended trade (a caller asking for
+/// N sessions must be able to receive N).
 const MAX_CANDIDATE_FETCH_ROWS: u32 = 1024;
 
 /// Sessions hydrated per batched round trip:
@@ -242,7 +251,7 @@ impl ClickHouseConversationRepository {
             "SELECT\n    n.session_id AS session_id,\n    n.turn_index AS turn_index,\n    n.is_user_message AS is_user_message,\n    n.actor_kind AS actor_kind,\n    n.event_kind AS event_kind,\n    n.payload_type AS payload_type,\n    n.tool_name AS tool_name,\n    n.source_name AS source_name,\n    n.source_file AS source_file,\n    n.harness AS harness,\n    n.inference_provider AS inference_provider,\n    n.display_time AS display_time,\n    n.event_ts AS event_ts,\n    n.event_uid AS event_uid,\n    {sort_tuple} AS sort_key,\n    sum(if(n.is_user_message = 1, 1, 0)) OVER counter_window AS running_u\n  {from}\n  WHERE n.session_id IN {ids}\n  WINDOW counter_window AS (PARTITION BY n.session_id ORDER BY {sort_tuple} ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"
         );
         format!(
-            "SELECT\n  nav.session_id AS session_id,\n  toUInt64(count()) AS total_events,\n  toUInt64(countIf({umsg})) AS user_messages,\n  toUInt64(countIf({assistant_msg})) AS assistant_messages,\n  toUInt64(countIf(nav.event_kind = 'tool_call')) AS tool_calls,\n  toUInt64(countIf(nav.event_kind = 'tool_result')) AS tool_results,\n  toUInt32(max(nav.turn_index)) AS max_override,\n  toUInt64(argMaxIf(nav.running_u, nav.sort_key, nav.turn_index = 0)) AS counter_user_messages,\n  toString(min(nav.display_time)) AS first_event_time,\n  toInt64(toUnixTimestamp64Milli(min(nav.display_time))) AS first_event_unix_ms,\n  toInt64(toUnixTimestamp64Milli(max(nav.display_time))) AS last_event_unix_ms,\n  ifNull(argMax(nullIf(nav.source_name, ''), {event_ts_tuple}), '') AS source,\n  ifNull(argMax(nullIf(nav.harness, ''), {event_ts_tuple}), '') AS harness,\n  ifNull(argMax(nullIf(nav.inference_provider, ''), {event_ts_tuple}), '') AS inference_provider,\n  ifNull(argMinIf(nullIf(trimBoth(replaceRegexpOne(arrayElement(splitByChar('/', replaceAll(nav.source_file, '\\\\', '/')), -1), '[.]jsonl$', '')), ''), {event_ts_tuple}, nav.source_name = 'omp' AND notEmpty(nav.session_id) AND endsWith(nav.source_file, '.jsonl') AND NOT endsWith(nav.source_file, concat(nav.session_id, '.jsonl'))), '') AS omp_dispatch_title,\n  {mode} AS mode\nFROM (\n  {inner}\n) AS nav\nGROUP BY nav.session_id\nFORMAT JSONEachRow"
+            "SELECT\n  nav.session_id AS session_id,\n  toUInt64(count()) AS total_events,\n  toUInt64(countIf({umsg})) AS user_messages,\n  toUInt64(countIf({assistant_msg})) AS assistant_messages,\n  toUInt64(countIf(nav.event_kind = 'tool_call')) AS tool_calls,\n  toUInt64(countIf(nav.event_kind = 'tool_result')) AS tool_results,\n  toUInt32(max(nav.turn_index)) AS max_override,\n  toUInt64(argMaxIf(nav.running_u, nav.sort_key, nav.turn_index = 0)) AS counter_user_messages,\n  toString(min(nav.display_time)) AS first_event_time,\n  toInt64(toUnixTimestamp64Milli(min(nav.display_time))) AS first_event_unix_ms,\n  toInt64(toUnixTimestamp64Milli(max(nav.display_time))) AS last_event_unix_ms,\n  ifNull(argMinIf(nav.cwd, {event_ts_tuple}, nav.cwd != ''), '') AS origin_cwd,\n  ifNull(argMax(nullIf(nav.source_name, ''), {event_ts_tuple}), '') AS source,\n  ifNull(argMax(nullIf(nav.harness, ''), {event_ts_tuple}), '') AS harness,\n  ifNull(argMax(nullIf(nav.inference_provider, ''), {event_ts_tuple}), '') AS inference_provider,\n  ifNull(argMinIf(nullIf(trimBoth(replaceRegexpOne(arrayElement(splitByChar('/', replaceAll(nav.source_file, '\\\\', '/')), -1), '[.]jsonl$', '')), ''), {event_ts_tuple}, nav.source_name = 'omp' AND notEmpty(nav.session_id) AND endsWith(nav.source_file, '.jsonl') AND NOT endsWith(nav.source_file, concat(nav.session_id, '.jsonl'))), '') AS omp_dispatch_title,\n  {mode} AS mode\nFROM (\n  {inner}\n) AS nav\nGROUP BY nav.session_id\nFORMAT JSONEachRow"
         )
     }
 
@@ -343,6 +352,15 @@ pub(super) struct SessionTotalsBatchRow {
     pub(super) first_event_time: String,
     pub(super) first_event_unix_ms: i64,
     pub(super) last_event_unix_ms: i64,
+    /// The session's origin cwd under the EXACT rule `scope.rs` applies —
+    /// `argMin(cwd, (event_ts, event_uid))` over rows with a non-empty cwd,
+    /// here over the navigation index read `FINAL`. Phase A's
+    /// `argMinIfMerge(origin_cwd_state)` is the same rule merged over the
+    /// directory's live-generation rows, but a `SimpleAggregateFunction`-style
+    /// merge cannot see a superseded version the way `FINAL` can, so scope is
+    /// re-checked against THIS value before a session is served. Scope decides
+    /// what a caller is allowed to see; it must not rest on a recall filter.
+    pub(super) origin_cwd: String,
     pub(super) source: String,
     pub(super) harness: String,
     pub(super) inference_provider: String,
@@ -457,8 +475,16 @@ mod tests {
     /// publication join and prunes nothing, so the statement would scan the
     /// whole `events` table with `FINAL`.
     fn assert_events_scan_is_key_pruned(sql: &str) {
-        let Some(start) = sql.find("(SELECT e.*") else {
+        // Only statements that actually open `events` are in scope…
+        if !sql.contains("`events`") {
             return;
+        }
+        // …and for those, an unrecognized derived-table shape is a FAILURE, not
+        // a pass. Returning early here would let any future shape through
+        // unexamined, which is exactly how the unpruned scan this guard exists
+        // for slipped past the `text_content` grep.
+        let Some(start) = sql.find("(SELECT e.*") else {
+            panic!("events scan is not in the recognized live-events derived-table shape:\n{sql}");
         };
         let body = &sql[start..];
         let end = body
@@ -664,6 +690,10 @@ mod tests {
             "max_override",
             "first_event_time",
             "first_event_unix_ms",
+            // `origin_cwd` is intentionally absent: it is batch-only, hydrated
+            // for the exact project-scope re-check. The single-session builder
+            // has no equivalent because `open(session)` is already scoped
+            // before it runs.
             // `last_event_time` is deliberately absent: the directory path
             // reports the value it orders by (`cand_last_time`), so hydrating
             // the display string here would transfer bytes that are discarded.

--- a/crates/moraine-conversations/src/clickhouse_repo/canonical_open.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/canonical_open.rs
@@ -266,7 +266,7 @@ impl ClickHouseConversationRepository {
     /// granule pruning on the navigation primary key, so
     /// [`Self::build_navigation_window_sql`] filters the pinned heads with a
     /// tuple-`IN` predicate instead and deduplicates versions client-side.
-    fn navigation_live_from(&self) -> String {
+    pub(super) fn navigation_live_from(&self) -> String {
         let nav = self.table_ref("mcp_event_navigation");
         let published = self.published_generations_subquery();
         format!(
@@ -276,7 +276,7 @@ impl ClickHouseConversationRepository {
 
     /// The navigation ordering tuple (the primary key with `sort_time`
     /// substituted for event_time) qualified to alias `n`.
-    fn navigation_sort_tuple(alias: &str) -> String {
+    pub(super) fn navigation_sort_tuple(alias: &str) -> String {
         format!(
             "tuple({a}.sort_time, {a}.source_host, {a}.source_file, {a}.source_generation, {a}.source_offset, {a}.source_line_no, {a}.event_uid)",
             a = alias
@@ -771,21 +771,36 @@ fn json_field(payload_json: &str, key: &str) -> String {
 }
 
 #[derive(Debug, Clone, Default)]
-struct MetadataPrecedence {
-    latest_metadata_title: String,
-    latest_metadata_name: String,
-    latest_metadata_summary: String,
-    session_slug: String,
-    omp_dispatch_title: String,
+pub(super) struct MetadataPrecedence {
+    pub(super) latest_metadata_title: String,
+    pub(super) latest_metadata_name: String,
+    pub(super) latest_metadata_summary: String,
+    /// LIST-only input: latest non-empty `coalesce(title, name, summary)` over
+    /// `session_meta` rows only (projector `latest_session_meta_title`).
+    pub(super) latest_session_meta_title: String,
+    /// LIST-only input: latest non-empty `coalesce(summary, title, name)` over
+    /// `session_meta` rows only (projector `latest_session_meta_summary`).
+    pub(super) latest_session_meta_summary: String,
+    pub(super) session_slug: String,
+    pub(super) omp_dispatch_title: String,
 }
 
-/// Reproduce the projector's OPEN metadata-precedence inputs
-/// (`projection.rs`) in Rust over the bounded metadata-bearing rows: latest
-/// non-empty per field by `(event_ts, event_uid)`, session-meta-only for
-/// name/summary/slug. The omp dispatch-title fallback is NOT derived here —
-/// v1 computes it over all canonical rows, so the caller seeds it from the
-/// session-totals pass (which scans every navigation row).
-fn metadata_precedence(rows: &[MetaRow]) -> MetadataPrecedence {
+/// Reproduce the projector's metadata-precedence inputs
+/// (`cd::session_header_rollup_columns`) in Rust over the bounded
+/// metadata-bearing rows: latest non-empty per field by `(event_ts,
+/// event_uid)`, session-meta-only for name/summary/slug and for the two
+/// `latest_session_meta_*` LIST inputs. The omp dispatch-title fallback is NOT
+/// derived here — v1 computes it over all canonical rows, so the caller seeds
+/// it from the session-totals pass (which scans every navigation row).
+///
+/// The two `latest_session_meta_*` fields are per-row coalesces resolved BEFORE
+/// the latest-wins selection, exactly as the projector's
+/// `argMaxIf(coalesce(...), tuple(event_ts, event_uid), event_kind =
+/// 'session_meta')` does. They are therefore NOT aliases of
+/// `latest_metadata_title` / `latest_metadata_summary`: a later `session_meta`
+/// row carrying only a `name` overrides an earlier row's `title` here, and the
+/// summary chain falls through to `title`/`name` on the same row.
+pub(super) fn metadata_precedence(rows: &[MetaRow]) -> MetadataPrecedence {
     let mut ordered: Vec<&MetaRow> = rows.iter().collect();
     ordered.sort_by(|a, b| {
         (a.event_ts.as_str(), a.event_uid.as_str())
@@ -795,55 +810,53 @@ fn metadata_precedence(rows: &[MetaRow]) -> MetadataPrecedence {
     for row in ordered {
         let title = json_field(&row.payload_json, "title");
         if !title.is_empty() {
-            precedence.latest_metadata_title = title;
+            precedence.latest_metadata_title = title.clone();
         }
         if row.event_kind == "session_meta" {
             let name = json_field(&row.payload_json, "name");
             if !name.is_empty() {
-                precedence.latest_metadata_name = name;
+                precedence.latest_metadata_name = name.clone();
             }
             let summary = json_field(&row.payload_json, "summary");
             if !summary.is_empty() {
-                precedence.latest_metadata_summary = summary;
+                precedence.latest_metadata_summary = summary.clone();
             }
             let slug = json_field(&row.payload_json, "slug");
             if !slug.is_empty() {
                 precedence.session_slug = slug;
+            }
+            let meta_title = first_non_empty(&[&title, &name, &summary]);
+            if !meta_title.is_empty() {
+                precedence.latest_session_meta_title = meta_title;
+            }
+            let meta_summary = first_non_empty(&[&summary, &title, &name]);
+            if !meta_summary.is_empty() {
+                precedence.latest_session_meta_summary = meta_summary;
             }
         }
     }
     precedence
 }
 
+/// The first non-empty candidate, or the empty string — the Rust form of the
+/// projector's `coalesce(nullIf(x, ''), …, '')` chains.
+fn first_non_empty(candidates: &[&str]) -> String {
+    candidates
+        .iter()
+        .find(|value| !value.is_empty())
+        .map(|value| (*value).to_string())
+        .unwrap_or_default()
+}
+
 /// The projector's OPEN title/summary coalesce chains (`projection.rs`):
 /// omp sources fall through to the dispatch title, non-omp sources do not.
 fn open_title_and_summary(source: &str, p: &MetadataPrecedence) -> (String, String) {
-    let coalesce = |candidates: &[&str]| -> String {
-        candidates
-            .iter()
-            .find(|value| !value.is_empty())
-            .map(|value| value.to_string())
-            .unwrap_or_default()
-    };
     let (title, summary) = if source == "omp" {
-        (
-            coalesce(&[
-                &p.latest_metadata_title,
-                &p.latest_metadata_name,
-                &p.latest_metadata_summary,
-                &p.omp_dispatch_title,
-            ]),
-            coalesce(&[
-                &p.latest_metadata_summary,
-                &p.latest_metadata_title,
-                &p.latest_metadata_name,
-                &p.omp_dispatch_title,
-            ]),
-        )
+        omp_title_and_summary(p)
     } else {
         (
-            coalesce(&[&p.latest_metadata_title, &p.latest_metadata_name]),
-            coalesce(&[
+            first_non_empty(&[&p.latest_metadata_title, &p.latest_metadata_name]),
+            first_non_empty(&[
                 &p.latest_metadata_summary,
                 &p.latest_metadata_title,
                 &p.latest_metadata_name,
@@ -851,6 +864,43 @@ fn open_title_and_summary(source: &str, p: &MetadataPrecedence) -> (String, Stri
         )
     };
     (title, summary)
+}
+
+/// The projector's LIST title/summary chains — `list_title` /
+/// `list_session_summary` in the `mcp_open_publication_headers` INSERT
+/// (`mcp_open_projection.rs`, golden
+/// `testdata/projector_golden/projected_publication_header.sql`). Migration
+/// `sql/035_mcp_list_metadata_projection.sql` exists precisely to preserve this
+/// divergence from [`open_title_and_summary`]: the omp branch is shared, while
+/// the non-omp branch reads the session-meta-only inputs instead of the
+/// metadata-bearing ones (so an OMP `title`/`title_change` payload on a
+/// non-omp source cannot become a listed title).
+pub(super) fn list_title_and_summary(source: &str, p: &MetadataPrecedence) -> (String, String) {
+    if source == "omp" {
+        return omp_title_and_summary(p);
+    }
+    (
+        p.latest_session_meta_title.clone(),
+        p.latest_session_meta_summary.clone(),
+    )
+}
+
+/// The omp branch, shared byte-for-byte by the OPEN and LIST chains.
+fn omp_title_and_summary(p: &MetadataPrecedence) -> (String, String) {
+    (
+        first_non_empty(&[
+            &p.latest_metadata_title,
+            &p.latest_metadata_name,
+            &p.latest_metadata_summary,
+            &p.omp_dispatch_title,
+        ]),
+        first_non_empty(&[
+            &p.latest_metadata_summary,
+            &p.latest_metadata_title,
+            &p.latest_metadata_name,
+            &p.omp_dispatch_title,
+        ]),
+    )
 }
 
 /// A per-event preview from a hydrated wide row: `text_content` if present,
@@ -2412,6 +2462,145 @@ mod tests {
         assert!(sql.contains("prefix_user_message_count"));
         assert!(sql.contains("WHERE n.session_id = 'session-a'"));
         assert!(sql.contains("n.sort_time <= fromUnixTimestamp64Milli"));
+    }
+
+    // --- metadata precedence: OPEN vs LIST (issue-599 §2.6) ----------------
+
+    fn meta_row(event_ts: &str, event_uid: &str, event_kind: &str, payload: Value) -> MetaRow {
+        MetaRow {
+            event_ts: event_ts.to_string(),
+            event_uid: event_uid.to_string(),
+            event_kind: event_kind.to_string(),
+            payload_json: payload.to_string(),
+        }
+    }
+
+    #[test]
+    fn session_meta_inputs_coalesce_per_row_before_latest_wins() {
+        // The projector's `latest_session_meta_*` are
+        // `argMaxIf(coalesce(...), tuple(event_ts, event_uid), event_kind =
+        // 'session_meta')`: the coalesce resolves PER ROW, then the latest
+        // non-empty result wins. They are therefore NOT aliases of
+        // `latest_metadata_title` / `latest_metadata_summary`.
+        let precedence = metadata_precedence(&[
+            meta_row(
+                "2026-01-01 00:00:00",
+                "evt-1",
+                "session_meta",
+                json!({ "title": "Earlier title" }),
+            ),
+            meta_row(
+                "2026-01-02 00:00:00",
+                "evt-2",
+                "session_meta",
+                json!({ "name": "Later name" }),
+            ),
+        ]);
+        assert_eq!(precedence.latest_metadata_title, "Earlier title");
+        assert_eq!(precedence.latest_metadata_name, "Later name");
+        assert_eq!(precedence.latest_session_meta_title, "Later name");
+        assert_eq!(precedence.latest_session_meta_summary, "Later name");
+    }
+
+    #[test]
+    fn omp_title_payloads_never_reach_the_session_meta_inputs() {
+        // `is_metadata_bearing` also admits omp `title`/`title_change`
+        // payloads. They feed `latest_metadata_title` (and so the OPEN chain)
+        // but must not feed the session-meta-only LIST inputs.
+        let precedence = metadata_precedence(&[
+            meta_row(
+                "2026-01-01 00:00:00",
+                "evt-1",
+                "session_meta",
+                json!({ "slug": "the-slug", "summary": "Meta summary" }),
+            ),
+            meta_row(
+                "2026-01-02 00:00:00",
+                "evt-2",
+                "event_msg",
+                json!({ "type": "title_change", "title": "Dispatch retitle" }),
+            ),
+        ]);
+        assert_eq!(precedence.latest_metadata_title, "Dispatch retitle");
+        assert_eq!(precedence.latest_session_meta_title, "Meta summary");
+        assert_eq!(precedence.session_slug, "the-slug");
+    }
+
+    /// A `MetadataPrecedence` with only the named fields populated.
+    fn precedence(
+        metadata_title: &str,
+        metadata_name: &str,
+        metadata_summary: &str,
+        session_meta_title: &str,
+        session_meta_summary: &str,
+        omp_dispatch_title: &str,
+    ) -> MetadataPrecedence {
+        MetadataPrecedence {
+            latest_metadata_title: metadata_title.to_string(),
+            latest_metadata_name: metadata_name.to_string(),
+            latest_metadata_summary: metadata_summary.to_string(),
+            latest_session_meta_title: session_meta_title.to_string(),
+            latest_session_meta_summary: session_meta_summary.to_string(),
+            session_slug: String::new(),
+            omp_dispatch_title: omp_dispatch_title.to_string(),
+        }
+    }
+
+    #[test]
+    fn list_and_open_chains_agree_for_omp_and_diverge_for_everything_else() {
+        // (metadata_title, metadata_name, metadata_summary,
+        //  session_meta_title, session_meta_summary, omp_dispatch_title)
+        //  -> expected non-omp LIST (title, summary)
+        let cases: [(MetadataPrecedence, (&str, &str)); 5] = [
+            // title only
+            (precedence("T", "", "", "T", "T", "Dispatch"), ("T", "T")),
+            // summary only
+            (precedence("", "", "S", "S", "S", "Dispatch"), ("S", "S")),
+            // name only
+            (precedence("", "N", "", "N", "N", "Dispatch"), ("N", "N")),
+            // dispatch title only: the non-omp chain must NOT fall through to it
+            (precedence("", "", "", "", "", "Dispatch"), ("", "")),
+            // all empty
+            (precedence("", "", "", "", "", ""), ("", "")),
+        ];
+        for (input, expected_list) in cases {
+            let (list_title, list_summary) = list_title_and_summary("codex", &input);
+            assert_eq!(
+                (list_title.as_str(), list_summary.as_str()),
+                expected_list,
+                "non-omp LIST chain for {input:?}"
+            );
+            // The omp branch is shared byte-for-byte by both chains.
+            assert_eq!(
+                list_title_and_summary("omp", &input),
+                open_title_and_summary("omp", &input),
+                "omp branch must not diverge for {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn list_chain_diverges_from_open_where_the_golden_says_it_does() {
+        // Non-omp, latest session_meta row carries only a `name`: OPEN keeps
+        // the earlier `title` (its chain reads `latest_metadata_title` first),
+        // LIST takes the later per-row coalesce. Getting this backwards
+        // silently changes every listed title.
+        let input = precedence(
+            "Earlier title",
+            "Later name",
+            "",
+            "Later name",
+            "Later name",
+            "",
+        );
+        assert_eq!(
+            open_title_and_summary("codex", &input),
+            ("Earlier title".to_string(), "Earlier title".to_string())
+        );
+        assert_eq!(
+            list_title_and_summary("codex", &input),
+            ("Later name".to_string(), "Later name".to_string())
+        );
     }
 
     #[test]

--- a/crates/moraine-conversations/src/clickhouse_repo/consistency.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/consistency.rs
@@ -614,11 +614,6 @@ impl ClickHouseConversationRepository {
         session_id: Option<&str>,
         event_ts_bounds_ms: Option<EventTsBounds>,
     ) -> String {
-        let snapshot = require_active_publication_snapshot("live event reads");
-
-        let history = self.table_ref("v_published_source_generation_history");
-        let revision_predicate = snapshot.publication_revision_predicate("history");
-        let events = self.table_ref("events");
         let mut inner_predicates: Vec<String> = Vec::new();
         if let Some(session_id) = session_id {
             inner_predicates.push(format!("e.session_id = {}", sql_quote(session_id)));
@@ -636,6 +631,33 @@ impl ClickHouseConversationRepository {
                 (None, false) => {}
             }
         }
+        self.live_events_source_filtered(&inner_predicates)
+    }
+
+    /// The K-session form of [`Self::live_events_source_scoped`]: `e.session_id
+    /// IN <array>` emitted **inside** the derived table. `events` leads its
+    /// primary key with `session_id`, so the `IN` prunes the `FINAL` scan to K
+    /// key ranges; the identical predicate on the OUTER query prunes nothing,
+    /// because the optimizer is not trusted to push it through the publication
+    /// join (issue-598 C2-R0 "no optimizer trust"). An empty slice emits
+    /// `IN []`, which authorizes no rows — callers must not open the relation
+    /// for an empty batch.
+    pub(super) fn live_events_source_sessions(&self, session_ids: &[String]) -> String {
+        self.live_events_source_filtered(&[format!(
+            "e.session_id IN {}",
+            sql_array_strings(session_ids)
+        )])
+    }
+
+    /// The published-generation-authorized `events` relation, with every
+    /// caller-supplied predicate emitted inside the derived table. An empty
+    /// slice reproduces the v1 `live_events_source` SQL byte-for-byte.
+    fn live_events_source_filtered(&self, inner_predicates: &[String]) -> String {
+        let snapshot = require_active_publication_snapshot("live event reads");
+
+        let history = self.table_ref("v_published_source_generation_history");
+        let revision_predicate = snapshot.publication_revision_predicate("history");
+        let events = self.table_ref("events");
         let session_filter = if inner_predicates.is_empty() {
             String::new()
         } else {
@@ -1415,6 +1437,13 @@ mod tests {
                     );
                 assert!(bounded.ends_with(
                     "AND published.source_generation = e.source_generation\nWHERE e.session_id = 'session-a' AND e.event_ts BETWEEN fromUnixTimestamp64Milli(1000) AND fromUnixTimestamp64Milli(2000))"
+                ));
+                // The K-session form lands in the same place, for the same
+                // reason: an outer `session_id IN` cannot prune the FINAL scan.
+                let batched = repository
+                    .live_events_source_sessions(&["sess-a".to_string(), "sess-b".to_string()]);
+                assert!(batched.ends_with(
+                    "AND published.source_generation = e.source_generation\nWHERE e.session_id IN ['sess-a','sess-b'])"
                 ));
             })
             .await;

--- a/crates/moraine-conversations/src/clickhouse_repo/list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/list.rs
@@ -493,9 +493,11 @@ FORMAT JSONEachRow",
         if totals.total_events == 0 {
             return None;
         }
-        // The directory aggregates ALL generations while hydration is
-        // published-filtered, so re-check the overlap on the exact bounds: a
-        // session whose only in-window generation is unpublished drops here.
+        // Both passes are published-filtered (Phase A carries the same
+        // `(host, name, file, generation) IN published` tuple-IN), so this is
+        // not a generation-visibility re-check. It refines the window on the
+        // EXACT hydrated bounds, which can sit inside the directory's
+        // aggregate when a re-inserted event lowered a display time.
         if totals.last_event_unix_ms < filter.start_unix_ms
             || totals.first_event_unix_ms >= filter.end_unix_ms
         {
@@ -531,8 +533,17 @@ FORMAT JSONEachRow",
                 session_id: session_id.to_string(),
                 first_event_time: totals.first_event_time.clone(),
                 first_event_unix_ms: totals.first_event_unix_ms,
-                last_event_time: totals.last_event_time.clone(),
-                last_event_unix_ms: totals.last_event_unix_ms,
+                // Report the value this page was ORDERED and KEYSET by, not
+                // the hydrated exact one: the published contract sorts by the
+                // `updated_at` the response reports, and Phase A can only
+                // order on the directory aggregate. The two differ only when
+                // an event is re-inserted within one live generation with a
+                // decreased display time — `SimpleAggregateFunction(max)`
+                // cannot retract that, navigation read `FINAL` can — so
+                // `cand_last_ms >= totals.last_event_unix_ms`, equal in every
+                // ordinary case (issue-599 B1).
+                last_event_time: candidate.cand_last_time.clone(),
+                last_event_unix_ms: candidate.cand_last_ms,
                 total_turns: total_turns_from_parts(
                     totals.total_events,
                     totals.max_override,

--- a/crates/moraine-conversations/src/clickhouse_repo/list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/list.rs
@@ -4,7 +4,10 @@ use super::canonical_list::{
 };
 use super::canonical_open::{list_title_and_summary, total_turns_from_parts, MetaRow};
 use super::*;
-use crate::cursor::{ACCEPTED_MCP_SESSION_LIST_CURSOR_VERSIONS, MCP_SESSION_LIST_CURSOR_VERSION};
+use crate::cursor::{
+    ACCEPTED_MCP_SESSION_LIST_CURSOR_VERSIONS, MCP_SESSION_LIST_CURSOR_VERSION_DIRECTORY,
+    MCP_SESSION_LIST_CURSOR_VERSION_HEADERS,
+};
 
 impl ClickHouseConversationRepository {
     pub(super) async fn list_conversations_impl(
@@ -178,16 +181,30 @@ FORMAT JSONEachRow",
         let limit = page.normalized_limit(self.cfg.max_results);
         let filter_sig = self.mcp_session_list_filter_sig(&filter);
         let sort = filter.sort;
-        let cursor = Self::decode_session_list_cursor(page.cursor.as_deref(), &filter_sig, sort)?;
-
         // Canonical-first when the issue-598 backfill has published coverage;
         // otherwise the projected-header path still serves the page. The
         // fallback is short-lived by design — it is deleted once the live
         // gates are green (issue-599 open question 4).
+        //
+        // The token is decoded against the SERVING path's version, so a
+        // readiness flip mid-pagination surfaces as a cursor mismatch rather
+        // than a silent gap.
         if self.canonical_list_path_ready().await {
+            let cursor = Self::decode_session_list_cursor(
+                page.cursor.as_deref(),
+                &filter_sig,
+                sort,
+                MCP_SESSION_LIST_CURSOR_VERSION_DIRECTORY,
+            )?;
             self.list_mcp_sessions_directory(&filter, filter_sig, sort, limit, cursor)
                 .await
         } else {
+            let cursor = Self::decode_session_list_cursor(
+                page.cursor.as_deref(),
+                &filter_sig,
+                sort,
+                MCP_SESSION_LIST_CURSOR_VERSION_HEADERS,
+            )?;
             self.list_mcp_sessions_headers(&filter, filter_sig, sort, limit, cursor)
                 .await
         }
@@ -195,12 +212,18 @@ FORMAT JSONEachRow",
 
     /// Decode and validate a `list_sessions` continuation token.
     ///
-    /// Both cursor versions are accepted (see [`McpSessionListCursor`]); the
-    /// two mismatch messages are contract surface asserted by the tool tests.
+    /// `serving_version` is the version the path about to use this token mints.
+    /// A token minted by the OTHER path anchors on a different value (see
+    /// [`McpSessionListCursor`]), so resuming it here would silently skip every
+    /// session whose two anchors straddle it. It is rejected as a cursor
+    /// mismatch instead, which a caller can recover from by restarting the
+    /// feed. The mismatch messages are contract surface asserted by the tool
+    /// tests.
     fn decode_session_list_cursor(
         token: Option<&str>,
         filter_sig: &str,
         sort: ConversationListSort,
+        serving_version: u8,
     ) -> RepoResult<Option<McpSessionListCursor>> {
         let Some(token) = token else {
             return Ok(None);
@@ -211,6 +234,11 @@ FORMAT JSONEachRow",
                 "unsupported list_sessions cursor version {}",
                 cursor.version
             )));
+        }
+        if cursor.version != serving_version {
+            return Err(RepoError::invalid_cursor(
+                "cursor was minted by a different list_sessions read path",
+            ));
         }
         if cursor.filter_sig != filter_sig {
             return Err(RepoError::invalid_cursor(
@@ -230,9 +258,10 @@ FORMAT JSONEachRow",
         session_id: &str,
         filter_sig: String,
         sort: ConversationListSort,
+        version: u8,
     ) -> RepoResult<String> {
         encode_cursor(&McpSessionListCursor {
-            version: MCP_SESSION_LIST_CURSOR_VERSION,
+            version,
             last_event_unix_ms,
             session_id: session_id.to_string(),
             filter_sig,
@@ -340,6 +369,7 @@ FORMAT JSONEachRow",
                         &survivor.item.session_id,
                         filter_sig,
                         sort,
+                        MCP_SESSION_LIST_CURSOR_VERSION_DIRECTORY,
                     )
                 })
                 .transpose()?
@@ -357,7 +387,13 @@ FORMAT JSONEachRow",
             last_resolved
                 .as_ref()
                 .map(|(last_ms, session_id)| {
-                    Self::mint_session_list_cursor(*last_ms, session_id, filter_sig, sort)
+                    Self::mint_session_list_cursor(
+                        *last_ms,
+                        session_id,
+                        filter_sig,
+                        sort,
+                        MCP_SESSION_LIST_CURSOR_VERSION_DIRECTORY,
+                    )
                 })
                 .transpose()?
         } else {
@@ -678,6 +714,7 @@ FORMAT JSONEachRow",
                         &last.session_id,
                         filter_sig,
                         sort,
+                        MCP_SESSION_LIST_CURSOR_VERSION_HEADERS,
                     )
                 })
                 .transpose()?

--- a/crates/moraine-conversations/src/clickhouse_repo/list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/list.rs
@@ -331,11 +331,14 @@ FORMAT JSONEachRow",
                 .map(|candidate| candidate.session_id.clone())
                 .collect();
             let hydrated = self.hydrate_session_list_chunk(&session_ids).await?;
-            survivors.extend(
-                batch
-                    .iter()
-                    .filter_map(|candidate| Self::session_list_item(candidate, &hydrated, filter)),
-            );
+            survivors.extend(batch.iter().filter_map(|candidate| {
+                Self::session_list_item(
+                    candidate,
+                    &hydrated,
+                    filter,
+                    self.cfg.session_scope.as_ref(),
+                )
+            }));
             last_resolved = batch
                 .last()
                 .map(|candidate| (candidate.cand_last_ms, candidate.session_id.clone()));
@@ -475,6 +478,7 @@ FORMAT JSONEachRow",
         candidate: &DirectoryCandidateRow,
         hydrated: &HashMap<String, HydratedSession>,
         filter: &McpSessionListFilter,
+        session_scope: Option<&SessionOriginScope>,
     ) -> Option<SurvivingCandidate> {
         let session_id = candidate.session_id.as_str();
         // Belt-and-braces with the SQL guard: a blank session_id never appears,
@@ -503,10 +507,25 @@ FORMAT JSONEachRow",
         {
             return None;
         }
+        // Project scope is re-checked EXACTLY here. Phase A's
+        // `argMinIfMerge(origin_cwd_state)` applies the same rule, but merged
+        // over the directory's live-generation rows rather than the
+        // `FINAL`-deduped navigation rows, so it is a recall filter like the
+        // others. Scope decides what a caller may see, so a false positive is
+        // not acceptable and it does not rest on recall.
+        if let Some(scope) = session_scope {
+            let cwd = totals.origin_cwd.as_str();
+            let in_scope = scope
+                .roots
+                .iter()
+                .any(|root| cwd == root.as_str() || cwd.starts_with(&format!("{root}/")));
+            if !in_scope {
+                return None;
+            }
+        }
         // Exact, case-sensitive equality against the hydrated aggregates: the
         // directory's `mode_hint` / `groupUniqArray` predicates are recall
-        // filters only. Project scope is NOT re-applied — Phase A's
-        // `argMinIfMerge(origin_cwd_state)` is already the exact rule.
+        // filters only.
         if filter.mode.is_some_and(|mode| totals.mode != mode.as_str()) {
             return None;
         }

--- a/crates/moraine-conversations/src/clickhouse_repo/list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/list.rs
@@ -1,4 +1,10 @@
+use super::canonical_list::{
+    candidate_fetch_size, hydration_chunk_size, DirectoryCandidateRow, DirectoryPageParams,
+    HydratedSession, SessionMetaBatchRow, SessionTerminalBatchRow, SessionTotalsBatchRow,
+};
+use super::canonical_open::{list_title_and_summary, total_turns_from_parts, MetaRow};
 use super::*;
+use crate::cursor::{ACCEPTED_MCP_SESSION_LIST_CURSOR_VERSIONS, MCP_SESSION_LIST_CURSOR_VERSION};
 
 impl ClickHouseConversationRepository {
     pub(super) async fn list_conversations_impl(
@@ -148,6 +154,20 @@ FORMAT JSONEachRow",
         })
     }
 
+    /// Session DISCOVERY. MCP `list_sessions` pages through it today; the
+    /// monitor feed still reads `list_session_analytics` and moves here in
+    /// WI-03 (issue-599 §1.1), which is why the `mcp_` prefix is already
+    /// historical and the operation carries no MCP-specific behavior.
+    ///
+    /// **Cursor contract (issue-599 §1.2).** The token is a VALUE anchor over
+    /// `(updated_at, session_id)`, not a snapshot. A session that receives
+    /// events while a caller pages moves its `updated_at` ahead of the anchor
+    /// and will not be seen again on a later page; restarting from page 1
+    /// observes the new order. Unrelated appends never invalidate the cursor.
+    /// A session can repeat across a paging run only if its `updated_at` moves
+    /// backwards, which append-only ingest cannot do under a fixed generation
+    /// — across a #602 generation replay it can, and that duplicate is
+    /// accepted rather than de-duplicated with server-side state.
     pub(super) async fn list_mcp_sessions_impl(
         &self,
         filter: McpSessionListFilter,
@@ -158,24 +178,355 @@ FORMAT JSONEachRow",
         let limit = page.normalized_limit(self.cfg.max_results);
         let filter_sig = self.mcp_session_list_filter_sig(&filter);
         let sort = filter.sort;
+        let cursor = Self::decode_session_list_cursor(page.cursor.as_deref(), &filter_sig, sort)?;
 
-        let cursor = if let Some(token) = page.cursor.as_deref() {
-            let cursor: McpSessionListCursor = decode_cursor(token)?;
-            if cursor.filter_sig != filter_sig {
-                return Err(RepoError::invalid_cursor(
-                    "cursor does not match current list_sessions filter",
-                ));
+        // Canonical-first when the issue-598 backfill has published coverage;
+        // otherwise the projected-header path still serves the page. The
+        // fallback is short-lived by design — it is deleted once the live
+        // gates are green (issue-599 open question 4).
+        if self.canonical_list_path_ready().await {
+            self.list_mcp_sessions_directory(&filter, filter_sig, sort, limit, cursor)
+                .await
+        } else {
+            self.list_mcp_sessions_headers(&filter, filter_sig, sort, limit, cursor)
+                .await
+        }
+    }
+
+    /// Decode and validate a `list_sessions` continuation token.
+    ///
+    /// Both cursor versions are accepted (see [`McpSessionListCursor`]); the
+    /// two mismatch messages are contract surface asserted by the tool tests.
+    fn decode_session_list_cursor(
+        token: Option<&str>,
+        filter_sig: &str,
+        sort: ConversationListSort,
+    ) -> RepoResult<Option<McpSessionListCursor>> {
+        let Some(token) = token else {
+            return Ok(None);
+        };
+        let cursor: McpSessionListCursor = decode_cursor(token)?;
+        if !ACCEPTED_MCP_SESSION_LIST_CURSOR_VERSIONS.contains(&cursor.version) {
+            return Err(RepoError::invalid_cursor(format!(
+                "unsupported list_sessions cursor version {}",
+                cursor.version
+            )));
+        }
+        if cursor.filter_sig != filter_sig {
+            return Err(RepoError::invalid_cursor(
+                "cursor does not match current list_sessions filter",
+            ));
+        }
+        if cursor.sort != sort {
+            return Err(RepoError::invalid_cursor(
+                "cursor sort does not match requested sort order",
+            ));
+        }
+        Ok(Some(cursor))
+    }
+
+    fn mint_session_list_cursor(
+        last_event_unix_ms: i64,
+        session_id: &str,
+        filter_sig: String,
+        sort: ConversationListSort,
+    ) -> RepoResult<String> {
+        encode_cursor(&McpSessionListCursor {
+            version: MCP_SESSION_LIST_CURSOR_VERSION,
+            last_event_unix_ms,
+            session_id: session_id.to_string(),
+            filter_sig,
+            sort,
+        })
+    }
+
+    /// The issue-599 canonical-first discovery page: content-free candidate
+    /// selection from `mcp_session_directory` (Phase A), batched hydration of
+    /// the bounded candidate chunks (Phase B), then the exact re-filter, title
+    /// fold, trim, and cursor mint (Phase C).
+    ///
+    /// **Phase A runs exactly once.** Its keyset predicate is post-aggregation
+    /// and the directory's sort key leads with `session_id`, so re-running it
+    /// with an advanced keyset would re-aggregate the whole directory without
+    /// pruning anything. The single pass therefore over-fetches the page's
+    /// entire hydration budget ([`candidate_fetch_size`]) and only HYDRATION is
+    /// chunked. Worst case per page: `1 + MAX_HYDRATION_CHUNKS × 3 = 13`
+    /// statements.
+    ///
+    /// Chunked hydration exists because the directory's recall filters are
+    /// inexact: a chunk can be eliminated wholesale by the exact re-filter and
+    /// the page must still make progress. When the budget runs out with
+    /// candidates remaining, the page returns what survived WITH a continuation
+    /// cursor (possibly on an empty `items`) rather than a short page that
+    /// reads as "no more results".
+    async fn list_mcp_sessions_directory(
+        &self,
+        filter: &McpSessionListFilter,
+        filter_sig: String,
+        sort: ConversationListSort,
+        limit: u16,
+        cursor: Option<McpSessionListCursor>,
+    ) -> RepoResult<Page<McpSessionListItem>> {
+        let fetch = candidate_fetch_size(limit);
+        let sql = {
+            let params = DirectoryPageParams {
+                start_unix_ms: filter.start_unix_ms,
+                end_unix_ms: filter.end_unix_ms,
+                mode: filter.mode,
+                harness: filter.harness.as_deref(),
+                source_name: filter.source_name.as_deref(),
+                sort,
+                after: cursor
+                    .as_ref()
+                    .map(|cursor| (cursor.last_event_unix_ms, cursor.session_id.as_str())),
+                limit: fetch,
+            };
+            self.build_session_directory_page_sql(&params)
+        };
+        let candidates: Vec<DirectoryCandidateRow> =
+            self.map_backend(self.query_rows(&sql, None).await)?;
+        // A short candidate page proves the directory holds nothing further
+        // under this filter and keyset.
+        let directory_exhausted = candidates.len() < fetch as usize;
+
+        let mut survivors: Vec<SurvivingCandidate> = Vec::new();
+        let mut last_resolved: Option<(i64, String)> = None;
+        for batch in candidates.chunks(hydration_chunk_size(limit) as usize) {
+            if survivors.len() > usize::from(limit) {
+                // The page is full and provably has more; the untouched tail of
+                // the over-fetch is resolved by the next request.
+                break;
             }
-            if cursor.sort != sort {
-                return Err(RepoError::invalid_cursor(
-                    "cursor sort does not match requested sort order",
-                ));
+            let session_ids: Vec<String> = batch
+                .iter()
+                .map(|candidate| candidate.session_id.clone())
+                .collect();
+            let hydrated = self.hydrate_session_list_chunk(&session_ids).await?;
+            survivors.extend(
+                batch
+                    .iter()
+                    .filter_map(|candidate| Self::session_list_item(candidate, &hydrated, filter)),
+            );
+            last_resolved = batch
+                .last()
+                .map(|candidate| (candidate.cand_last_ms, candidate.session_id.clone()));
+        }
+
+        // Phase A ordered CANDIDATES; hydration is unordered, so re-establish
+        // the keyset order here — on the directory value Phase A ordered and
+        // filtered by, never on the hydrated timestamp, which the next page's
+        // `HAVING` cannot compare against (see `DirectoryCandidateRow`).
+        survivors.sort_by(|a, b| {
+            let ordering = a
+                .keyset_ms
+                .cmp(&b.keyset_ms)
+                .then_with(|| a.item.session_id.cmp(&b.item.session_id));
+            match sort {
+                ConversationListSort::Desc => ordering.reverse(),
+                ConversationListSort::Asc => ordering,
             }
-            Some(cursor)
+        });
+        let has_more_survivors = survivors.len() > usize::from(limit);
+        survivors.truncate(usize::from(limit));
+
+        let next_cursor = if has_more_survivors {
+            // Anchored on the LAST KEPT item, so the trailing survivors this
+            // page dropped are served by the next one.
+            survivors
+                .last()
+                .map(|survivor| {
+                    Self::mint_session_list_cursor(
+                        survivor.keyset_ms,
+                        &survivor.item.session_id,
+                        filter_sig,
+                        sort,
+                    )
+                })
+                .transpose()?
+        } else if !directory_exhausted {
+            // The hydration budget ran out with directory candidates left, so
+            // the page returns short (possibly empty) but WITH a continuation.
+            //
+            // The anchor is the last RESOLVED CANDIDATE, not the last kept
+            // item: every candidate up to it has already been hydrated and
+            // judged, so resuming strictly after it loses nothing, and it is
+            // what guarantees forward progress. Anchoring on the last kept item
+            // instead would make the next request re-examine the same rejects
+            // and, when a filter is selective enough to eliminate the whole
+            // budget, hand back the identical cursor forever.
+            last_resolved
+                .as_ref()
+                .map(|(last_ms, session_id)| {
+                    Self::mint_session_list_cursor(*last_ms, session_id, filter_sig, sort)
+                })
+                .transpose()?
         } else {
             None
         };
 
+        Ok(Page {
+            items: survivors
+                .into_iter()
+                .map(|survivor| survivor.item)
+                .collect(),
+            next_cursor,
+        })
+    }
+
+    /// Phase B (issue-599 §1.4): three batched statements hydrate the whole
+    /// candidate chunk. Never a per-session loop — 3 × K sequential round trips
+    /// cannot fit a 3 s tool deadline.
+    async fn hydrate_session_list_chunk(
+        &self,
+        session_ids: &[String],
+    ) -> RepoResult<HashMap<String, HydratedSession>> {
+        if session_ids.is_empty() {
+            return Ok(HashMap::default());
+        }
+        let totals_sql = self.build_session_totals_batch_sql(session_ids);
+        let totals: Vec<SessionTotalsBatchRow> =
+            self.map_backend(self.query_rows(&totals_sql, None).await)?;
+        let mut hydrated: HashMap<String, HydratedSession> = totals
+            .into_iter()
+            .map(|totals| {
+                (
+                    totals.session_id.clone(),
+                    HydratedSession {
+                        totals,
+                        metadata: Vec::new(),
+                        completed: false,
+                    },
+                )
+            })
+            .collect();
+        // Every candidate failed the published-generation join: nothing to
+        // hydrate, and the two remaining statements would read nothing.
+        if hydrated.is_empty() {
+            return Ok(hydrated);
+        }
+
+        let metadata_sql = self.build_session_metadata_batch_sql(session_ids);
+        let metadata: Vec<SessionMetaBatchRow> =
+            self.map_backend(self.query_rows(&metadata_sql, None).await)?;
+        for row in metadata {
+            if let Some(session) = hydrated.get_mut(&row.session_id) {
+                session.metadata.push(MetaRow {
+                    event_ts: row.event_ts,
+                    event_uid: row.event_uid,
+                    event_kind: row.event_kind,
+                    payload_json: row.payload_json,
+                });
+            }
+        }
+
+        let terminal_sql = self.build_session_terminal_batch_sql(session_ids);
+        let terminal: Vec<SessionTerminalBatchRow> =
+            self.map_backend(self.query_rows(&terminal_sql, None).await)?;
+        for row in terminal {
+            if let Some(session) = hydrated.get_mut(&row.session_id) {
+                session.completed = row.completed != 0;
+            }
+        }
+
+        Ok(hydrated)
+    }
+
+    /// Phase C (issue-599 §1.5): re-apply the exact filters to one candidate's
+    /// hydrated values and fold it into a list item, or drop it. The candidate's
+    /// keyset value travels with the item because ordering and cursor minting
+    /// must read it, not the hydrated timestamp.
+    fn session_list_item(
+        candidate: &DirectoryCandidateRow,
+        hydrated: &HashMap<String, HydratedSession>,
+        filter: &McpSessionListFilter,
+    ) -> Option<SurvivingCandidate> {
+        let session_id = candidate.session_id.as_str();
+        // Belt-and-braces with the SQL guard: a blank session_id never appears,
+        // never consumes a LIMIT slot, and never anchors a cursor. mcp-core
+        // applies the same `trim().is_empty()` rejection and the two halves
+        // must agree, or the contiguous-`rank` and `result_count` invariants
+        // break.
+        if session_id.trim().is_empty() {
+            return None;
+        }
+        // A candidate with no live navigation rows under the pinned
+        // publication has no totals row at all — the canonical replacement for
+        // the retired `tombstone` column (issue-599 §2.7).
+        let session = hydrated.get(session_id)?;
+        let totals = &session.totals;
+        if totals.total_events == 0 {
+            return None;
+        }
+        // The directory aggregates ALL generations while hydration is
+        // published-filtered, so re-check the overlap on the exact bounds: a
+        // session whose only in-window generation is unpublished drops here.
+        if totals.last_event_unix_ms < filter.start_unix_ms
+            || totals.first_event_unix_ms >= filter.end_unix_ms
+        {
+            return None;
+        }
+        // Exact, case-sensitive equality against the hydrated aggregates: the
+        // directory's `mode_hint` / `groupUniqArray` predicates are recall
+        // filters only. Project scope is NOT re-applied — Phase A's
+        // `argMinIfMerge(origin_cwd_state)` is already the exact rule.
+        if filter.mode.is_some_and(|mode| totals.mode != mode.as_str()) {
+            return None;
+        }
+        if filter
+            .harness
+            .as_deref()
+            .is_some_and(|harness| totals.harness != harness)
+        {
+            return None;
+        }
+        if filter
+            .source_name
+            .as_deref()
+            .is_some_and(|source_name| totals.source != source_name)
+        {
+            return None;
+        }
+
+        let precedence = session.precedence();
+        let (title, session_summary) = list_title_and_summary(&totals.source, &precedence);
+        Some(SurvivingCandidate {
+            keyset_ms: candidate.cand_last_ms,
+            item: McpSessionListItem {
+                session_id: session_id.to_string(),
+                first_event_time: totals.first_event_time.clone(),
+                first_event_unix_ms: totals.first_event_unix_ms,
+                last_event_time: totals.last_event_time.clone(),
+                last_event_unix_ms: totals.last_event_unix_ms,
+                total_turns: total_turns_from_parts(
+                    totals.total_events,
+                    totals.max_override,
+                    totals.counter_user_messages,
+                ),
+                total_events: totals.total_events,
+                mode: Self::parse_mode(&totals.mode),
+                completed: session.completed,
+                title: non_empty_string(title),
+                source: non_empty_string(totals.source.clone()),
+                harness: non_empty_string(totals.harness.clone()),
+                inference_provider: non_empty_string(totals.inference_provider.clone()),
+                session_slug: non_empty_string(precedence.session_slug),
+                session_summary: non_empty_string(session_summary),
+                tool_calls: totals.tool_calls,
+            },
+        })
+    }
+
+    /// The pre-#599 projected-header discovery page, kept behind the
+    /// canonical read-index readiness gate for stores whose issue-598 backfill
+    /// has not published coverage yet.
+    async fn list_mcp_sessions_headers(
+        &self,
+        filter: &McpSessionListFilter,
+        filter_sig: String,
+        sort: ConversationListSort,
+        limit: u16,
+        cursor: Option<McpSessionListCursor>,
+    ) -> RepoResult<Page<McpSessionListItem>> {
         let snapshot = require_active_publication_snapshot("projected MCP session list reads");
         let headers = self.table_ref("mcp_open_publication_headers");
         let history = self.table_ref("v_published_source_generation_history");
@@ -289,9 +640,11 @@ SELECT
   toUInt64(s.total_events) AS total_events,
   s.mode AS mode,
   toUInt8(s.completed) AS completed,
+  toUInt64(s.tool_calls) AS tool_calls,
   s.list_title AS title,
   s.source AS source,
   s.harness AS harness,
+  s.inference_provider AS inference_provider,
   s.session_slug AS session_slug,
   s.list_session_summary AS session_summary
 FROM current_headers AS s
@@ -317,16 +670,17 @@ FORMAT JSONEachRow",
             .collect();
 
         let next_cursor = if rows.len() > limit as usize {
-            if let Some(last) = items.last() {
-                Some(encode_cursor(&McpSessionListCursor {
-                    last_event_unix_ms: last.last_event_unix_ms,
-                    session_id: last.session_id.clone(),
-                    filter_sig,
-                    sort,
-                })?)
-            } else {
-                None
-            }
+            items
+                .last()
+                .map(|last| {
+                    Self::mint_session_list_cursor(
+                        last.last_event_unix_ms,
+                        &last.session_id,
+                        filter_sig,
+                        sort,
+                    )
+                })
+                .transpose()?
         } else {
             None
         };
@@ -571,4 +925,14 @@ FORMAT JSONEachRow",
         let items = rows.into_iter().map(Self::map_trace_event).collect();
         Ok(Page { items, next_cursor })
     }
+}
+
+/// A Phase-A candidate that survived Phase C, paired with the directory keyset
+/// value it was selected by. `keyset_ms` — not `item.last_event_unix_ms` —
+/// orders the page and mints the continuation cursor, because it is the only
+/// value the next page's Phase A can filter on
+/// ([`DirectoryCandidateRow::cand_last_ms`]).
+struct SurvivingCandidate {
+    keyset_ms: i64,
+    item: McpSessionListItem,
 }

--- a/crates/moraine-conversations/src/clickhouse_repo/mod.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/mod.rs
@@ -98,6 +98,7 @@ use crate::repo::ConversationRepository;
 
 mod analytics;
 mod cache;
+mod canonical_list;
 mod canonical_open;
 mod consistency;
 mod file_attention;
@@ -137,6 +138,10 @@ pub struct ClickHouseConversationRepository {
     /// replaces the prior revision for the same session, and the total entry
     /// count is bounded. Negative results are not cached.
     scoped_session_cache: Arc<RwLock<HashMap<String, String>>>,
+    /// One-shot canonical read-index readiness latch (issue #598 `open_v2`),
+    /// gating the issue-599 directory session-listing path.
+    /// See [`Self::canonical_list_path_ready`].
+    canonical_list_ready: Arc<OnceLock<bool>>,
 }
 
 impl ClickHouseConversationRepository {
@@ -164,11 +169,55 @@ impl ClickHouseConversationRepository {
             search_doc_extra_cache: Arc::new(RwLock::new(HashMap::new())),
             analytics_cache: Arc::new(std::array::from_fn(|_| Mutex::new(None))),
             scoped_session_cache: Arc::new(RwLock::new(HashMap::new())),
+            canonical_list_ready: Arc::new(OnceLock::new()),
         }
     }
 
     pub fn config(&self) -> &RepoConfig {
         &self.cfg
+    }
+
+    /// Whether session listing may use the issue-599 directory path.
+    ///
+    /// The gate is the issue-598 `open_v2` readiness key — the SAME authority
+    /// the `open` cutover uses ([`crate::probe_open_v2_ready`]), deliberately
+    /// not the weaker `core_indexes` coverage flag. `open_v2.ready` is
+    /// published only when the backfill sweep has completed AND the persisted
+    /// overlap audit passed (`ClickHouseClient::promote_open_v2_reader`), so
+    /// gating on `core_indexes` alone would let listing read indexes the
+    /// `open` path refuses — including a store whose audit is failing. Both
+    /// cutovers read `mcp_session_directory` / `mcp_event_navigation`; one
+    /// readiness authority, one verdict.
+    ///
+    /// The verdict is latched on the first SUCCESSFUL probe, for this
+    /// repository and every clone of it — one instance per routed backend, so
+    /// in practice one point read per backend per process.
+    ///
+    /// A transport failure is deliberately NOT latched: it degrades to the
+    /// header path and re-probes on the next request. That diverges from the
+    /// `open` cutover, where [`crate::probe_open_v2_ready`] collapses an
+    /// unreachable backend to `false` and the caller's `OnceCell` latches it
+    /// for the process. The divergence is intentional and one-way-safe: that
+    /// probe runs once at startup and cannot retry, while this one is already
+    /// on a request path that can. Both latch a genuine `false`, so neither
+    /// gate can flap open and shut mid-process.
+    pub(super) async fn canonical_list_path_ready(&self) -> bool {
+        if let Some(ready) = self.canonical_list_ready.get() {
+            return *ready;
+        }
+        match self.ch.open_v2_reader_ready().await {
+            Ok(ready) => {
+                let _ = self.canonical_list_ready.set(ready);
+                ready
+            }
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    "open_v2 reader readiness probe failed; session listing stays on the projected-header path"
+                );
+                false
+            }
+        }
     }
 
     pub(super) fn table_ref(&self, table: &str) -> String {

--- a/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
@@ -118,6 +118,16 @@ impl ConversationRepository for ClickHouseConversationRepository {
         filter: McpSessionListFilter,
         page: PageRequest,
     ) -> RepoResult<Page<McpSessionListItem>> {
+        // MovingFeed, not AnchoredSession: that class exists for a single
+        // anchored session and a K-session page has no single scope.
+        //
+        // No deadline narrowing here. Callers scope the envelope around this
+        // whole call (`list_sessions_v1` narrows to `LIST_SESSIONS_DEADLINE_MS`),
+        // which already puts every statement of the page — snapshot capture and
+        // revalidation, the directory pass, and the batched hydration — under
+        // one wall with the server-side `max_execution_time` tracking it.
+        // A second narrowing inside the repository would be that same bound
+        // applied twice.
         self.run_publication_consistent(PublicationReadClass::MovingFeed, || {
             self.list_mcp_sessions_impl(filter.clone(), page.clone())
         })

--- a/crates/moraine-conversations/src/clickhouse_repo/rows.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/rows.rs
@@ -60,9 +60,13 @@ pub(super) struct McpSessionListRow {
     #[serde(default)]
     pub(super) harness: String,
     #[serde(default)]
+    pub(super) inference_provider: String,
+    #[serde(default)]
     pub(super) session_slug: String,
     #[serde(default)]
     pub(super) session_summary: String,
+    #[serde(default)]
+    pub(super) tool_calls: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -636,8 +640,10 @@ impl ClickHouseConversationRepository {
             title: non_empty_string(row.title),
             source: non_empty_string(row.source),
             harness: non_empty_string(row.harness),
+            inference_provider: non_empty_string(row.inference_provider),
             session_slug: non_empty_string(row.session_slug),
             session_summary: non_empty_string(row.session_summary),
+            tool_calls: row.tool_calls,
         }
     }
 

--- a/crates/moraine-conversations/src/cursor.rs
+++ b/crates/moraine-conversations/src/cursor.rs
@@ -16,20 +16,25 @@ pub struct ConversationCursor {
 
 /// Keyset anchor over `(updated_at, session_id)` for `list_sessions`.
 ///
-/// `version` separates the pre-#599 projected-header token (key absent, decoded
-/// as `0`) from the #599 directory token (`2`). Any other value is rejected as
-/// an invalid cursor.
+/// `version` identifies the READ PATH that minted the token, because the two
+/// paths anchor on different values. The projected-header path anchors on
+/// `mcp_open_publication_headers.last_event_time`, the projector's exact
+/// aggregate; the #599 directory path anchors on
+/// `max(mcp_session_directory.max_observed_event_time)` over the session's live
+/// source generations, which is also the `updated_at` that path reports. The
+/// two coincide for a session that was never re-ingested and diverge otherwise
+/// — a `SimpleAggregateFunction(max)` cannot retract a display time that a
+/// retry-replay lowered, a `ReplacingMergeTree` read `FINAL` can.
 ///
-/// Both are accepted because the anchor is the same `cd::DISPLAY_TIME_EXPR`
-/// maximum under either implementation — the header path projects it, the
-/// directory path re-aggregates it. The two differ only where an event version
-/// has been superseded: the directory's `SimpleAggregateFunction(max)` cannot
-/// retract one, so a v2 anchor can sit above the header path's exact value.
-/// Resuming a v0 token on the directory path may therefore re-serve the
-/// boundary session, the same duplicate class the moving-feed contract already
-/// accepts across a #602 generation replay. WITHIN one implementation the
-/// anchor is always the value that implementation filters on, which is what
-/// makes paging skip-free.
+/// A token is therefore only meaningful to the path that minted it: resumed on
+/// the other path it would silently skip every session whose two values
+/// straddle the anchor. A cross-path token is rejected with the cursor-mismatch
+/// error rather than resumed, so a readiness flip mid-pagination surfaces as an
+/// error the caller can restart from instead of a gap it cannot see.
+///
+/// An absent `version` key decodes to
+/// [`MCP_SESSION_LIST_CURSOR_VERSION_HEADERS`], which is what a pre-#599 token
+/// is — that build served every page from the header path.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpSessionListCursor {
     #[serde(default)]
@@ -41,12 +46,20 @@ pub struct McpSessionListCursor {
     pub sort: ConversationListSort,
 }
 
-/// The token version this build mints.
-pub const MCP_SESSION_LIST_CURSOR_VERSION: u8 = 2;
+/// Token version minted by the projected-header path — `0`, the value an absent
+/// `version` key decodes to, so every pre-#599 token is a header token.
+pub const MCP_SESSION_LIST_CURSOR_VERSION_HEADERS: u8 = 0;
 
-/// Token versions this build accepts: the legacy header token (`0`) and the
-/// directory token ([`MCP_SESSION_LIST_CURSOR_VERSION`]).
-pub const ACCEPTED_MCP_SESSION_LIST_CURSOR_VERSIONS: [u8; 2] = [0, MCP_SESSION_LIST_CURSOR_VERSION];
+/// Token version minted by the #599 directory path.
+pub const MCP_SESSION_LIST_CURSOR_VERSION_DIRECTORY: u8 = 2;
+
+/// Token versions this build can decode. A version outside this set is an
+/// invalid cursor; a version inside it that names the other path is a cursor
+/// mismatch (see [`McpSessionListCursor`]).
+pub const ACCEPTED_MCP_SESSION_LIST_CURSOR_VERSIONS: [u8; 2] = [
+    MCP_SESSION_LIST_CURSOR_VERSION_HEADERS,
+    MCP_SESSION_LIST_CURSOR_VERSION_DIRECTORY,
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TurnCursor {

--- a/crates/moraine-conversations/src/cursor.rs
+++ b/crates/moraine-conversations/src/cursor.rs
@@ -14,14 +14,39 @@ pub struct ConversationCursor {
     pub sort: ConversationListSort,
 }
 
+/// Keyset anchor over `(updated_at, session_id)` for `list_sessions`.
+///
+/// `version` separates the pre-#599 projected-header token (key absent, decoded
+/// as `0`) from the #599 directory token (`2`). Any other value is rejected as
+/// an invalid cursor.
+///
+/// Both are accepted because the anchor is the same `cd::DISPLAY_TIME_EXPR`
+/// maximum under either implementation — the header path projects it, the
+/// directory path re-aggregates it. The two differ only where an event version
+/// has been superseded: the directory's `SimpleAggregateFunction(max)` cannot
+/// retract one, so a v2 anchor can sit above the header path's exact value.
+/// Resuming a v0 token on the directory path may therefore re-serve the
+/// boundary session, the same duplicate class the moving-feed contract already
+/// accepts across a #602 generation replay. WITHIN one implementation the
+/// anchor is always the value that implementation filters on, which is what
+/// makes paging skip-free.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpSessionListCursor {
+    #[serde(default)]
+    pub version: u8,
     pub last_event_unix_ms: i64,
     pub session_id: String,
     pub filter_sig: String,
     #[serde(default)]
     pub sort: ConversationListSort,
 }
+
+/// The token version this build mints.
+pub const MCP_SESSION_LIST_CURSOR_VERSION: u8 = 2;
+
+/// Token versions this build accepts: the legacy header token (`0`) and the
+/// directory token ([`MCP_SESSION_LIST_CURSOR_VERSION`]).
+pub const ACCEPTED_MCP_SESSION_LIST_CURSOR_VERSIONS: [u8; 2] = [0, MCP_SESSION_LIST_CURSOR_VERSION];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TurnCursor {

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -53,6 +53,16 @@ pub struct ConversationListFilter {
     pub sort: ConversationListSort,
 }
 
+/// Every field here is a QUERY dimension and participates in the cursor filter
+/// signature.
+///
+/// It deliberately carries neither an execution budget nor a cancellation
+/// token, unlike [`FileAttentionQuery`]. Callers narrow the ambient
+/// [`QueryEnvelope`](crate::QueryEnvelope) around the whole operation, which
+/// already bounds every statement of a page, and the transport injects the
+/// active envelope's `request_id` as each statement's `query_id`. Listing has
+/// nothing left to override. `file_attention` needs both only because it mints
+/// its own token and issues the KILL itself.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpSessionListFilter {
     pub start_unix_ms: i64,
@@ -420,10 +430,18 @@ pub struct McpSessionListItem {
     pub source: Option<String>,
     #[serde(default)]
     pub harness: Option<String>,
+    /// Latest `inference_provider` by `(event_ts, event_uid)`. Carried for the
+    /// monitor's provider facet; MCP's `session_json` does not emit it.
+    #[serde(default)]
+    pub inference_provider: Option<String>,
     #[serde(default)]
     pub session_slug: Option<String>,
     #[serde(default)]
     pub session_summary: Option<String>,
+    /// Session-wide `tool_call` event count, for the monitor's per-card badge.
+    /// MCP's `session_json` does not emit it.
+    #[serde(default)]
+    pub tool_calls: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/moraine-conversations/src/repo.rs
+++ b/crates/moraine-conversations/src/repo.rs
@@ -57,6 +57,21 @@ pub trait ConversationRepository: Send + Sync {
 
     async fn get_mcp_session(&self, session_id: &str) -> RepoResult<Option<McpSessionOpen>>;
 
+    /// Session DISCOVERY, and the operation the monitor feed is being
+    /// consolidated onto (issue-599 WI-03; it still reads
+    /// [`Self::list_session_analytics`] today). The `mcp_` prefix is already
+    /// historical; renaming it is recorded as a post-epic cleanup.
+    ///
+    /// Whether more results exist is `Page::next_cursor.is_some()` — there is
+    /// deliberately no `total`, because a corpus-wide count is exactly the
+    /// corpus-sized work this operation exists to remove. An empty `items`
+    /// carrying a `next_cursor` is a legal "keep going" signal, not "no
+    /// results".
+    ///
+    /// The cursor is a VALUE anchor over `(updated_at, session_id)`, not a
+    /// snapshot: concurrent appends may move a session ahead of an existing
+    /// cursor, and it will not be seen again until the caller restarts from
+    /// page 1.
     async fn list_mcp_sessions(
         &self,
         filter: McpSessionListFilter,

--- a/crates/moraine-conversations/tests/repository_integration/errors.rs
+++ b/crates/moraine-conversations/tests/repository_integration/errors.rs
@@ -132,7 +132,8 @@ async fn typed_budget_errors_take_the_consistency_non_retry_arm() {
         // Only ReadModelChanged re-runs the publication-consistent operation.
         // A typed deadline error must propagate after exactly one attempt: one
         // snapshot capture, one operation read, no revalidation, no retry.
-        let (repo, state) = build_scripted_repo(vec![ScriptedResponse::failure(
+        // The readiness gate is declared, so the probe never consumes a script.
+        let (repo, state) = build_scripted_header_repo(vec![ScriptedResponse::failure(
             &[],
             "Code: 159. DB::Exception: Timeout exceeded: elapsed 2.0 seconds",
         )])

--- a/crates/moraine-conversations/tests/repository_integration/sessions.rs
+++ b/crates/moraine-conversations/tests/repository_integration/sessions.rs
@@ -761,8 +761,40 @@ async fn list_mcp_sessions_directory_page_never_prefilters_mcp_internal_mode() {
 }
 
 /// One Phase-A candidate row.
+/// Render a millisecond instant the way ClickHouse renders `DateTime64(3)`.
+fn format_directory_display_time(unix_ms: i64) -> String {
+    let secs = unix_ms.div_euclid(1_000);
+    let millis = unix_ms.rem_euclid(1_000);
+    let days = secs.div_euclid(86_400);
+    let time_of_day = secs.rem_euclid(86_400);
+    // 1970-01-01 + `days`, via the civil-from-days algorithm.
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!(
+        "{y:04}-{m:02}-{d:02} {:02}:{:02}:{:02}.{millis:03}",
+        time_of_day / 3_600,
+        (time_of_day % 3_600) / 60,
+        time_of_day % 60
+    )
+}
+
 fn candidate_row(session_id: &str, cand_last_ms: i64) -> serde_json::Value {
-    json!({ "session_id": session_id, "cand_last_ms": cand_last_ms })
+    // `cand_last_time` is the display form of the same instant: the directory
+    // path orders by `cand_last_ms` and reports its display form, so a fixture
+    // that let them describe different instants would not model the real row.
+    json!({
+        "session_id": session_id,
+        "cand_last_ms": cand_last_ms,
+        "cand_last_time": format_directory_display_time(cand_last_ms),
+    })
 }
 
 /// [`totals_row`] with explicit exact `display_time` bounds, for the case where
@@ -831,9 +863,14 @@ async fn list_mcp_sessions_directory_page_orders_and_anchors_on_the_directory_ke
             page.items[0].session_id, "sess-p",
             "survivors must be ordered by the directory keyset, not the hydrated timestamp"
         );
+        // B1: the response reports the value the page was ORDERED and KEYSET
+        // by, so it is sorted by the field it returns. sess-p's directory
+        // aggregate (1_767_400_000_000) sits above its hydrated exact value
+        // (1_767_300_000_000) — the re-inserted-event case — and it is the
+        // aggregate that is reported.
         assert_eq!(
-            page.items[0].last_event_unix_ms, 1_767_300_000_000_i64,
-            "the item still reports the EXACT aggregate"
+            page.items[0].last_event_unix_ms, 1_767_400_000_000_i64,
+            "the item must report the directory aggregate it was ordered by"
         );
 
         let cursor = page.next_cursor.expect("next cursor");

--- a/crates/moraine-conversations/tests/repository_integration/sessions.rs
+++ b/crates/moraine-conversations/tests/repository_integration/sessions.rs
@@ -479,18 +479,34 @@ async fn list_sessions_semantics_are_identical_on_both_paths() {
             ));
         }
 
-        // Same filter, same fixture corpus: the two readers must agree field
-        // for field, including the minted continuation token. The cursor is
-        // part of the comparison because both paths anchor it on the same
-        // `(updated_at, session_id)` value — that equality is what lets an
-        // in-flight token survive the cutover.
+        // Same filter, same fixture corpus: the two readers must agree on the
+        // session set and on every per-item field.
+        //
+        // The CURSOR is deliberately excluded from that comparison and asserted
+        // to differ instead. The two paths anchor on different values — the
+        // header path on the projector's exact aggregate, the directory path on
+        // the live-generation `max_observed_event_time` it also reports — so a
+        // token is only meaningful to the path that minted it. Comparing the
+        // tokens for equality would re-assert the false premise this test used
+        // to carry, and would fail the moment the anchors legitimately diverge.
         let (reference_path, reference) = &pages[0];
         for (path, page) in &pages[1..] {
             assert_eq!(
-                serde_json::to_value(page).expect("serialize page"),
-                serde_json::to_value(reference).expect("serialize page"),
+                serde_json::to_value(&page.items).expect("serialize items"),
+                serde_json::to_value(&reference.items).expect("serialize items"),
                 "{path:?} diverged from {reference_path:?}"
             );
+            assert_eq!(
+                page.next_cursor.is_some(),
+                reference.next_cursor.is_some(),
+                "{path:?} and {reference_path:?} must agree on whether more pages exist"
+            );
+            if let (Some(theirs), Some(ours)) = (&page.next_cursor, &reference.next_cursor) {
+                assert_ne!(
+                    theirs, ours,
+                    "{path:?} must mint a path-tagged token distinct from {reference_path:?}"
+                );
+            }
         }
     })
     .await;
@@ -1007,9 +1023,16 @@ async fn list_mcp_sessions_accepts_legacy_cursors_and_rejects_unknown_versions()
             URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).expect("re-encode cursor"))
         };
 
-        // A pre-#599 token carries no `version` key and must still resume: the
-        // ordering value is identical under both implementations.
-        let legacy = repo
+        // This repository serves the DIRECTORY path. A pre-#599 token carries
+        // no `version` key, which decodes to the header path's version — so it
+        // is a token this path did not mint, and it must be REFUSED rather
+        // than resumed. The two paths anchor on different values (the header
+        // path on the projector's exact aggregate, the directory path on the
+        // live-generation `max_observed_event_time` it also reports), so
+        // resuming it here would silently skip every session whose two anchors
+        // straddle it — a gap the caller cannot see. A mismatch is recoverable:
+        // restart the feed.
+        let error = repo
             .list_mcp_sessions(
                 filter.clone(),
                 PageRequest {
@@ -1018,9 +1041,30 @@ async fn list_mcp_sessions_accepts_legacy_cursors_and_rejects_unknown_versions()
                 },
             )
             .await
-            .expect("legacy cursor resumes");
-        assert_eq!(legacy.items.len(), 1);
-        assert_eq!(legacy.items[0].session_id, "sess_a");
+            .expect_err("a header-minted token must not resume on the directory path");
+        assert!(
+            error
+                .to_string()
+                .contains("different list_sessions read path"),
+            "cross-path cursor must report a path mismatch, got: {error}"
+        );
+
+        // The path's OWN token still resumes, so the rejection above is about
+        // provenance and not a blanket refusal.
+        let resumed = repo
+            .list_mcp_sessions(
+                filter.clone(),
+                PageRequest {
+                    limit: 2,
+                    // 2 = MCP_SESSION_LIST_CURSOR_VERSION_DIRECTORY (the
+                    // cursor module is crate-private, so the literal stands in
+                    // here the same way the rejected versions below do).
+                    cursor: Some(retoken(Some(2))),
+                },
+            )
+            .await
+            .expect("a directory-minted token resumes on the directory path");
+        assert!(resumed.items.len() <= 2);
 
         for version in [1_u64, 3] {
             let error = repo

--- a/crates/moraine-conversations/tests/repository_integration/sessions.rs
+++ b/crates/moraine-conversations/tests/repository_integration/sessions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use moraine_conversations::{ClickHouseConversationRepository, McpSessionListItem, Page};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn publication_snapshot_combines_head_and_fence_round_trips() {
@@ -285,6 +286,816 @@ async fn list_mcp_sessions_uses_overlap_filter_and_cursor_pagination() {
     })
     .await;
 }
+/// The issue-599 filter: every dimension populated, so the assertions below
+/// exercise each one's recall predicate and exact re-check.
+fn directory_filter() -> McpSessionListFilter {
+    McpSessionListFilter {
+        start_unix_ms: 1767261600000_i64,
+        end_unix_ms: 1767500000000_i64,
+        mode: Some(ConversationMode::WebSearch),
+        harness: Some("codex".to_string()),
+        source_name: Some("codex".to_string()),
+        sort: ConversationListSort::Desc,
+    }
+}
+
+/// The two `list_sessions` implementations behind
+/// [`ClickHouseConversationRepository::list_mcp_sessions`].
+///
+/// The semantics-preservation checklist (issue-599 §4) is a contract on the
+/// OPERATION, not on one implementation of it, so every shared assertion runs
+/// against both. The mock serves the same three fixture sessions to each path,
+/// which is what makes a field-for-field page comparison meaningful.
+#[derive(Copy, Clone, Debug)]
+enum ListPath {
+    /// Pre-#599 `mcp_open_publication_headers` reader (`open_v2` unpublished).
+    Headers,
+    /// Issue-599 `mcp_session_directory` reader (`open_v2` published).
+    Directory,
+}
+
+impl ListPath {
+    const ALL: [Self; 2] = [Self::Headers, Self::Directory];
+
+    async fn repo(self) -> (ClickHouseConversationRepository, Arc<MockState>) {
+        match self {
+            Self::Headers => build_repo().await,
+            Self::Directory => build_directory_repo().await,
+        }
+    }
+
+    async fn scoped_repo(
+        self,
+        roots: &[&str],
+    ) -> (ClickHouseConversationRepository, Arc<MockState>) {
+        match self {
+            Self::Headers => build_scoped_repo(roots).await,
+            Self::Directory => build_scoped_directory_repo(roots).await,
+        }
+    }
+}
+
+/// The issue-599 §4 semantics-preservation checklist, expressed as behavioral
+/// assertions so it runs unchanged against either implementation: argument
+/// validation, overlap filtering, keyset continuation, the exact
+/// cursor-mismatch contract string, and the additive monitor facets. Returns
+/// the first page so the caller can compare the two paths directly.
+async fn assert_shared_list_sessions_semantics(
+    repo: &ClickHouseConversationRepository,
+    path: ListPath,
+) -> Page<McpSessionListItem> {
+    let filter = directory_filter();
+
+    // Argument validation runs before any read on both paths.
+    for (start_unix_ms, end_unix_ms) in [(1_767_500_000_000_i64, 1_767_261_600_000_i64), (7, 7)] {
+        let error = repo
+            .list_mcp_sessions(
+                McpSessionListFilter {
+                    start_unix_ms,
+                    end_unix_ms,
+                    ..filter.clone()
+                },
+                PageRequest {
+                    limit: 2,
+                    cursor: None,
+                },
+            )
+            .await
+            .expect_err("an empty or inverted window must be rejected");
+        assert_eq!(
+            error.to_string(),
+            "invalid argument: start_unix_ms must be strictly less than end_unix_ms",
+            "{path:?}"
+        );
+    }
+
+    let first = repo
+        .list_mcp_sessions(
+            filter.clone(),
+            PageRequest {
+                limit: 2,
+                cursor: None,
+            },
+        )
+        .await
+        .expect("first page");
+
+    assert_eq!(first.items.len(), 2, "{path:?}");
+    assert_eq!(first.items[0].session_id, "sess_c", "{path:?}");
+    assert_eq!(first.items[1].session_id, "sess_b", "{path:?}");
+    assert_eq!(
+        first.items[0].title.as_deref(),
+        Some("Session C title"),
+        "{path:?}"
+    );
+    assert_eq!(
+        first.items[0].session_summary.as_deref(),
+        Some("Session C summary"),
+        "{path:?}"
+    );
+    assert_eq!(
+        first.items[0].session_slug.as_deref(),
+        Some("project-c"),
+        "{path:?}"
+    );
+    assert_eq!(first.items[0].source.as_deref(), Some("codex"), "{path:?}");
+    assert_eq!(first.items[0].harness.as_deref(), Some("codex"), "{path:?}");
+    assert_eq!(first.items[0].total_turns, 3, "{path:?}");
+    assert_eq!(first.items[0].total_events, 30, "{path:?}");
+    assert_eq!(first.items[0].mode, ConversationMode::WebSearch, "{path:?}");
+    assert!(first.items[0].completed, "{path:?}");
+    assert_eq!(
+        first.items[0].inference_provider.as_deref(),
+        Some("openai"),
+        "{path:?}"
+    );
+    assert_eq!(first.items[0].tool_calls, 6, "{path:?}");
+
+    // Private projection columns never reach the public item on either path.
+    let public_items = serde_json::to_string(&first.items).expect("serialize public list items");
+    assert!(!public_items.contains("\"originator\":"), "{path:?}");
+    assert!(!public_items.contains("\"project\":"), "{path:?}");
+    assert!(!public_items.contains("acme-secret-merger"), "{path:?}");
+
+    let cursor = first.next_cursor.clone().expect("next cursor");
+
+    let second = repo
+        .list_mcp_sessions(
+            filter.clone(),
+            PageRequest {
+                limit: 2,
+                cursor: Some(cursor.clone()),
+            },
+        )
+        .await
+        .expect("second page");
+    assert_eq!(second.items.len(), 1, "{path:?}");
+    assert_eq!(second.items[0].session_id, "sess_a", "{path:?}");
+    assert!(!second.items[0].completed, "{path:?}");
+    assert!(second.items[0].title.is_none(), "{path:?}");
+    assert!(second.next_cursor.is_none(), "{path:?}");
+
+    // The exact contract string, for a changed filter dimension and for the
+    // absent-vs-sentinel distinction the tool tests depend on.
+    for changed in [
+        McpSessionListFilter {
+            mode: Some(ConversationMode::Chat),
+            ..filter.clone()
+        },
+        McpSessionListFilter {
+            source_name: Some("__none__".to_string()),
+            ..filter.clone()
+        },
+    ] {
+        let error = repo
+            .list_mcp_sessions(
+                changed,
+                PageRequest {
+                    limit: 2,
+                    cursor: Some(cursor.clone()),
+                },
+            )
+            .await
+            .expect_err("a cursor must not resume under a different filter");
+        assert_eq!(
+            error.to_string(),
+            "invalid cursor: cursor does not match current list_sessions filter",
+            "{path:?}"
+        );
+    }
+
+    first
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_sessions_semantics_are_identical_on_both_paths() {
+    scoped(async {
+        let mut pages: Vec<(ListPath, Page<McpSessionListItem>)> = Vec::new();
+        for path in ListPath::ALL {
+            let (repo, _state) = path.repo().await;
+            pages.push((
+                path,
+                assert_shared_list_sessions_semantics(&repo, path).await,
+            ));
+        }
+
+        // Same filter, same fixture corpus: the two readers must agree field
+        // for field, including the minted continuation token. The cursor is
+        // part of the comparison because both paths anchor it on the same
+        // `(updated_at, session_id)` value — that equality is what lets an
+        // in-flight token survive the cutover.
+        let (reference_path, reference) = &pages[0];
+        for (path, page) in &pages[1..] {
+            assert_eq!(
+                serde_json::to_value(page).expect("serialize page"),
+                serde_json::to_value(reference).expect("serialize page"),
+                "{path:?} diverged from {reference_path:?}"
+            );
+        }
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_sessions_rejects_foreign_scope_cursors_on_both_paths() {
+    scoped(async {
+        for path in ListPath::ALL {
+            let (unscoped_repo, _unscoped_state) = path.repo().await;
+            let (scoped_repo, _scoped_state) = path.scoped_repo(&["/work/project"]).await;
+            let filter = directory_filter();
+
+            let first = unscoped_repo
+                .list_mcp_sessions(
+                    filter.clone(),
+                    PageRequest {
+                        limit: 1,
+                        cursor: None,
+                    },
+                )
+                .await
+                .expect("first page from unscoped repo");
+            let cursor = first.next_cursor.expect("next cursor");
+
+            let error = scoped_repo
+                .list_mcp_sessions(
+                    filter,
+                    PageRequest {
+                        limit: 1,
+                        cursor: Some(cursor),
+                    },
+                )
+                .await
+                .expect_err("cursor minted without the scope must be rejected");
+            assert_eq!(
+                error.to_string(),
+                "invalid cursor: cursor does not match current list_sessions filter",
+                "{path:?}"
+            );
+        }
+    })
+    .await;
+}
+
+/// A batched-totals fixture row for a session with no metadata and one turn.
+fn totals_row(session_id: &str, harness: &str) -> serde_json::Value {
+    json!({
+        "session_id": session_id,
+        "total_events": 4_u64,
+        "tool_calls": 1_u64,
+        "max_override": 0_u32,
+        "counter_user_messages": 1_u64,
+        "first_event_time": "2026-01-02 10:00:00",
+        "first_event_unix_ms": 1_767_348_000_000_i64,
+        "last_event_time": "2026-01-02 10:10:00",
+        "last_event_unix_ms": 1_767_348_600_000_i64,
+        "source": "codex",
+        "harness": harness,
+        "inference_provider": "openai",
+        "omp_dispatch_title": "",
+        "mode": "chat"
+    })
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_mcp_sessions_directory_path_emits_the_content_free_candidate_page() {
+    scoped(async {
+        // The page's OUTPUT is asserted against the projected-header page by
+        // `list_sessions_semantics_are_identical_on_both_paths`; this test
+        // pins the SQL that produces it.
+        let (repo, state) = build_directory_repo().await;
+
+        repo.list_mcp_sessions(
+            directory_filter(),
+            PageRequest {
+                limit: 2,
+                cursor: None,
+            },
+        )
+        .await
+        .expect("directory page");
+
+        let queries = state.queries.lock().expect("queries lock").clone();
+        let directory_query = queries
+            .iter()
+            .find(|query| query.contains("FROM `moraine`.`mcp_session_directory` AS d"))
+            .expect("directory candidate query should be captured");
+        assert!(directory_query.contains("cand_last_ms >= 1767261600000"));
+        assert!(directory_query.contains("cand_first_ms < 1767500000000"));
+        assert!(directory_query.contains("mode_hint >= 3"));
+        assert!(directory_query.contains("has(harnesses, 'codex')"));
+        assert!(directory_query.contains("has(sources, 'codex')"));
+        assert!(directory_query.contains("notEmpty(trimBoth(d.session_id))"));
+        assert!(directory_query.contains("argMinIfMerge(d.origin_cwd_state)"));
+        assert!(directory_query.contains("ORDER BY cand_last_ms DESC, session_id DESC"));
+        // One statement fetches the page's whole hydration budget
+        // (hydration_chunk_size(2) = 6, x MAX_HYDRATION_CHUNKS = 24).
+        assert!(directory_query.contains("LIMIT 24"));
+        assert_eq!(
+            queries
+                .iter()
+                .filter(|query| query.contains("FROM `moraine`.`mcp_session_directory` AS d"))
+                .count(),
+            1,
+            "Phase A must run once per page — a second pass re-aggregates the whole directory: {queries:#?}"
+        );
+
+        // The events relation is opened only for the bounded metadata read, and
+        // only with its session filter INSIDE the derived table: `SELECT e.*`
+        // republishes every wide column, so an outer-only filter is a
+        // whole-corpus FINAL scan that no column-name grep can see.
+        for query in queries
+            .iter()
+            .filter(|query| query.contains("FROM `moraine`.`events` AS e FINAL"))
+        {
+            assert!(
+                query.contains(
+                    "AND published.source_generation = e.source_generation\nWHERE e.session_id IN ["
+                ),
+                "unpruned events scan on the discovery path: {query}"
+            );
+        }
+
+        // The whole point of the cutover: no statement of the page touches the
+        // projector, the legacy view chain, or transcript content.
+        for query in &queries {
+            assert!(
+                !query.contains("mcp_open_"),
+                "list_sessions must not read the projector: {query}"
+            );
+            assert!(
+                !query.contains("v_session_summary")
+                    && !query.contains("v_conversation_trace")
+                    && !query.contains("v_turn_summary"),
+                "list_sessions must not read the legacy view chain: {query}"
+            );
+            assert!(
+                !query.contains("text_content"),
+                "list_sessions must not read transcript content: {query}"
+            );
+            assert!(
+                !query.contains("argMin(cwd"),
+                "list_sessions must not run the corpus-wide scope subquery: {query}"
+            );
+        }
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_mcp_sessions_directory_page_uses_batched_hydration() {
+    scoped(async {
+        let (repo, state) = build_directory_repo().await;
+
+        repo.list_mcp_sessions(
+            directory_filter(),
+            PageRequest {
+                limit: 25,
+                cursor: None,
+            },
+        )
+        .await
+        .expect("directory page");
+
+        let queries = state.queries.lock().expect("queries lock").clone();
+        // One directory pass plus three batched hydration statements. The
+        // ceiling is 1 + MAX_HYDRATION_CHUNKS x 3 = 13; anything above it means
+        // a per-session loop or a repeated directory aggregation crept back in.
+        assert_eq!(queries.len(), 4, "captured queries: {queries:#?}");
+        let hydration = queries
+            .iter()
+            .filter(|query| query.contains("['sess_c','sess_b','sess_a']"))
+            .count();
+        assert_eq!(
+            hydration, 3,
+            "totals, metadata and terminal must each batch the whole chunk: {queries:#?}"
+        );
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_mcp_sessions_directory_page_applies_session_origin_scope_exactly() {
+    scoped(async {
+        let (repo, state) = build_scoped_directory_repo(&["/work/project"]).await;
+
+        repo.list_mcp_sessions(
+            McpSessionListFilter {
+                mode: None,
+                harness: None,
+                source_name: None,
+                ..directory_filter()
+            },
+            PageRequest {
+                limit: 5,
+                cursor: None,
+            },
+        )
+        .await
+        .expect("scoped directory page");
+
+        let queries = state.queries.lock().expect("queries lock").clone();
+        let directory_query = queries
+            .iter()
+            .find(|query| query.contains("FROM `moraine`.`mcp_session_directory` AS d"))
+            .expect("directory candidate query should be captured");
+        assert!(directory_query.contains("origin_cwd = '/work/project'"));
+        assert!(directory_query.contains("startsWith(origin_cwd, '/work/project/')"));
+        assert!(
+            !directory_query.contains("argMin(cwd"),
+            "scope is served by the merged directory state, not a corpus scan"
+        );
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_mcp_sessions_directory_page_never_prefilters_mcp_internal_mode() {
+    scoped(async {
+        let (repo, state) = build_directory_repo().await;
+
+        repo.list_mcp_sessions(
+            McpSessionListFilter {
+                mode: Some(ConversationMode::McpInternal),
+                harness: None,
+                source_name: None,
+                ..directory_filter()
+            },
+            PageRequest {
+                limit: 5,
+                cursor: None,
+            },
+        )
+        .await
+        .expect("mcp_internal page");
+
+        let queries = state.queries.lock().expect("queries lock").clone();
+        let directory_query = queries
+            .iter()
+            .find(|query| query.contains("FROM `moraine`.`mcp_session_directory` AS d"))
+            .expect("directory candidate query should be captured");
+        // sql/036:156 freezes the internal-tool allowlist inside the MV body,
+        // so a session using a tool added later carries a hint BELOW its live
+        // rank. Any hint predicate would silently drop it.
+        assert!(
+            !directory_query.contains("mode_hint >="),
+            "mcp_internal must not push a mode_hint predicate: {directory_query}"
+        );
+    })
+    .await;
+}
+
+/// One Phase-A candidate row.
+fn candidate_row(session_id: &str, cand_last_ms: i64) -> serde_json::Value {
+    json!({ "session_id": session_id, "cand_last_ms": cand_last_ms })
+}
+
+/// [`totals_row`] with explicit exact `display_time` bounds, for the case where
+/// hydration's `max(display_time)` is BELOW the directory's
+/// `max(max_observed_event_time)` — what a superseded event version leaves
+/// behind, since the directory aggregate can never retract one.
+fn totals_row_at(
+    session_id: &str,
+    first_event_unix_ms: i64,
+    last_event_unix_ms: i64,
+) -> serde_json::Value {
+    let mut row = totals_row(session_id, "codex");
+    row["first_event_unix_ms"] = json!(first_event_unix_ms);
+    row["last_event_unix_ms"] = json!(last_event_unix_ms);
+    row
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_mcp_sessions_directory_page_orders_and_anchors_on_the_directory_keyset() {
+    scoped(async {
+        // The directory aggregate and the hydrated aggregate are different
+        // numbers whenever an event version has been superseded. Ordering and
+        // the cursor MUST use the directory value — it is the only one the next
+        // page's `HAVING` can compare against — while the item still REPORTS
+        // the exact hydrated value.
+        //
+        // sess-p: directory 1_767_400_000_000, exact 1_767_300_000_000
+        // sess-q: directory 1_767_350_000_000, exact 1_767_350_000_000
+        // Keyset DESC is (p, q); hydrated DESC would be (q, p).
+        let responses = {
+            let mut responses = vec![ScriptedResponse::rows(
+                &["FROM `moraine`.`mcp_session_directory` AS d", "LIMIT 16"],
+                json!([
+                    candidate_row("sess-p", 1_767_400_000_000_i64),
+                    candidate_row("sess-q", 1_767_350_000_000_i64),
+                ]),
+            )];
+            responses.extend(hydration_script(
+                "'sess-p','sess-q'",
+                json!([
+                    totals_row_at("sess-p", 1_767_290_000_000_i64, 1_767_300_000_000_i64),
+                    totals_row_at("sess-q", 1_767_340_000_000_i64, 1_767_350_000_000_i64),
+                ]),
+            ));
+            responses
+        };
+        let (repo, _state) = build_scripted_directory_repo(responses).await;
+
+        let page = repo
+            .list_mcp_sessions(
+                McpSessionListFilter {
+                    mode: None,
+                    source_name: None,
+                    ..directory_filter()
+                },
+                PageRequest {
+                    limit: 1,
+                    cursor: None,
+                },
+            )
+            .await
+            .expect("keyset page");
+
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(
+            page.items[0].session_id, "sess-p",
+            "survivors must be ordered by the directory keyset, not the hydrated timestamp"
+        );
+        assert_eq!(
+            page.items[0].last_event_unix_ms, 1_767_300_000_000_i64,
+            "the item still reports the EXACT aggregate"
+        );
+
+        let cursor = page.next_cursor.expect("next cursor");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(&cursor).expect("cursor is base64"))
+                .expect("cursor payload is json");
+        assert_eq!(payload["session_id"], json!("sess-p"));
+        assert_eq!(
+            payload["last_event_unix_ms"],
+            json!(1_767_400_000_000_i64),
+            "the cursor must be minted from the directory keyset value; anchoring on the \
+             hydrated value skips every session whose aggregate falls between the two"
+        );
+    })
+    .await;
+}
+
+/// The three batched hydration responses for one chunk, in issue order. `ids`
+/// is a substring that must appear in each statement's `session_id IN` array so
+/// the script cannot silently accept a mis-chunked batch.
+fn hydration_script(ids: &'static str, totals: serde_json::Value) -> Vec<ScriptedResponse> {
+    vec![
+        ScriptedResponse::rows(&["AS counter_user_messages", ids], totals),
+        ScriptedResponse::rows(&["n.is_metadata_bearing = 1", ids], json!([])),
+        ScriptedResponse::rows(&["GROUP BY session_id, turn_seq", ids], json!([])),
+    ]
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_mcp_sessions_directory_page_advances_through_eliminated_chunks() {
+    scoped(async {
+        // limit 1 -> hydration_chunk_size(1) == 4, candidate_fetch_size(1) == 16.
+        // ONE Phase-A pass fetches 8 candidates; the first hydration chunk is
+        // eliminated wholesale by the exact harness re-filter, so the page must
+        // hydrate the next chunk rather than return empty — WITHOUT re-running
+        // the directory aggregation.
+        let candidates = (1..=4)
+            .map(|i| candidate_row(&format!("sess-x{i}"), 1_767_400_000_000_i64 - i))
+            .chain((1..=4).map(|i| candidate_row(&format!("sess-y{i}"), 1_767_300_000_000_i64 - i)))
+            .collect::<Vec<_>>();
+        let mut responses = vec![ScriptedResponse::rows(
+            &["FROM `moraine`.`mcp_session_directory` AS d", "LIMIT 16"],
+            json!(candidates),
+        )];
+        responses.extend(hydration_script(
+            "'sess-x1','sess-x2','sess-x3','sess-x4'",
+            json!((1..=4)
+                .map(|i| totals_row(&format!("sess-x{i}"), "claude-code"))
+                .collect::<Vec<_>>()),
+        ));
+        responses.extend(hydration_script(
+            "'sess-y1','sess-y2','sess-y3','sess-y4'",
+            json!([
+                totals_row("sess-y1", "codex"),
+                totals_row("sess-y2", "claude-code"),
+                totals_row("sess-y3", "claude-code"),
+                totals_row("sess-y4", "claude-code"),
+            ]),
+        ));
+        let (repo, state) = build_scripted_directory_repo(responses).await;
+
+        let page = repo
+            .list_mcp_sessions(
+                McpSessionListFilter {
+                    mode: None,
+                    source_name: None,
+                    ..directory_filter()
+                },
+                PageRequest {
+                    limit: 1,
+                    cursor: None,
+                },
+            )
+            .await
+            .expect("chunked page");
+
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.items[0].session_id, "sess-y1");
+        // The candidate page was short, so the directory is exhausted: no cursor.
+        assert!(page.next_cursor.is_none());
+        // 1 directory + 2 x 3 hydration. A second directory statement here
+        // would be a full re-aggregation of the whole table.
+        assert_script_consumed(&state, 7);
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_mcp_sessions_directory_page_exhausts_the_hydration_budget_with_a_cursor() {
+    scoped(async {
+        // Every candidate is eliminated by the exact re-filter. Once the whole
+        // over-fetch is hydrated the page returns empty but WITH a cursor, so
+        // the caller can keep going instead of reading it as "no more results".
+        // The cursor anchors on the last RESOLVED CANDIDATE, which is what
+        // guarantees the next request makes progress rather than re-examining
+        // the same rejects forever.
+        let candidates = (1..=16_i64)
+            .map(|i| candidate_row(&format!("sess-c{i:02}"), 1_767_400_000_000_i64 - i))
+            .collect::<Vec<_>>();
+        let mut responses = vec![ScriptedResponse::rows(
+            &["FROM `moraine`.`mcp_session_directory` AS d", "LIMIT 16"],
+            json!(candidates),
+        )];
+        for chunk in 0..4_i64 {
+            let ids: &'static str = match chunk {
+                0 => "'sess-c01','sess-c02','sess-c03','sess-c04'",
+                1 => "'sess-c05','sess-c06','sess-c07','sess-c08'",
+                2 => "'sess-c09','sess-c10','sess-c11','sess-c12'",
+                _ => "'sess-c13','sess-c14','sess-c15','sess-c16'",
+            };
+            responses.extend(hydration_script(
+                ids,
+                json!((1..=4_i64)
+                    .map(|i| totals_row(&format!("sess-c{:02}", chunk * 4 + i), "claude-code"))
+                    .collect::<Vec<_>>()),
+            ));
+        }
+        let (repo, state) = build_scripted_directory_repo(responses).await;
+
+        let page = repo
+            .list_mcp_sessions(
+                McpSessionListFilter {
+                    mode: None,
+                    source_name: None,
+                    ..directory_filter()
+                },
+                PageRequest {
+                    limit: 1,
+                    cursor: None,
+                },
+            )
+            .await
+            .expect("budget-exhausted page");
+
+        assert!(page.items.is_empty());
+        let cursor = page
+            .next_cursor
+            .expect("an exhausted hydration budget must still hand back a continuation");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(&cursor).expect("cursor is base64"))
+                .expect("cursor payload is json");
+        assert_eq!(payload["session_id"], json!("sess-c16"));
+        assert_eq!(
+            payload["last_event_unix_ms"],
+            json!(1_767_400_000_000_i64 - 16)
+        );
+        // 1 directory pass + MAX_HYDRATION_CHUNKS x 3 hydration = 13, the
+        // ceiling. The pre-fix shape ran Phase A once per chunk for 16.
+        assert_script_consumed(&state, 13);
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_mcp_sessions_accepts_legacy_cursors_and_rejects_unknown_versions() {
+    scoped(async {
+        let (repo, _state) = build_directory_repo().await;
+        let filter = directory_filter();
+
+        let first = repo
+            .list_mcp_sessions(
+                filter.clone(),
+                PageRequest {
+                    limit: 2,
+                    cursor: None,
+                },
+            )
+            .await
+            .expect("first page");
+        let cursor = first.next_cursor.expect("next cursor");
+        let payload: serde_json::Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(&cursor).expect("cursor is base64"))
+                .expect("cursor payload is json");
+        assert_eq!(payload["version"], json!(2));
+
+        let retoken = |version: Option<u64>| {
+            let mut payload = payload.clone();
+            match version {
+                Some(version) => payload["version"] = json!(version),
+                None => {
+                    payload
+                        .as_object_mut()
+                        .expect("cursor object")
+                        .remove("version");
+                }
+            }
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).expect("re-encode cursor"))
+        };
+
+        // A pre-#599 token carries no `version` key and must still resume: the
+        // ordering value is identical under both implementations.
+        let legacy = repo
+            .list_mcp_sessions(
+                filter.clone(),
+                PageRequest {
+                    limit: 2,
+                    cursor: Some(retoken(None)),
+                },
+            )
+            .await
+            .expect("legacy cursor resumes");
+        assert_eq!(legacy.items.len(), 1);
+        assert_eq!(legacy.items[0].session_id, "sess_a");
+
+        for version in [1_u64, 3] {
+            let error = repo
+                .list_mcp_sessions(
+                    filter.clone(),
+                    PageRequest {
+                        limit: 2,
+                        cursor: Some(retoken(Some(version))),
+                    },
+                )
+                .await
+                .expect_err("unknown cursor versions are rejected");
+            assert_eq!(
+                error.to_string(),
+                format!("invalid cursor: unsupported list_sessions cursor version {version}")
+            );
+        }
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_sessions_gates_on_the_same_readiness_key_as_the_open_cutover() {
+    scoped(async {
+        let (repo, state) = build_directory_repo().await;
+
+        repo.list_mcp_sessions(
+            directory_filter(),
+            PageRequest {
+                limit: 2,
+                cursor: None,
+            },
+        )
+        .await
+        .expect("directory page");
+
+        let probes = state
+            .readiness_probe_queries
+            .lock()
+            .expect("readiness probe lock")
+            .clone();
+        let state_read = probes
+            .iter()
+            .find(|query| !query.contains("FROM system.tables"))
+            .expect("readiness probe should be captured");
+        // `open_v2`, not `core_indexes`: the weaker coverage key is published
+        // before the overlap audit runs, so gating on it would let listing read
+        // indexes the `open` path refuses.
+        assert!(
+            state_read.contains("WHERE state_key = 'open_v2'"),
+            "list_sessions must share the open cutover's readiness authority: {state_read}"
+        );
+        // Latched per repository: paging does not re-probe.
+        repo.list_mcp_sessions(
+            directory_filter(),
+            PageRequest {
+                limit: 2,
+                cursor: None,
+            },
+        )
+        .await
+        .expect("second directory page");
+        assert_eq!(
+            state
+                .readiness_probe_queries
+                .lock()
+                .expect("readiness probe lock")
+                .len(),
+            probes.len(),
+            "the readiness verdict must be latched for the process"
+        );
+    })
+    .await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn list_mcp_sessions_rejects_cursor_filter_mismatch() {
     scoped(async {

--- a/crates/moraine-conversations/tests/repository_integration/sessions.rs
+++ b/crates/moraine-conversations/tests/repository_integration/sessions.rs
@@ -564,6 +564,7 @@ fn totals_row(session_id: &str, harness: &str) -> serde_json::Value {
         "first_event_unix_ms": 1_767_348_000_000_i64,
         "last_event_time": "2026-01-02 10:10:00",
         "last_event_unix_ms": 1_767_348_600_000_i64,
+        "origin_cwd": "/repo",
         "source": "codex",
         "harness": harness,
         "inference_provider": "openai",
@@ -813,13 +814,76 @@ fn totals_row_at(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn list_mcp_sessions_directory_page_rechecks_origin_scope_against_the_hydrated_cwd() {
+    scoped(async {
+        // Phase A's `argMinIfMerge(origin_cwd_state)` is a RECALL filter: it
+        // merges the directory's live-generation rows, which cannot see a
+        // superseded version the way navigation read `FINAL` can. So a
+        // candidate can survive Phase A while its exact origin cwd lies
+        // OUTSIDE the configured scope.
+        //
+        // Scope decides what a caller is allowed to see, so the exact re-check
+        // must drop it. Scripting the candidate directly is what models "Phase
+        // A admitted it" without having to reproduce the aggregate skew.
+        let responses = {
+            let mut responses = vec![ScriptedResponse::rows(
+                &["FROM `moraine`.`mcp_session_directory` AS d"],
+                json!([
+                    candidate_row("sess-inside", 1_767_400_000_000_i64),
+                    candidate_row("sess-outside", 1_767_350_000_000_i64),
+                ]),
+            )];
+            let mut inside = totals_row("sess-inside", "codex");
+            inside["origin_cwd"] = json!("/work/project/sub");
+            let mut outside = totals_row("sess-outside", "codex");
+            outside["origin_cwd"] = json!("/work/other");
+            responses.extend(hydration_script(
+                "'sess-inside','sess-outside'",
+                json!([inside, outside]),
+            ));
+            responses
+        };
+        let (repo, _state) =
+            build_scoped_scripted_directory_repo(&["/work/project"], responses).await;
+
+        let page = repo
+            .list_mcp_sessions(
+                McpSessionListFilter {
+                    mode: None,
+                    harness: None,
+                    source_name: None,
+                    ..directory_filter()
+                },
+                PageRequest {
+                    limit: 5,
+                    cursor: None,
+                },
+            )
+            .await
+            .expect("scoped directory page");
+
+        let served: Vec<&str> = page
+            .items
+            .iter()
+            .map(|item| item.session_id.as_str())
+            .collect();
+        assert_eq!(
+            served,
+            vec!["sess-inside"],
+            "a candidate whose EXACT origin cwd is outside the scope must not be served"
+        );
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn list_mcp_sessions_directory_page_orders_and_anchors_on_the_directory_keyset() {
     scoped(async {
         // The directory aggregate and the hydrated aggregate are different
         // numbers whenever an event version has been superseded. Ordering and
         // the cursor MUST use the directory value — it is the only one the next
-        // page's `HAVING` can compare against — while the item still REPORTS
-        // the exact hydrated value.
+        // page's `HAVING` can compare against — and the item REPORTS that same
+        // directory value, so the page is sorted by the field it returns (B1).
         //
         // sess-p: directory 1_767_400_000_000, exact 1_767_300_000_000
         // sess-q: directory 1_767_350_000_000, exact 1_767_350_000_000
@@ -1171,7 +1235,7 @@ async fn list_sessions_gates_on_the_same_readiness_key_as_the_open_cutover() {
                 .expect("readiness probe lock")
                 .len(),
             probes.len(),
-            "the readiness verdict must be latched for the process"
+            "the readiness verdict must be latched for this repository and its clones"
         );
     })
     .await;

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -92,12 +92,23 @@ pub(crate) struct MockOptions {
     pub(crate) repeat_duplicate_search_pages: bool,
     pub(crate) scripted_responses: Vec<ScriptedResponse>,
     pub(crate) query_barrier: Option<QueryBarrier>,
+    /// Verdict for the issue-598 `open_v2` readiness key, which gates the
+    /// issue-599 directory session-listing path. `Some` answers the
+    /// `mcp_read_index_state` probe out of band, so it neither consumes a
+    /// scripted response nor lands in the recorded query log; `None` leaves the
+    /// probe visible to the scripts, which is what the store health tests
+    /// assert on directly.
+    pub(crate) open_v2_reader_ready: Option<bool>,
 }
 
 #[derive(Default)]
 pub(crate) struct MockState {
     pub(crate) queries: Mutex<Vec<String>>,
     pub(crate) publication_snapshot_queries: Mutex<Vec<String>>,
+    /// `mcp_read_index_state` reads answered out of band by
+    /// [`MockOptions::open_v2_reader_ready`]. Kept out of `queries` so the
+    /// per-test statement budgets stay about the operation under test.
+    pub(crate) readiness_probe_queries: Mutex<Vec<String>>,
     pub(crate) query_ids: Mutex<Vec<Option<String>>>,
     pub(crate) request_params: Mutex<Vec<HashMap<String, String>>>,
     pub(crate) options: MockOptions,
@@ -151,6 +162,21 @@ pub(crate) fn test_clickhouse_config(url: String) -> ClickHouseConfig {
         allow_newer_server: false,
     }
 }
+/// The subset of `rows` whose `session_id` appears in a batched statement's
+/// `session_id IN ['…']` array literal — the mock's stand-in for the
+/// primary-key prune the real hydration statements get.
+fn rows_for_requested_sessions(query: &str, rows: &serde_json::Value) -> Vec<serde_json::Value> {
+    rows.as_array()
+        .expect("fixture rows are an array")
+        .iter()
+        .filter(|row| {
+            let session_id = row["session_id"].as_str().unwrap_or_default();
+            query.contains(&format!("'{session_id}'"))
+        })
+        .cloned()
+        .collect()
+}
+
 pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<MockState>) {
     async fn handler(
         State(state): State<Arc<MockState>>,
@@ -233,6 +259,32 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                     }
                 ])),
             );
+        }
+        // The issue-599 readiness gate probes `mcp_read_index_state` once per
+        // repository before the first session-list page. It is repository
+        // infrastructure like the publication snapshot above, so a mock that
+        // declares a verdict answers it out of band and keeps the per-test
+        // query scripts focused on the operation under test.
+        if let Some(ready) = state.options.open_v2_reader_ready {
+            if query.contains("mcp_read_index_state") {
+                state
+                    .readiness_probe_queries
+                    .lock()
+                    .expect("readiness probe lock")
+                    .push(query.clone());
+                if query.contains("FROM system.tables") {
+                    return (StatusCode::OK, json_each_row(json!([{ "value": "1" }])));
+                }
+                return (
+                    StatusCode::OK,
+                    json_each_row(json!([{
+                        "state_key": "open_v2",
+                        "ready": u8::from(ready),
+                        "generation": "1",
+                        "cursor": ""
+                    }])),
+                );
+            }
         }
         state
             .queries
@@ -488,6 +540,138 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
             );
         }
 
+        // --- issue-599 canonical-first session discovery -------------------
+        // Phase A: the content-free directory candidate page. The same three
+        // fixture sessions the projected-header page serves, so the two paths
+        // can be asserted against identical expectations.
+        if query.contains("FROM `moraine`.`mcp_session_directory` AS d")
+            && query.contains("AS cand_last_ms")
+        {
+            let candidates = json!([
+                { "session_id": "sess_c", "cand_last_ms": 1_767_435_000_000_i64 },
+                { "session_id": "sess_b", "cand_last_ms": 1_767_348_600_000_i64 },
+                { "session_id": "sess_a", "cand_last_ms": 1_767_262_200_000_i64 }
+            ]);
+            let rows = candidates
+                .as_array()
+                .expect("candidate rows")
+                .iter()
+                .filter(|row| {
+                    let session_id = row["session_id"].as_str().unwrap_or_default();
+                    // Honor whichever keyset the page carries.
+                    if query.contains("session_id < 'sess_b'") {
+                        return session_id < "sess_b";
+                    }
+                    if query.contains("session_id > 'sess_b'") {
+                        return session_id > "sess_b";
+                    }
+                    true
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            return (StatusCode::OK, json_each_row(json!(rows)));
+        }
+
+        // Phase B1: batched totals.
+        if query.contains("AS counter_user_messages") && query.contains("GROUP BY nav.session_id") {
+            let totals = json!([
+                {
+                    "session_id": "sess_c",
+                    "total_events": 30_u64,
+                    "tool_calls": 6_u64,
+                    "max_override": 0_u32,
+                    "counter_user_messages": 3_u64,
+                    "first_event_time": "2026-01-03 10:00:00",
+                    "first_event_unix_ms": 1_767_434_400_000_i64,
+                    "last_event_time": "2026-01-03 10:10:00",
+                    "last_event_unix_ms": 1_767_435_000_000_i64,
+                    "source": "codex",
+                    "harness": "codex",
+                    "inference_provider": "openai",
+                    "omp_dispatch_title": "",
+                    "mode": "web_search"
+                },
+                {
+                    "session_id": "sess_b",
+                    "total_events": 22_u64,
+                    "tool_calls": 4_u64,
+                    "max_override": 0_u32,
+                    "counter_user_messages": 2_u64,
+                    "first_event_time": "2026-01-02 10:00:00",
+                    "first_event_unix_ms": 1_767_348_000_000_i64,
+                    "last_event_time": "2026-01-02 10:10:00",
+                    "last_event_unix_ms": 1_767_348_600_000_i64,
+                    "source": "codex",
+                    "harness": "codex",
+                    "inference_provider": "openai",
+                    "omp_dispatch_title": "",
+                    "mode": "web_search"
+                },
+                {
+                    "session_id": "sess_a",
+                    "total_events": 20_u64,
+                    "tool_calls": 2_u64,
+                    "max_override": 0_u32,
+                    "counter_user_messages": 2_u64,
+                    "first_event_time": "2026-01-01 10:00:00",
+                    "first_event_unix_ms": 1_767_261_600_000_i64,
+                    "last_event_time": "2026-01-01 10:10:00",
+                    "last_event_unix_ms": 1_767_262_200_000_i64,
+                    "source": "codex",
+                    "harness": "codex",
+                    "inference_provider": "openai",
+                    "omp_dispatch_title": "",
+                    "mode": "web_search"
+                }
+            ]);
+            return (
+                StatusCode::OK,
+                json_each_row(json!(rows_for_requested_sessions(&query, &totals))),
+            );
+        }
+
+        // Phase B2: batched metadata, bounded to metadata-bearing rows.
+        if query.contains("n.is_metadata_bearing = 1")
+            && query.contains("e.payload_json AS payload_json")
+            && query.contains("WHERE e.session_id IN [")
+        {
+            let metadata = json!([
+                {
+                    "session_id": "sess_c",
+                    "event_ts": "2026-01-03 10:00:00",
+                    "event_uid": "evt-c-meta",
+                    "event_kind": "session_meta",
+                    "payload_json": "{\"title\":\"Session C title\",\"summary\":\"Session C summary\",\"slug\":\"project-c\"}"
+                },
+                {
+                    "session_id": "sess_b",
+                    "event_ts": "2026-01-02 10:00:00",
+                    "event_uid": "evt-b-meta",
+                    "event_kind": "session_meta",
+                    "payload_json": "{\"title\":\"Session B title\",\"summary\":\"Session B summary\",\"slug\":\"project-b\"}"
+                }
+            ]);
+            return (
+                StatusCode::OK,
+                json_each_row(json!(rows_for_requested_sessions(&query, &metadata))),
+            );
+        }
+
+        // Phase B3: batched terminal state.
+        if query.contains("argMax(turn_completed, turn_seq)")
+            && query.contains("GROUP BY session_id, turn_seq")
+        {
+            let terminal = json!([
+                { "session_id": "sess_c", "completed": 1_u8 },
+                { "session_id": "sess_b", "completed": 1_u8 },
+                { "session_id": "sess_a", "completed": 0_u8 }
+            ]);
+            return (
+                StatusCode::OK,
+                json_each_row(json!(rows_for_requested_sessions(&query, &terminal))),
+            );
+        }
+
         if query.contains("FROM `moraine`.`mcp_open_publication_headers` AS h FINAL")
             && query.contains("current_headers AS")
             && query.contains("toUInt8(s.completed) AS completed")
@@ -509,6 +693,8 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                             "title": "",
                             "source": "codex",
                             "harness": "codex",
+                            "inference_provider": "openai",
+                            "tool_calls": 2,
                             "session_slug": "",
                             "session_summary": ""
                         }
@@ -532,6 +718,8 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                         "title": "Session C title",
                         "source": "codex",
                         "harness": "codex",
+                        "inference_provider": "openai",
+                        "tool_calls": 6,
                         "originator": "Codex Desktop",
                         "origin_cwd": "/work/acme-secret-merger",
                         "project": "acme-secret-merger",
@@ -551,6 +739,8 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                         "title": "Session B title",
                         "source": "codex",
                         "harness": "codex",
+                        "inference_provider": "openai",
+                        "tool_calls": 4,
                         "session_slug": "project-b",
                         "session_summary": "Session B summary"
                     },
@@ -567,6 +757,8 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                         "title": "",
                         "source": "codex",
                         "harness": "codex",
+                        "inference_provider": "openai",
+                        "tool_calls": 2,
                         "session_slug": "",
                         "session_summary": ""
                     }
@@ -2271,6 +2463,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
     let state = Arc::new(MockState {
         queries: Mutex::default(),
         publication_snapshot_queries: Mutex::default(),
+        readiness_probe_queries: Mutex::default(),
         query_ids: Mutex::default(),
         request_params: Mutex::default(),
         options,
@@ -2295,7 +2488,16 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
 pub(crate) async fn build_repo_with_max_results(
     max_results: u16,
 ) -> (ClickHouseConversationRepository, Arc<MockState>) {
-    build_repo_with_options(max_results, MockOptions::default()).await
+    build_repo_with_options(
+        max_results,
+        MockOptions {
+            // Not-ready store: session listing stays on the projected-header
+            // path, which is what the pre-#599 fixtures below describe.
+            open_v2_reader_ready: Some(false),
+            ..MockOptions::default()
+        },
+    )
+    .await
 }
 
 pub(crate) async fn build_repo_with_options(
@@ -2337,7 +2539,69 @@ pub(crate) async fn build_repo() -> (ClickHouseConversationRepository, Arc<MockS
 pub(crate) async fn build_scoped_repo(
     roots: &[&str],
 ) -> (ClickHouseConversationRepository, Arc<MockState>) {
-    let (base_url, state) = spawn_mock_server(MockOptions::default()).await;
+    build_scoped_repo_with_readiness(roots, Some(false)).await
+}
+
+/// Repository whose backend reports the issue-598 `open_v2` key ready, so
+/// session listing takes the issue-599 directory path.
+pub(crate) async fn build_directory_repo() -> (ClickHouseConversationRepository, Arc<MockState>) {
+    build_repo_with_options(
+        100,
+        MockOptions {
+            open_v2_reader_ready: Some(true),
+            ..MockOptions::default()
+        },
+    )
+    .await
+}
+
+/// [`build_directory_repo`] with a `--project-only` session origin scope.
+pub(crate) async fn build_scoped_directory_repo(
+    roots: &[&str],
+) -> (ClickHouseConversationRepository, Arc<MockState>) {
+    build_scoped_repo_with_readiness(roots, Some(true)).await
+}
+
+/// [`build_scripted_repo`] against a directory-ready backend.
+pub(crate) async fn build_scripted_directory_repo(
+    scripted_responses: Vec<ScriptedResponse>,
+) -> (ClickHouseConversationRepository, Arc<MockState>) {
+    build_repo_with_options(
+        100,
+        MockOptions {
+            scripted_responses,
+            open_v2_reader_ready: Some(true),
+            ..MockOptions::default()
+        },
+    )
+    .await
+}
+
+/// [`build_scripted_repo`] against a backend whose `open_v2` reader is not
+/// published, so scripts describe the projected-header path.
+pub(crate) async fn build_scripted_header_repo(
+    scripted_responses: Vec<ScriptedResponse>,
+) -> (ClickHouseConversationRepository, Arc<MockState>) {
+    build_repo_with_options(
+        100,
+        MockOptions {
+            scripted_responses,
+            open_v2_reader_ready: Some(false),
+            ..MockOptions::default()
+        },
+    )
+    .await
+}
+
+async fn build_scoped_repo_with_readiness(
+    roots: &[&str],
+    open_v2_reader_ready: Option<bool>,
+) -> (ClickHouseConversationRepository, Arc<MockState>) {
+    let (base_url, state) = spawn_mock_server(MockOptions {
+        open_v2_reader_ready,
+        ..MockOptions::default()
+    })
+    .await;
     let client =
         ClickHouseClient::new(test_clickhouse_config(base_url)).expect("valid clickhouse client");
 

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -547,10 +547,28 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
         if query.contains("FROM `moraine`.`mcp_session_directory` AS d")
             && query.contains("AS cand_last_ms")
         {
+            // `cand_last_time` is the display form of `cand_last_ms` — the
+            // value the directory path both orders by and reports. It matches
+            // the projected header fixture exactly, because the aggregate and
+            // the hydrated value agree for every session that was not
+            // re-ingested; they diverge only when a re-inserted event lowered
+            // a display time within one live generation.
             let candidates = json!([
-                { "session_id": "sess_c", "cand_last_ms": 1_767_435_000_000_i64 },
-                { "session_id": "sess_b", "cand_last_ms": 1_767_348_600_000_i64 },
-                { "session_id": "sess_a", "cand_last_ms": 1_767_262_200_000_i64 }
+                {
+                    "session_id": "sess_c",
+                    "cand_last_ms": 1_767_435_000_000_i64,
+                    "cand_last_time": "2026-01-03 10:10:00"
+                },
+                {
+                    "session_id": "sess_b",
+                    "cand_last_ms": 1_767_348_600_000_i64,
+                    "cand_last_time": "2026-01-02 10:10:00"
+                },
+                {
+                    "session_id": "sess_a",
+                    "cand_last_ms": 1_767_262_200_000_i64,
+                    "cand_last_time": "2026-01-01 10:10:00"
+                }
             ]);
             let rows = candidates
                 .as_array()

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -593,55 +593,58 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
         // Phase B1: batched totals.
         if query.contains("AS counter_user_messages") && query.contains("GROUP BY nav.session_id") {
             let totals = json!([
-                {
-                    "session_id": "sess_c",
-                    "total_events": 30_u64,
-                    "tool_calls": 6_u64,
-                    "max_override": 0_u32,
-                    "counter_user_messages": 3_u64,
-                    "first_event_time": "2026-01-03 10:00:00",
-                    "first_event_unix_ms": 1_767_434_400_000_i64,
-                    "last_event_time": "2026-01-03 10:10:00",
-                    "last_event_unix_ms": 1_767_435_000_000_i64,
-                    "source": "codex",
-                    "harness": "codex",
-                    "inference_provider": "openai",
-                    "omp_dispatch_title": "",
-                    "mode": "web_search"
-                },
-                {
-                    "session_id": "sess_b",
-                    "total_events": 22_u64,
-                    "tool_calls": 4_u64,
-                    "max_override": 0_u32,
-                    "counter_user_messages": 2_u64,
-                    "first_event_time": "2026-01-02 10:00:00",
-                    "first_event_unix_ms": 1_767_348_000_000_i64,
-                    "last_event_time": "2026-01-02 10:10:00",
-                    "last_event_unix_ms": 1_767_348_600_000_i64,
-                    "source": "codex",
-                    "harness": "codex",
-                    "inference_provider": "openai",
-                    "omp_dispatch_title": "",
-                    "mode": "web_search"
-                },
-                {
-                    "session_id": "sess_a",
-                    "total_events": 20_u64,
-                    "tool_calls": 2_u64,
-                    "max_override": 0_u32,
-                    "counter_user_messages": 2_u64,
-                    "first_event_time": "2026-01-01 10:00:00",
-                    "first_event_unix_ms": 1_767_261_600_000_i64,
-                    "last_event_time": "2026-01-01 10:10:00",
-                    "last_event_unix_ms": 1_767_262_200_000_i64,
-                    "source": "codex",
-                    "harness": "codex",
-                    "inference_provider": "openai",
-                    "omp_dispatch_title": "",
-                    "mode": "web_search"
-                }
-            ]);
+                    {
+                        "session_id": "sess_c",
+                        "total_events": 30_u64,
+                        "tool_calls": 6_u64,
+                        "max_override": 0_u32,
+                        "counter_user_messages": 3_u64,
+                        "first_event_time": "2026-01-03 10:00:00",
+                        "first_event_unix_ms": 1_767_434_400_000_i64,
+                        "last_event_time": "2026-01-03 10:10:00",
+                        "last_event_unix_ms": 1_767_435_000_000_i64,
+                        "origin_cwd": "/repo",
+            "source": "codex",
+                        "harness": "codex",
+                        "inference_provider": "openai",
+                        "omp_dispatch_title": "",
+                        "mode": "web_search"
+                    },
+                    {
+                        "session_id": "sess_b",
+                        "total_events": 22_u64,
+                        "tool_calls": 4_u64,
+                        "max_override": 0_u32,
+                        "counter_user_messages": 2_u64,
+                        "first_event_time": "2026-01-02 10:00:00",
+                        "first_event_unix_ms": 1_767_348_000_000_i64,
+                        "last_event_time": "2026-01-02 10:10:00",
+                        "last_event_unix_ms": 1_767_348_600_000_i64,
+                        "origin_cwd": "/repo",
+            "source": "codex",
+                        "harness": "codex",
+                        "inference_provider": "openai",
+                        "omp_dispatch_title": "",
+                        "mode": "web_search"
+                    },
+                    {
+                        "session_id": "sess_a",
+                        "total_events": 20_u64,
+                        "tool_calls": 2_u64,
+                        "max_override": 0_u32,
+                        "counter_user_messages": 2_u64,
+                        "first_event_time": "2026-01-01 10:00:00",
+                        "first_event_unix_ms": 1_767_261_600_000_i64,
+                        "last_event_time": "2026-01-01 10:10:00",
+                        "last_event_unix_ms": 1_767_262_200_000_i64,
+                        "origin_cwd": "/repo",
+            "source": "codex",
+                        "harness": "codex",
+                        "inference_provider": "openai",
+                        "omp_dispatch_title": "",
+                        "mode": "web_search"
+                    }
+                ]);
             return (
                 StatusCode::OK,
                 json_each_row(json!(rows_for_requested_sessions(&query, &totals))),
@@ -698,89 +701,93 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                 return (
                     StatusCode::OK,
                     json_each_row(json!([
-                        {
-                            "session_id": "sess_a",
-                            "first_event_time": "2026-01-01 10:00:00",
-                            "first_event_unix_ms": 1767261600000_i64,
-                            "last_event_time": "2026-01-01 10:10:00",
-                            "last_event_unix_ms": 1767262200000_i64,
-                            "total_turns": 2,
-                            "total_events": 20,
-                            "mode": "web_search",
-                            "completed": 0_u8,
-                            "title": "",
-                            "source": "codex",
-                            "harness": "codex",
-                            "inference_provider": "openai",
-                            "tool_calls": 2,
-                            "session_slug": "",
-                            "session_summary": ""
-                        }
-                    ])),
+                                    {
+                                        "session_id": "sess_a",
+                                        "first_event_time": "2026-01-01 10:00:00",
+                                        "first_event_unix_ms": 1767261600000_i64,
+                                        "last_event_time": "2026-01-01 10:10:00",
+                                        "last_event_unix_ms": 1767262200000_i64,
+                                        "total_turns": 2,
+                                        "total_events": 20,
+                                        "mode": "web_search",
+                                        "completed": 0_u8,
+                                        "title": "",
+                                        "origin_cwd": "/repo",
+                    "source": "codex",
+                                        "harness": "codex",
+                                        "inference_provider": "openai",
+                                        "tool_calls": 2,
+                                        "session_slug": "",
+                                        "session_summary": ""
+                                    }
+                                ])),
                 );
             }
 
             return (
                 StatusCode::OK,
                 json_each_row(json!([
-                    {
-                        "session_id": "sess_c",
-                        "first_event_time": "2026-01-03 10:00:00",
-                        "first_event_unix_ms": 1767434400000_i64,
-                        "last_event_time": "2026-01-03 10:10:00",
-                        "last_event_unix_ms": 1767435000000_i64,
-                        "total_turns": 3,
-                        "total_events": 30,
-                        "mode": "web_search",
-                        "completed": 1_u8,
-                        "title": "Session C title",
-                        "source": "codex",
-                        "harness": "codex",
-                        "inference_provider": "openai",
-                        "tool_calls": 6,
-                        "originator": "Codex Desktop",
-                        "origin_cwd": "/work/acme-secret-merger",
-                        "project": "acme-secret-merger",
-                        "session_slug": "project-c",
-                        "session_summary": "Session C summary"
-                    },
-                    {
-                        "session_id": "sess_b",
-                        "first_event_time": "2026-01-02 10:00:00",
-                        "first_event_unix_ms": 1767348000000_i64,
-                        "last_event_time": "2026-01-02 10:10:00",
-                        "last_event_unix_ms": 1767348600000_i64,
-                        "total_turns": 2,
-                        "total_events": 22,
-                        "mode": "web_search",
-                        "completed": 1_u8,
-                        "title": "Session B title",
-                        "source": "codex",
-                        "harness": "codex",
-                        "inference_provider": "openai",
-                        "tool_calls": 4,
-                        "session_slug": "project-b",
-                        "session_summary": "Session B summary"
-                    },
-                    {
-                        "session_id": "sess_a",
-                        "first_event_time": "2026-01-01 10:00:00",
-                        "first_event_unix_ms": 1767261600000_i64,
-                        "last_event_time": "2026-01-01 10:10:00",
-                        "last_event_unix_ms": 1767262200000_i64,
-                        "total_turns": 2,
-                        "total_events": 20,
-                        "mode": "web_search",
-                        "completed": 0_u8,
-                        "title": "",
-                        "source": "codex",
-                        "harness": "codex",
-                        "inference_provider": "openai",
-                        "tool_calls": 2,
-                        "session_slug": "",
-                        "session_summary": ""
-                    }
-                ])),
+                            {
+                                "session_id": "sess_c",
+                                "first_event_time": "2026-01-03 10:00:00",
+                                "first_event_unix_ms": 1767434400000_i64,
+                                "last_event_time": "2026-01-03 10:10:00",
+                                "last_event_unix_ms": 1767435000000_i64,
+                                "total_turns": 3,
+                                "total_events": 30,
+                                "mode": "web_search",
+                                "completed": 1_u8,
+                                "title": "Session C title",
+                                "origin_cwd": "/repo",
+                "source": "codex",
+                                "harness": "codex",
+                                "inference_provider": "openai",
+                                "tool_calls": 6,
+                                "originator": "Codex Desktop",
+                                "origin_cwd": "/work/acme-secret-merger",
+                                "project": "acme-secret-merger",
+                                "session_slug": "project-c",
+                                "session_summary": "Session C summary"
+                            },
+                            {
+                                "session_id": "sess_b",
+                                "first_event_time": "2026-01-02 10:00:00",
+                                "first_event_unix_ms": 1767348000000_i64,
+                                "last_event_time": "2026-01-02 10:10:00",
+                                "last_event_unix_ms": 1767348600000_i64,
+                                "total_turns": 2,
+                                "total_events": 22,
+                                "mode": "web_search",
+                                "completed": 1_u8,
+                                "title": "Session B title",
+                                "origin_cwd": "/repo",
+                "source": "codex",
+                                "harness": "codex",
+                                "inference_provider": "openai",
+                                "tool_calls": 4,
+                                "session_slug": "project-b",
+                                "session_summary": "Session B summary"
+                            },
+                            {
+                                "session_id": "sess_a",
+                                "first_event_time": "2026-01-01 10:00:00",
+                                "first_event_unix_ms": 1767261600000_i64,
+                                "last_event_time": "2026-01-01 10:10:00",
+                                "last_event_unix_ms": 1767262200000_i64,
+                                "total_turns": 2,
+                                "total_events": 20,
+                                "mode": "web_search",
+                                "completed": 0_u8,
+                                "title": "",
+                                "origin_cwd": "/repo",
+                "source": "codex",
+                                "harness": "codex",
+                                "inference_provider": "openai",
+                                "tool_calls": 2,
+                                "session_slug": "",
+                                "session_summary": ""
+                            }
+                        ])),
             );
         }
 
@@ -2609,6 +2616,32 @@ pub(crate) async fn build_scripted_header_repo(
         },
     )
     .await
+}
+
+/// [`build_scripted_directory_repo`] with a configured project scope, so a
+/// test can script a candidate that Phase A's recall predicate admitted and
+/// assert the exact Phase C re-check still rejects it.
+pub(crate) async fn build_scoped_scripted_directory_repo(
+    roots: &[&str],
+    scripted_responses: Vec<ScriptedResponse>,
+) -> (ClickHouseConversationRepository, Arc<MockState>) {
+    let (base_url, state) = spawn_mock_server(MockOptions {
+        scripted_responses,
+        open_v2_reader_ready: Some(true),
+        ..MockOptions::default()
+    })
+    .await;
+    let client =
+        ClickHouseClient::new(test_clickhouse_config(base_url)).expect("valid clickhouse client");
+    let repo = ClickHouseConversationRepository::new(
+        client,
+        RepoConfig {
+            max_results: 100,
+            session_scope: SessionOriginScope::from_roots(roots.iter().copied()),
+            ..RepoConfig::default()
+        },
+    );
+    (repo, state)
 }
 
 async fn build_scoped_repo_with_readiness(

--- a/crates/moraine-mcp-core/src/concurrency_tests.rs
+++ b/crates/moraine-mcp-core/src/concurrency_tests.rs
@@ -1385,9 +1385,24 @@ async fn internal_list_timeout_kills_abandoned_transport_statement() {
     };
     let hung = hung_query_ids.lock().expect("hung lock").clone();
     assert!(!hung.is_empty(), "mock never saw a data query");
+    // The KILL must COVER the abandoned statement, which it can do two ways:
+    // by naming the statement id outright (the transport drop guard), or by
+    // the request-scoped prefix `list_sessions` now issues explicitly, which
+    // matches every statement of that request. Requiring the literal id would
+    // reject the prefix form even though it kills strictly more.
+    let request_prefix = kill
+        .split("moraine-request-")
+        .nth(1)
+        .map(|tail| {
+            let end = tail.find("%27").unwrap_or(tail.len());
+            format!("moraine-request-{}", &tail[..end])
+        })
+        .expect("KILL names a request-scoped id");
     assert!(
-        hung.iter().any(|query_id| kill.contains(query_id.as_str())),
-        "KILL must target the abandoned statement: kill={kill}, hung={hung:?}"
+        hung.iter().any(|query_id| {
+            kill.contains(query_id.as_str()) || query_id.starts_with(&request_prefix)
+        }),
+        "KILL must cover the abandoned statement: kill={kill}, hung={hung:?}, prefix={request_prefix}"
     );
     assert!(
         kill.contains("moraine-request-"),

--- a/crates/moraine-mcp-core/src/list_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/list_sessions_v1.rs
@@ -527,8 +527,10 @@ mod tests {
                 title: Some("Build failure triage".to_string()),
                 source: Some("codex".to_string()),
                 harness: Some("codex".to_string()),
+                inference_provider: None,
                 session_slug: Some("build-failure".to_string()),
                 session_summary: Some("Build failure triage summary.".to_string()),
+                tool_calls: 0,
             }],
             next_cursor: None,
         };
@@ -616,8 +618,10 @@ mod tests {
                 title: None,
                 source: Some("codex".to_string()),
                 harness: Some("codex".to_string()),
+                inference_provider: None,
                 session_slug: None,
                 session_summary: None,
+                tool_calls: 0,
             }],
             next_cursor: None,
         };
@@ -665,8 +669,10 @@ mod tests {
                 title: Some("   ".to_string()),
                 source: Some("codex".to_string()),
                 harness: Some("codex".to_string()),
+                inference_provider: None,
                 session_slug: Some("useful-slug".to_string()),
                 session_summary: Some("\t\n".to_string()),
+                tool_calls: 0,
             }],
             next_cursor: None,
         };
@@ -743,8 +749,10 @@ mod tests {
             title: None,
             source: Some("claude-code".to_string()),
             harness: Some("claude-code".to_string()),
+            inference_provider: None,
             session_slug: None,
             session_summary: None,
+            tool_calls: 0,
         };
 
         // A leading empty-session_id orphan (the #386 junk) must be dropped,
@@ -796,8 +804,10 @@ mod tests {
             title: None,
             source: Some("claude-code".to_string()),
             harness: Some("claude-code".to_string()),
+            inference_provider: None,
             session_slug: None,
             session_summary: None,
+            tool_calls: 0,
         };
 
         // A whitespace-only id (rejected by the contract's trim check) and a

--- a/crates/moraine-mcp-core/src/list_sessions_v1.rs
+++ b/crates/moraine-mcp-core/src/list_sessions_v1.rs
@@ -1,6 +1,6 @@
 use super::{
-    handled_tool_error_result, internal_id_error, repo_error_to_contract_error,
-    request_performance, tool_success_result, AppState,
+    backend_query_id, cancel_query_with_deadline, handled_tool_error_result, internal_id_error,
+    repo_error_to_contract_error, request_performance, tool_success_result, AppState,
 };
 use crate::contract::{
     format_rfc3339_utc_millis, CanonicalListSessionsArgs, ContractError, ListSessionsArgs,
@@ -42,6 +42,16 @@ impl AppState {
             cursor: args.cursor.clone(),
         };
 
+        // The request id the statements below run under, so a fired timeout
+        // can KILL them by prefix. Outside an envelope (direct unit-test
+        // calls) keep a bespoke id so unenveloped statements stay
+        // attributable — the same rule `file_attention` follows, which is what
+        // keeps the cancelled id on the `moraine-request-` prefix the
+        // concurrency tests assert.
+        let query_id = QueryEnvelope::current()
+            .map(|envelope| envelope.request_id().to_string())
+            .unwrap_or_else(|_| backend_query_id("list-sessions"));
+
         // The tool-level cap narrows the request envelope (never widens it),
         // so the server-side max_execution_time of every statement below
         // tracks this 3s bound. When the tokio timeout fires the dropped
@@ -66,6 +76,10 @@ impl AppState {
                 );
             }
             Err(_) => {
+                // Belt-and-suspenders alongside the transport drop guards: an
+                // explicit bounded prefix KILL on the request id, so a page
+                // that timed out cannot leave a server query running.
+                cancel_query_with_deadline(self, &query_id).await;
                 return encode_list_sessions_error(
                     canonical_request,
                     ContractError::new(
@@ -419,6 +433,46 @@ mod tests {
             result["structuredContent"]["error"]["code"],
             "deadline_exceeded"
         );
+    }
+
+    /// The repository's budget errors must surface as their own contract
+    /// codes. The silent regression this guards is either collapsing to
+    /// `internal_error`, which tells a caller nothing actionable and hides a
+    /// budget problem as a server fault.
+    #[test]
+    fn query_budget_errors_keep_their_contract_codes() {
+        for (repo_error, expected_code) in [
+            (
+                moraine_conversations::RepoError::DeadlineExceeded {
+                    budget_note: "interactive 3s".to_string(),
+                },
+                "deadline_exceeded",
+            ),
+            (
+                moraine_conversations::RepoError::ResourceExhausted {
+                    budget_note: "read rows".to_string(),
+                },
+                "resource_exhausted",
+            ),
+        ] {
+            let contract_error = repo_error_to_contract_error(repo_error);
+            let result = encode_list_sessions_error(
+                json!({}),
+                contract_error,
+                Performance::builder().finish(),
+            )
+            .expect("budget error response");
+
+            assert_eq!(result["isError"], true);
+            assert_eq!(
+                result["structuredContent"]["error"]["code"], expected_code,
+                "a query-budget failure must not be reported as an internal error"
+            );
+            assert_eq!(
+                result["structuredContent"]["error"]["details"]["reason"], "query_budget",
+                "the caller needs to know it hit a budget, not a bug"
+            );
+        }
     }
 
     #[test]

--- a/docs/mcp-search-interface-spec.md
+++ b/docs/mcp-search-interface-spec.md
@@ -792,6 +792,12 @@ Rules:
   same semantics as `search_sessions`. Blank provided values return
   `invalid_request`; when both are present, both must match.
 - `sort` is `desc` or `asc`, ordered by session `updated_at` and session ID.
+  The response is always sorted by the `updated_at` it reports. For session
+  discovery that value is the session's latest observed event time across its
+  live source generations — the value the page is both ordered and paged by.
+  It equals the session's latest event timestamp except where an event was
+  re-ingested within one live generation with an earlier display time, in
+  which case it can sit slightly above that timestamp; it never sits below.
 
 ### Response Shape
 


### PR DESCRIPTION
## Description

**What.** Session discovery reads the content-free `mcp_session_directory` joined to #602's published generations, hydrates exact summaries for a bounded candidate slice, re-filters exactly, and pages by keyset. The projected-header path survives as the fallback until #598 readiness.

**Why.** The legacy list path executes `v_session_summary → v_conversation_trace → events FINAL`, recomputing every session to return a small page — one call has read 10.73M rows / 6.28 GiB (#599).

Scope is **WI-01 and WI-02 only**. WI-03…WI-09 (the MCP #600 push-down, monitor API and frontend, live gates, docs, and the #597-blocked search) follow as separate PRs.

## No migration required

Every filter gap closes through hydration or a Rust fold. The biggest win: `argMinIfMerge(origin_cwd_state)` reproduces the origin-cwd scope rule, which deletes a corpus-sized session-origin subquery that previously ran in the `WHERE` clause of every project-scoped list query.

## Design decisions worth review

**The directory's live-generation `max_observed_event_time` is the authoritative `updated_at`** — ordered by, keyset on, minted into the cursor, *and* reported. It is the only value Phase A can prune on, so anything else forces a second ordering source and a seam where sessions are skipped. `mcp_session_directory` carries `source_generation` in its sort key and Phase A joins the published generations, so the aggregate covers live rows only. It differs from the hydrated exact value solely when an event is re-inserted within one live generation with a decreased display time, where it sits slightly above and never below. `docs/mcp-search-interface-spec.md` states this.

**Cursors are path-tagged.** The header and directory paths anchor on different values, so each mints its own version and a cross-path token is refused with a recoverable mismatch rather than resumed. Without this, a readiness flip mid-pagination silently skipped every session whose two anchors straddled the token.

**Project scope is re-checked exactly.** Phase A's `argMinIfMerge` is a recall filter; scope decides what a caller may see, so Phase C re-applies the root predicate against a hydrated `origin_cwd` computed under the exact `scope.rs` rule.

## Errors found in the plan while implementing

Each is pinned by a test:

- The plan's cursor rule could **livelock**: anchoring on the last surviving item mints a cursor at or before where the page started whenever a selective filter rejects every candidate, so the next request re-examines the same rejects forever. The budget-exhausted branch anchors on the last resolved candidate instead.
- The plan mis-specified the LIST metadata fold. `latest_session_meta_title`/`_summary` are per-row coalesces resolved *before* the latest-wins selection; aliasing `latest_metadata_summary` as the plan suggested would have silently changed listed summaries whenever the newest `session_meta` row carried a title but no summary.
- The plan's statement arithmetic contradicted itself between sections.
- `WITH <subquery> AS published` is not valid ClickHouse for a multi-column set; the subquery is inlined into the tuple-`IN`.

## Verification method

Guards are verified by **mutation** — reintroduce the defect, confirm a *named* test fails — not by a green suite. That caught a real gap: removing the exact scope re-check passed all 114 integration tests, so the guard was untested until a test was added that makes Phase A admit a candidate whose exact origin cwd is out of scope.

Two earlier review rounds found and fixed: keyset and cursor drawing on different time sources, Phase A re-aggregating the whole directory once per chunk, a corpus-sized `SELECT e.*` whose filter sat outside the derived table, and a fixture matrix that left the legacy assertion suite exercising only the old path.

## Validation

- `cargo test --workspace --locked` — **1,314 passed, 0 failed**
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Live sandbox gates are WI-07 and are not part of this PR.

## References

Part of #599 (WI-01, WI-02). Builds on #598's directory and bounded hydration, #602's atomic publication, and #600's query envelopes.