### PR TITLE
fix(598): locator coverage is scoped by uid, not by session

### DIFF
--- a/crates/moraine-clickhouse/src/canonical_indexes.rs
+++ b/crates/moraine-clickhouse/src/canonical_indexes.rs
@@ -1277,6 +1277,17 @@ fn audit_sample_sessions_sql(db: &str) -> String {
 }
 
 /// The overlap-audit coverage probe for one slice of the sampled sessions.
+///
+/// `loc_present` is scoped by UID, not by session, and that distinction is
+/// load-bearing. `mcp_event_locator` is keyed `(event_uid, source_host)` — one
+/// row per uid — while `event_uid` is content-addressed and excludes
+/// `session_id` (#608), so an ingest double-attribution puts one uid under two
+/// sessions. The locator keeps a single row carrying ONE of those sessions.
+/// Filtering the locator by the sampled session list therefore reports the
+/// other session's event as missing from an index that is not supposed to
+/// carry it per session, and no corpus containing a double-attributed uid can
+/// ever pass. Asking "is this uid in the locator at all" is the question the
+/// reader's uid seek actually depends on; a genuinely absent uid still fails.
 fn audit_coverage_sql(db: &str, session_list: &str, slice: AuditSlice) -> String {
     let dir = slice.order_direction();
     format!(
@@ -1291,7 +1302,9 @@ fn audit_coverage_sql(db: &str, session_list: &str, slice: AuditSlice) -> String
                WHERE session_id IN ({session_list})) AS nav_present,\n\
              event_uid IN (\n\
                SELECT event_uid FROM {db}.mcp_event_locator\n\
-               WHERE session_id IN ({session_list})) AS loc_present\n\
+               WHERE event_uid IN (\n\
+                 SELECT event_uid FROM {db}.mcp_event_navigation\n\
+                 WHERE session_id IN ({session_list}))) AS loc_present\n\
            FROM {db}.events\n\
            WHERE notEmpty(session_id) AND session_id IN ({session_list})\n\
            ORDER BY session_id, event_ts {dir}, source_offset {dir}, source_line_no {dir}, event_uid {dir}\n\


### PR DESCRIPTION
## Description

The second half of the defect [#613](https://github.com/eric-tramel/moraine/pull/613) fixed. Two independent checks in the same overlap audit shared one wrong assumption: that `mcp_event_locator` is session-grained. It is uid-grained by design.

#613 corrected the cardinality check. This corrects the **coverage probe**, which asked whether each sampled event's uid appears in the locator *filtered by the sampled session list*. The locator is keyed `(event_uid, source_host)` — one row per uid — and `event_uid` is content-addressed and excludes `session_id` (#608). So an ingest double-attribution puts one uid under two sessions, the locator keeps a single row carrying one of them, and the other session's event reads as missing from an index that never carried it per session. **No corpus containing a double-attributed uid could pass.**

## The fix

Scope the locator lookup by uid. That asks the question the reader's uid seek actually depends on — is this uid in the locator at all — and a genuinely absent uid still fails the probe, so the gate keeps its teeth.

## How it was found

#597's `bounded-search-attribution` live gate seeds exactly this shape (one uid under two sessions) and kept failing at **setup** with `canonical backfill completed without publishing open_v2 readiness` even after #613 merged. A setup failure means the environment cannot reach the state under test — a different signal from a wrong answer — and following it exposed the second site. That fixture is the only thing in the codebase that reproduces the shape.

## Operational Impact

No schema change, no migration, no data rewritten. Hosts blocked on a nonzero `locator_missing` can complete the `open_v2` cutover once their indexes genuinely agree.

## Validation

- `cargo test -p moraine-clickhouse --locked` — 137 passed, 0 failed
- `cargo clippy -p moraine-clickhouse --all-targets --locked -- -D warnings` — clean
- The doc comment states why the distinction is load-bearing, so the next reader does not re-derive it.

## References

Completes the #598 readiness-gate correction begun in #613. Unblocks #597's attribution gate and the reference host's cutover.