### PR TITLE
fix(598): the cardinality audit compares uid SETS, not per-session counts

### DIFF
--- a/crates/moraine-clickhouse/src/canonical_indexes.rs
+++ b/crates/moraine-clickhouse/src/canonical_indexes.rs
@@ -1134,6 +1134,14 @@ impl ClickHouseClient {
     /// Distinct uids is the invariant the reader actually depends on: the two
     /// indexes must agree on WHICH events exist, not on how many physical rows
     /// encode them. A genuinely missing index row still moves this number.
+    ///
+    /// The comparison is also a SET comparison, not a per-session one, for the
+    /// same reason the coverage probe is uid-scoped: the locator holds one row
+    /// per uid carrying ONE session, so grouping both sides by `session_id`
+    /// makes the other session of a double-attributed uid compare 1 against 0
+    /// and the delta can never reach 0. Measured directly — with per-session
+    /// grouping the #597 attribution gate reported
+    /// `navigation_missing: 0, locator_missing: 0, cardinality_delta: 1`.
     async fn audit_cardinality_delta(&self, session_list: &str) -> Result<i64> {
         let query = Self::audit_cardinality_delta_sql(&self.cfg.database, session_list);
         let rows: Vec<CardinalityRow> = self
@@ -1150,19 +1158,19 @@ impl ClickHouseClient {
     pub(crate) fn audit_cardinality_delta_sql(database: &str, session_list: &str) -> String {
         let db = escape_identifier(database);
         let query = format!(
-            "SELECT toString(sum(abs(nav_count - loc_count))) AS delta\n\
+            "SELECT toString(abs(nav_count - loc_count)) AS delta\n\
              FROM (\n\
-               SELECT session_id, uniqExact(event_uid) AS nav_count\n\
+               SELECT uniqExact(event_uid) AS nav_count\n\
                FROM {db}.mcp_event_navigation FINAL\n\
                WHERE session_id IN ({session_list})\n\
-               GROUP BY session_id\n\
              ) AS n\n\
-             FULL OUTER JOIN (\n\
-               SELECT session_id, uniqExact(event_uid) AS loc_count\n\
+             CROSS JOIN (\n\
+               SELECT uniqExact(event_uid) AS loc_count\n\
                FROM {db}.mcp_event_locator FINAL\n\
-               WHERE session_id IN ({session_list})\n\
-               GROUP BY session_id\n\
-             ) AS l USING (session_id)\n\
+               WHERE event_uid IN (\n\
+                 SELECT event_uid FROM {db}.mcp_event_navigation\n\
+                 WHERE session_id IN ({session_list}))\n\
+             ) AS l\n\
              SETTINGS join_algorithm = 'grace_hash', grace_hash_join_initial_buckets = 32,\n\
                       max_bytes_in_join = {join_bytes}\n\
              FORMAT JSONEachRow",


### PR DESCRIPTION
## Description

Third and final site of one wrong assumption — that `mcp_event_locator` is session-grained when it is uid-grained by design — and **the first one I measured rather than inferred**.

[#613](https://github.com/eric-tramel/moraine/pull/613) changed both sides of the cardinality check to `uniqExact(event_uid)` but kept `GROUP BY session_id`. The locator holds one row per uid carrying **one** session, so for a uid attributed to sessions A and B the join compares 1 against 0 on session B, and the delta can never reach 0. [#614](https://github.com/eric-tramel/moraine/pull/614) fixed the same assumption in the coverage probe; this fixes the cardinality probe.

## Measured, not guessed

After #613 and #614 merged, #597's `bounded-search-attribution` gate still failed at setup. Rather than infer a third cause, I made the gate report what it observed:

```text
navigation_missing: 0
locator_missing: 0
directory_missing_sessions: 0
navigation_locator_cardinality_delta: 1
```

That isolates this as the only remaining check — and confirms #614 worked (`locator_missing: 0`).

Both earlier fixes were reasoned from the schema and were correct defects that would have blocked any real host regardless. But shipping two fixes for a symptom I had not measured is the same pattern this epic has been correcting in its test suite, so the instrumentation went in before the third attempt.

## The fix

Compare **uid sets**: distinct uids navigation holds for the sampled sessions, against distinct uids the locator holds for those same uids. A genuinely missing uid still moves the number, so the gate keeps its teeth.

## Operational Impact

No schema change, no migration, no data rewritten. Completes the readiness-gate correction; hosts with double-attributed uids or replayed generations can reach the `open_v2` cutover.

## Validation

- `cargo test -p moraine-clickhouse --locked` — 137 passed, 0 failed
- `cargo clippy -p moraine-clickhouse --all-targets --locked -- -D warnings` — clean
- The doc comment records the measurement so the next reader does not re-derive it.

## References

Completes the correction begun in #613 and continued in #614. Unblocks #597's attribution gate and the reference host's cutover.
