### PR TITLE
fix(598): the overlap audit compares distinct uids, not row counts

### DIFF
--- a/crates/moraine-clickhouse/src/canonical_indexes.rs
+++ b/crates/moraine-clickhouse/src/canonical_indexes.rs
@@ -1115,29 +1115,27 @@ impl ClickHouseClient {
         Ok((sessions.len() as u64).saturating_sub(covered))
     }
 
-    /// Summed absolute per-session cardinality delta between navigation and
-    /// locator over the sampled sessions (0 means agreement).
+    /// Summed absolute per-session delta in DISTINCT `event_uid` between
+    /// navigation and locator over the sampled sessions (0 means agreement).
+    ///
+    /// Counting ROWS here was wrong in two independent ways, and the two
+    /// together made the gate unreachable on any real corpus:
+    ///
+    /// * `mcp_event_navigation` keeps one row per generation (its sort key
+    ///   carries `source_generation`) while `mcp_event_locator` keeps one per
+    ///   uid, so a replayed source made the row counts differ permanently even
+    ///   though both indexes agreed on which events exist.
+    /// * `event_uid` is content-addressed and excludes `session_id` (#608), so
+    ///   an ingest double-attribution puts one uid under two sessions.
+    ///   Navigation keeps both rows; the locator collapses them. On the
+    ///   reference host that is 19,846 uids, i.e. a permanent delta of 19,846
+    ///   against a gate that requires exactly 0.
+    ///
+    /// Distinct uids is the invariant the reader actually depends on: the two
+    /// indexes must agree on WHICH events exist, not on how many physical rows
+    /// encode them. A genuinely missing index row still moves this number.
     async fn audit_cardinality_delta(&self, session_list: &str) -> Result<i64> {
-        let db = escape_identifier(&self.cfg.database);
-        let query = format!(
-            "SELECT toString(sum(abs(nav_count - loc_count))) AS delta\n\
-             FROM (\n\
-               SELECT session_id, count() AS nav_count\n\
-               FROM {db}.mcp_event_navigation FINAL\n\
-               WHERE session_id IN ({session_list})\n\
-               GROUP BY session_id\n\
-             ) AS n\n\
-             FULL OUTER JOIN (\n\
-               SELECT session_id, count() AS loc_count\n\
-               FROM {db}.mcp_event_locator FINAL\n\
-               WHERE session_id IN ({session_list})\n\
-               GROUP BY session_id\n\
-             ) AS l USING (session_id)\n\
-             SETTINGS join_algorithm = 'grace_hash', grace_hash_join_initial_buckets = 32,\n\
-                      max_bytes_in_join = {join_bytes}\n\
-             FORMAT JSONEachRow",
-            join_bytes = AUDIT_MAX_BYTES_IN_JOIN,
-        );
+        let query = Self::audit_cardinality_delta_sql(&self.cfg.database, session_list);
         let rows: Vec<CardinalityRow> = self
             .query_json_each_row(&query, Some(&self.cfg.database))
             .await
@@ -1147,6 +1145,30 @@ impl ClickHouseClient {
             .next()
             .and_then(|row| row.delta.parse().ok())
             .unwrap_or(0))
+    }
+
+    pub(crate) fn audit_cardinality_delta_sql(database: &str, session_list: &str) -> String {
+        let db = escape_identifier(database);
+        let query = format!(
+            "SELECT toString(sum(abs(nav_count - loc_count))) AS delta\n\
+             FROM (\n\
+               SELECT session_id, uniqExact(event_uid) AS nav_count\n\
+               FROM {db}.mcp_event_navigation FINAL\n\
+               WHERE session_id IN ({session_list})\n\
+               GROUP BY session_id\n\
+             ) AS n\n\
+             FULL OUTER JOIN (\n\
+               SELECT session_id, uniqExact(event_uid) AS loc_count\n\
+               FROM {db}.mcp_event_locator FINAL\n\
+               WHERE session_id IN ({session_list})\n\
+               GROUP BY session_id\n\
+             ) AS l USING (session_id)\n\
+             SETTINGS join_algorithm = 'grace_hash', grace_hash_join_initial_buckets = 32,\n\
+                      max_bytes_in_join = {join_bytes}\n\
+             FORMAT JSONEachRow",
+            join_bytes = AUDIT_MAX_BYTES_IN_JOIN,
+        );
+        query
     }
 
     async fn persist_audit_outcome(&self, outcome: &CoreIndexAuditOutcome) -> Result<()> {
@@ -1316,6 +1338,36 @@ fn now_unix_millis() -> i64 {
 
 #[cfg(test)]
 mod tests {
+
+    /// The overlap audit must compare DISTINCT uids, never row counts.
+    ///
+    /// MUTATION: change either `uniqExact(event_uid)` back to `count()`; this
+    /// fails. Row counts made the gate unreachable on any real corpus — a
+    /// replayed generation gives navigation more rows than the locator, and an
+    /// ingest double-attribution (one uid under two sessions, 19,846 of them on
+    /// the reference host) gives a permanent nonzero delta against a gate that
+    /// requires exactly 0. Distinct uids is what the reader depends on: the two
+    /// indexes must agree on WHICH events exist.
+    #[test]
+    fn overlap_audit_compares_distinct_uids_not_row_counts() {
+        let sql = ClickHouseClient::audit_cardinality_delta_sql("moraine", "'sess-a'");
+
+        assert_eq!(
+            sql.matches("uniqExact(event_uid)").count(),
+            2,
+            "both sides of the audit must count distinct uids:\n{sql}"
+        );
+        assert!(
+            !sql.contains("count() AS nav_count") && !sql.contains("count() AS loc_count"),
+            "a row-count side makes the gate unreachable on a replayed or \
+             double-attributed corpus:\n{sql}"
+        );
+        assert!(
+            sql.contains("mcp_event_navigation") && sql.contains("mcp_event_locator"),
+            "the audit must still compare the two indexes:\n{sql}"
+        );
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
## Description

The core-index readiness gate is **unreachable on any real corpus**. It blocks two things at once: the reference host's `open_v2` cutover, and #597's own attribution live gate — whose fixture (one uid under two sessions) is exactly the shape that trips it.

Found empirically: #597's `bounded-search-attribution` gate fails at setup with `canonical backfill completed without publishing open_v2 readiness`.

## Why counting rows was wrong

Twice over, and the two compound:

- `mcp_event_navigation` keeps **one row per generation** (`source_generation` is in its sort key) while `mcp_event_locator` keeps **one per uid**. A replayed source therefore makes the row counts differ permanently, even though both indexes agree on which events exist.
- `event_uid` is content-addressed over `source_file|source_generation|source_line_no|source_offset|record_fingerprint|suffix` and **excludes `session_id`** (#608), so an ingest double-attribution puts one uid under two sessions. Navigation keeps both rows; the locator collapses them.

On the reference host that second case is **19,846 uids** — a permanent nonzero delta against a gate that requires exactly 0. It cannot be cleared by replay either: **23,920 of the affected rows are in dormant sources that will never be re-read**, so the #609 fingerprint replay repairs only part of the corpus.

## The fix

Compare **distinct `event_uid`** per session on both sides. That is the invariant the reader actually depends on — the two indexes must agree on *which* events exist, not on how many physical rows encode them. The gate keeps its teeth: a genuinely missing index row still moves the number.

## Changelog

- `audit_cardinality_delta` counts `uniqExact(event_uid)` on both sides.
- The SQL builder is extracted (`audit_cardinality_delta_sql`) so the denomination is testable.
- `overlap_audit_compares_distinct_uids_not_row_counts` fails if either side reverts to `count()` — **verified by mutation**.
- The doc comment states both failure modes, so the next reader does not have to re-derive them.

## Operational Impact

Hosts blocked on a nonzero cardinality delta can complete the `open_v2` cutover once their indexes genuinely agree. No schema change, no migration, no data rewritten.

## Validation

- `cargo test --workspace --locked` — 1,346 passed, 0 failed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- Guard mutation-verified: reverting the navigation side to `count()` fails the named test.

## References

Corrects #598's readiness gate. Unblocks #597's attribution gate and the reference host's cutover. Shipped alone rather than folded into #597, since it is a #598 correction.