### PR TITLE
feat(599): monitor search covers the whole corpus, not the loaded page

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo/canonical_list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/canonical_list.rs
@@ -156,10 +156,12 @@ impl ClickHouseConversationRepository {
     ///   deletes a corpus-sized `events FINAL` scan from every scoped page.
     /// * `harness` / `source` / `mode_hint` are RECALL filters only; the exact
     ///   values are re-checked in Phase C against the hydrated aggregates.
-    /// * **`cand_last_ms` is the operation's single keyset time source.** It is
-    ///   the only time value this statement can filter on, so it is also what
-    ///   Phase C orders survivors by and mints the cursor from
-    ///   ([`DirectoryCandidateRow::cand_last_ms`]).
+    /// * **`cand_last_ms` is the operation's single `updated_at`.** It is the
+    ///   only time value this statement can filter on, so it is what Phase C
+    ///   orders survivors by, mints the cursor from, AND reports
+    ///   ([`DirectoryCandidateRow::cand_last_ms`]). `cand_last_time` is its
+    ///   display form, projected here rather than derived in Rust so the two
+    ///   come from one aggregate.
     pub(super) fn build_session_directory_page_sql(&self, params: &DirectoryPageParams) -> String {
         let directory = self.table_ref("mcp_session_directory");
         let published = self.published_generations_subquery();
@@ -211,6 +213,38 @@ impl ClickHouseConversationRepository {
             "SELECT\n  d.session_id AS session_id,\n  toInt64(toUnixTimestamp64Milli(max(d.max_observed_event_time))) AS cand_last_ms,\n  toString(max(d.max_observed_event_time)) AS cand_last_time,\n  toInt64(toUnixTimestamp64Milli(min(d.min_observed_event_time))) AS cand_first_ms,\n  toUInt8(max(d.mode_hint)) AS mode_hint,\n  argMinIfMerge(d.origin_cwd_state) AS origin_cwd,\n  groupUniqArray(d.harness) AS harnesses,\n  groupUniqArray(d.source_name) AS sources\nFROM {directory} AS d\nWHERE notEmpty(trimBoth(d.session_id))\n  AND (d.source_host, d.source_name, d.source_file, d.source_generation) IN {published}\nGROUP BY d.session_id\nHAVING {having}\nORDER BY cand_last_ms {order_dir}, session_id {order_dir}\nLIMIT {limit}\nFORMAT JSONEachRow",
             having = having.join("\n   AND "),
             limit = params.limit,
+        )
+    }
+
+    /// The SAME directory aggregate Phase A selects by, for a bounded set of
+    /// session ids that some OTHER selector chose — today, content ranking
+    /// (issue-599 WI-09).
+    ///
+    /// Session discovery by content does not page a keyset, so it has no
+    /// Phase A. It still has to report `updated_at`, and the whole point of
+    /// this statement is that it reports the SAME quantity the time-ordered
+    /// feed does. Deriving it from hydration instead would make one session
+    /// carry two different instants depending on which surface asked, and
+    /// `status` in the monitor is derived from that instant against a 60 s
+    /// window — so the divergence is a rendered contradiction, not a rounding
+    /// difference.
+    ///
+    /// Cost: `mcp_session_directory` leads its sort key with `session_id`
+    /// (`sql/036:49`), so an `IN` set of at most `SESSION_SEARCH_MAX_LIMIT`
+    /// ids is a PK-pruned point-range scan of a narrow, content-free table —
+    /// the same shape [`Self::build_search_scope_exists_sql`] already issues on
+    /// every scoped search, widened from one id to K.
+    ///
+    /// A session with no row here has no live published generation, which is
+    /// the canonical replacement for the retired `tombstone` column and is
+    /// exactly what makes it absent from Phase A too. The caller drops it, so
+    /// the two surfaces agree about visibility as well as about the value.
+    pub(super) fn build_session_keyset_batch_sql(&self, session_ids: &[String]) -> String {
+        let directory = self.table_ref("mcp_session_directory");
+        let published = self.published_generations_subquery();
+        let ids = sql_array_strings(session_ids);
+        format!(
+            "SELECT\n  d.session_id AS session_id,\n  toInt64(toUnixTimestamp64Milli(max(d.max_observed_event_time))) AS cand_last_ms,\n  toString(max(d.max_observed_event_time)) AS cand_last_time\nFROM {directory} AS d\nWHERE notEmpty(trimBoth(d.session_id))\n  AND d.session_id IN {ids}\n  AND (d.source_host, d.source_name, d.source_file, d.source_generation) IN {published}\nGROUP BY d.session_id\nFORMAT JSONEachRow"
         )
     }
 
@@ -304,26 +338,28 @@ impl ClickHouseConversationRepository {
 // Deserialization rows.
 // ---------------------------------------------------------------------------
 
-/// One Phase-A candidate. The recall columns (`mode_hint`, `origin_cwd`,
-/// `harnesses`, `sources`) are consumed by the statement's own `HAVING` and
-/// deliberately not deserialized.
-#[derive(Debug, Clone, Deserialize)]
-pub(super) struct DirectoryCandidateRow {
-    pub(super) session_id: String,
-    /// Display form of [`Self::cand_last_ms`], reported as the item's
-    /// `last_event_time` so the response's timestamp is the value the page was
-    /// ordered and keyset by (issue-599 B1). Reporting the hydrated exact value
-    /// instead would leave the page sorted by a field it does not return.
-    pub(super) cand_last_time: String,
-    /// **The operation's one keyset time source.** Phase A orders by it, its
-    /// `HAVING` keyset resumes strictly after it, Phase C sorts survivors by
-    /// it, and the continuation cursor is minted from it. Candidate filtering,
-    /// result ordering and cursor minting must all read this same value or a
-    /// page can skip sessions.
+/// One session's directory `updated_at`, in both the form the page filters,
+/// orders and pages by and the form it renders.
+///
+/// **One quantity, one name.** The alternative this replaced kept the keyset
+/// value beside the item and reported the hydrated aggregate instead, which
+/// made `updated_at` a number the response was NOT ordered by (the published
+/// `docs/mcp-search-interface-spec.md` contract says it is) and made two
+/// discovery surfaces describe one session two ways. Both defects have the same
+/// root: two relations answering "when did this session last have an event".
+/// This type is the answer, and every surface takes it from here.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct SessionKeyset<'a> {
+    /// **The operation's one `updated_at`.** Phase A orders by it, its `HAVING`
+    /// keyset resumes strictly after it, Phase C sorts survivors by it, the
+    /// continuation cursor is minted from it, and the item REPORTS it.
     ///
     /// It is authoritative because it is the ONLY time value Phase A can filter
     /// on: `mcp_session_directory` is the only relation the candidate pass
     /// reads, and `max(max_observed_event_time)` is its only upper time bound.
+    /// Minting a cursor from anything else and then comparing it against
+    /// `cand_last_ms` on the next page silently skips every session whose
+    /// directory aggregate falls between the two.
     ///
     /// The hydrated `SessionTotalsBatchRow::last_event_unix_ms` is a DIFFERENT
     /// number. The directory is an `AggregatingMergeTree` whose
@@ -332,14 +368,53 @@ pub(super) struct DirectoryCandidateRow {
     /// `mcp_event_navigation` is `ReplacingMergeTree(event_version)` read with
     /// `FINAL`, so hydration sees only the winning version. Hence
     /// `cand_last_ms >= last_event_unix_ms`, with equality in the common
-    /// never-re-ingested case. Minting the cursor from the hydrated value and
-    /// then comparing it against `cand_last_ms` on the next page silently skips
-    /// every session whose directory aggregate falls between the two.
-    ///
-    /// The hydrated value is what the item REPORTS as `last_event_unix_ms`
-    /// (response fidelity — it is the same exact aggregate the projected-header
-    /// path served) and is never an ordering or cursor input.
+    /// never-re-ingested case — which is exactly the "it can sit slightly above
+    /// that timestamp; it never sits below" clause the MCP spec publishes.
+    pub(super) last_unix_ms: i64,
+    /// The display form of [`Self::last_unix_ms`], from the same aggregate in
+    /// the same statement rather than formatted in Rust, so the millis and the
+    /// string can never describe two instants.
+    pub(super) last_time: &'a str,
+}
+
+/// One Phase-A candidate. The recall columns (`mode_hint`, `origin_cwd`,
+/// `harnesses`, `sources`) are consumed by the statement's own `HAVING` and
+/// deliberately not deserialized.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct DirectoryCandidateRow {
+    pub(super) session_id: String,
+    /// See [`SessionKeyset::last_unix_ms`].
     pub(super) cand_last_ms: i64,
+    /// See [`SessionKeyset::last_time`].
+    pub(super) cand_last_time: String,
+}
+
+impl DirectoryCandidateRow {
+    pub(super) fn keyset(&self) -> SessionKeyset<'_> {
+        SessionKeyset {
+            last_unix_ms: self.cand_last_ms,
+            last_time: self.cand_last_time.as_str(),
+        }
+    }
+}
+
+/// One row of [`ClickHouseConversationRepository::build_session_keyset_batch_sql`]
+/// — the same two columns [`DirectoryCandidateRow`] carries, for ids a
+/// non-paging selector chose.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct SessionKeysetBatchRow {
+    pub(super) session_id: String,
+    cand_last_ms: i64,
+    cand_last_time: String,
+}
+
+impl SessionKeysetBatchRow {
+    pub(super) fn keyset(&self) -> SessionKeyset<'_> {
+        SessionKeyset {
+            last_unix_ms: self.cand_last_ms,
+            last_time: self.cand_last_time.as_str(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -351,6 +426,16 @@ pub(super) struct SessionTotalsBatchRow {
     pub(super) counter_user_messages: u64,
     pub(super) first_event_time: String,
     pub(super) first_event_unix_ms: i64,
+    /// The EXACT `FINAL`-deduped upper bound, used to re-filter the requested
+    /// window in Phase C and NOT reported: `updated_at` on both discovery
+    /// surfaces is [`SessionKeyset::last_unix_ms`], the value the feed also
+    /// orders and pages by.
+    ///
+    /// There is deliberately no `last_event_time` beside it. The batch builder
+    /// projected one only for the item's display form, and the item now takes
+    /// that from [`SessionKeyset::last_time`]; carrying a second, unreported
+    /// rendering of "when did this session end" is how the two of them drifted
+    /// apart in the first place.
     pub(super) last_event_unix_ms: i64,
     /// The session's origin cwd under the EXACT rule `scope.rs` applies —
     /// `argMin(cwd, (event_ts, event_uid))` over rows with a non-empty cwd,
@@ -732,10 +817,10 @@ mod tests {
             // `origin_cwd` is intentionally absent: it is batch-only, hydrated
             // for the exact project-scope re-check. The single-session builder
             // has no equivalent because `open(session)` is already scoped
-            // before it runs.
-            // `last_event_time` is deliberately absent: the directory path
-            // reports the value it orders by (`cand_last_time`), so hydrating
-            // the display string here would transfer bytes that are discarded.
+            // before it runs. `last_event_time` is absent for the opposite
+            // reason: the single-session builder projects it and the batch
+            // deliberately does not, because discovery renders
+            // `SessionKeyset::last_time` — the value it also pages by.
             "last_event_unix_ms",
             "source",
             "harness",

--- a/crates/moraine-conversations/src/clickhouse_repo/list.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/list.rs
@@ -1,13 +1,96 @@
 use super::canonical_list::{
     candidate_fetch_size, hydration_chunk_size, DirectoryCandidateRow, DirectoryPageParams,
-    HydratedSession, SessionMetaBatchRow, SessionTerminalBatchRow, SessionTotalsBatchRow,
+    HydratedSession, SessionKeyset, SessionKeysetBatchRow, SessionMetaBatchRow,
+    SessionTerminalBatchRow, SessionTotalsBatchRow,
 };
 use super::canonical_open::{list_title_and_summary, total_turns_from_parts, MetaRow};
+use super::search::McpEventRankingOptions;
 use super::*;
 use crate::cursor::{
     ACCEPTED_MCP_SESSION_LIST_CURSOR_VERSIONS, MCP_SESSION_LIST_CURSOR_VERSION_DIRECTORY,
     MCP_SESSION_LIST_CURSOR_VERSION_HEADERS,
 };
+
+/// Sessions returned by a content search when the caller names no `limit`.
+const SESSION_SEARCH_DEFAULT_LIMIT: u16 = 10;
+
+/// Ranked sessions one content search may return, clamped HERE rather than
+/// left to whichever transport called in.
+///
+/// `/api/v1/sessions/search` applies the same bound (`SESSION_SEARCH_MAX_LIMIT`
+/// in `moraine-monitor-core`) and is today the only caller, so this changes no
+/// answer. It is here because every bound below — the hit budget, the fan-in
+/// floor, and therefore the ranking's candidate window — is derived from
+/// `limit`, and a derivation whose safety depends on a constant in another
+/// crate is not a bound, it is a coincidence. With this clamp the whole
+/// reachable domain is `1..=SESSION_SEARCH_MAX_LIMIT` and
+/// [`session_search_hit_budget`]'s invariants can be (and are) asserted over
+/// all of it.
+pub(super) const SESSION_SEARCH_MAX_LIMIT: u16 = 50;
+
+/// Ranked EVENT hits requested per requested SESSION, while
+/// [`SESSION_SEARCH_HIT_BUDGET_MAX`] allows it. Hits cluster inside a session —
+/// a query that matches a session usually matches it several times — so a 1:1
+/// request would return a fraction of the sessions asked for.
+///
+/// This factor is applied to an INTERNAL hit budget that is deliberately not
+/// clamped to the caller-facing `[mcp] max_results`. It used to be, and in
+/// every shipped configuration `max_results` is also the session limit, so the
+/// budget collapsed to exactly `limit` and this constant never did anything.
+/// See [`super::search::McpEventRankingOptions::hit_cap`].
+const SESSION_SEARCH_HITS_PER_SESSION: u16 = 4;
+
+/// Ceiling on the internal hit budget, and the reason the fan-in factor cannot
+/// grow the ranking's cost without bound.
+///
+/// The hit budget sets `unique_fetch_limit`, which sets the ranking's candidate
+/// window through `mcp_candidate_fetch_size` — the most expensive stage of the
+/// whole request. Left as `limit x factor`, the shipped default shape
+/// (`max_results = 25`, a client asking for 25) produced a budget of 100, a
+/// window of `min(3 x 101, 256) = 256`, and therefore pinned the HARD ceiling
+/// [`super::search_canonical::MCP_SEARCH_CANDIDATE_MAX`] on every default
+/// interactive search — 3.3x the pre-fix cost, on the default path, ungated.
+///
+/// `50` is not a fresh magic number: it is the largest `n_hits` the MCP event
+/// search tool itself accepts (`n_hits must be between 1 and 50`), so an
+/// internal consumer may out-fetch `max_results` but never spends more ranking
+/// budget than the tool path's own documented maximum.
+const SESSION_SEARCH_HIT_BUDGET_MAX: u16 = 50;
+
+/// The internal hit budget for a page of `limit` ranked sessions.
+///
+/// Three shapes, in `limit` order, and the reason for each:
+///
+/// * `limit <= 12` — the full `SESSION_SEARCH_HITS_PER_SESSION` fan-in.
+/// * `13 <= limit <= 33` — [`SESSION_SEARCH_HIT_BUDGET_MAX`] binds and the
+///   effective factor DECAYS as `50 / limit` (4.0 down to 1.52). This is the
+///   deliberate degradation: a bounded ranking cost is worth more than a
+///   constant fan-in, and it is what keeps the shipped default shape
+///   (`limit = 25`) at a candidate window of 153 instead of the hard ceiling.
+/// * `limit >= 34` — the decay would take the factor to 1.0, so a FLOOR of
+///   `1.5x` takes over. That floor is not cosmetic: the budget must exceed
+///   `limit`, or `ranked.hits` bounds the distinct sessions at `limit`,
+///   `truncated: ranked_sessions > limit` becomes structurally unsettable, and
+///   the fan-in this function exists for collapses to 1:1 at exactly the
+///   largest page a caller may ask for. `.max(limit + 1)` states that
+///   requirement literally rather than leaving it implied by the arithmetic.
+///
+/// Over the whole reachable domain `1..=SESSION_SEARCH_MAX_LIMIT` this yields a
+/// budget in `4..=75`, always strictly greater than `limit`, and therefore a
+/// candidate window `C = mcp_candidate_fetch_size(budget + 1)` in `15..=228` —
+/// strictly below [`super::search_canonical::MCP_SEARCH_CANDIDATE_MAX`], which
+/// stays a guard against a raised cap rather than a number requests land on.
+/// `session_search_hit_budget_holds_its_bounds_across_the_whole_reachable_domain`
+/// asserts all of it, per `limit`.
+pub(super) fn session_search_hit_budget(limit: u16) -> u16 {
+    // 1.5x, rounded UP so an odd `limit` cannot land just under the floor, and
+    // never below `limit + 1` (which is what 1.5x rounds to at `limit = 1`).
+    let fan_in_floor = (limit.saturating_mul(3).saturating_add(1) / 2).max(limit.saturating_add(1));
+    limit
+        .saturating_mul(SESSION_SEARCH_HITS_PER_SESSION)
+        .min(SESSION_SEARCH_HIT_BUDGET_MAX)
+        .max(fan_in_floor)
+}
 
 impl ClickHouseConversationRepository {
     pub(super) async fn list_conversations_impl(
@@ -162,7 +245,10 @@ FORMAT JSONEachRow",
     /// historical and the operation carries no MCP-specific behavior.
     ///
     /// **Cursor contract (issue-599 §1.2).** The token is a VALUE anchor over
-    /// `(updated_at, session_id)`, not a snapshot. A session that receives
+    /// `(updated_at, session_id)` — the `updated_at` the page ORDERS by and the
+    /// same one it REPORTS, because both are [`SessionKeyset::last_unix_ms`]
+    /// (`docs/mcp-search-interface-spec.md`: "The response is always sorted by
+    /// the `updated_at` it reports"). It is not a snapshot. A session that receives
     /// events while a caller pages moves its `updated_at` ahead of the anchor
     /// and will not be seen again on a later page; restarting from page 1
     /// observes the new order. Unrelated appends never invalidate the cursor.
@@ -317,7 +403,7 @@ FORMAT JSONEachRow",
         // under this filter and keyset.
         let directory_exhausted = candidates.len() < fetch as usize;
 
-        let mut survivors: Vec<SurvivingCandidate> = Vec::new();
+        let mut survivors: Vec<McpSessionListItem> = Vec::new();
         let mut last_resolved: Option<(i64, String)> = None;
         for batch in candidates.chunks(hydration_chunk_size(limit) as usize) {
             if survivors.len() > usize::from(limit) {
@@ -344,14 +430,15 @@ FORMAT JSONEachRow",
         }
 
         // Phase A ordered CANDIDATES; hydration is unordered, so re-establish
-        // the keyset order here — on the directory value Phase A ordered and
-        // filtered by, never on the hydrated timestamp, which the next page's
-        // `HAVING` cannot compare against (see `DirectoryCandidateRow`).
+        // the keyset order here. `last_event_unix_ms` IS the directory value
+        // Phase A ordered and filtered by (`SessionKeyset`), which is what lets
+        // the sort, the cursor and the response all read one field — and what
+        // makes the page sorted by the `updated_at` it reports.
         survivors.sort_by(|a, b| {
             let ordering = a
-                .keyset_ms
-                .cmp(&b.keyset_ms)
-                .then_with(|| a.item.session_id.cmp(&b.item.session_id));
+                .last_event_unix_ms
+                .cmp(&b.last_event_unix_ms)
+                .then_with(|| a.session_id.cmp(&b.session_id));
             match sort {
                 ConversationListSort::Desc => ordering.reverse(),
                 ConversationListSort::Asc => ordering,
@@ -365,10 +452,10 @@ FORMAT JSONEachRow",
             // page dropped are served by the next one.
             survivors
                 .last()
-                .map(|survivor| {
+                .map(|item| {
                     Self::mint_session_list_cursor(
-                        survivor.keyset_ms,
-                        &survivor.item.session_id,
+                        item.last_event_unix_ms,
+                        &item.session_id,
                         filter_sig,
                         sort,
                         MCP_SESSION_LIST_CURSOR_VERSION_DIRECTORY,
@@ -403,12 +490,33 @@ FORMAT JSONEachRow",
         };
 
         Ok(Page {
-            items: survivors
-                .into_iter()
-                .map(|survivor| survivor.item)
-                .collect(),
+            items: survivors,
             next_cursor,
         })
+    }
+
+    /// The directory `updated_at` for a bounded id set a NON-paging selector
+    /// chose, keyed by session id.
+    ///
+    /// The time-ordered page gets this for free from Phase A; content ranking
+    /// has no Phase A and buys it here, so that both surfaces report the value
+    /// the feed also orders and pages by rather than each deriving its own. One
+    /// PK-pruned, content-free statement — see
+    /// [`Self::build_session_keyset_batch_sql`].
+    async fn session_keyset_batch(
+        &self,
+        session_ids: &[String],
+    ) -> RepoResult<HashMap<String, SessionKeysetBatchRow>> {
+        if session_ids.is_empty() {
+            return Ok(HashMap::default());
+        }
+        let sql = self.build_session_keyset_batch_sql(session_ids);
+        let rows: Vec<SessionKeysetBatchRow> =
+            self.map_backend(self.query_rows(&sql, None).await)?;
+        Ok(rows
+            .into_iter()
+            .map(|row| (row.session_id.clone(), row))
+            .collect())
     }
 
     /// Phase B (issue-599 §1.4): three batched statements hydrate the whole
@@ -469,17 +577,268 @@ FORMAT JSONEachRow",
         Ok(hydrated)
     }
 
-    /// Phase C (issue-599 §1.5): re-apply the exact filters to one candidate's
-    /// hydrated values and fold it into a list item, or drop it. The candidate's
-    /// keyset value travels with the item because ordering and cursor minting
-    /// must read it, not the hydrated timestamp.
-    fn session_list_item(
-        candidate: &DirectoryCandidateRow,
+    /// Session DISCOVERY BY CONTENT (issue-599 WI-09).
+    ///
+    /// Candidate selection is issue #597's bounded postings ranking, reached
+    /// through the SAME repository entry point MCP `search_sessions` uses, so
+    /// there is one ranking, one corpus-stats cache and one candidate-budget
+    /// contract rather than a monitor-only copy. Everything after ranking is
+    /// [`Self::list_mcp_sessions_impl`]'s hydration and visibility rules, on
+    /// whichever read model that operation is currently serving — so the two
+    /// discovery surfaces cannot disagree about who may be served, what a
+    /// session is called, or which harness it ran under.
+    ///
+    /// **Readiness is branched on exactly like the sibling list path.** While
+    /// the issue-598 canonical read indexes are unpublished, `mcp_event_navigation`
+    /// is empty and hydrating from it would answer every query with "nothing in
+    /// the corpus matched" — a confident falsehood, served with `ok: true`,
+    /// while `/api/v1/sessions` was still serving the same sessions from the
+    /// projected headers. The not-ready arm hydrates from
+    /// `mcp_open_publication_headers` instead, which is what
+    /// [`Self::list_mcp_sessions_headers`] reads, so session summaries stay
+    /// available throughout the cutover (docs/monitor-http-api.md).
+    ///
+    /// **Readiness is resolved ONCE, at the top, and threaded into both
+    /// stages.** Ranking branches on the latch to pick its engine and hydration
+    /// branches on it to pick its read model. Probing twice costs a second
+    /// `mcp_read_index_state` point read on every pre-cutover search, and — the
+    /// reason that matters — the latch flips when a backfill publishes, so two
+    /// probes in one request can disagree and produce an answer ranked over the
+    /// `mcp_open_*` projection and then hydrated from the canonical navigation
+    /// index. `list_mcp_sessions_impl` branches once and cannot straddle the
+    /// flip; this must not be weaker.
+    ///
+    /// Statement budget: 1 readiness point read (skipped once the latch is
+    /// positive for the process), ranking at most 9 (issue #597 §1), then the
+    /// directory keyset batch + hydration — 4 (directory) or 1 (headers) — so
+    /// at most 14, bounded well inside the Interactive `statement_cap` even at
+    /// `SESSION_SEARCH_MAX_LIMIT`.
+    ///
+    /// Ranking hydrates message text to build snippets. **None of it survives
+    /// this function** — the only thing carried out of `ranked` is the ordered
+    /// list of session ids.
+    pub(super) async fn search_session_summaries_impl(
+        &self,
+        query: SessionSearchQuery,
+    ) -> RepoResult<SessionSearchResults> {
+        let canonical_ready = self.canonical_list_path_ready().await;
+        let max_results = self.cfg.max_results.max(1);
+        // Two clamps: the operation's own documented bound, then the backend's
+        // `max_results`. The first is what makes `limit` — and therefore every
+        // budget derived from it below — bounded by this crate rather than by
+        // whichever transport happened to call in.
+        let limit = query
+            .limit
+            .unwrap_or(SESSION_SEARCH_DEFAULT_LIMIT)
+            .clamp(1, SESSION_SEARCH_MAX_LIMIT)
+            .min(max_results);
+        // Several ranked hits routinely land in one session, so asking the
+        // ranking for exactly `limit` hits answers with far fewer than `limit`
+        // sessions. The over-fetch is an INTERNAL budget and is passed as the
+        // ranking's own ceiling: clamping it to the caller-facing `max_results`
+        // (as this did) makes it inert, because `max_results` is also what
+        // `limit` is clamped to, so the two collapse to the same number in
+        // every shipped configuration.
+        let hit_budget = session_search_hit_budget(limit);
+
+        let ranked = self
+            .search_mcp_events_ranked(
+                SearchMcpEventsQuery {
+                    query: query.query.clone(),
+                    cancellation_token: query.cancellation_token.clone(),
+                    n_hits: Some(hit_budget),
+                    // Whole-corpus by construction: a session or turn scope here
+                    // would make this a within-session search, which is `open`'s
+                    // job, not discovery's.
+                    session_id: None,
+                    turn_seq: None,
+                    event_types: None,
+                    harness: query.harness.clone(),
+                    source_name: query.source_name.clone(),
+                    min_score: None,
+                    min_should_match: None,
+                },
+                McpEventRankingOptions {
+                    hit_cap: hit_budget,
+                    canonical_ready: Some(canonical_ready),
+                },
+            )
+            .await?;
+
+        // Distinct sessions in RANK order: a session's best hit is its rank.
+        // Ranking is EVENT-grained and a matching session is normally matched
+        // several times, so without this a session is rendered once per hit and
+        // `result_count` counts hits while claiming to count sessions.
+        let mut ranked_session_ids: Vec<String> = Vec::new();
+        let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for hit in &ranked.hits {
+            if hit.session_id.trim().is_empty() {
+                continue;
+            }
+            if seen.insert(hit.session_id.as_str()) {
+                ranked_session_ids.push(hit.session_id.clone());
+            }
+        }
+        let ranked_sessions = ranked_session_ids.len();
+        ranked_session_ids.truncate(usize::from(limit));
+        let considered = ranked_session_ids.len();
+
+        // ONE hydration round, not a chunk loop: `hydration_chunk_size(limit)`
+        // is at least `limit + 1` and the id list is at most `limit`, so the
+        // LIST path's chunking would always produce exactly one batch here.
+        // (LIST needs the loop because its Phase A over-fetches a whole
+        // multi-chunk candidate budget; a ranking hands back at most `limit`.)
+        //
+        // Ranked order is the response order in BOTH arms, so each folds over
+        // the ranked id sequence and not over the (unordered) hydration map.
+        //
+        // The SAME verdict the ranking used, never a fresh probe.
+        let sessions = if canonical_ready {
+            // The directory value FIRST, for the same reason the time-ordered
+            // page derives it first: it is this operation's `updated_at`, and
+            // an id with no row here has no live published generation — the
+            // canonical replacement for the retired `tombstone` column, and
+            // exactly what would keep it out of Phase A on the feed. Dropping
+            // it here is what makes the two surfaces agree about visibility as
+            // well as about the value, and hydration is narrowed to what
+            // survives so no statement pays for a session that cannot be
+            // served.
+            let keysets = self.session_keyset_batch(&ranked_session_ids).await?;
+            let live_ids: Vec<String> = ranked_session_ids
+                .iter()
+                .filter(|session_id| keysets.contains_key(session_id.as_str()))
+                .cloned()
+                .collect();
+            let hydrated = self.hydrate_session_list_chunk(&live_ids).await?;
+            ranked_session_ids
+                .iter()
+                .filter_map(|session_id| {
+                    Self::hydrated_session_summary(
+                        session_id,
+                        keysets.get(session_id.as_str())?.keyset(),
+                        &hydrated,
+                        self.cfg.session_scope.as_ref(),
+                        query.harness.as_deref(),
+                        query.source_name.as_deref(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        } else {
+            let mut headers = self
+                .hydrate_session_headers(
+                    &ranked_session_ids,
+                    query.harness.as_deref(),
+                    query.source_name.as_deref(),
+                )
+                .await?;
+            ranked_session_ids
+                .iter()
+                .filter_map(|session_id| headers.remove(session_id.as_str()))
+                .collect::<Vec<_>>()
+        };
+
+        let bounds = SessionSearchBounds::derive(
+            ranked_sessions,
+            limit,
+            considered,
+            sessions.len(),
+            ranked.truncated,
+        );
+
+        Ok(SessionSearchResults {
+            query_id: ranked.query_id,
+            query: ranked.query,
+            terms: ranked.terms,
+            sessions,
+            truncated: bounds.truncated,
+            hits_truncated: bounds.hits_truncated,
+            incomplete: ranked.incomplete_due_to_candidate_budget,
+            dropped: bounds.dropped,
+        })
+    }
+
+    /// Hydrate a bounded set of session ids from the PROJECTED HEADERS, keyed
+    /// by session id.
+    ///
+    /// The not-ready counterpart to [`Self::hydrate_session_list_chunk`]. One
+    /// statement, and its visibility predicates come from
+    /// [`Self::header_visibility_clauses`] — the same builder
+    /// [`Self::list_mcp_sessions_headers`] uses — so a session the feed would
+    /// serve and a session a search may disclose are decided by one rule set.
+    ///
+    /// An id with no row in the answer was dropped (tombstoned, out of scope,
+    /// wrong harness/source, unpublished); the caller reports that rather than
+    /// silently returning a shorter page.
+    async fn hydrate_session_headers(
+        &self,
+        session_ids: &[String],
+        harness: Option<&str>,
+        source_name: Option<&str>,
+    ) -> RepoResult<HashMap<String, McpSessionListItem>> {
+        if session_ids.is_empty() {
+            return Ok(HashMap::default());
+        }
+        let mut clauses = self.header_visibility_clauses(harness, source_name);
+        clauses.push(format!(
+            "s.session_id IN {}",
+            sql_array_strings(session_ids)
+        ));
+        let sql = self.build_session_headers_sql(
+            &clauses.join("\n  AND "),
+            "s.session_id ASC",
+            session_ids.len(),
+        );
+        let rows: Vec<McpSessionListRow> = self.map_backend(self.query_rows(&sql, None).await)?;
+        Ok(rows
+            .into_iter()
+            .map(|row| (row.session_id.clone(), Self::map_mcp_session_list_row(row)))
+            .collect())
+    }
+
+    /// One hydrated session folded into the summary both discovery paths serve,
+    /// or dropped.
+    ///
+    /// **This is the single authority for who may be served at all, and for
+    /// what a session's facets are, on the canonical read model.** The blank id
+    /// rule, the tombstone rule, the exact project-scope re-check and the exact
+    /// harness/source equality live here and nowhere else, so time-ordered LIST
+    /// and content-ranked SEARCH cannot disagree about a session's visibility
+    /// or about whether it belongs to a requested harness. A second copy would
+    /// be a second place for it to rot — and a scope check that rots discloses
+    /// sessions.
+    ///
+    /// `harness` / `source_name` are re-checked EXACTLY because neither
+    /// candidate pass can decide them. LIST's directory predicate is
+    /// `has(groupUniqArray(harness), …)` over the session's whole history;
+    /// SEARCH's ranking predicate is `p.harness = …` on a single POSTING. The
+    /// summary's own `harness` is `argMax(…)` — the session's LATEST value — so
+    /// both passes admit a session whose current harness differs from the one
+    /// asked for, and rendering it would show a card whose `harness` field
+    /// contradicts the filter that produced it.
+    ///
+    /// **`updated_at` is the caller's [`SessionKeyset`], on BOTH paths, and it
+    /// is a required argument for exactly that reason.** The time-ordered page
+    /// can only ORDER and keyset by the directory aggregate — it is the only
+    /// value its next `HAVING` can compare against — so that is what it
+    /// reports, and a ranked search buys the same value for its winners
+    /// ([`ClickHouseConversationRepository::build_session_keyset_batch_sql`])
+    /// rather than deriving a second one from hydration. Two quantities
+    /// answering "when did this session last have an event" is what made the
+    /// page unsorted by the field it returns AND made one session render two
+    /// ways: `endedAt` drives the monitor's `active`/`completed` derivation, so
+    /// a 60 s difference is a contradiction in words, not in rounding
+    /// (issue-599 B1).
+    ///
+    /// `first_event_*` stays hydrated: nothing orders or pages by it, and the
+    /// exact `FINAL`-deduped lower bound is the better answer for `started_at`.
+    fn hydrated_session_summary(
+        session_id: &str,
+        keyset: SessionKeyset<'_>,
         hydrated: &HashMap<String, HydratedSession>,
-        filter: &McpSessionListFilter,
         session_scope: Option<&SessionOriginScope>,
-    ) -> Option<SurvivingCandidate> {
-        let session_id = candidate.session_id.as_str();
+        harness: Option<&str>,
+        source_name: Option<&str>,
+    ) -> Option<McpSessionListItem> {
         // Belt-and-braces with the SQL guard: a blank session_id never appears,
         // never consumes a LIMIT slot, and never anchors a cursor. mcp-core
         // applies the same `trim().is_empty()` rejection and the two halves
@@ -496,21 +855,15 @@ FORMAT JSONEachRow",
         if totals.total_events == 0 {
             return None;
         }
-        // Both passes are published-filtered (Phase A carries the same
-        // `(host, name, file, generation) IN published` tuple-IN), so this is
-        // not a generation-visibility re-check. It refines the window on the
-        // EXACT hydrated bounds, which can sit inside the directory's
-        // aggregate when a re-inserted event lowered a display time.
-        if totals.last_event_unix_ms < filter.start_unix_ms
-            || totals.first_event_unix_ms >= filter.end_unix_ms
-        {
-            return None;
-        }
-        // Project scope is re-checked EXACTLY here. Phase A's
-        // `argMinIfMerge(origin_cwd_state)` applies the same rule, but merged
-        // over the directory's live-generation rows rather than the
-        // `FINAL`-deduped navigation rows, so it is a recall filter like the
-        // others. Scope decides what a caller may see, so a false positive is
+        // Project scope is re-checked EXACTLY here, against the hydrated
+        // `origin_cwd`. For LIST the candidate pass is the directory's
+        // `argMinIfMerge(origin_cwd_state)`, merged over live-generation rows
+        // rather than the `FINAL`-deduped navigation rows — a genuine recall
+        // filter. For SEARCH the ranking's directory subquery is recall too,
+        // and issue #597's own Phase 4 already re-checks the same value; this
+        // is then redundant with it and kept anyway, so that ONE function
+        // decides disclosure for both surfaces instead of each surface owning
+        // a copy. Scope decides what a caller may see, so a false positive is
         // not acceptable and it does not rest on recall.
         if let Some(scope) = session_scope {
             let cwd = totals.origin_cwd.as_str();
@@ -522,83 +875,96 @@ FORMAT JSONEachRow",
                 return None;
             }
         }
-        // Exact, case-sensitive equality against the hydrated aggregates: the
-        // directory's `mode_hint` / `groupUniqArray` predicates are recall
-        // filters only.
-        if filter.mode.is_some_and(|mode| totals.mode != mode.as_str()) {
+        // Exact, case-sensitive equality against the hydrated aggregates. Both
+        // candidate passes are recall-only here (see the function doc).
+        if harness.is_some_and(|harness| totals.harness != harness) {
             return None;
         }
-        if filter
-            .harness
-            .as_deref()
-            .is_some_and(|harness| totals.harness != harness)
-        {
-            return None;
-        }
-        if filter
-            .source_name
-            .as_deref()
-            .is_some_and(|source_name| totals.source != source_name)
-        {
+        if source_name.is_some_and(|source_name| totals.source != source_name) {
             return None;
         }
 
         let precedence = session.precedence();
         let (title, session_summary) = list_title_and_summary(&totals.source, &precedence);
-        Some(SurvivingCandidate {
-            keyset_ms: candidate.cand_last_ms,
-            item: McpSessionListItem {
-                session_id: session_id.to_string(),
-                first_event_time: totals.first_event_time.clone(),
-                first_event_unix_ms: totals.first_event_unix_ms,
-                // Report the value this page was ORDERED and KEYSET by, not
-                // the hydrated exact one: the published contract sorts by the
-                // `updated_at` the response reports, and Phase A can only
-                // order on the directory aggregate. The two differ only when
-                // an event is re-inserted within one live generation with a
-                // decreased display time — `SimpleAggregateFunction(max)`
-                // cannot retract that, navigation read `FINAL` can — so
-                // `cand_last_ms >= totals.last_event_unix_ms`, equal in every
-                // ordinary case (issue-599 B1).
-                last_event_time: candidate.cand_last_time.clone(),
-                last_event_unix_ms: candidate.cand_last_ms,
-                total_turns: total_turns_from_parts(
-                    totals.total_events,
-                    totals.max_override,
-                    totals.counter_user_messages,
-                ),
-                total_events: totals.total_events,
-                mode: Self::parse_mode(&totals.mode),
-                completed: session.completed,
-                title: non_empty_string(title),
-                source: non_empty_string(totals.source.clone()),
-                harness: non_empty_string(totals.harness.clone()),
-                inference_provider: non_empty_string(totals.inference_provider.clone()),
-                session_slug: non_empty_string(precedence.session_slug),
-                session_summary: non_empty_string(session_summary),
-                tool_calls: totals.tool_calls,
-            },
+        Some(McpSessionListItem {
+            session_id: session_id.to_string(),
+            first_event_time: totals.first_event_time.clone(),
+            first_event_unix_ms: totals.first_event_unix_ms,
+            last_event_time: keyset.last_time.to_string(),
+            last_event_unix_ms: keyset.last_unix_ms,
+            total_turns: total_turns_from_parts(
+                totals.total_events,
+                totals.max_override,
+                totals.counter_user_messages,
+            ),
+            total_events: totals.total_events,
+            mode: Self::parse_mode(&totals.mode),
+            completed: session.completed,
+            title: non_empty_string(title),
+            source: non_empty_string(totals.source.clone()),
+            harness: non_empty_string(totals.harness.clone()),
+            inference_provider: non_empty_string(totals.inference_provider.clone()),
+            session_slug: non_empty_string(precedence.session_slug),
+            session_summary: non_empty_string(session_summary),
+            tool_calls: totals.tool_calls,
         })
     }
 
-    /// The pre-#599 projected-header discovery page, kept behind the
-    /// canonical read-index readiness gate for stores whose issue-598 backfill
-    /// has not published coverage yet.
-    async fn list_mcp_sessions_headers(
-        &self,
+    /// Phase C (issue-599 §1.5): re-apply the exact filters to one candidate's
+    /// hydrated values and fold it into a list item, or drop it. The candidate
+    /// carries the [`SessionKeyset`] the item reports, so ordering, cursor
+    /// minting and rendering all read one number and cannot drift apart.
+    fn session_list_item(
+        candidate: &DirectoryCandidateRow,
+        hydrated: &HashMap<String, HydratedSession>,
         filter: &McpSessionListFilter,
-        filter_sig: String,
-        sort: ConversationListSort,
-        limit: u16,
-        cursor: Option<McpSessionListCursor>,
-    ) -> RepoResult<Page<McpSessionListItem>> {
-        let snapshot = require_active_publication_snapshot("projected MCP session list reads");
-        let headers = self.table_ref("mcp_open_publication_headers");
-        let history = self.table_ref("v_published_source_generation_history");
-        let dirty_sessions = self.table_ref("mcp_open_dirty_sessions");
-        let captured_heads = snapshot.captured_source_heads_sql(&history);
+        session_scope: Option<&SessionOriginScope>,
+    ) -> Option<McpSessionListItem> {
+        let session_id = candidate.session_id.as_str();
+        let item = Self::hydrated_session_summary(
+            session_id,
+            candidate.keyset(),
+            hydrated,
+            session_scope,
+            filter.harness.as_deref(),
+            filter.source_name.as_deref(),
+        )?;
+        let totals = &hydrated.get(session_id)?.totals;
+        // Both passes are published-filtered (Phase A carries the same
+        // `(host, name, file, generation) IN published` tuple-IN), so this is
+        // not a generation-visibility re-check. It refines the window on the
+        // EXACT hydrated bounds, which can sit inside the directory's
+        // aggregate when a re-inserted event lowered a display time.
+        if totals.last_event_unix_ms < filter.start_unix_ms
+            || totals.first_event_unix_ms >= filter.end_unix_ms
+        {
+            return None;
+        }
+        // Exact, case-sensitive equality against the hydrated aggregates: the
+        // directory's `mode_hint` predicate is a recall filter only. Harness and
+        // source are re-checked in the shared fold above, because SEARCH needs
+        // the identical check and a second copy is a second place to rot.
+        if filter.mode.is_some_and(|mode| totals.mode != mode.as_str()) {
+            return None;
+        }
+        Some(item)
+    }
 
-        let mut where_clauses = vec![
+    /// The projected-header VISIBILITY rules, in one place.
+    ///
+    /// This is the header read model's counterpart to
+    /// [`Self::hydrated_session_summary`]. On the headers these values are
+    /// materialized and exact — `origin_cwd`, `harness` and `source` are
+    /// columns, not recall hints — so the rules are enforced in SQL rather than
+    /// re-checked in Rust, which is what the pre-#599 list path has always
+    /// done. Both discovery surfaces build their header predicate from here, so
+    /// one rule set decides who may be served on this read model too.
+    fn header_visibility_clauses(
+        &self,
+        harness: Option<&str>,
+        source_name: Option<&str>,
+    ) -> Vec<String> {
+        let mut clauses = vec![
             // A blank session_id is never a real session (e.g. the orphan
             // Workflow-journal events ingested before #386's exclusion). Drop
             // them here so they never consume a LIMIT slot or anchor the keyset
@@ -607,14 +973,6 @@ FORMAT JSONEachRow",
             // skip agree on what counts as blank.
             "s.tombstone = 0".to_string(),
             "notEmpty(trimBoth(s.session_id))".to_string(),
-            format!(
-                "toUnixTimestamp64Milli(s.last_event_time) >= {}",
-                filter.start_unix_ms
-            ),
-            format!(
-                "toUnixTimestamp64Milli(s.first_event_time) < {}",
-                filter.end_unix_ms
-            ),
         ];
         if let Some(scope) = self.cfg.session_scope.as_ref() {
             let roots = scope
@@ -629,45 +987,39 @@ FORMAT JSONEachRow",
                 })
                 .collect::<Vec<_>>()
                 .join(" OR ");
-            where_clauses.push(format!("({roots})"));
+            clauses.push(format!("({roots})"));
         }
-        if let Some(mode) = filter.mode {
-            where_clauses.push(format!("s.mode = {}", sql_quote(mode.as_str())));
+        if let Some(harness) = harness {
+            clauses.push(format!("s.harness = {}", sql_quote(harness)));
         }
-        if let Some(harness) = filter.harness.as_deref() {
-            where_clauses.push(format!("s.harness = {}", sql_quote(harness)));
+        if let Some(source_name) = source_name {
+            clauses.push(format!("s.source = {}", sql_quote(source_name)));
         }
-        if let Some(source_name) = filter.source_name.as_deref() {
-            where_clauses.push(format!("s.source = {}", sql_quote(source_name)));
-        }
+        clauses
+    }
 
-        if let Some(cursor) = &cursor {
-            let (time_cmp, session_cmp) = match sort {
-                ConversationListSort::Desc => ("<", "<"),
-                ConversationListSort::Asc => (">", ">"),
-            };
-            where_clauses.push(format!(
-                "(toUnixTimestamp64Milli(s.last_event_time) {time_cmp} {} OR (toUnixTimestamp64Milli(s.last_event_time) = {} AND s.session_id {session_cmp} {}))",
-                cursor.last_event_unix_ms,
-                cursor.last_event_unix_ms,
-                sql_quote(&cursor.session_id)
-            ));
-        }
+    /// The projected-header projection, shared by the time-ordered feed and the
+    /// ranked search.
+    ///
+    /// Callers differ only in `where_sql`, `order_sql` and `limit`. Everything
+    /// that decides which header REVISION is current and whether it may be
+    /// served at all — publication source-head authorization, dirty-revision
+    /// fencing, the `LIMIT 1 BY session_id` collapse — is single-sourced here.
+    ///
+    /// Listing is a moving-feed read over the already materialized session
+    /// headers. Source-head authorization pins each candidate to this
+    /// operation's publication snapshot, while the dirty revision prevents a
+    /// header from being served after its canonical session changes. This
+    /// avoids rebuilding all list metadata from the canonical event corpus on
+    /// every page.
+    fn build_session_headers_sql(&self, where_sql: &str, order_sql: &str, limit: usize) -> String {
+        let snapshot = require_active_publication_snapshot("projected MCP session list reads");
+        let headers = self.table_ref("mcp_open_publication_headers");
+        let history = self.table_ref("v_published_source_generation_history");
+        let dirty_sessions = self.table_ref("mcp_open_dirty_sessions");
+        let captured_heads = snapshot.captured_source_heads_sql(&history);
 
-        let where_sql = where_clauses.join("\n  AND ");
-        let order_dir = match sort {
-            ConversationListSort::Desc => "DESC",
-            ConversationListSort::Asc => "ASC",
-        };
-        let limit_plus = (limit as usize) + 1;
-
-        // Listing is a moving-feed read over the already materialized session
-        // headers. Source-head authorization pins each candidate to this
-        // operation's publication snapshot, while the dirty revision prevents a
-        // header from being served after its canonical session changes. This
-        // avoids rebuilding all list metadata from the canonical event corpus on
-        // every page.
-        let query = format!(
+        format!(
             "WITH
   {captured_heads} AS captured_heads,
 current_dirty AS (
@@ -714,15 +1066,61 @@ SELECT
   s.list_session_summary AS session_summary
 FROM current_headers AS s
 WHERE {where_sql}
-ORDER BY s.last_event_time {order_dir}, s.session_id {order_dir}
-LIMIT {limit_plus}
+ORDER BY {order_sql}
+LIMIT {limit}
 FORMAT JSONEachRow",
-            headers = headers,
-            dirty_sessions = dirty_sessions,
-            captured_heads = captured_heads,
-            where_sql = where_sql,
-            order_dir = order_dir,
-            limit_plus = limit_plus,
+        )
+    }
+
+    /// The pre-#599 projected-header discovery page, kept behind the
+    /// canonical read-index readiness gate for stores whose issue-598 backfill
+    /// has not published coverage yet.
+    async fn list_mcp_sessions_headers(
+        &self,
+        filter: &McpSessionListFilter,
+        filter_sig: String,
+        sort: ConversationListSort,
+        limit: u16,
+        cursor: Option<McpSessionListCursor>,
+    ) -> RepoResult<Page<McpSessionListItem>> {
+        let mut where_clauses = self
+            .header_visibility_clauses(filter.harness.as_deref(), filter.source_name.as_deref());
+        where_clauses.push(format!(
+            "toUnixTimestamp64Milli(s.last_event_time) >= {}",
+            filter.start_unix_ms
+        ));
+        where_clauses.push(format!(
+            "toUnixTimestamp64Milli(s.first_event_time) < {}",
+            filter.end_unix_ms
+        ));
+        if let Some(mode) = filter.mode {
+            where_clauses.push(format!("s.mode = {}", sql_quote(mode.as_str())));
+        }
+
+        if let Some(cursor) = &cursor {
+            let (time_cmp, session_cmp) = match sort {
+                ConversationListSort::Desc => ("<", "<"),
+                ConversationListSort::Asc => (">", ">"),
+            };
+            where_clauses.push(format!(
+                "(toUnixTimestamp64Milli(s.last_event_time) {time_cmp} {} OR (toUnixTimestamp64Milli(s.last_event_time) = {} AND s.session_id {session_cmp} {}))",
+                cursor.last_event_unix_ms,
+                cursor.last_event_unix_ms,
+                sql_quote(&cursor.session_id)
+            ));
+        }
+
+        let where_sql = where_clauses.join("\n  AND ");
+        let order_dir = match sort {
+            ConversationListSort::Desc => "DESC",
+            ConversationListSort::Asc => "ASC",
+        };
+        let limit_plus = (limit as usize) + 1;
+
+        let query = self.build_session_headers_sql(
+            &where_sql,
+            &format!("s.last_event_time {order_dir}, s.session_id {order_dir}"),
+            limit_plus,
         );
 
         let rows: Vec<McpSessionListRow> = self.map_backend(self.query_rows(&query, None).await)?;
@@ -993,12 +1391,512 @@ FORMAT JSONEachRow",
     }
 }
 
-/// A Phase-A candidate that survived Phase C, paired with the directory keyset
-/// value it was selected by. `keyset_ms` — not `item.last_event_unix_ms` —
-/// orders the page and mints the continuation cursor, because it is the only
-/// value the next page's Phase A can filter on
-/// ([`DirectoryCandidateRow::cand_last_ms`]).
-struct SurvivingCandidate {
-    keyset_ms: i64,
-    item: McpSessionListItem,
+/// The bounded-answer facts a ranked session page reports, and the ONE place
+/// they are derived (issue-599 WI-09).
+///
+/// They are separate because their causes are separate and so are their
+/// remedies. `incomplete` is not here: it is issue #597's candidate-budget
+/// verdict, propagated verbatim from the ranking with nothing derived from it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SessionSearchBounds {
+    /// SESSION grain: the ranking yielded more distinct sessions than `limit`.
+    truncated: bool,
+    /// EVENT grain: the ranking filled its hit budget.
+    hits_truncated: bool,
+    /// The exact post-ranking re-check shortened the answer, unrefilled.
+    ///
+    /// Never a project-scope removal: both ranking arms apply scope while they
+    /// choose candidates, so an out-of-scope session is not in `considered` to
+    /// begin with. See [`crate::domain::SessionSearchResults::dropped`] for why
+    /// that distinction is a disclosure property and not a detail.
+    dropped: bool,
+}
+
+impl SessionSearchBounds {
+    /// * `ranked_sessions` — distinct sessions the ranking yielded, BEFORE the
+    ///   trim to `limit`.
+    /// * `considered` — sessions actually hydrated, i.e.
+    ///   `min(ranked_sessions, limit)`.
+    /// * `disclosed` — sessions that survived the exact re-check.
+    /// * `ranking_hit_truncated` — the ranking's own report, at EVENT grain.
+    ///
+    /// **`truncated` must not absorb `ranking_hit_truncated`.** Ranking is over
+    /// events and hits cluster inside a session, so a term appearing thirty
+    /// times in ONE session fills the hit budget while yielding one session.
+    /// Reporting that as `truncated` tells the reader "more sessions existed
+    /// than `limit` returned, raise `limit`" — advice that returns the same one
+    /// session forever, and a statement about the corpus that is false.
+    fn derive(
+        ranked_sessions: usize,
+        limit: u16,
+        considered: usize,
+        disclosed: usize,
+        ranking_hit_truncated: bool,
+    ) -> Self {
+        Self {
+            truncated: ranked_sessions > usize::from(limit),
+            hits_truncated: ranking_hit_truncated,
+            dropped: disclosed < considered,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn totals(session_id: &str, origin_cwd: &str) -> SessionTotalsBatchRow {
+        SessionTotalsBatchRow {
+            session_id: session_id.to_string(),
+            total_events: 12,
+            tool_calls: 2,
+            max_override: 0,
+            counter_user_messages: 3,
+            first_event_time: "2026-01-01 10:00:00".to_string(),
+            first_event_unix_ms: 1_767_261_600_000,
+            last_event_unix_ms: 1_767_262_200_000,
+            origin_cwd: origin_cwd.to_string(),
+            source: "codex".to_string(),
+            harness: "codex".to_string(),
+            inference_provider: "openai".to_string(),
+            omp_dispatch_title: String::new(),
+            mode: "tool_calling".to_string(),
+        }
+    }
+
+    fn hydrated(rows: Vec<SessionTotalsBatchRow>) -> HashMap<String, HydratedSession> {
+        rows.into_iter()
+            .map(|totals| {
+                (
+                    totals.session_id.clone(),
+                    HydratedSession {
+                        totals,
+                        metadata: Vec::new(),
+                        completed: false,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn scope(roots: &[&str]) -> Option<SessionOriginScope> {
+        SessionOriginScope::from_roots(roots.iter().copied())
+    }
+
+    /// The directory `updated_at` every fixture session carries, and its
+    /// display form. The SEARCH arm buys it with
+    /// `build_session_keyset_batch_sql`; the LIST arm gets it from Phase A.
+    const KEYSET_MS: i64 = 1_767_262_260_000;
+    const KEYSET_TIME: &str = "2026-01-01 10:11:00";
+
+    fn keyset() -> SessionKeyset<'static> {
+        SessionKeyset {
+            last_unix_ms: KEYSET_MS,
+            last_time: KEYSET_TIME,
+        }
+    }
+
+    /// The SEARCH arm of the shared fold: no time window, no mode.
+    fn searched(
+        session_id: &str,
+        hydrated: &HashMap<String, HydratedSession>,
+        session_scope: Option<&SessionOriginScope>,
+        harness: Option<&str>,
+        source_name: Option<&str>,
+    ) -> Option<McpSessionListItem> {
+        ClickHouseConversationRepository::hydrated_session_summary(
+            session_id,
+            keyset(),
+            hydrated,
+            session_scope,
+            harness,
+            source_name,
+        )
+    }
+
+    fn candidate(session_id: &str) -> DirectoryCandidateRow {
+        DirectoryCandidateRow {
+            session_id: session_id.to_string(),
+            cand_last_ms: KEYSET_MS,
+            cand_last_time: KEYSET_TIME.to_string(),
+        }
+    }
+
+    fn unfiltered_list_filter() -> McpSessionListFilter {
+        McpSessionListFilter {
+            start_unix_ms: 0,
+            end_unix_ms: i64::MAX,
+            mode: None,
+            sort: ConversationListSort::Desc,
+            harness: None,
+            source_name: None,
+        }
+    }
+
+    /// **The scope guard.** A ranked hit is not permission to disclose the
+    /// session it sits in: `--project-only` decides that, and it decides it on
+    /// the hydrated `origin_cwd`, exactly.
+    ///
+    /// The fixture is deliberately mixed rather than all-out-of-scope: an
+    /// in-scope session, a same-prefix-different-directory sibling (the classic
+    /// `startsWith` false positive), a nested child that MUST be kept, and a
+    /// session whose harness recorded no cwd at all. A guard that only dropped
+    /// the obviously-foreign row would still pass an all-out-of-scope fixture.
+    #[test]
+    fn search_never_discloses_a_session_outside_the_configured_scope() {
+        let scope = scope(&["/work/moraine"]);
+        let rows = vec![
+            totals("in-scope-root", "/work/moraine"),
+            totals("in-scope-child", "/work/moraine/crates/x"),
+            // `/work/moraine-other` starts with `/work/moraine` as a STRING but
+            // is a different project.
+            totals("prefix-sibling", "/work/moraine-other"),
+            totals("foreign", "/elsewhere/repo"),
+            // A harness that records no cwd matches no root (issue-599 §4).
+            totals("no-cwd", ""),
+        ];
+        let hydrated = hydrated(rows);
+
+        let disclosed: Vec<String> = [
+            "in-scope-root",
+            "in-scope-child",
+            "prefix-sibling",
+            "foreign",
+            "no-cwd",
+        ]
+        .into_iter()
+        .filter_map(|session_id| searched(session_id, &hydrated, scope.as_ref(), None, None))
+        .map(|item| item.session_id)
+        .collect();
+
+        assert_eq!(disclosed, vec!["in-scope-root", "in-scope-child"]);
+    }
+
+    /// The unscoped backend is the control arm: without it, a fold that dropped
+    /// EVERY session would pass the guard above.
+    #[test]
+    fn an_unscoped_backend_discloses_every_hydrated_session() {
+        let hydrated = hydrated(vec![
+            totals("a", "/work/moraine"),
+            totals("b", "/elsewhere/repo"),
+            totals("c", ""),
+        ]);
+        let disclosed: Vec<String> = ["a", "b", "c"]
+            .into_iter()
+            .filter_map(|session_id| searched(session_id, &hydrated, None, None, None))
+            .map(|item| item.session_id)
+            .collect();
+        assert_eq!(disclosed, vec!["a", "b", "c"]);
+    }
+
+    /// **The facet guard.** `harness` / `source` reach candidate selection as
+    /// recall predicates on relations that are not the summary's own value:
+    /// LIST pushes `has(groupUniqArray(harness), …)` over the session's whole
+    /// history, SEARCH pushes `p.harness = …` on a single POSTING. The summary
+    /// reports `argMax(harness)` — the LATEST value. So both passes admit a
+    /// session that later renders under a different harness, and only the exact
+    /// re-check can drop it.
+    ///
+    /// MUTATION: delete either `is_some_and` block in
+    /// `hydrated_session_summary`; the narrowed arms below then disclose
+    /// `re-harnessed` / `re-sourced` and this fails.
+    #[test]
+    fn both_discovery_paths_drop_a_session_whose_current_facet_differs() {
+        let mut re_harnessed = totals("re-harnessed", "/work/moraine");
+        re_harnessed.harness = "omp".to_string();
+        let mut re_sourced = totals("re-sourced", "/work/moraine");
+        re_sourced.source = "omp".to_string();
+        let hydrated = hydrated(vec![
+            totals("matches", "/work/moraine"),
+            re_harnessed,
+            re_sourced,
+        ]);
+        let ids = ["matches", "re-harnessed", "re-sourced"];
+
+        // Control arm: unnarrowed, every candidate is disclosed, so the arms
+        // below can only be shortened by the re-check.
+        let unnarrowed: Vec<String> = ids
+            .into_iter()
+            .filter_map(|session_id| searched(session_id, &hydrated, None, None, None))
+            .map(|item| item.session_id)
+            .collect();
+        assert_eq!(unnarrowed, ids.to_vec());
+
+        let by_harness: Vec<String> = ids
+            .into_iter()
+            .filter_map(|session_id| searched(session_id, &hydrated, None, Some("codex"), None))
+            .map(|item| item.session_id)
+            .collect();
+        assert_eq!(by_harness, vec!["matches", "re-sourced"]);
+
+        let by_source: Vec<String> = ids
+            .into_iter()
+            .filter_map(|session_id| searched(session_id, &hydrated, None, None, Some("codex")))
+            .map(|item| item.session_id)
+            .collect();
+        assert_eq!(by_source, vec!["matches", "re-harnessed"]);
+
+        // And the time-ordered path answers identically, because it reaches the
+        // same fold rather than owning a copy of the rule.
+        let listed: Vec<String> = ids
+            .into_iter()
+            .filter_map(|session_id| {
+                ClickHouseConversationRepository::session_list_item(
+                    &candidate(session_id),
+                    &hydrated,
+                    &McpSessionListFilter {
+                        harness: Some("codex".to_string()),
+                        ..unfiltered_list_filter()
+                    },
+                    None,
+                )
+            })
+            .map(|item| item.session_id)
+            .collect();
+        assert_eq!(listed, by_harness);
+    }
+
+    /// Every disclosed summary's own `harness` / `source` equals the value the
+    /// request narrowed by. This is the property a reader sees: a card rendered
+    /// `source: "omp"` under `?source=pi` is the defect, whatever produced it.
+    #[test]
+    fn a_narrowed_search_never_renders_a_session_under_another_facet() {
+        let mut drifted = totals("drifted", "/work/moraine");
+        drifted.harness = "omp".to_string();
+        drifted.source = "omp".to_string();
+        let hydrated = hydrated(vec![totals("kept", "/work/moraine"), drifted]);
+
+        for (harness, source_name) in [(Some("codex"), None), (None, Some("codex"))] {
+            let disclosed = ["kept", "drifted"]
+                .into_iter()
+                .filter_map(|session_id| {
+                    searched(session_id, &hydrated, None, harness, source_name)
+                })
+                .collect::<Vec<_>>();
+            assert!(!disclosed.is_empty(), "fixture must disclose something");
+            for item in disclosed {
+                if let Some(harness) = harness {
+                    assert_eq!(item.harness.as_deref(), Some(harness), "{item:?}");
+                }
+                if let Some(source_name) = source_name {
+                    assert_eq!(item.source.as_deref(), Some(source_name), "{item:?}");
+                }
+            }
+        }
+    }
+
+    /// The canonical replacement for the retired `tombstone` column: a session
+    /// with no live navigation rows under the pinned publication has no totals
+    /// row, or a zero-event one, and is not discoverable by either path.
+    #[test]
+    fn a_session_with_no_live_rows_is_not_discoverable() {
+        let mut zeroed = totals("emptied", "/work/moraine");
+        zeroed.total_events = 0;
+        let hydrated = hydrated(vec![zeroed]);
+
+        assert!(searched("emptied", &hydrated, None, None, None).is_none());
+        assert!(searched("never-hydrated", &hydrated, None, None, None).is_none());
+        assert!(searched("   ", &hydrated, None, None, None).is_none());
+    }
+
+    /// **The one-`updated_at` guard (issue-599 B1).** Both discovery paths
+    /// report the DIRECTORY keyset — the value the time-ordered page also
+    /// orders by and mints its cursor from — and neither reports the hydrated
+    /// aggregate.
+    ///
+    /// The fixture's keyset is deliberately 60 s ahead of the hydrated value —
+    /// exactly the monitor's activity window — because that is the width at
+    /// which a divergence stops being cosmetic: `monitor_session_json` derives
+    /// `status` from `last_event_unix_ms`, so two surfaces disagreeing by that
+    /// much render one session `active` and `completed` at one instant. With
+    /// the two values equal (every ordinary session) neither half of this test
+    /// could fail however the code were written.
+    ///
+    /// MUTATION: report `totals.last_event_unix_ms` instead of
+    /// `keyset.last_unix_ms` in `hydrated_session_summary`; the first block
+    /// fails.
+    #[test]
+    fn both_discovery_paths_report_the_directory_keyset_they_page_by() {
+        let hydrated = hydrated(vec![totals("sess-a", "/work/moraine")]);
+        let filter = unfiltered_list_filter();
+
+        let ranked = searched("sess-a", &hydrated, None, None, None).expect("in-scope session");
+        assert_eq!(ranked.last_event_unix_ms, KEYSET_MS);
+        assert_eq!(ranked.last_event_time, KEYSET_TIME);
+        // The hydrated aggregate is a DIFFERENT number, and is not what either
+        // surface reports.
+        assert_ne!(ranked.last_event_unix_ms, 1_767_262_200_000);
+        // `started_at` still comes from hydration: nothing orders or pages by
+        // it, and the exact `FINAL`-deduped bound is the better answer.
+        assert_eq!(ranked.first_event_unix_ms, 1_767_261_600_000);
+
+        let listed = ClickHouseConversationRepository::session_list_item(
+            &candidate("sess-a"),
+            &hydrated,
+            &filter,
+            None,
+        )
+        .expect("surviving candidate");
+        // The listed item is the SAME object the ranked search returns, field
+        // for field. Asserting the whole item, not just the timestamps, is what
+        // stops the next field that gets "adjusted for paging" from
+        // reintroducing the divergence under a different name.
+        assert_eq!(listed, ranked);
+    }
+
+    /// **The hit-budget bounds, over the WHOLE reachable domain.**
+    ///
+    /// `limit` is clamped to `1..=SESSION_SEARCH_MAX_LIMIT` inside
+    /// `search_session_summaries_impl`, so this is not a sample of the input
+    /// space — it is all of it. Each assertion is one of the properties
+    /// `session_search_hit_budget` exists to hold, and the previous shape
+    /// (`.max(limit).min(MAX.max(limit))`) violated two of them at every
+    /// `limit >= 50`: the budget collapsed to exactly `limit`, which makes the
+    /// fan-in 1:1 and `truncated: ranked_sessions > limit` unsettable.
+    ///
+    /// MUTATION: drop the `.max(fan_in_floor)` and the loop panics at
+    /// `limit 34: fan-in 50/34 fell below 1.5x` — the floor assertion, not the
+    /// "must exceed" one, and well before `limit = 50`. Drop the
+    /// `.min(SESSION_SEARCH_HIT_BUDGET_MAX)` instead and it panics at
+    /// `limit 22: window 256 pinned the hard candidate ceiling`, because 22
+    /// already derives `min(3 × 89, 256) = 256`.
+    ///
+    /// Both recipes are stated at the limit where the loop ACTUALLY stops. An
+    /// earlier revision named `limit = 50` for both; the loop never gets there,
+    /// so a contributor checking the stated limit would look in the wrong place.
+    #[test]
+    fn session_search_hit_budget_holds_its_bounds_across_the_whole_reachable_domain() {
+        use super::super::search_canonical::{mcp_candidate_fetch_size, MCP_SEARCH_CANDIDATE_MAX};
+
+        let mut previous = 0;
+        for limit in 1..=SESSION_SEARCH_MAX_LIMIT {
+            let budget = session_search_hit_budget(limit);
+
+            // 1. The budget must EXCEED the session limit, or the ranking's own
+            //    hit ceiling bounds the distinct sessions at `limit` and
+            //    `truncated` can never be set.
+            assert!(
+                budget > limit,
+                "limit {limit}: budget {budget} does not exceed the session limit",
+            );
+            // 2. The fan-in degrades but never collapses: 4x while the ceiling
+            //    allows, and never below 1.5x.
+            assert!(
+                budget * 2 >= limit * 3,
+                "limit {limit}: fan-in {budget}/{limit} fell below 1.5x",
+            );
+            assert!(
+                budget <= limit * SESSION_SEARCH_HITS_PER_SESSION,
+                "limit {limit}: budget {budget} exceeds the {SESSION_SEARCH_HITS_PER_SESSION}x \
+                 fan-in it is derived from",
+            );
+            // 3. Monotone in `limit`: asking for more sessions never buys a
+            //    smaller ranking.
+            assert!(budget >= previous, "limit {limit}: budget went backwards");
+            previous = budget;
+
+            // 4. The derived candidate window stays strictly BELOW the hard
+            //    ceiling, so that constant remains a guard against a raised cap
+            //    rather than the number requests land on.
+            let window = mcp_candidate_fetch_size(budget + 1);
+            assert!(
+                window < MCP_SEARCH_CANDIDATE_MAX,
+                "limit {limit}: window {window} pinned the hard candidate ceiling",
+            );
+        }
+
+        // The three documented shapes, at their boundaries.
+        assert_eq!(session_search_hit_budget(1), 4, "full 4x fan-in");
+        assert_eq!(session_search_hit_budget(12), 48, "last 4x limit");
+        assert_eq!(session_search_hit_budget(13), 50, "the ceiling binds");
+        assert_eq!(session_search_hit_budget(25), 50, "the shipped default");
+        assert_eq!(
+            session_search_hit_budget(33),
+            50,
+            "last ceiling-bound limit"
+        );
+        assert_eq!(
+            session_search_hit_budget(34),
+            51,
+            "the 1.5x floor takes over"
+        );
+        assert_eq!(session_search_hit_budget(50), 75, "the largest page");
+        // …and the windows those derive, which is what the cost actually is.
+        assert_eq!(
+            mcp_candidate_fetch_size(session_search_hit_budget(1) + 1),
+            15
+        );
+        assert_eq!(
+            mcp_candidate_fetch_size(session_search_hit_budget(25) + 1),
+            153
+        );
+        assert_eq!(
+            mcp_candidate_fetch_size(session_search_hit_budget(50) + 1),
+            228
+        );
+    }
+
+    /// **The bounded-answer derivation.** Each fact is asserted through an
+    /// input that sets it and leaves the others clear, so a field wired to a
+    /// neighbour, deleted, or inverted has nowhere to hide.
+    ///
+    /// MUTATION (the shipped defect): restore
+    /// `truncated: ranked_sessions > limit || ranking_hit_truncated`; the
+    /// `one_session_hit_many_times` case then reports `truncated: true` and
+    /// this fails.
+    #[test]
+    fn the_bounded_answer_facts_are_derived_from_independent_causes() {
+        // Everything fitted: two ranked sessions for a requested ten, both
+        // disclosed, hit budget not filled.
+        let complete = SessionSearchBounds::derive(2, 10, 2, 2, false);
+        assert_eq!(
+            complete,
+            SessionSearchBounds {
+                truncated: false,
+                hits_truncated: false,
+                dropped: false,
+            }
+        );
+
+        // SESSION grain: eleven ranked sessions, ten returned.
+        let more_sessions = SessionSearchBounds::derive(11, 10, 10, 10, false);
+        assert!(more_sessions.truncated);
+        assert!(!more_sessions.hits_truncated);
+        assert!(!more_sessions.dropped);
+
+        // HIT grain, and the case the old `||` got wrong: a term appearing
+        // thirty times in ONE session fills the hit budget and yields ONE
+        // session. There is nothing more to return at the session grain, and
+        // raising `limit` returns the same one session forever.
+        let one_session_hit_many_times = SessionSearchBounds::derive(1, 10, 1, 1, true);
+        assert!(
+            !one_session_hit_many_times.truncated,
+            "one ranked session is not 'more sessions existed than limit returned'",
+        );
+        assert!(one_session_hit_many_times.hits_truncated);
+        assert!(!one_session_hit_many_times.dropped);
+
+        // The exact re-check shortened the answer and nothing refilled it.
+        let shortened = SessionSearchBounds::derive(4, 10, 4, 1, false);
+        assert!(shortened.dropped);
+        assert!(!shortened.truncated);
+        assert!(!shortened.hits_truncated);
+
+        // A full page that dropped nothing is not "dropped", even though it is
+        // exactly `limit` long.
+        let exactly_limit = SessionSearchBounds::derive(10, 10, 10, 10, false);
+        assert!(!exactly_limit.dropped);
+        assert!(!exactly_limit.truncated);
+
+        // And the causes compose rather than mask each other.
+        let everything = SessionSearchBounds::derive(11, 10, 10, 3, true);
+        assert_eq!(
+            everything,
+            SessionSearchBounds {
+                truncated: true,
+                hits_truncated: true,
+                dropped: true,
+            }
+        );
+    }
 }

--- a/crates/moraine-conversations/src/clickhouse_repo/mod.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/mod.rs
@@ -89,8 +89,9 @@ use crate::domain::{
     SearchEventHit, SearchEventKind, SearchEventsQuery, SearchEventsResult, SearchEventsStats,
     SearchMcpEventHit, SearchMcpEventsQuery, SearchMcpEventsResult, SearchMcpEventsStats,
     SearchStrategyHint, SessionAnalytics, SessionAnalyticsQuery, SessionEventsDirection,
-    SessionEventsQuery, SessionMetadata, SessionOriginScope, SessionStep, SessionTurn, ToolResult,
-    TraceEvent, Turn, TurnListFilter, TurnSummary, WebSearchEvent,
+    SessionEventsQuery, SessionMetadata, SessionOriginScope, SessionSearchQuery,
+    SessionSearchResults, SessionStep, SessionTurn, ToolResult, TraceEvent, Turn, TurnListFilter,
+    TurnSummary, WebSearchEvent,
 };
 use crate::error::{RepoError, RepoResult};
 use crate::repo::ConversationRepository;

--- a/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
@@ -134,6 +134,21 @@ impl ConversationRepository for ClickHouseConversationRepository {
         .await
     }
 
+    async fn search_session_summaries(
+        &self,
+        query: SessionSearchQuery,
+    ) -> RepoResult<SessionSearchResults> {
+        // Same read class as the two operations it is composed of
+        // (`search_mcp_events` and `list_mcp_sessions`): a corpus-wide ranking
+        // has no single anchored session, and pinning the whole request to one
+        // publication snapshot is what keeps the ranking pass and the hydration
+        // pass describing the same store.
+        self.run_publication_consistent(PublicationReadClass::MovingFeed, || {
+            self.search_session_summaries_impl(query.clone())
+        })
+        .await
+    }
+
     async fn list_turns(
         &self,
         session_id: &str,

--- a/crates/moraine-conversations/src/clickhouse_repo/search.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search.rs
@@ -49,6 +49,55 @@ pub(super) struct McpSearchPage {
     pub(super) incomplete_due_to_candidate_budget: bool,
 }
 
+/// The two knobs an INTERNAL consumer of the event ranking may set and the
+/// public `search_mcp_events` tool may not.
+///
+/// It is a struct rather than two positional arguments because both are
+/// easy-to-transpose small scalars whose defaults are correct for the tool path
+/// and wrong for the internal one.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct McpEventRankingOptions {
+    /// Ceiling on ranked HITS.
+    ///
+    /// `max_results` bounds *rows a caller may receive*, and a consumer that
+    /// folds many hits into one result row is not bounded by the same number.
+    /// Session discovery by content ranks EVENTS and answers in SESSIONS —
+    /// several hits routinely land in one session — so it must be able to ask
+    /// for more hits than the sessions it returns. Clamping its request to
+    /// `max_results` made the over-fetch inert in every shipped configuration,
+    /// because `max_results` is also the session limit.
+    ///
+    /// It is still bounded, and bounded from BOTH sides rather than by
+    /// `limit x factor` alone: see [`super::list::session_search_hit_budget`],
+    /// which caps the fan-in so the derived candidate window cannot reach
+    /// [`super::search_canonical::MCP_SEARCH_CANDIDATE_MAX`], and floors it
+    /// above `limit` so the fan-in cannot collapse to 1:1 at the largest page.
+    /// `effective_n_hits` stays part of the result cache key, so two callers
+    /// with different ceilings cannot serve each other's windows.
+    pub(super) hit_cap: u16,
+    /// The issue-598 `open_v2` readiness verdict, when the caller has already
+    /// resolved it.
+    ///
+    /// `None` means "probe it" and is right for a request whose only readiness
+    /// branch is the ranking engine. `Some` is required of any caller that
+    /// branches on readiness AGAIN after ranking: a second probe is a second
+    /// point read, and — because the latch flips when a backfill publishes —
+    /// two probes in one request can disagree, ranking over the `mcp_open_*`
+    /// projection and then hydrating from the canonical navigation index.
+    pub(super) canonical_ready: Option<bool>,
+}
+
+impl McpEventRankingOptions {
+    /// The public tool's settings: hits bounded by the rows a caller may
+    /// receive, readiness resolved by the ranking itself.
+    pub(super) fn for_tool_caller(cfg: &RepoConfig) -> Self {
+        Self {
+            hit_cap: cfg.max_results,
+            canonical_ready: None,
+        }
+    }
+}
+
 impl ClickHouseConversationRepository {
     /// Session headers that are authorized by the operation's captured source
     /// heads and by the current canonical session contents.
@@ -1174,6 +1223,12 @@ FORMAT JSONEachRow",
     /// While the canonical read indexes are not published the legacy
     /// projected-header engine still serves; it is deleted wholesale in the
     /// projector-retirement PR.
+    ///
+    /// `canonical_ready` is that latch's verdict, PASSED IN rather than probed
+    /// here: a request whose later stages also branch on readiness must reach
+    /// them with the same verdict this one used, or a backfill publishing
+    /// mid-request produces one answer ranked over the `mcp_open_*` projection
+    /// and hydrated from the canonical navigation index.
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn search_mcp_event_page(
         &self,
@@ -1186,8 +1241,9 @@ FORMAT JSONEachRow",
         min_should_match: u16,
         min_score: f64,
         unique_fetch_limit: u16,
+        canonical_ready: bool,
     ) -> RepoResult<McpSearchPage> {
-        if self.canonical_list_path_ready().await {
+        if canonical_ready {
             return self
                 .search_mcp_event_page_v2(
                     terms,
@@ -3273,10 +3329,30 @@ FORMAT JSONEachRow",
         })
     }
 
+    /// Event-grained MCP search as CALLERS see it: `n_hits` is clamped to the
+    /// caller-facing `[mcp] max_results`, which is the number of RESULT ROWS a
+    /// tool response may contain. Readiness is resolved inside, because this
+    /// request has no earlier stage that already needed the verdict.
     pub(super) async fn search_mcp_events_impl(
         &self,
         query: SearchMcpEventsQuery,
     ) -> RepoResult<SearchMcpEventsResult> {
+        self.search_mcp_events_ranked(query, McpEventRankingOptions::for_tool_caller(&self.cfg))
+            .await
+    }
+
+    /// The ranking with the knobs an INTERNAL consumer may set.
+    ///
+    /// See [`McpEventRankingOptions`] for why each exists. Everything else —
+    /// validation, tokenization, the result cache, the truncation report — is
+    /// the tool path's, unchanged, so an internal consumer cannot drift into a
+    /// second ranking with its own rules.
+    pub(super) async fn search_mcp_events_ranked(
+        &self,
+        query: SearchMcpEventsQuery,
+        options: McpEventRankingOptions,
+    ) -> RepoResult<SearchMcpEventsResult> {
+        let hit_cap = options.hit_cap.max(1);
         let query_text = query.query.trim();
         if query_text.is_empty() {
             return Err(RepoError::invalid_argument("query cannot be empty"));
@@ -3314,7 +3390,7 @@ FORMAT JSONEachRow",
         let event_types = Self::normalize_mcp_event_types(query.event_types)?;
 
         let requested_n_hits = query.n_hits.unwrap_or(10).max(1);
-        let effective_n_hits = requested_n_hits.min(self.cfg.max_results);
+        let effective_n_hits = requested_n_hits.min(hit_cap);
         let limit_capped = requested_n_hits > effective_n_hits;
         let unique_fetch_limit = effective_n_hits.saturating_add(1);
 
@@ -3367,6 +3443,17 @@ FORMAT JSONEachRow",
                     false,
                 )
             } else {
+                // Resolved HERE and not one frame down, so that a caller which
+                // already needed the verdict for a later stage pays for one
+                // point read instead of two — and, more importantly, so one
+                // request cannot straddle a mid-request readiness flip by
+                // ranking on one read model and hydrating from the other. A
+                // cache hit skips this entirely, which is why it is not hoisted
+                // above the lookup.
+                let canonical_ready = match options.canonical_ready {
+                    Some(ready) => ready,
+                    None => self.canonical_list_path_ready().await,
+                };
                 let page = self
                     .search_mcp_event_page(
                         &terms,
@@ -3378,6 +3465,7 @@ FORMAT JSONEachRow",
                         min_should_match,
                         min_score,
                         unique_fetch_limit,
+                        canonical_ready,
                     )
                     .await?;
                 let McpSearchPage {

--- a/crates/moraine-conversations/src/clickhouse_repo/search_canonical.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/search_canonical.rs
@@ -42,9 +42,30 @@ use super::*;
 /// single pass. There is deliberately no second pass: the retired refill loop
 /// re-executed every corpus-sized preamble up to 16 times per request.
 pub(super) const MCP_SEARCH_CANDIDATE_MULTIPLIER: u32 = 3;
-/// Hard ceiling on one ranking pass's candidate window. `n_hits` is 1..=50 and
-/// is further capped by `max_results`, so `C ∈ [2, 153]` in practice; the
-/// constant bounds the window even if those caps are raised.
+/// Hard ceiling on one ranking pass's candidate window.
+///
+/// Two callers set `n_hits`, and each derives a bounded budget, so
+/// `C ∈ [2, 228]` in practice and this constant guards against a RAISED cap
+/// rather than being a number requests land on:
+///
+/// * the MCP event search tool, whose contract validates `n_hits ∈ 1..=50` and
+///   which additionally clamps to `[mcp] max_results`. Worst case
+///   `C = 3 × (50 + 1) = 153`;
+/// * session discovery by content, whose INTERNAL hit budget is deliberately
+///   NOT clamped to `max_results` — a consumer that folds many hits into one
+///   result row is not bounded by the rows a caller may receive. It is bounded
+///   instead by [`super::list::session_search_hit_budget`], which caps the
+///   budget at 75 over its whole reachable `limit` domain (`1..=50`, clamped in
+///   the repository, not by a route). Worst case `C = 3 × (75 + 1) = 228`, at
+///   the largest page a caller may ask for; the shipped default (`limit = 25`)
+///   derives 153.
+///
+/// The second caller is why "further capped by `max_results`" no longer holds
+/// as the reason. Do not restore that wording: out-fetching `max_results` is
+/// the point of that path, and the second bullet is the bound that replaced it.
+/// Without an explicit budget ceiling there, the shipped default shape
+/// (`max_results = 25`, a client asking for 25) derives `C = 256` and pins this
+/// constant on every interactive search.
 pub(super) const MCP_SEARCH_CANDIDATE_MAX: u32 = 256;
 /// Turn-scoped ranking inlines the turn's live event uids as a literal `IN`
 /// set. Above this many events in one turn the request falls back to

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -426,7 +426,12 @@ pub struct McpSessionOpen {
     pub snapshot: Option<McpOpenSnapshot>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// One session as BOTH discovery surfaces render it.
+///
+/// `PartialEq` is derived so "the ranked search and the time-ordered feed
+/// describe this session identically" can be ONE assertion rather than a field
+/// checklist a newly added field silently falls off (issue-599 B1).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct McpSessionListItem {
     pub session_id: String,
     pub first_event_time: String,
@@ -455,6 +460,92 @@ pub struct McpSessionListItem {
     /// MCP's `session_json` does not emit it.
     #[serde(default)]
     pub tool_calls: u64,
+}
+
+/// Session DISCOVERY BY CONTENT (issue-599 WI-09): the ranked counterpart to
+/// [`McpSessionListFilter`].
+///
+/// The two discovery inputs differ only in how candidates are chosen — a time
+/// window versus a BM25 ranking over the whole permitted corpus — and agree on
+/// everything after: the same exact project-scope re-check, the same LIST
+/// title/summary fold, and the same [`McpSessionListItem`] output. A result
+/// therefore opens through exactly the reader a listed session opens through.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionSearchQuery {
+    pub query: String,
+    /// Reported back as the result's `query_id`. Cancellation itself targets
+    /// the active query envelope's request id, not this token.
+    #[serde(skip)]
+    pub cancellation_token: Option<String>,
+    /// Maximum SESSIONS to return. Clamped to the backend's `max_results`.
+    #[serde(default)]
+    pub limit: Option<u16>,
+    #[serde(default)]
+    pub harness: Option<String>,
+    #[serde(default)]
+    pub source_name: Option<String>,
+}
+
+/// Ranked whole-corpus session search results.
+///
+/// Carries **no** transcript content — no snippet, no `text_content`, no
+/// `payload_json`. The ranking pass reads message text to score it; nothing it
+/// read survives into this type, so a search response stays flat as transcripts
+/// grow, exactly like the session feed (issue-599 §5.3).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionSearchResults {
+    pub query_id: String,
+    /// The trimmed query text that was ranked.
+    pub query: String,
+    /// The tokenized query terms, for a client that wants to highlight.
+    pub terms: Vec<String>,
+    /// Sessions in ranked order, best first.
+    pub sessions: Vec<McpSessionListItem>,
+    /// SESSION grain: the ranking yielded more distinct sessions than `limit`
+    /// allowed, so raising `limit` returns more of them.
+    ///
+    /// Deliberately NOT the hit-grain signal. Ranking is over EVENTS and hits
+    /// cluster inside a session, so "more hits existed" and "more sessions
+    /// existed" are different facts with different remedies; conflating them
+    /// tells a reader to raise `limit` when raising `limit` cannot help. See
+    /// [`Self::hits_truncated`].
+    pub truncated: bool,
+    /// HIT grain: the ranking filled its internal event-hit budget, so matching
+    /// events existed that it never examined and sessions beyond those returned
+    /// may exist.
+    ///
+    /// A term that matches one session thirty times sets this and leaves
+    /// [`Self::truncated`] false, which is the honest description of that
+    /// corpus: one session matched, and the answer is complete at the session
+    /// grain. The hit budget scales with `limit`, so raising `limit` widens the
+    /// window this reports on — but it is not a promise of more sessions.
+    pub hits_truncated: bool,
+    /// Issue #597 §1.6, propagated verbatim: the single bounded candidate
+    /// window was saturated and post-ranking validation cut it short. The
+    /// sessions present are valid and a true ranking prefix; this is never an
+    /// error.
+    pub incomplete: bool,
+    /// Ranked sessions were removed by the exact post-ranking re-check — exact
+    /// harness/source, the tombstone rule, a blank id — and were NOT refilled
+    /// from further down the ranking.
+    ///
+    /// Without it a request that returns three sessions for `limit = 10`
+    /// because seven were dropped is indistinguishable from one where the
+    /// corpus genuinely held three, i.e. it would claim to be complete when it
+    /// is a strict subset of what the ranking offered.
+    ///
+    /// **Project scope cannot set this bit.** Both ranking arms apply the
+    /// configured scope while they are still choosing candidates — against the
+    /// navigation `argMinIf(cwd, …)` on the canonical path, against
+    /// `mcp_open_publication_headers.origin_cwd` on the pre-cutover path — so
+    /// an out-of-scope session never enters the ranked set and cannot be
+    /// subtracted from it afterwards. That is what stops `limit -
+    /// result_count`, which is exact whenever `truncated` is also set, from
+    /// being a per-term count of activity outside the caller's scope. The
+    /// post-hydration scope re-check exists so ONE function decides disclosure
+    /// for both discovery surfaces; it is defence in depth, not this bit's
+    /// cause.
+    pub dropped: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/moraine-conversations/src/in_memory_repo.rs
+++ b/crates/moraine-conversations/src/in_memory_repo.rs
@@ -16,7 +16,8 @@ use crate::domain::{
     McpSessionListFilter, McpSessionListItem, McpSessionOpen, McpTurnOpen, OpenContext,
     OpenEventRequest, Page, PageRequest, RepoConfig, SearchEventsQuery, SearchEventsResult,
     SearchEventsStats, SearchMcpEventsQuery, SearchMcpEventsResult, SearchMcpEventsStats,
-    SessionEventsQuery, SessionMetadata, TraceEvent, Turn, TurnListFilter, TurnSummary,
+    SessionEventsQuery, SessionMetadata, SessionSearchQuery, SessionSearchResults, TraceEvent,
+    Turn, TurnListFilter, TurnSummary,
 };
 use crate::error::{RepoError, RepoResult};
 use crate::repo::ConversationRepository;
@@ -42,6 +43,7 @@ pub struct InMemoryConversationResponses {
     /// [`Self::list_mcp_sessions`], so a caller that drops the cursor is served
     /// page 1 again and the overlap is visible to the test.
     pub list_mcp_sessions_by_cursor: BTreeMap<String, RepoResult<Page<McpSessionListItem>>>,
+    pub search_session_summaries: Option<RepoResult<SessionSearchResults>>,
     pub canonical_open_session_page: Option<CanonicalSessionPageResponse>,
     /// A static session traversal: the page served after a given
     /// `after_turn_seq`, with `0` keying the uncursored first page. Takes
@@ -83,6 +85,7 @@ pub struct InMemoryConversationCalls {
     pub get_session_metadata: Vec<String>,
     pub get_mcp_session: Vec<String>,
     pub list_mcp_sessions: Vec<(McpSessionListFilter, PageRequest)>,
+    pub search_session_summaries: Vec<SessionSearchQuery>,
     pub canonical_open_session_page: Vec<(String, u16, Option<CanonicalContinuation>)>,
     pub list_turns: Vec<(String, TurnListFilter, PageRequest)>,
     pub get_turn: Vec<(String, u32)>,
@@ -392,6 +395,30 @@ impl ConversationRepository for InMemoryConversationRepository {
             mutex_lock(&self.minted_session_cursors).insert(next.clone(), filter_sig);
         }
         result
+    }
+
+    async fn search_session_summaries(
+        &self,
+        query: SessionSearchQuery,
+    ) -> RepoResult<SessionSearchResults> {
+        self.record(|calls| calls.search_session_summaries.push(query.clone()));
+        response_or!(
+            self,
+            search_session_summaries,
+            SessionSearchResults {
+                query_id: query
+                    .cancellation_token
+                    .clone()
+                    .unwrap_or_else(|| "in-memory".to_string()),
+                query: query.query.clone(),
+                terms: Vec::new(),
+                sessions: Vec::new(),
+                truncated: false,
+                hits_truncated: false,
+                incomplete: false,
+                dropped: false,
+            }
+        )
     }
 
     async fn list_turns(

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -21,7 +21,8 @@ pub use domain::{
     SearchEventHit, SearchEventKind, SearchEventsQuery, SearchEventsResult, SearchEventsStats,
     SearchMcpEventHit, SearchMcpEventsQuery, SearchMcpEventsResult, SearchMcpEventsStats,
     SearchStrategyHint, SessionEventsDirection, SessionEventsQuery, SessionMetadata,
-    SessionOriginScope, TraceEvent, Turn, TurnListFilter, TurnSummary,
+    SessionOriginScope, SessionSearchQuery, SessionSearchResults, TraceEvent, Turn, TurnListFilter,
+    TurnSummary,
 };
 pub use domain::{
     AnalyticsConcurrencyPoint, AnalyticsRange, AnalyticsSnapshot, AnalyticsTokenPoint,

--- a/crates/moraine-conversations/src/repo.rs
+++ b/crates/moraine-conversations/src/repo.rs
@@ -11,8 +11,8 @@ use crate::domain::{
     ConversationSearchResults, FileAttentionQuery, FileAttentionTouch, McpEventOpen,
     McpSessionListFilter, McpSessionListItem, McpSessionOpen, McpTurnOpen, OpenContext,
     OpenEventRequest, Page, PageRequest, RepoConfig, SearchEventsQuery, SearchEventsResult,
-    SearchMcpEventsQuery, SearchMcpEventsResult, SessionEventsQuery, SessionMetadata, TraceEvent,
-    Turn, TurnListFilter, TurnSummary,
+    SearchMcpEventsQuery, SearchMcpEventsResult, SessionEventsQuery, SessionMetadata,
+    SessionSearchQuery, SessionSearchResults, TraceEvent, Turn, TurnListFilter, TurnSummary,
 };
 use crate::error::{RepoError, RepoResult};
 
@@ -91,6 +91,36 @@ pub trait ConversationRepository: Send + Sync {
         filter: McpSessionListFilter,
         page: PageRequest,
     ) -> RepoResult<Page<McpSessionListItem>>;
+
+    /// Session DISCOVERY BY CONTENT over the whole permitted corpus
+    /// (issue-599 WI-09).
+    ///
+    /// Candidate selection is issue #597's bounded postings ranking; every step
+    /// after it is shared with [`Self::list_mcp_sessions`] — the same read
+    /// model, chosen by the same readiness latch, then the same hydration and
+    /// the same visibility rules — so the two discovery surfaces cannot
+    /// disagree about what a session is, what it is called, whether the caller
+    /// may see it, or which harness it ran under.
+    ///
+    /// Two re-checks against the HYDRATED session are load-bearing:
+    ///
+    /// * **Project scope**, against `origin_cwd`. Scope decides what a caller
+    ///   is allowed to see, so it does not rest on a recall filter.
+    /// * **`harness` / `source_name`, exactly.** Ranking narrows per POSTING
+    ///   (`p.harness = …`) while a summary reports the session's LATEST value,
+    ///   so without this a `harness`-narrowed search returns a card rendered
+    ///   under a different harness — and disagrees with the feed, which has
+    ///   always re-checked exactly.
+    ///
+    /// The result carries session SUMMARIES only. Ranking reads message text to
+    /// score it; none of that text reaches the caller.
+    ///
+    /// The bounded-answer flags on [`SessionSearchResults`] describe different
+    /// facts with different remedies and must be surfaced separately.
+    async fn search_session_summaries(
+        &self,
+        query: SessionSearchQuery,
+    ) -> RepoResult<SessionSearchResults>;
 
     async fn list_turns(
         &self,

--- a/crates/moraine-conversations/tests/repository_integration/main.rs
+++ b/crates/moraine-conversations/tests/repository_integration/main.rs
@@ -10,8 +10,8 @@ use moraine_conversations::{
     ConversationRepository, ConversationSearchQuery, FileAttentionQuery, McpEventType,
     McpSessionListFilter, PageRequest, QueryClass, QueryEnvelope, RepoError, SearchEventKind,
     SearchEventsQuery, SearchMcpEventsQuery, SearchStrategyHint, SessionAnalyticsQuery,
-    SessionEventsDirection, SessionEventsQuery, SessionLookback, SessionStep, StoreProbe,
-    TablePreviewQuery, TurnListFilter,
+    SessionEventsDirection, SessionEventsQuery, SessionLookback, SessionSearchQuery, SessionStep,
+    StoreProbe, TablePreviewQuery, TurnListFilter,
 };
 use serde_json::json;
 use tokio::sync::Notify;

--- a/crates/moraine-conversations/tests/repository_integration/sessions.rs
+++ b/crates/moraine-conversations/tests/repository_integration/sessions.rs
@@ -483,12 +483,14 @@ async fn list_sessions_semantics_are_identical_on_both_paths() {
         // session set and on every per-item field.
         //
         // The CURSOR is deliberately excluded from that comparison and asserted
-        // to differ instead. The two paths anchor on different values — the
-        // header path on the projector's exact aggregate, the directory path on
-        // the live-generation `max_observed_event_time` it also reports — so a
-        // token is only meaningful to the path that minted it. Comparing the
-        // tokens for equality would re-assert the false premise this test used
-        // to carry, and would fail the moment the anchors legitimately diverge.
+        // to differ instead. Each path anchors on the `updated_at` IT reports,
+        // and those come from different relations — the header path from the
+        // projector's exact aggregate, the directory path from the
+        // live-generation `max_observed_event_time` — so a token is only
+        // meaningful to the path that minted it. Comparing the tokens for
+        // equality would re-assert the false premise this test used to carry,
+        // and would fail the moment the two relations legitimately diverge (the
+        // fixture holds them equal, which is the ordinary corpus).
         let (reference_path, reference) = &pages[0];
         for (path, page) in &pages[1..] {
             assert_eq!(
@@ -761,40 +763,29 @@ async fn list_mcp_sessions_directory_page_never_prefilters_mcp_internal_mode() {
     .await;
 }
 
-/// One Phase-A candidate row.
-/// Render a millisecond instant the way ClickHouse renders `DateTime64(3)`.
-fn format_directory_display_time(unix_ms: i64) -> String {
-    let secs = unix_ms.div_euclid(1_000);
-    let millis = unix_ms.rem_euclid(1_000);
-    let days = secs.div_euclid(86_400);
-    let time_of_day = secs.rem_euclid(86_400);
-    // 1970-01-01 + `days`, via the civil-from-days algorithm.
-    let z = days + 719_468;
-    let era = z.div_euclid(146_097);
-    let doe = z.rem_euclid(146_097);
-    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    format!(
-        "{y:04}-{m:02}-{d:02} {:02}:{:02}:{:02}.{millis:03}",
-        time_of_day / 3_600,
-        (time_of_day % 3_600) / 60,
-        time_of_day % 60
-    )
+/// The directory display form paired with [`candidate_row`]'s default keyset,
+/// for candidates whose RENDERING is not what the test is about.
+const CANDIDATE_DISPLAY_TIME: &str = "2026-01-01 10:10:00";
+
+/// One directory candidate row. Content-free and time-free apart from the
+/// keyset: `cand_last_ms` is what the page orders by, keysets on, mints its
+/// cursor from AND reports, and `cand_last_time` is that same value's display
+/// form from the same aggregate.
+fn candidate_row(session_id: &str, cand_last_ms: i64) -> serde_json::Value {
+    candidate_row_at(session_id, cand_last_ms, CANDIDATE_DISPLAY_TIME)
 }
 
-fn candidate_row(session_id: &str, cand_last_ms: i64) -> serde_json::Value {
-    // `cand_last_time` is the display form of the same instant: the directory
-    // path orders by `cand_last_ms` and reports its display form, so a fixture
-    // that let them describe different instants would not model the real row.
+/// [`candidate_row`] with the two halves of the keyset paired explicitly, for
+/// the tests that assert WHICH statement a rendered timestamp came from.
+fn candidate_row_at(
+    session_id: &str,
+    cand_last_ms: i64,
+    cand_last_time: &str,
+) -> serde_json::Value {
     json!({
         "session_id": session_id,
         "cand_last_ms": cand_last_ms,
-        "cand_last_time": format_directory_display_time(cand_last_ms),
+        "cand_last_time": cand_last_time,
     })
 }
 
@@ -880,10 +871,17 @@ async fn list_mcp_sessions_directory_page_rechecks_origin_scope_against_the_hydr
 async fn list_mcp_sessions_directory_page_orders_and_anchors_on_the_directory_keyset() {
     scoped(async {
         // The directory aggregate and the hydrated aggregate are different
-        // numbers whenever an event version has been superseded. Ordering and
-        // the cursor MUST use the directory value — it is the only one the next
-        // page's `HAVING` can compare against — and the item REPORTS that same
-        // directory value, so the page is sorted by the field it returns (B1).
+        // numbers whenever an event version has been superseded, and ONE of
+        // them is this operation's `updated_at` (issue-599 B1):
+        //
+        // * ORDERING, the CURSOR and the ITEM all read the directory value. It
+        //   is the only one the next page's `HAVING` can compare against, so
+        //   anchoring on anything else skips every session whose aggregate
+        //   falls between — and the published contract says the response is
+        //   sorted by the `updated_at` it reports, which is only true if the
+        //   two are the same number.
+        // * The hydrated value stays internal: Phase C re-filters the requested
+        //   window against it, and nothing renders it.
         //
         // sess-p: directory 1_767_400_000_000, exact 1_767_300_000_000
         // sess-q: directory 1_767_350_000_000, exact 1_767_350_000_000
@@ -892,8 +890,8 @@ async fn list_mcp_sessions_directory_page_orders_and_anchors_on_the_directory_ke
             let mut responses = vec![ScriptedResponse::rows(
                 &["FROM `moraine`.`mcp_session_directory` AS d", "LIMIT 16"],
                 json!([
-                    candidate_row("sess-p", 1_767_400_000_000_i64),
-                    candidate_row("sess-q", 1_767_350_000_000_i64),
+                    candidate_row_at("sess-p", 1_767_400_000_000_i64, "2026-01-02 22:26:40.000"),
+                    candidate_row_at("sess-q", 1_767_350_000_000_i64, "2026-01-02 08:33:20.000"),
                 ]),
             )];
             responses.extend(hydration_script(
@@ -927,14 +925,33 @@ async fn list_mcp_sessions_directory_page_orders_and_anchors_on_the_directory_ke
             page.items[0].session_id, "sess-p",
             "survivors must be ordered by the directory keyset, not the hydrated timestamp"
         );
-        // B1: the response reports the value the page was ORDERED and KEYSET
-        // by, so it is sorted by the field it returns. sess-p's directory
-        // aggregate (1_767_400_000_000) sits above its hydrated exact value
-        // (1_767_300_000_000) — the re-inserted-event case — and it is the
-        // aggregate that is reported.
+        // The RENDERED timestamp is the directory keyset, in both the millis and
+        // its display form — the value the page is ORDERED and PAGED by, which
+        // is what `docs/mcp-search-interface-spec.md` publishes. sess-p's
+        // directory aggregate (1_767_400_000_000) sits above its hydrated exact
+        // value (1_767_300_000_000), the re-inserted-event case, and the item
+        // reports the former.
+        //
+        // MUTATION: report `totals.last_event_unix_ms` from
+        // `hydrated_session_summary` instead of `keyset.last_unix_ms`. The run
+        // panics FIRST on the order assertion above (`left: "sess-q", right:
+        // "sess-p"`), never reaching this one; neutralise the preceding asserts
+        // and the cursor assertion fails too, minting `sess-q`.
+        //
+        // An earlier revision of this comment claimed the reverse — that the
+        // cursor assertion survives, so the page is "ordered by a number it does
+        // not return". That diagnosis is inverted. Since round 4 the rendered
+        // field IS the sort key and the cursor source, so a mutation moves all
+        // three together: ordering and rendering stay in agreement, on the wrong
+        // value, and the cursor is minted from a number Phase A's `HAVING`
+        // cannot compare against — the page-2 skip this test exists to prevent.
         assert_eq!(
             page.items[0].last_event_unix_ms, 1_767_400_000_000_i64,
-            "the item must report the directory aggregate it was ordered by"
+            "the item must report the value the page is ordered and paged by"
+        );
+        assert_eq!(
+            page.items[0].last_event_time, "2026-01-02 22:26:40.000",
+            "the display form must come from the same directory aggregate as the millis"
         );
 
         let cursor = page.next_cursor.expect("next cursor");
@@ -2409,6 +2426,859 @@ async fn web_feed_propagates_backend_and_json_each_row_decode_errors() {
             }
             assert_script_consumed(&state, 1);
         }
+    })
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// issue-599 WI-09 — session DISCOVERY BY CONTENT.
+// ---------------------------------------------------------------------------
+
+/// The happy path, end to end through the mock: issue #597's bounded ranking
+/// picks the candidates, the issue-599 hydration and fold turn them into the
+/// SAME summary type the time-ordered feed serves, and ranked order survives.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_search_returns_ranked_summaries_from_the_shared_discovery_fold() {
+    scoped(async {
+        let (repo, _state) = build_directory_repo().await;
+
+        let result = repo
+            .search_session_summaries(SessionSearchQuery {
+                query: "hello world".to_string(),
+                limit: Some(10),
+                ..SessionSearchQuery::default()
+            })
+            .await
+            .expect("whole-corpus session search");
+
+        // `evt-c-42` outranks `evt-a-11` (12.5 vs 7.0), so `sess_c` leads. The
+        // response is session-grained: two ranked EVENTS in two sessions become
+        // two sessions, deduplicated by the session a hit sits in.
+        assert_eq!(
+            result
+                .sessions
+                .iter()
+                .map(|session| session.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sess_c", "sess_a"],
+        );
+
+        // Every summary field the feed reports is hydrated, not carried from
+        // the ranking row. `total_turns`, `tool_calls` and the title chain only
+        // exist after Phase B.
+        let leader = &result.sessions[0];
+        assert_eq!(leader.total_events, 30);
+        assert_eq!(leader.tool_calls, 6);
+        assert_eq!(leader.title.as_deref(), Some("Session C title"));
+        assert_eq!(leader.session_slug.as_deref(), Some("project-c"));
+        assert_eq!(leader.last_event_unix_ms, 1_767_435_000_000);
+        assert_eq!(leader.last_event_time, "2026-01-03 10:10:00");
+        assert!(!result.incomplete);
+        // Nothing was cut: two ranked sessions for a requested ten, both
+        // hydrated and both disclosed.
+        assert!(!result.truncated);
+        assert!(!result.hits_truncated);
+        assert!(!result.dropped);
+    })
+    .await;
+}
+
+/// **The dedup guard.** Ranking is EVENT grained and a matching session is
+/// normally matched several times. `two_distinct_events_in_one_turn` ranks two
+/// genuinely different events INSIDE `sess_c`, which is the shape every other
+/// fixture lacked — and without which the guard could not fail.
+///
+/// MUTATION: replace `if seen.insert(...) { ranked_session_ids.push(...) }` in
+/// `search_session_summaries_impl` with an unconditional push; `sess_c` is then
+/// returned twice, `result_count` counts hits while claiming to count sessions,
+/// and this fails on the very first assertion.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_search_returns_one_row_per_session_when_a_session_is_hit_twice() {
+    scoped(async {
+        let (repo, _state) = build_repo_with_options(
+            100,
+            MockOptions {
+                open_v2_reader_ready: Some(true),
+                two_distinct_events_in_one_turn: true,
+                ..MockOptions::default()
+            },
+        )
+        .await;
+
+        let result = repo
+            .search_session_summaries(SessionSearchQuery {
+                query: "hello world".to_string(),
+                limit: Some(10),
+                ..SessionSearchQuery::default()
+            })
+            .await
+            .expect("whole-corpus session search");
+
+        assert_eq!(
+            result
+                .sessions
+                .iter()
+                .map(|session| session.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sess_c"],
+            "two ranked hits inside one session are one result row",
+        );
+        // Two hits collapsed into one session is not "more sessions existed".
+        assert!(!result.truncated);
+        assert!(!result.dropped);
+    })
+    .await;
+}
+
+/// The hit-to-session fan-in the over-fetch exists for, with `limit` set below
+/// the number of ranked HITS: the ranking is asked for `limit x
+/// SESSION_SEARCH_HITS_PER_SESSION` events precisely because several of them
+/// land in one session.
+///
+/// MUTATION: clamp the internal hit budget back to `self.cfg.max_results` —
+/// `session_search_hit_budget(limit).min(max_results)` in
+/// `search_session_summaries_impl` — the shipped shape before this fix. The
+/// fixture's `max_results` is already 1, so the ranking then receives
+/// `n_hits = 1`, sees only `evt-c-42`, and the assertion that the ranking was
+/// asked for MORE hits than the sessions requested fails.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_search_over_fetches_hits_because_hits_cluster_inside_a_session() {
+    scoped(async {
+        // `max_results == 1` is the shape that made the old clamp inert: it is
+        // simultaneously the session limit and the hit ceiling.
+        let (repo, state) = build_repo_with_options(
+            1,
+            MockOptions {
+                open_v2_reader_ready: Some(true),
+                two_distinct_events_in_one_turn: true,
+                ..MockOptions::default()
+            },
+        )
+        .await;
+
+        let result = repo
+            .search_session_summaries(SessionSearchQuery {
+                query: "hello world".to_string(),
+                limit: Some(1),
+                ..SessionSearchQuery::default()
+            })
+            .await
+            .expect("whole-corpus session search");
+
+        assert_eq!(
+            result
+                .sessions
+                .iter()
+                .map(|session| session.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sess_c"],
+        );
+
+        // The ranking statement's candidate window is `3 x (n_hits + 1)`
+        // (`mcp_candidate_fetch_size`), so the internal hit budget is
+        // observable in the SQL. One session was requested against a backend
+        // whose `max_results` is also 1, and the budget must still be
+        // `1 x SESSION_SEARCH_HITS_PER_SESSION = 4` hits: `3 x (4 + 1) = 15`.
+        // The pre-fix shape clamped the budget to `max_results`, giving
+        // `n_hits = 1` and a window of `3 x (1 + 1) = 6`.
+        let queries = state.queries.lock().expect("queries lock").clone();
+        let ranking = queries
+            .iter()
+            .find(|query| query.contains("FROM term_postings AS p"))
+            .expect("a bounded ranking statement");
+        let window = ranking
+            .rsplit_once("\nLIMIT ")
+            .and_then(|(_, tail)| tail.split_whitespace().next())
+            .and_then(|value| value.parse::<u32>().ok())
+            .expect("a ranking LIMIT");
+        assert_eq!(
+            window, 15,
+            "the internal hit budget must not collapse to the caller-facing `max_results`",
+        );
+    })
+    .await;
+}
+
+/// A ranked session the exact re-check removed is not silently absent. Nothing
+/// refills it, so an answer shorter than `limit` must say it is a strict subset
+/// of what the ranking offered rather than reading as "the corpus holds one".
+///
+/// MUTATION: hard-code `dropped: false` in `search_session_summaries_impl`;
+/// the scoped arm below then claims completeness and this fails.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_search_reports_that_the_exact_recheck_shortened_the_answer() {
+    scoped(async {
+        let query = || SessionSearchQuery {
+            query: "hello world".to_string(),
+            limit: Some(10),
+            ..SessionSearchQuery::default()
+        };
+
+        let (intact_repo, _state) = build_scoped_directory_repo_with_options(
+            &["/repo"],
+            MockOptions {
+                out_of_scope_hydrated_cwd_for_sess_a: false,
+                ..MockOptions::default()
+            },
+        )
+        .await;
+        let intact = intact_repo
+            .search_session_summaries(query())
+            .await
+            .expect("in-scope search");
+        assert_eq!(intact.sessions.len(), 2);
+        assert!(
+            !intact.dropped,
+            "control arm: nothing was removed, so nothing may be reported as removed",
+        );
+
+        let (shortened_repo, _state) = build_scoped_directory_repo_with_options(
+            &["/repo"],
+            MockOptions {
+                out_of_scope_hydrated_cwd_for_sess_a: true,
+                ..MockOptions::default()
+            },
+        )
+        .await;
+        let shortened = shortened_repo
+            .search_session_summaries(query())
+            .await
+            .expect("scoped search");
+        assert_eq!(shortened.sessions.len(), 1);
+        assert!(
+            shortened.dropped,
+            "an answer shortened by the exact re-check must not claim completeness",
+        );
+        // And it is NOT reported as "raise your limit": nothing more would come.
+        assert!(!shortened.truncated);
+    })
+    .await;
+}
+
+/// **The readiness guard.** While the issue-598 canonical read indexes are
+/// unpublished, `mcp_event_navigation` is EMPTY. Hydrating discovery from it
+/// anyway answers every query with `sessions: []` — a confident "the whole
+/// corpus was searched and nothing matched" — at the same moment
+/// `list_mcp_sessions` is still serving those very sessions from the projected
+/// headers. Both discovery surfaces must branch on the same latch.
+///
+/// The fixture models **a store whose backfill has not started**: the canonical
+/// relations are empty for every reader. That is the pre-backfill worst case,
+/// and the shape that makes the branch observable at all. A not-ready store can
+/// also be PARTIALLY backfilled — `open_v2.ready` is published only after the
+/// coverage sweep completes and the overlap audit passes, so rows can be
+/// present while coverage is incomplete — but that regime is out of scope on
+/// both discovery surfaces precisely because both refuse the canonical read
+/// model until the latch flips, rather than reading it and answering short.
+///
+/// MUTATION: delete the `if canonical_ready` branch in
+/// `search_session_summaries_impl` and always call
+/// `hydrate_session_list_chunk`; the mock's canonical relations answer nothing
+/// on a not-ready backend and the first assertion fails.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_search_serves_summaries_while_the_canonical_indexes_are_unpublished() {
+    scoped(async {
+        let (repo, state) = build_repo_with_options(
+            100,
+            MockOptions {
+                open_v2_reader_ready: Some(false),
+                ..MockOptions::default()
+            },
+        )
+        .await;
+
+        let result = repo
+            .search_session_summaries(SessionSearchQuery {
+                query: "hello world".to_string(),
+                limit: Some(10),
+                ..SessionSearchQuery::default()
+            })
+            .await
+            .expect("whole-corpus session search on a not-ready store");
+
+        assert!(
+            !result.sessions.is_empty(),
+            "a not-ready store must serve session summaries, never an empty match set",
+        );
+
+        // The sibling surface answers from the same read model in the same
+        // regime, which is the disagreement this guard exists to prevent.
+        let feed = repo
+            .list_mcp_sessions(
+                McpSessionListFilter {
+                    start_unix_ms: 0,
+                    end_unix_ms: 1_800_000_000_000,
+                    mode: None,
+                    harness: None,
+                    source_name: None,
+                    sort: ConversationListSort::Desc,
+                },
+                PageRequest::default(),
+            )
+            .await
+            .expect("session feed on a not-ready store");
+        assert!(!feed.items.is_empty());
+        for session in &result.sessions {
+            assert!(
+                feed.items
+                    .iter()
+                    .any(|item| item.session_id == session.session_id),
+                "search disclosed {} which the feed does not serve",
+                session.session_id,
+            );
+        }
+
+        let queries = state.queries.lock().expect("queries lock").clone();
+        assert!(
+            queries
+                .iter()
+                .any(|query| query.contains("current_headers AS")),
+            "the fallback must hydrate from the projected headers",
+        );
+        assert!(
+            !queries
+                .iter()
+                .any(|query| query.contains("AS counter_user_messages")),
+            "a not-ready store must not be hydrated from the canonical navigation index",
+        );
+    })
+    .await;
+}
+
+/// The fallback narrows SERVER-SIDE, through the one predicate builder the
+/// projected-header feed uses. A fallback that hydrated unnarrowed rows would
+/// disclose out-of-scope sessions and render sessions under a harness the
+/// caller did not ask for.
+///
+/// MUTATION: stop threading `harness` / `source_name` into
+/// `hydrate_session_headers`, or drop the scope clause from
+/// `header_visibility_clauses`; the corresponding assertion below fails.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_projected_header_fallback_narrows_through_the_shared_predicate_builder() {
+    scoped(async {
+        // A `--project-only` backend whose canonical read indexes are not
+        // published: the projected headers are the only read model available.
+        let (repo, state) = build_scoped_repo(&["/repo"]).await;
+
+        repo.search_session_summaries(SessionSearchQuery {
+            query: "hello world".to_string(),
+            limit: Some(10),
+            harness: Some("codex".to_string()),
+            source_name: Some("ci-codex".to_string()),
+            ..SessionSearchQuery::default()
+        })
+        .await
+        .expect("scoped, narrowed search on a not-ready store");
+
+        let queries = state.queries.lock().expect("queries lock").clone();
+        let hydration = queries
+            .iter()
+            .find(|query| query.contains("current_headers AS") && query.contains("s.session_id IN"))
+            .expect("a projected-header hydration statement");
+        assert!(hydration.contains("s.tombstone = 0"));
+        assert!(hydration.contains("notEmpty(trimBoth(s.session_id))"));
+        assert!(hydration.contains("s.origin_cwd = '/repo'"));
+        assert!(hydration.contains("startsWith(s.origin_cwd, '/repo/')"));
+        assert!(hydration.contains("s.harness = 'codex'"));
+        assert!(hydration.contains("s.source = 'ci-codex'"));
+    })
+    .await;
+}
+
+/// **The scope guard, wired.** A ranked hit is not permission to disclose the
+/// session it sits in.
+///
+/// This check is REDUNDANT with issue #597's own Phase 4 re-check, and
+/// deliberately so. Both compute the identical
+/// `ifNull(argMinIf(n.cwd, tuple(n.event_ts, n.event_uid), n.cwd != ''), '')`
+/// over `navigation_live_from()` — `build_session_totals_batch_sql` and
+/// `build_search_candidate_derivation_sql`'s `session_cwd` CTE — and the whole
+/// request is pinned to one publication, so in production the two values are
+/// the same value and cannot disagree. The fold-level check is kept anyway so
+/// that ONE function decides disclosure for BOTH discovery surfaces: a
+/// per-surface copy is a second place for a scope rule to rot, and a scope rule
+/// that rots discloses sessions. The coherent authority for the rule itself is
+/// the unit test `search_never_discloses_a_session_outside_the_configured_scope`.
+///
+/// The fixture below therefore drives an input combination the pinned
+/// publication makes physically unreachable — `/repo` from the derivation arm
+/// and `/elsewhere` from the totals arm inside one request — because that is
+/// the only way to isolate the fold-level guard from the ranking-level one. It
+/// is not a claim that the two relations can disagree.
+///
+/// The in-scope arm runs first and is not decoration: it proves the mock's
+/// totals arm is still matching and still serving `sess_a`, so the scoped arm's
+/// shorter answer can only be the guard.
+///
+/// MUTATION: delete the `if let Some(scope) = session_scope` block in
+/// `ClickHouseConversationRepository::hydrated_session_summary`, or pass `None`
+/// for the scope from `search_session_summaries_impl`; the scoped arm below
+/// then discloses `sess_a` and this fails.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_search_never_discloses_a_session_outside_the_project_scope() {
+    scoped(async {
+        let query = || SessionSearchQuery {
+            query: "hello world".to_string(),
+            limit: Some(10),
+            ..SessionSearchQuery::default()
+        };
+
+        let (in_scope_repo, _state) = build_scoped_directory_repo_with_options(
+            &["/repo"],
+            MockOptions {
+                out_of_scope_hydrated_cwd_for_sess_a: false,
+                ..MockOptions::default()
+            },
+        )
+        .await;
+        let in_scope = in_scope_repo
+            .search_session_summaries(query())
+            .await
+            .expect("in-scope search");
+        assert_eq!(
+            in_scope
+                .sessions
+                .iter()
+                .map(|session| session.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sess_c", "sess_a"],
+            "control arm: both ranked sessions hydrate inside /repo",
+        );
+
+        let (scoped_repo, _state) = build_scoped_directory_repo_with_options(
+            &["/repo"],
+            MockOptions {
+                out_of_scope_hydrated_cwd_for_sess_a: true,
+                ..MockOptions::default()
+            },
+        )
+        .await;
+        let scoped_result = scoped_repo
+            .search_session_summaries(query())
+            .await
+            .expect("scoped search");
+        assert_eq!(
+            scoped_result
+                .sessions
+                .iter()
+                .map(|session| session.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sess_c"],
+            "a session whose hydrated origin_cwd is outside the scope must not be disclosed",
+        );
+    })
+    .await;
+}
+
+/// Ranking hydrates snippets, `text_content` and `payload_json` to score and
+/// preview events. None of it may reach a discovery caller — the search
+/// response is the same navigation-scalar-and-label shape the feed proved flat
+/// under 50x fatter transcripts (issue-599 §5.3).
+///
+/// MUTATION: add any content-bearing field to `SessionSearchResults` (or to
+/// `McpSessionListItem`) and populate it from `ranked.hits`; this fails.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_search_results_carry_no_transcript_content() {
+    scoped(async {
+        let (repo, _state) = build_directory_repo().await;
+
+        let result = repo
+            .search_session_summaries(SessionSearchQuery {
+                query: "hello world".to_string(),
+                limit: Some(10),
+                ..SessionSearchQuery::default()
+            })
+            .await
+            .expect("whole-corpus session search");
+        assert!(!result.sessions.is_empty(), "fixture must return sessions");
+
+        // Serialize the whole result and assert on the KEYS, so a future field
+        // cannot smuggle content in under a name this test never heard of.
+        let payload = serde_json::to_value(&result).expect("serializable results");
+        let mut keys = Vec::new();
+        collect_keys(&payload, &mut keys);
+        for forbidden in [
+            "snippet",
+            "text_content",
+            "text_preview",
+            "payload_json",
+            "events",
+            "turns",
+            "hits",
+        ] {
+            assert!(
+                !keys.iter().any(|key| key == forbidden),
+                "search results must not carry {forbidden:?}: {payload}"
+            );
+        }
+
+        // And the corpus fixture's own message bodies, by value.
+        let rendered = payload.to_string();
+        for body in [
+            "best assistant event in session c with extra context",
+            "weaker assistant event in session a with extra context",
+        ] {
+            assert!(
+                !rendered.contains(body),
+                "search results leaked message content {body:?}: {rendered}"
+            );
+        }
+    })
+    .await;
+}
+
+fn collect_keys(value: &serde_json::Value, out: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, nested) in map {
+                out.push(key.clone());
+                collect_keys(nested, out);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_keys(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// **The cross-surface agreement guard, through REAL hydration (issue-599 B1).**
+///
+/// The two surfaces select different sessions — one by recency, one by
+/// relevance — but for a session BOTH return they must describe it identically.
+/// The monitor derives `status` from `last_event_unix_ms` against a 60 s
+/// activity window, so a disagreement there is not cosmetic: it renders one
+/// session `active` in the feed and `completed` in search, from one store, at
+/// one instant.
+///
+/// The fixture is what gives this test teeth. `directory_aggregate_ahead_of_
+/// hydration_for_sess_a` puts `sess_a`'s Phase-A `cand_last_ms` exactly one
+/// activity window above its hydrated `last_event_unix_ms` — the
+/// re-inserted-event regime, and the only regime in which "which value does the
+/// feed render?" is answerable. With the two equal (every other fixture) this
+/// assertion cannot fail however the code is written.
+///
+/// MUTATION: give the SEARCH arm an `updated_at` of its own again — in
+/// `search_session_summaries_impl`'s canonical arm, replace
+/// `keysets.get(session_id.as_str())?.keyset()` with a `SessionKeyset` built
+/// from `hydrated.get(session_id.as_str())?.totals.last_event_unix_ms`. The
+/// search then reports 1_767_262_200_000 while the feed reports
+/// 1_767_262_260_000 and this fails.
+///
+/// Note the mutation has to be applied to ONE surface: reporting the hydrated
+/// value from the shared fold changes both, they agree again, and this test
+/// stays green while `both_discovery_paths_report_the_directory_keyset_they_page_by`
+/// and `list_mcp_sessions_directory_page_orders_and_anchors_on_the_directory_keyset`
+/// are the ones that catch it.
+#[tokio::test(flavor = "multi_thread")]
+async fn both_discovery_surfaces_describe_one_session_identically() {
+    scoped(async {
+        let (repo, _state) = build_repo_with_options(
+            100,
+            MockOptions {
+                open_v2_reader_ready: Some(true),
+                directory_aggregate_ahead_of_hydration_for_sess_a: true,
+                ..MockOptions::default()
+            },
+        )
+        .await;
+
+        let feed = repo
+            .list_mcp_sessions(
+                McpSessionListFilter {
+                    start_unix_ms: 0,
+                    end_unix_ms: 1_800_000_000_000,
+                    mode: None,
+                    harness: None,
+                    source_name: None,
+                    sort: ConversationListSort::Desc,
+                },
+                PageRequest {
+                    limit: 25,
+                    cursor: None,
+                },
+            )
+            .await
+            .expect("session feed");
+
+        let searched = repo
+            .search_session_summaries(SessionSearchQuery {
+                query: "hello world".to_string(),
+                limit: Some(10),
+                ..SessionSearchQuery::default()
+            })
+            .await
+            .expect("whole-corpus session search");
+
+        let overlap: Vec<(&McpSessionListItem, &McpSessionListItem)> = searched
+            .sessions
+            .iter()
+            .filter_map(|ranked| {
+                feed.items
+                    .iter()
+                    .find(|listed| listed.session_id == ranked.session_id)
+                    .map(|listed| (ranked, listed))
+            })
+            .collect();
+        assert!(
+            overlap
+                .iter()
+                .any(|(ranked, _)| ranked.session_id == "sess_a"),
+            "the fixture must put the skewed session on BOTH surfaces, or this proves nothing",
+        );
+        for (ranked, listed) in overlap {
+            assert_eq!(
+                ranked, listed,
+                "the two discovery surfaces described {} differently",
+                ranked.session_id,
+            );
+        }
+    })
+    .await;
+}
+
+/// **The `dropped` disclosure guard (issue-599 WI-09).**
+///
+/// `dropped` plus `truncated` makes `limit - result_count` an exact count of
+/// what the answer withheld. That is acceptable only because project scope can
+/// never be one of the causes: BOTH ranking arms apply the configured scope
+/// while they are still choosing candidates, so an out-of-scope session never
+/// enters the ranked set and cannot be subtracted from it afterwards. Were it
+/// otherwise, `?q=term&limit=50` on a `--project-only` backend would report an
+/// exact, per-term count of activity outside the caller's scope.
+///
+/// The two arms of this test are the two ways a session can leave the answer:
+///
+/// * scope, removed DURING ranking — the answer is shorter and `dropped` stays
+///   false, because nothing was subtracted after ranking;
+/// * the hydrated-scope re-check, which is defence in depth and physically
+///   unreachable under one pinned publication (see
+///   `session_search_never_discloses_a_session_outside_the_project_scope`), and
+///   is driven here only to show it is not what carries the count.
+///
+/// MUTATION: delete the `if let Some(scope)` block in
+/// `search_mcp_event_page_v2`; `sess_a` then reaches the ranked set, is removed
+/// by the post-hydration re-check instead, and the first arm's
+/// `assert!(!dropped)` fails.
+///
+/// Deleting the `posting_origin_clause` push in `build_search_mcp_events_sql`
+/// does NOT fail this test; an earlier revision of this comment offered it as
+/// an equivalent recipe and it was never executed. That builder is the
+/// pre-cutover projected-header path, while this fixture sets
+/// `open_v2_reader_ready: Some(true)` and therefore issues the canonical v2
+/// statement, which never carries that clause. The v1 clause is guarded —
+/// by `search::search_mcp_events_applies_session_origin_scope`, not here.
+///
+/// That mutation only reaches `dropped` because the first arm ALSO sets
+/// `out_of_scope_hydrated_cwd_for_sess_a`. Without it the ranking mutation is
+/// still observable — `sess_a` gets disclosed and the `assert_eq!` above fails
+/// first — but the run never evaluates the `dropped` assertion, so the bit this
+/// test is named for would be pinned by nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_project_scope_removal_never_reaches_the_dropped_bit() {
+    scoped(async {
+        let query = || SessionSearchQuery {
+            query: "hello world".to_string(),
+            limit: Some(10),
+            ..SessionSearchQuery::default()
+        };
+
+        // Scope removes `sess_a`'s only hit while RANKING. The answer is one
+        // session shorter than the unscoped control…
+        let (ranking_scoped, _state) = build_scoped_directory_repo_with_options(
+            &["/repo"],
+            MockOptions {
+                out_of_scope_cwd_for_second_candidate: true,
+                // Armed but unreachable while ranking does its job: `sess_a`
+                // never gets hydrated, so this cannot affect the answer. It is
+                // what makes the ranking guard's removal show up as `dropped`
+                // rather than as an earlier, different failure.
+                out_of_scope_hydrated_cwd_for_sess_a: true,
+                ..MockOptions::default()
+            },
+        )
+        .await;
+        let ranked_out = ranking_scoped
+            .search_session_summaries(query())
+            .await
+            .expect("scoped search");
+        assert_eq!(
+            ranked_out
+                .sessions
+                .iter()
+                .map(|session| session.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sess_c"],
+            "an out-of-scope session must not be disclosed",
+        );
+        // …and `dropped` stays clear, so the count of what scope withheld is
+        // not derivable from the envelope.
+        assert!(
+            !ranked_out.dropped,
+            "a scope removal happens before ranking answers and must not be reported as a \
+             post-ranking subtraction",
+        );
+
+        // The post-hydration re-check is what `dropped` reports, and it is a
+        // different input entirely.
+        let (hydration_scoped, _state) = build_scoped_directory_repo_with_options(
+            &["/repo"],
+            MockOptions {
+                out_of_scope_hydrated_cwd_for_sess_a: true,
+                ..MockOptions::default()
+            },
+        )
+        .await;
+        let hydrated_out = hydration_scoped
+            .search_session_summaries(query())
+            .await
+            .expect("scoped search");
+        assert_eq!(hydrated_out.sessions.len(), 1);
+        assert!(hydrated_out.dropped);
+    })
+    .await;
+}
+
+/// **The over-fetch ceiling, at every reachable `limit` REGION (issue-599
+/// WI-09, issue #597 §1).**
+///
+/// The internal hit budget sets the ranking's candidate window — the most
+/// expensive stage of the request — so it is asserted here as the SQL the
+/// request actually issued, not as the arithmetic
+/// `session_search_hit_budget_holds_its_bounds_across_the_whole_reachable_domain`
+/// already pins in a unit test.
+///
+/// The three cases are the three shapes of that function, and `limit = 50` is
+/// the one the previous tests missed entirely — which is exactly where the
+/// previous expression collapsed the fan-in to 1:1 and made `truncated`
+/// unsettable.
+///
+/// MUTATION: delete the `.min(SESSION_SEARCH_HIT_BUDGET_MAX)` clamp in
+/// `session_search_hit_budget`; the `limit = 25` window becomes
+/// `min(3 x 101, 256) = 256` and that case fails.
+/// MUTATION: raise `SESSION_SEARCH_HITS_PER_SESSION` from 4 to 100; the clamp
+/// absorbs it at `limit = 25` and `limit = 50`, but `limit = 1` budgets 50
+/// instead of 4 and its window becomes 153, so the first case fails. Covering
+/// the small-`limit` region is what makes this test see that constant at all —
+/// the single-shape test it replaced could not.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_search_over_fetch_is_bounded_at_every_reachable_limit_region() {
+    scoped(async {
+        // `max_results = 25` is the shipped default (`config/moraine.toml`) and
+        // 25 is what the monitor's search client asks for, so the backend here
+        // is configured wide enough to let every region through and the
+        // per-case `limit` is what varies.
+        for (limit, expected_window, label) in [
+            // budget = min(1 x 4, 50).max(2) = 4; 3 x (4 + 1) = 15.
+            (1_u16, 15_u32, "the 4x fan-in region"),
+            // budget = min(25 x 4, 50).max(37) = 50; 3 x (50 + 1) = 153.
+            (25, 153, "the shipped default shape"),
+            // budget = min(50 x 4, 50).max(75) = 75; 3 x (75 + 1) = 228. The
+            // 1.5x floor, not the ceiling, is what decides this one.
+            (50, 228, "the largest page a caller may ask for"),
+        ] {
+            let (repo, state) = build_repo_with_options(
+                50,
+                MockOptions {
+                    open_v2_reader_ready: Some(true),
+                    ..MockOptions::default()
+                },
+            )
+            .await;
+
+            repo.search_session_summaries(SessionSearchQuery {
+                query: "hello world".to_string(),
+                limit: Some(limit),
+                ..SessionSearchQuery::default()
+            })
+            .await
+            .expect("whole-corpus session search");
+
+            let queries = state.queries.lock().expect("queries lock").clone();
+            let ranking = queries
+                .iter()
+                .find(|query| query.contains("FROM term_postings AS p"))
+                .expect("a bounded ranking statement");
+            let window = ranking
+                .rsplit_once("\nLIMIT ")
+                .and_then(|(_, tail)| tail.split_whitespace().next())
+                .and_then(|value| value.parse::<u32>().ok())
+                .expect("a ranking LIMIT");
+            assert_eq!(
+                window, expected_window,
+                "{label} (limit {limit}): candidate window changed",
+            );
+            assert!(
+                window < 256,
+                "{label} (limit {limit}): must not sit on the hard candidate ceiling: {window}",
+            );
+            // The fan-in is what the window is FOR: a window of `3 x (limit + 1)`
+            // would mean the ranking was asked for exactly `limit` hits, which
+            // bounds the distinct sessions at `limit` and makes
+            // `truncated: ranked_sessions > limit` structurally unsettable.
+            assert!(
+                window > 3 * (u32::from(limit) + 1),
+                "{label} (limit {limit}): the fan-in collapsed to 1:1",
+            );
+        }
+    })
+    .await;
+}
+
+/// **The one-verdict guard (issue-599 WI-09).**
+///
+/// A content search branches on the issue-598 readiness latch TWICE — once to
+/// pick the ranking engine, once to pick the hydration read model — and both
+/// branches must see the SAME verdict. Probing separately costs a second
+/// `mcp_read_index_state` point read on every pre-cutover search, and, because
+/// the latch flips when a backfill publishes, two probes in one request can
+/// disagree: the answer would then be ranked over the `mcp_open_*` projection
+/// and hydrated from the canonical navigation index, a mixed regime nothing
+/// tests and `list_mcp_sessions` cannot produce.
+///
+/// The backend is declared NOT ready on purpose. A positive verdict latches on
+/// first success (`canonical_list_path_ready`), so a second probe would be
+/// served from the latch and this count could not see it.
+///
+/// MUTATION: restore `if self.canonical_list_path_ready().await` inside
+/// `search_mcp_event_page` (or drop `canonical_ready` from
+/// `McpEventRankingOptions`); the count becomes 2 and this fails.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_content_search_resolves_canonical_readiness_exactly_once() {
+    scoped(async {
+        let (repo, state) = build_repo_with_options(
+            100,
+            MockOptions {
+                open_v2_reader_ready: Some(false),
+                ..MockOptions::default()
+            },
+        )
+        .await;
+
+        repo.search_session_summaries(SessionSearchQuery {
+            query: "hello world".to_string(),
+            limit: Some(10),
+            ..SessionSearchQuery::default()
+        })
+        .await
+        .expect("whole-corpus session search on a not-ready store");
+
+        // One logical probe is TWO statements — the `system.tables` existence
+        // check and the state read itself (`ClickHouseClient::read_index_state`)
+        // — so counting the state read alone is what counts VERDICTS.
+        let probes = state
+            .readiness_probe_queries
+            .lock()
+            .expect("readiness probe lock")
+            .iter()
+            .filter(|query| !query.contains("FROM system.tables"))
+            .count();
+        assert_eq!(
+            probes, 1,
+            "ranking and hydration must share one readiness verdict, not probe for one each",
+        );
     })
     .await;
 }

--- a/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
+++ b/crates/moraine-conversations/tests/repository_integration/support/mock_clickhouse.rs
@@ -120,6 +120,25 @@ pub(crate) struct MockOptions {
     /// the exact Phase 4 re-check can drop it (the directory recall filter
     /// admitted it).
     pub(crate) out_of_scope_cwd_for_second_candidate: bool,
+    /// Report an out-of-scope HYDRATED `origin_cwd` for `sess_a` in the Phase B
+    /// totals batch — the value session-summary discovery re-checks scope
+    /// against. Distinct from
+    /// [`Self::out_of_scope_cwd_for_second_candidate`], which describes the
+    /// per-EVENT navigation value the ranking path re-checks: the two guards
+    /// read different relations and each needs its own way to be made to fail.
+    pub(crate) out_of_scope_hydrated_cwd_for_sess_a: bool,
+    /// Report a directory `cand_last_ms` for `sess_a` that sits one monitor
+    /// activity window ABOVE its hydrated `last_event_unix_ms`.
+    ///
+    /// This is the re-inserted-event regime: the directory's
+    /// `SimpleAggregateFunction(max)` accumulates every physically inserted
+    /// version and cannot retract a superseded one, while
+    /// `mcp_event_navigation` read `FINAL` sees only the winner — so
+    /// `cand_last_ms >= last_event_unix_ms` always, with equality in the
+    /// ordinary case. Without this option every fixture session has the two
+    /// values equal, and "which of them do the two surfaces RENDER, and do they
+    /// render the same one?" is unobservable.
+    pub(crate) directory_aggregate_ahead_of_hydration_for_sess_a: bool,
     /// The requested turn's live uid set exceeds `MAX_TURN_SCOPE_UIDS`, so
     /// ranking falls back to session recall and the turn is enforced only by
     /// the exact Phase 4 re-check.
@@ -196,6 +215,29 @@ pub(crate) fn test_clickhouse_config(url: String) -> ClickHouseConfig {
         allow_newer_server: false,
     }
 }
+/// Whether the migration-036 canonical read indexes carry rows at all.
+///
+/// **The regime modelled here is "a store whose backfill has not started."** Its
+/// `mcp_session_directory` / `mcp_event_navigation` are EMPTY for every reader,
+/// not only for readers that consulted the latch — which is what makes a
+/// MISSING readiness branch observable. A fixture that answered canonical
+/// statements regardless of readiness would hide exactly the defect where a
+/// reader skips the gate and then reports an empty index as "nothing in the
+/// corpus matched".
+///
+/// It is deliberately NOT the only shape a not-ready store can have.
+/// `open_v2.ready` is published only after the coverage sweep completes AND the
+/// overlap audit passes (`canonical_indexes.rs`), so a store can legitimately
+/// report not-ready with a PARTIALLY backfilled `mcp_event_navigation` — rows
+/// present, coverage incomplete. Empty is the pre-backfill worst case and the
+/// one that discriminates the branch; the partial regime, where canonical
+/// hydration would answer with a silently short result set, is out of scope on
+/// both discovery surfaces because both refuse the canonical read model
+/// entirely until the latch flips.
+fn canonical_read_indexes_published(state: &MockState) -> bool {
+    state.options.open_v2_reader_ready != Some(false)
+}
+
 /// The subset of `rows` whose `session_id` appears in a batched statement's
 /// `session_id IN ['…']` array literal — the mock's stand-in for the
 /// primary-key prune the real hydration statements get.
@@ -793,18 +835,34 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
         }
 
         // --- issue-599 canonical-first session discovery -------------------
-        // Phase A: the content-free directory candidate page. The same three
-        // fixture sessions the projected-header page serves, so the two paths
-        // can be asserted against identical expectations.
+        // The directory read, in BOTH its shapes: the time-ordered page's
+        // Phase A, and the ranked search's keyset batch for ids it already
+        // chose. They project the same two columns from the same relation, so
+        // one fixture answers both — which is the point, because both surfaces
+        // must report the same `updated_at` for one session.
         if query.contains("FROM `moraine`.`mcp_session_directory` AS d")
             && query.contains("AS cand_last_ms")
         {
-            // `cand_last_time` is the display form of `cand_last_ms` — the
-            // value the directory path both orders by and reports. It matches
-            // the projected header fixture exactly, because the aggregate and
-            // the hydrated value agree for every session that was not
-            // re-ingested; they diverge only when a re-inserted event lowered
-            // a display time within one live generation.
+            if !canonical_read_indexes_published(&state) {
+                return (StatusCode::OK, json_each_row(json!([])));
+            }
+            // `cand_last_ms` is the aggregate the directory page orders,
+            // keysets AND renders by. It equals the hydrated fixture value by
+            // default, as it does for every session that was not re-ingested —
+            // the two diverge only when a re-inserted event lowered a display
+            // time within one live generation, which
+            // `directory_aggregate_ahead_of_hydration_for_sess_a` models.
+            let (sess_a_cand_last_ms, sess_a_cand_last_time) = if state
+                .options
+                .directory_aggregate_ahead_of_hydration_for_sess_a
+            {
+                // One monitor activity window (60 s) ahead of the hydrated
+                // `1_767_262_200_000`, and still below `sess_b`, so the page
+                // order is unchanged and only the RENDERED value can differ.
+                (1_767_262_260_000_i64, "2026-01-01 10:11:00")
+            } else {
+                (1_767_262_200_000_i64, "2026-01-01 10:10:00")
+            };
             let candidates = json!([
                 {
                     "session_id": "sess_c",
@@ -818,8 +876,8 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                 },
                 {
                     "session_id": "sess_a",
-                    "cand_last_ms": 1_767_262_200_000_i64,
-                    "cand_last_time": "2026-01-01 10:10:00"
+                    "cand_last_ms": sess_a_cand_last_ms,
+                    "cand_last_time": sess_a_cand_last_time
                 }
             ]);
             let rows = candidates
@@ -828,7 +886,14 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                 .iter()
                 .filter(|row| {
                     let session_id = row["session_id"].as_str().unwrap_or_default();
-                    // Honor whichever keyset the page carries.
+                    // The keyset batch names its ids explicitly; a fixture that
+                    // ignored the `IN` set would answer for sessions the caller
+                    // never ranked.
+                    if let Some((_, tail)) = query.split_once("AND d.session_id IN [") {
+                        let ids = tail.split(']').next().unwrap_or_default();
+                        return ids.contains(&format!("'{session_id}'"));
+                    }
+                    // Otherwise honor whichever keyset the page carries.
                     if query.contains("session_id < 'sess_b'") {
                         return session_id < "sess_b";
                     }
@@ -1216,6 +1281,17 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
 
         // Phase B1: batched totals.
         if query.contains("AS counter_user_messages") && query.contains("GROUP BY nav.session_id") {
+            if !canonical_read_indexes_published(&state) {
+                return (StatusCode::OK, json_each_row(json!([])));
+            }
+            // The hydrated `origin_cwd` for `sess_a`. This is the value the
+            // shared discovery fold re-checks project scope against, and the
+            // ONLY input that can drop a session that ranking already admitted.
+            let sess_a_cwd = if state.options.out_of_scope_hydrated_cwd_for_sess_a {
+                "/elsewhere"
+            } else {
+                "/repo"
+            };
             let totals = json!([
                     {
                         "session_id": "sess_c",
@@ -1261,7 +1337,7 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
                         "first_event_unix_ms": 1_767_261_600_000_i64,
                         "last_event_time": "2026-01-01 10:10:00",
                         "last_event_unix_ms": 1_767_262_200_000_i64,
-                        "origin_cwd": "/repo",
+                        "origin_cwd": sess_a_cwd,
             "source": "codex",
                         "harness": "codex",
                         "inference_provider": "openai",
@@ -1280,6 +1356,9 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
             && query.contains("e.payload_json AS payload_json")
             && query.contains("WHERE e.session_id IN [")
         {
+            if !canonical_read_indexes_published(&state) {
+                return (StatusCode::OK, json_each_row(json!([])));
+            }
             let metadata = json!([
                 {
                     "session_id": "sess_c",
@@ -1306,6 +1385,9 @@ pub(crate) async fn spawn_mock_server(options: MockOptions) -> (String, Arc<Mock
         if query.contains("argMax(turn_completed, turn_seq)")
             && query.contains("GROUP BY session_id, turn_seq")
         {
+            if !canonical_read_indexes_published(&state) {
+                return (StatusCode::OK, json_each_row(json!([])));
+            }
             let terminal = json!([
                 { "session_id": "sess_c", "completed": 1_u8 },
                 { "session_id": "sess_b", "completed": 1_u8 },

--- a/crates/moraine-mcp-core/src/concurrency_tests.rs
+++ b/crates/moraine-mcp-core/src/concurrency_tests.rs
@@ -6,9 +6,9 @@ use moraine_conversations::{
     McpSessionListFilter, McpSessionListItem, McpSessionOpen, McpTurnOpen, OpenContext,
     OpenEventRequest, Page, PageRequest, RepoConfig, RepoResult, SearchEventsQuery,
     SearchEventsResult, SearchMcpEventsQuery, SearchMcpEventsResult, SessionAnalytics,
-    SessionAnalyticsQuery, SessionEventsQuery, SessionMetadata, StoreDiagnostics, StoreHealth,
-    TablePreview, TablePreviewQuery, TableSummaries, TraceEvent, Turn, TurnListFilter, TurnSummary,
-    WebSearchEvent,
+    SessionAnalyticsQuery, SessionEventsQuery, SessionMetadata, SessionSearchQuery,
+    SessionSearchResults, StoreDiagnostics, StoreHealth, TablePreview, TablePreviewQuery,
+    TableSummaries, TraceEvent, Turn, TurnListFilter, TurnSummary, WebSearchEvent,
 };
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use tokio::io::{AsyncWriteExt, ReadHalf, WriteHalf};
@@ -198,6 +198,13 @@ impl ConversationRepository for BlockingRepository {
             self.block_forever().await
         }
         self.inner.list_mcp_sessions(filter, page).await
+    }
+
+    async fn search_session_summaries(
+        &self,
+        query: SessionSearchQuery,
+    ) -> RepoResult<SessionSearchResults> {
+        self.inner.search_session_summaries(query).await
     }
 
     async fn list_turns(

--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -19,7 +19,8 @@ use moraine_conversations::{
     CanonicalReadOutcome, ConversationListSort, ConversationMode, CoreIndexHealth, IngestHeartbeat,
     IngestHeartbeatRead, McpSessionListFilter, McpSessionListItem, McpSessionOpen, McpTurnCompact,
     PageRequest, PublicationDiagnostics, QueryClass, QueryEnvelope, RepoError, SessionLookback,
-    StoreConnectionMetrics, StoreHealth, StoreProbe, TablePreviewQuery, TableSummaries,
+    SessionSearchQuery, StoreConnectionMetrics, StoreHealth, StoreProbe, TablePreviewQuery,
+    TableSummaries,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -96,6 +97,14 @@ struct SessionsQuery {
 struct SessionPageQuery {
     limit: Option<u32>,
     cursor: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SessionSearchParams {
+    q: Option<String>,
+    limit: Option<u32>,
+    harness: Option<String>,
+    source: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -236,6 +245,23 @@ fn dashboard_routes(read_limits: Arc<MonitorReadLimits>) -> Router<Arc<AppState>
         .route("/web-searches", get(api_web_searches))
         .route("/tables/:table", get(api_table_rows))
         .route("/sessions", get(api_sessions))
+        // `/sessions/search` is a fixed path, never a session named "search",
+        // and route ORDER has nothing to do with it. The three `/sessions`
+        // routes here have one, two and three path segments respectively, so no
+        // request path can match two of them and there is no precedence
+        // question to get wrong. (`/sessions/search/page` reaches the page
+        // handler with `id = "search"`, which is correct: a session really
+        // called `search` is still readable.)
+        //
+        // Precedence would start to matter only if a two-segment parameterised
+        // sibling were added — `/sessions/:id` — and it would still be safe,
+        // because axum routes through matchit, whose radix trie prefers a
+        // static segment over a parameter regardless of insertion order.
+        // `matchit_prefers_a_static_segment_over_a_parameter_at_any_registration_order`
+        // pins that property against a router built for the purpose: insurance
+        // for that future, not the mechanism keeping this table unambiguous
+        // today.
+        .route("/sessions/search", get(api_session_search))
         .route("/sessions/:id/page", get(api_session_page))
         .route_layer(middleware::from_fn_with_state(
             read_limits,
@@ -305,12 +331,20 @@ async fn monitor_read_admission(
 /// outcomes never reach this mapping: they travel as `Ok(None)`/empty
 /// results, not as `RepoError`.
 ///
-/// A rejected continuation token is the one repository failure caused by the
-/// request rather than the backend, so it is a 400. Paging must be able to tell
-/// "your cursor is stale, restart the feed" apart from "the store is down":
-/// `list_mcp_sessions` refuses a cursor minted by the other read path, and a
-/// caller that reads that as a transient 503 and retries would page a silent
-/// gap instead of restarting (issue-599 §1.2).
+/// The two repository failures caused by the REQUEST rather than by the
+/// backend are 400s, because a client must be able to tell "fix your request"
+/// apart from "the store is down" — the second is worth retrying and the first
+/// never is.
+///
+/// * A rejected continuation token: paging must distinguish "your cursor is
+///   stale, restart the feed" from a transient outage, or a caller that retries
+///   pages a silent gap instead of restarting (issue-599 §1.2).
+/// * An invalid argument: the repository validates inputs the route cannot
+///   (`search_sessions` rejects a query with no searchable terms, and the
+///   tokenizer's rules are the repository's to own — a route that re-derived
+///   them in its own language would be a second copy that rots). Reported as
+///   503 this rendered a typo as an outage, permanently and unrecoverably, for
+///   any query the tokenizer cannot split.
 fn repo_error_status(error: &RepoError) -> (StatusCode, Option<&'static str>) {
     match error {
         RepoError::DeadlineExceeded { .. } => {
@@ -320,6 +354,7 @@ fn repo_error_status(error: &RepoError) -> (StatusCode, Option<&'static str>) {
             (StatusCode::TOO_MANY_REQUESTS, Some("resource_exhausted"))
         }
         RepoError::InvalidCursor(_) => (StatusCode::BAD_REQUEST, Some("invalid_cursor")),
+        RepoError::InvalidArgument(_) => (StatusCode::BAD_REQUEST, Some("invalid_argument")),
         _ => (StatusCode::SERVICE_UNAVAILABLE, None),
     }
 }
@@ -1060,6 +1095,121 @@ async fn api_sessions(
     )
 }
 
+/// Route bound on ranked sessions per search. Well below `/api/v1/sessions`'
+/// `200`, deliberately: a BM25 ranking's value is concentrated in its head, and
+/// every ranked session costs a hydration slot in the same bounded budget the
+/// feed spends. The backend's `max_results` clamps this further.
+const SESSION_SEARCH_MAX_LIMIT: u32 = 50;
+
+/// Default ranked sessions per search, matching the repository's own default.
+const SESSION_SEARCH_DEFAULT_LIMIT: u32 = 10;
+
+/// Whole-corpus session search (issue-599 WI-09).
+///
+/// Ranked by content over the entire corpus this backend may serve — not over
+/// the page the client happens to have loaded, which is what the interim
+/// client-side filter could do and said so. Results are the SAME summary
+/// objects `/api/v1/sessions` returns, built by
+/// [`monitor_session_json`], so a result opens through
+/// `/api/v1/sessions/:id/page` exactly like a listed session.
+///
+/// There is deliberately no `cursor`. A keyset over a relevance ranking is not
+/// the keyset the feed uses — scores are not a monotone anchor and a
+/// re-ranked corpus would silently skip or repeat — so this route bounds
+/// instead of paging, and says so with `truncated`.
+///
+/// Project scope is enforced by the repository operation, against each
+/// session's hydrated `origin_cwd`; the ranking's own directory predicate is a
+/// recall filter. This handler composes no second repository read, so there is
+/// no path by which it can assemble an out-of-scope session.
+async fn api_session_search(
+    Query(params): Query<SessionSearchParams>,
+    Extension(backend): Extension<Arc<BackendRepository>>,
+) -> Response {
+    let repository = backend.repository();
+    let query = params.q.as_deref().map(str::trim).unwrap_or_default();
+    if query.is_empty() {
+        // Not an empty result: an absent or blank `q` is a client bug, and
+        // answering it with "no sessions match" would read as an empty corpus.
+        return bad_request("q must be a non-empty search query".to_string());
+    }
+
+    // Two clamps, as on the feed: the route's documented bound, then the
+    // backend's own `max_results`. The response reports the second.
+    let requested = params
+        .limit
+        .unwrap_or(SESSION_SEARCH_DEFAULT_LIMIT)
+        .clamp(1, SESSION_SEARCH_MAX_LIMIT) as u16;
+    let limit = requested.min(repository.config().max_results.max(1));
+
+    let results = match repository
+        .search_session_summaries(SessionSearchQuery {
+            query: query.to_string(),
+            // The #600 envelope this route runs inside. Threading its request id
+            // is what makes the repository's `query_id` — and therefore the
+            // statements it issues — traceable back to one HTTP request, and it
+            // is absent exactly when the route is not enveloped.
+            cancellation_token: QueryEnvelope::current()
+                .ok()
+                .map(|envelope| envelope.request_id().to_string()),
+            limit: Some(limit),
+            // A cleared dashboard filter arrives as an empty value; treat it as
+            // absent rather than as a filter that matches nothing.
+            harness: optional_filter_value(params.harness.as_deref()),
+            source_name: optional_filter_value(params.source.as_deref()),
+        })
+        .await
+    {
+        Ok(results) => results,
+        Err(error) => {
+            return repo_error_response(format!("session search failed: {error}"), &error);
+        }
+    };
+
+    let now_ms = unix_now_ms();
+    let sessions = results
+        .sessions
+        .iter()
+        .map(|session| monitor_session_json(session, now_ms))
+        .collect::<Vec<_>>();
+
+    json_response(
+        json!({
+            "ok": true,
+            "read_model": "live",
+            "query": results.query,
+            "terms": results.terms,
+            "sessions": sessions,
+            "limit": limit,
+            "result_count": sessions.len(),
+            // Four distinct facts about the bound, never collapsed. Ranking is
+            // over EVENTS and answers in SESSIONS, and the exact re-check runs
+            // after both, so "there is more" and "this is short" have different
+            // causes with different remedies. None of them is an error and the
+            // sessions returned are a true ranking prefix in every case.
+            //
+            //   truncated      more ranked SESSIONS existed than `limit`
+            //                  returned. Raising `limit` returns more.
+            //   hits_truncated the ranking filled its event-hit budget, so
+            //                  matching events existed that it never examined.
+            //                  Raising `limit` widens that window but promises
+            //                  no additional sessions.
+            //   incomplete     the ranking's bounded candidate window was
+            //                  exhausted before the answer could be filled
+            //                  (issue #597 §1.6). Raising `limit` cannot help.
+            //   dropped        ranked sessions were removed by the exact
+            //                  post-ranking re-check (scope, harness/source,
+            //                  tombstone) and nothing refilled them, so this
+            //                  answer is a strict subset of what was ranked.
+            "truncated": results.truncated,
+            "hits_truncated": results.hits_truncated,
+            "incomplete": results.incomplete,
+            "dropped": results.dropped,
+        }),
+        StatusCode::OK,
+    )
+}
+
 fn bad_request(message: String) -> Response {
     json_response(
         json!({"ok": false, "error": message}),
@@ -1721,8 +1871,8 @@ mod tests {
         AnalyticsWindow, CanonicalReadAnchor, CanonicalSessionPage, CanonicalSessionSignals,
         ConversationMode, ConversationRepository, InMemoryConversationRepository,
         InMemoryConversationResponses, IngestHeartbeat, McpTurnCompact, Page, RepoConfig,
-        SessionMetadata, StoreDiagnostics, TableColumn, TablePreview, TableSummary, TurnSummary,
-        WebSearchEvent,
+        SessionMetadata, SessionSearchResults, StoreDiagnostics, TableColumn, TablePreview,
+        TableSummary, TurnSummary, WebSearchEvent,
     };
     use std::collections::BTreeMap;
     use std::fs;
@@ -3376,6 +3526,500 @@ mod tests {
         assert_eq!(payload["session"]["turns"][0]["turnSeq"], json!(1));
     }
 
+    // -----------------------------------------------------------------------
+    // issue-599 WI-09 — whole-corpus session search.
+    // -----------------------------------------------------------------------
+
+    fn search_params(q: &str) -> SessionSearchParams {
+        SessionSearchParams {
+            q: Some(q.to_string()),
+            limit: None,
+            harness: None,
+            source: None,
+        }
+    }
+
+    fn search_results(sessions: Vec<McpSessionListItem>) -> SessionSearchResults {
+        SessionSearchResults {
+            query_id: "monitor-search".to_string(),
+            query: "repository".to_string(),
+            terms: vec!["repository".to_string()],
+            sessions,
+            truncated: false,
+            hits_truncated: false,
+            incomplete: false,
+            dropped: false,
+        }
+    }
+
+    /// **Scope: the SERIALIZER, not the store.** Both routes are handed the
+    /// identical `McpSessionListItem` here, so what this proves is that
+    /// `api_session_search` and `api_sessions` render one summary the same way
+    /// — same keys, same values, no search-shaped near-miss that would need its
+    /// own reader.
+    ///
+    /// It deliberately cannot observe the two routes being handed DIFFERENT
+    /// items for one session; only real hydration can produce that, and the
+    /// repository integration test
+    /// `both_discovery_surfaces_describe_one_session_identically` is what
+    /// covers it. `status_is_derived_from_ended_at_so_a_divergent_timestamp_is
+    /// _a_cross_surface_contradiction` below is the other half: why a
+    /// divergence there would not stay cosmetic.
+    #[tokio::test]
+    async fn search_results_are_rendered_by_the_same_summary_serializer_as_the_feed() {
+        let (backend, _) = fake_backend(InMemoryConversationResponses {
+            search_session_summaries: Some(Ok(search_results(vec![sample_session()]))),
+            list_mcp_sessions: Some(Ok(Page {
+                items: vec![sample_session()],
+                next_cursor: None,
+            })),
+            ..Default::default()
+        })
+        .await;
+        let (feed_backend, _) = fake_backend(InMemoryConversationResponses {
+            list_mcp_sessions: Some(Ok(Page {
+                items: vec![sample_session()],
+                next_cursor: None,
+            })),
+            ..Default::default()
+        })
+        .await;
+
+        let searched = response_json(
+            api_session_search(Query(search_params("repository")), Extension(backend)).await,
+        )
+        .await;
+        let listed =
+            response_json(api_sessions(Query(sessions_query()), Extension(feed_backend)).await)
+                .await;
+
+        assert_eq!(searched["sessions"][0], listed["sessions"][0]);
+        assert_eq!(searched["read_model"], json!("live"));
+        assert_eq!(searched["result_count"], json!(1));
+        assert_eq!(searched["query"], json!("repository"));
+    }
+
+    /// Why the two discovery surfaces must agree about `last_event_unix_ms` and
+    /// not merely "about roughly when the session ended".
+    ///
+    /// `monitor_session_json` derives `status` from `endedAt` against a 60 s
+    /// activity window, so two renderings of one session that differ by that
+    /// window differ by a WORD: `active` versus `completed`. Two relations in
+    /// the store can answer "when did this session last have an event" — the
+    /// directory's `max(max_observed_event_time)` and navigation's
+    /// `argMax(display_time)`, the former never below the latter — and for a
+    /// while the feed reported one and the ranked search the other. This is the
+    /// consequence that made that unacceptable, which is why both surfaces now
+    /// report the directory value (`SessionKeyset`).
+    ///
+    /// MUTATION: make `status` a constant; this fails.
+    ///
+    /// Widening `SESSION_ACTIVE_WINDOW_MS` does NOT fail it, and an earlier
+    /// revision of this comment offered that as a second recipe without running
+    /// it. The test builds its gap FROM the constant
+    /// (`last_event_unix_ms = now_ms - SESSION_ACTIVE_WINDOW_MS`), so widening
+    /// the window widens the gap in lockstep — there is no fixed "gap used
+    /// here". Verified at 600_000 and 86_400_000; both pass.
+    #[test]
+    fn status_is_derived_from_ended_at_so_a_divergent_timestamp_is_a_cross_surface_contradiction() {
+        let now_ms = 1_767_262_260_000_i64;
+        let mut session = sample_session();
+        session.completed = false;
+
+        // The hydrated aggregate.
+        session.last_event_unix_ms = now_ms - SESSION_ACTIVE_WINDOW_MS;
+        let hydrated = monitor_session_json(&session, now_ms);
+        // The directory aggregate, which is >= the hydrated one, never below.
+        session.last_event_unix_ms = now_ms;
+        let keyset = monitor_session_json(&session, now_ms);
+
+        assert_eq!(hydrated["status"], json!("completed"));
+        assert_eq!(keyset["status"], json!("active"));
+        assert_ne!(
+            hydrated["status"], keyset["status"],
+            "a timestamp difference of one activity window is a status contradiction, \
+             not a rounding difference"
+        );
+    }
+
+    /// The ranking pass reads message text to score and preview it. A search
+    /// response must stay the same flat navigation-scalar shape the feed proved
+    /// under 50x fatter transcripts (issue-599 §5.3).
+    ///
+    /// MUTATION: emit any hit-derived content on the response (a `snippet`, a
+    /// `highlight`, a `preview`); this fails on the key scan.
+    #[tokio::test]
+    async fn search_response_carries_summaries_and_no_transcript_content() {
+        let (backend, _) = fake_backend(InMemoryConversationResponses {
+            search_session_summaries: Some(Ok(search_results(vec![sample_session()]))),
+            ..Default::default()
+        })
+        .await;
+
+        let payload = response_json(
+            api_session_search(Query(search_params("repository")), Extension(backend)).await,
+        )
+        .await;
+
+        let mut keys = Vec::new();
+        all_keys(&payload, &mut keys);
+        for forbidden in [
+            "turns",
+            "steps",
+            "text",
+            "events",
+            "payload_json",
+            "snippet",
+            "text_content",
+            "text_preview",
+        ] {
+            assert!(
+                !keys.iter().any(|key| key == forbidden),
+                "search response must not carry {forbidden:?}: {payload}"
+            );
+        }
+
+        let mut fields = payload["sessions"][0]
+            .as_object()
+            .expect("session object")
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        fields.sort();
+        assert_eq!(
+            fields,
+            vec![
+                "displayLabel",
+                "endedAt",
+                "eventCount",
+                "harness",
+                "id",
+                "inferenceProvider",
+                "mode",
+                "sessionSlug",
+                "sessionSummary",
+                "source",
+                "startedAt",
+                "status",
+                "title",
+                "toolCallCount",
+                "turnCount",
+            ]
+        );
+    }
+
+    /// The four bounded-answer signals stay distinct on the wire. Collapsing
+    /// any pair tells a reader to apply the wrong remedy: "raise `limit`" when
+    /// the ranking ran out of candidate budget, or "this is everything" when
+    /// the exact re-check removed half the answer.
+    ///
+    /// The matrix is exhaustive over all sixteen combinations, so a field wired
+    /// to its neighbour's value cannot survive.
+    #[tokio::test]
+    async fn search_reports_every_bounded_answer_signal_separately() {
+        for bits in 0u8..16 {
+            let (truncated, hits_truncated, incomplete, dropped) =
+                (bits & 1 != 0, bits & 2 != 0, bits & 4 != 0, bits & 8 != 0);
+            let (backend, _) = fake_backend(InMemoryConversationResponses {
+                search_session_summaries: Some(Ok(SessionSearchResults {
+                    truncated,
+                    hits_truncated,
+                    incomplete,
+                    dropped,
+                    ..search_results(vec![sample_session()])
+                })),
+                ..Default::default()
+            })
+            .await;
+            let payload = response_json(
+                api_session_search(Query(search_params("repository")), Extension(backend)).await,
+            )
+            .await;
+            assert_eq!(payload["truncated"], json!(truncated), "bits={bits}");
+            assert_eq!(
+                payload["hits_truncated"],
+                json!(hits_truncated),
+                "bits={bits}"
+            );
+            assert_eq!(payload["incomplete"], json!(incomplete), "bits={bits}");
+            assert_eq!(payload["dropped"], json!(dropped), "bits={bits}");
+        }
+    }
+
+    /// A blank or absent query is a client bug. Answering it with an empty
+    /// result set would render as "nothing in the corpus matches", which is a
+    /// different and false statement.
+    #[tokio::test]
+    async fn a_blank_search_query_is_refused_rather_than_answered_with_no_results() {
+        for q in [None, Some(String::new()), Some("   ".to_string())] {
+            let (backend, repository) = fake_backend(InMemoryConversationResponses {
+                search_session_summaries: Some(Ok(search_results(vec![sample_session()]))),
+                ..Default::default()
+            })
+            .await;
+            let response = api_session_search(
+                Query(SessionSearchParams {
+                    q: q.clone(),
+                    limit: None,
+                    harness: None,
+                    source: None,
+                }),
+                Extension(backend),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "q={q:?}");
+            assert!(
+                repository.calls().search_session_summaries.is_empty(),
+                "q={q:?}: a blank query must not reach the repository",
+            );
+        }
+    }
+
+    /// Search narrowing must reach the repository, and a cleared dashboard
+    /// filter must arrive as "no filter" rather than as a filter for the empty
+    /// string. Both clamps on `limit` are real and the second one is the
+    /// backend's own `max_results`.
+    #[tokio::test]
+    async fn search_parameters_reach_the_shared_repository_query() {
+        let (backend, repository) = fake_backend(InMemoryConversationResponses {
+            search_session_summaries: Some(Ok(search_results(Vec::new()))),
+            ..Default::default()
+        })
+        .await;
+
+        let payload = response_json(
+            api_session_search(
+                Query(SessionSearchParams {
+                    q: Some("  repository inspection  ".to_string()),
+                    limit: Some(9_999),
+                    harness: Some(" codex ".to_string()),
+                    source: Some("   ".to_string()),
+                }),
+                Extension(backend),
+            )
+            .await,
+        )
+        .await;
+
+        let calls = repository.calls().search_session_summaries;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].query, "repository inspection");
+        assert_eq!(calls[0].harness.as_deref(), Some("codex"));
+        assert_eq!(calls[0].source_name, None);
+        // `9_999` clamps to the route's own bound, then to `RepoConfig`'s
+        // `max_results` (25). The response reports the effective value.
+        assert_eq!(calls[0].limit, Some(25));
+        assert_eq!(payload["limit"], json!(25));
+        assert_eq!(payload["sessions"], json!([]));
+        assert_eq!(payload["result_count"], json!(0));
+    }
+
+    /// Search is one repository read, and a failure of it keeps the same
+    /// budget-classified envelope every other monitor read uses. A deadline
+    /// answered as an empty result set would read as "nothing matches".
+    ///
+    /// **The client-error arm is the load-bearing one.** The repository owns
+    /// the tokenizer, so it — not the route — decides that `?q=x` or a
+    /// Cyrillic query carries no searchable term, and it says so with
+    /// `InvalidArgument`. Classified as 503 that rendered as "Search
+    /// unavailable", i.e. an outage banner for a typo, permanently, with a
+    /// retry that could never succeed.
+    ///
+    /// MUTATION: delete the `RepoError::InvalidArgument` arm from
+    /// `repo_error_status`; the `invalid_argument` row falls through to
+    /// `503`/no-code and this fails.
+    #[tokio::test]
+    async fn a_failed_search_is_classified_by_whether_the_client_or_the_store_is_at_fault() {
+        let cases = [
+            (
+                RepoError::deadline_exceeded("search deadline exceeded"),
+                StatusCode::GATEWAY_TIMEOUT,
+                Some("deadline_exceeded"),
+            ),
+            (
+                RepoError::resource_exhausted("statement cap"),
+                StatusCode::TOO_MANY_REQUESTS,
+                Some("resource_exhausted"),
+            ),
+            (
+                RepoError::invalid_argument(
+                    "query has no searchable terms (tokens shorter than 2 characters are excluded)",
+                ),
+                StatusCode::BAD_REQUEST,
+                Some("invalid_argument"),
+            ),
+            (
+                RepoError::backend("clickhouse is unreachable"),
+                StatusCode::SERVICE_UNAVAILABLE,
+                None,
+            ),
+        ];
+
+        for (error, expected_status, expected_code) in cases {
+            let label = format!("{error}");
+            let (backend, _) = fake_backend(InMemoryConversationResponses {
+                search_session_summaries: Some(Err(error)),
+                ..Default::default()
+            })
+            .await;
+
+            let response =
+                api_session_search(Query(search_params("repository")), Extension(backend)).await;
+            assert_eq!(response.status(), expected_status, "{label}");
+            let payload = response_json(response).await;
+            assert_eq!(payload["ok"], json!(false), "{label}");
+            match expected_code {
+                Some(code) => assert_eq!(payload["code"], json!(code), "{label}"),
+                None => assert!(payload.get("code").is_none(), "{label}: {payload}"),
+            }
+        }
+    }
+
+    /// The route runs inside a #600 interactive envelope — asserted through the
+    /// REAL router, not a synthetic probe route bolted onto the middleware.
+    ///
+    /// The handler threads `QueryEnvelope::current()`'s request id into the
+    /// repository query, so the recorded call proves an envelope was in scope
+    /// when the read was issued. A route registered outside the envelope layer
+    /// records `None` here.
+    ///
+    /// MUTATION: register `/sessions/search` on `versioned_routes` in
+    /// `monitor_router` instead of inside `dashboard_routes` — i.e. beside
+    /// `/capabilities`, which is the one route deliberately outside the
+    /// envelope `route_layer` — or pass `cancellation_token: None` from the
+    /// handler; either fails.
+    ///
+    /// Moving the route WITHIN `dashboard_routes` does not: `route_layer` is
+    /// applied to that whole router in `monitor_router`, above both the
+    /// `admitted` group and the bare `/health` group, so no reordering of
+    /// `.route(...)` lines there can leave a route unenveloped. A previous
+    /// version of this comment named that reordering, and it survives.
+    #[tokio::test]
+    async fn the_session_search_route_runs_inside_an_interactive_monitor_envelope() {
+        let (state, repository) = fake_state(InMemoryConversationResponses {
+            search_session_summaries: Some(Ok(search_results(vec![sample_session()]))),
+            ..Default::default()
+        });
+        let app = monitor_router(state);
+
+        let (status, _) = router_json(&app, "/api/v1/sessions/search?q=repository").await;
+        assert_eq!(status, StatusCode::OK);
+        let (second_status, _) = router_json(&app, "/api/v1/sessions/search?q=repository").await;
+        assert_eq!(second_status, StatusCode::OK);
+
+        let calls = repository.calls().search_session_summaries;
+        assert_eq!(calls.len(), 2);
+        let ids = calls
+            .iter()
+            .map(|call| {
+                call.cancellation_token
+                    .clone()
+                    .expect("the handler must see a #600 envelope")
+            })
+            .collect::<Vec<_>>();
+        for id in &ids {
+            assert!(
+                id.starts_with("moraine-monitor-"),
+                "monitor request ids must carry the monitor kind: {id}"
+            );
+        }
+        // Per request, never per client.
+        assert_ne!(ids[0], ids[1]);
+    }
+
+    /// `search` is a fixed path segment, not a session id — and a session that
+    /// really is called `search` is still readable.
+    ///
+    /// Both halves are asserted by the RESPONSE BODY, not by "did not 404".
+    /// The two handlers answer different shapes, so a 404-only assertion would
+    /// pass even if `/sessions/search/page` had been answered by the search
+    /// handler, or vice versa.
+    #[tokio::test]
+    async fn search_is_a_fixed_path_and_does_not_shadow_the_session_page_route() {
+        let (state, _) = fake_state(InMemoryConversationResponses {
+            search_session_summaries: Some(Ok(search_results(vec![sample_session()]))),
+            canonical_open_session_page: Some(Ok(Some(CanonicalReadOutcome::Page(
+                sample_session_page(vec![sample_turn(1)], None),
+            )))),
+            ..Default::default()
+        });
+        let app = monitor_router(state);
+
+        let (status, payload) = router_json(&app, "/api/v1/sessions/search?q=repository").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(session_ids(&payload), vec!["session-1"]);
+        // The search envelope, not a session page.
+        assert_eq!(payload["terms"], json!(["repository"]));
+        assert!(payload.get("session").is_none(), "{payload}");
+
+        // …and the parameterized sibling still resolves, for the session id
+        // `search`, with the PAGE envelope.
+        let (page_status, page_payload) =
+            router_json(&app, "/api/v1/sessions/search/page?limit=1").await;
+        assert_eq!(page_status, StatusCode::OK);
+        assert!(
+            page_payload["session"].is_object(),
+            "`/sessions/search/page` must reach the session page handler: {page_payload}"
+        );
+        assert!(page_payload.get("terms").is_none(), "{page_payload}");
+    }
+
+    /// **Insurance, not the current mechanism.** Today's `/sessions` routes are
+    /// unambiguous because their segment counts differ (1, 2 and 3), so nothing
+    /// in `dashboard_routes` depends on static-over-parameter precedence — the
+    /// registration comment there says so, and this test is deliberately built
+    /// against a SYNTHETIC router the real table does not have.
+    ///
+    /// It exists for the day a two-segment `/sessions/:id` is added, which is
+    /// when `/sessions/search` would start to need the rule. Two earlier
+    /// versions of that comment each named a mechanism that was not the
+    /// operative one — first REGISTRATION ORDER, which axum does not use at
+    /// all, then matchit precedence, which the real table never reaches — so
+    /// the property is pinned here rather than asserted in prose, and labelled
+    /// for what it is.
+    ///
+    /// This registers the PARAMETER FIRST and asserts the static segment still
+    /// wins, because insertion order is the thing a contributor would otherwise
+    /// assume matters.
+    #[tokio::test]
+    async fn matchit_prefers_a_static_segment_over_a_parameter_at_any_registration_order() {
+        async fn param() -> &'static str {
+            "param"
+        }
+        async fn statik() -> &'static str {
+            "static"
+        }
+
+        for register_static_first in [false, true] {
+            let router: Router<()> = if register_static_first {
+                Router::new()
+                    .route("/sessions/search", get(statik))
+                    .route("/sessions/:id", get(param))
+            } else {
+                Router::new()
+                    .route("/sessions/:id", get(param))
+                    .route("/sessions/search", get(statik))
+            };
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .uri("/sessions/search")
+                        .body(Body::empty())
+                        .expect("request"),
+                )
+                .await
+                .expect("response");
+            let body = axum::body::to_bytes(response.into_body(), 64)
+                .await
+                .expect("body");
+            assert_eq!(
+                std::str::from_utf8(&body).expect("utf8"),
+                "static",
+                "register_static_first={register_static_first}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn api_health_redacts_full_heartbeat_internals() {
         let (backend, _) = fake_backend(InMemoryConversationResponses {
@@ -3627,6 +4271,10 @@ mod tests {
             (
                 "/api/v1/sessions?since=30d&limit=1",
                 "/api/sessions?since=30d&limit=1",
+            ),
+            (
+                "/api/v1/sessions/search?q=repository",
+                "/api/sessions/search?q=repository",
             ),
         ];
         for (canonical_path, legacy_path) in route_matrix {

--- a/docs/monitor-http-api.md
+++ b/docs/monitor-http-api.md
@@ -21,6 +21,7 @@ All canonical routes are `GET` routes and successful responses use JSON.
 | `/api/v1/tables/:table` | `limit` | Return the named table's schema and a bounded row preview. `:table` is a path parameter. |
 | `/api/v1/web-searches` | `limit` | Return a bounded list of normalized web-search activity. |
 | `/api/v1/sessions` | `since`, `limit`, `cursor`, `harness`, `source`, `mode`, `sort` | Return one keyset page of session **summaries**. Never transcripts. |
+| `/api/v1/sessions/search` | `q`, `limit`, `harness`, `source` | Rank sessions by message content across the whole permitted corpus. Returns the same session **summaries**. Never transcripts. |
 | `/api/v1/sessions/:id/page` | `limit`, `cursor` | Return one bounded page of a session's turns. `:id` is a path parameter. |
 
 The session collection carries summaries only. It has no `turns` key and no
@@ -31,7 +32,160 @@ repository operations the MCP `list_sessions` and `open` tools use, so the two
 surfaces report the same session facts.
 
 `/api/v1/sessions/:id` itself is still not a route: the detail path is
-`/api/v1/sessions/:id/page`.
+`/api/v1/sessions/:id/page`. `/api/v1/sessions/search` is a fixed path, not a
+session id; a session that happens to be named `search` is still readable at
+`/api/v1/sessions/search/page`.
+
+### Session Search
+
+`/api/v1/sessions/search` answers "which sessions talked about this?" It ranks
+message content across every session this backend is configured to serve — not
+across the pages a client happens to have loaded — and returns session
+summaries. It reads the same bounded ranking the MCP `search_sessions` tool
+uses, then the same session hydration the feed uses, so for any session both
+routes return, the summary object is identical field for field — including
+`endedAt` and the `status` derived from it — and a result opens through
+`/api/v1/sessions/:id/page` like any other row. The two routes select different
+sessions, by relevance and by recency; they never describe the same session
+differently.
+
+```json
+{
+  "ok": true,
+  "read_model": "live",
+  "query": "projection runaway",
+  "terms": ["projection", "runaway"],
+  "sessions": [ ... summary objects, identical in shape to /api/v1/sessions ... ],
+  "limit": 10,
+  "result_count": 2,
+  "truncated": false,
+  "hits_truncated": false,
+  "incomplete": false,
+  "dropped": false
+}
+```
+
+- `q` is required and must be non-empty after trimming. A missing or blank `q`
+  is HTTP `400`, never an empty result set: "you asked nothing" and "nothing
+  matches" are different answers and must not render alike.
+- `limit` defaults to `10` and is clamped to `1..=50`, then further to the
+  backend's `[mcp] max_results`. The response reports the value actually used.
+- `sessions` is ordered by relevance, best first. Clients must not re-sort it;
+  the feed's recency order does not apply here.
+- **There is no `cursor` and no `has_more`.** A relevance ranking is bounded
+  rather than paged: scores are not a monotone keyset anchor, and a cursor over
+  them would silently skip or repeat as the corpus changes. A `next_cursor` from
+  `/api/v1/sessions` belongs to the feed's query and is not redeemable here.
+- **Four separate signals describe the bound**, tabulated below. None of them is
+  an error, and the sessions returned are a true prefix of the ranking in every
+  case.
+- The response carries no snippets, highlights, or matched text. Ranking reads
+  message bodies to score them; none of that reaches the client, so a search
+  response stays flat as transcripts grow, exactly like the session feed.
+- `harness` and `source` narrow the ranking server-side, with the same trimming
+  and same blank-means-no-filter rule as the feed. There is no `since`, `mode`,
+  or `sort`: the route ranks, it does not window or order.
+- Results are restricted to this backend's configured project scope
+  (`--project-only`). Scope is applied against each session's exact origin
+  directory *while candidates are being ranked*, and the same rule is applied
+  again after hydration, so an out-of-scope session is never disclosed and
+  never even reaches the ranked set. `harness` and `source` are re-checked
+  exactly after hydration, so a
+  narrowed search never returns a session whose reported `harness`/`source`
+  contradicts the filter, and never disagrees with `/api/v1/sessions` under the
+  same narrowing.
+
+#### The four bounded-answer signals
+
+Ranking is over *events* and the response is over *sessions*, and an exact
+re-check runs after both, so "there is more" and "this is short" have different
+causes and different remedies. They are reported separately for that reason.
+
+| Field | Grain | What it means | Remedy |
+| --- | --- | --- | --- |
+| `truncated` | session | More ranked **sessions** existed than `limit` returned. | Raise `limit`, up to the route maximum of `50`. See the note below on what that buys. |
+| `hits_truncated` | event | The ranking filled its internal event-hit budget, so matching **events** existed that it never examined. Sessions beyond those returned may exist. | Raising `limit` widens the hit budget too, but promises no additional sessions. |
+| `incomplete` | ranking | The ranking's bounded candidate window was saturated before the answer could be filled (issue #597 §1.6). | None; narrow the query. |
+| `dropped` | response | Ranked sessions were removed by the exact post-ranking re-check — exact `harness`/`source`, the tombstone rule — and nothing refilled them, so this answer is a strict subset of what was ranked. | None; it is not a shortfall of the corpus. |
+
+A term that appears thirty times in one session returns `result_count: 1` with
+`truncated: false` and `hits_truncated: true`. That is the honest description:
+one session matched, and raising `limit` returns the same one session. Clients
+must not present `hits_truncated` as "raise your limit for more sessions", and
+must not present `dropped` or `incomplete` as a complete answer.
+
+##### What raising `limit` actually buys
+
+The ranking is over *events*, so the server asks it for more hits than the
+sessions it intends to return — several hits routinely land in one session.
+That internal budget is bounded, and the bound is what makes raising `limit`
+sub-linear rather than useless:
+
+| `limit` | internal hit budget | effective hits per requested session |
+| --- | --- | --- |
+| 1–12 | `4 × limit` | 4.0 |
+| 13–33 | 50 | 3.8 down to 1.5 |
+| 34–50 | `ceil(1.5 × limit)` | 1.5 |
+
+So a larger `limit` never buys a *smaller* ranking, but it does not buy a
+proportionally larger one either: between 13 and 33 the budget is a constant
+50, so raising `limit` inside that band returns more sessions from the same
+ranking window rather than from a wider one. The budget is monotone
+non-decreasing, not strictly increasing.
+
+`truncated` stays meaningful at every `limit` the route accepts: the budget
+always exceeds `limit`, so the ranking can always yield more distinct sessions
+than the page returns. Read it together with `hits_truncated`, though.
+`truncated` is computed only over the hits the budget admitted, so a clustered
+corpus — 25 sessions holding 3 hits each, at `limit: 50` — can answer
+`truncated: false` while lower-ranked matching sessions were never examined.
+Only `truncated: false` **and** `hits_truncated: false` together mean the corpus
+held no more matching sessions. This is why the dashboard's own count label
+qualifies on `truncated || hitsTruncated` rather than on `truncated` alone.
+
+##### What `dropped` discloses
+
+`dropped` carries no id and no reason, and the envelope carries no explicit
+count of what was removed. It would be wrong to describe it as carrying no
+magnitude, though: when `truncated` is also set the answer was cut from exactly
+`limit` ranked sessions, so `limit - result_count` is precisely how many the
+re-check removed. Suppressing `result_count` or `limit` here would hide nothing
+— `result_count` is the length of `sessions`, and a client knows the `limit` it
+asked for — so this documents what can be counted rather than pretending
+nothing can be.
+
+- **Never project scope.** A `--project-only` backend does not rank
+  out-of-scope sessions at all. Scope is applied while candidates are still
+  being chosen — against the navigation `argMinIf(cwd, …)` on the canonical
+  path, and against `mcp_open_publication_headers.origin_cwd` on the
+  pre-cutover path — so an out-of-scope session never enters the ranked set and
+  can never be part of `limit - result_count`. This route therefore cannot be
+  used to count out-of-scope activity for a search term. The identical scope
+  rule is re-applied after hydration as well, so that one function decides
+  disclosure for both discovery surfaces; that copy is defence in depth and is
+  not what the bit reports.
+- **Facet drift and tombstones.** What `dropped` does report is a session whose
+  *current* `harness`/`source` differs from the one the request narrowed by
+  (ranking matches per posting, a summary reports the session's latest value),
+  or one whose rows are no longer live under the pinned publication. A caller
+  who supplies `harness` or `source` can therefore learn how many of the top
+  `limit` matches have drifted or been retired. That is a fact about sessions
+  the caller is already permitted to see.
+
+#### Known limitation: the query tokenizer is ASCII-only
+
+Queries are tokenized on runs of `[A-Za-z0-9_]` of length 2 to 64. A query with
+no such run therefore yields no searchable term and is refused with HTTP `400`
+and `code: "invalid_argument"`. This includes any query written **entirely in a
+non-Latin script** — CJK, Cyrillic, Greek, Hebrew, Arabic, Devanagari — and any
+query that is a single character. The refusal is permanent for that query text,
+not transient, and retrying it will not succeed.
+
+This is a property of the indexing tokenizer (issue #597), not of this route:
+the same restriction applies to the MCP event search. Clients should render the
+`400` as a hint to rephrase, never as a service failure — and must not
+re-implement the rule locally, since the server owns it and the two copies would
+drift.
 
 `/api/v1/status` carries `known_harnesses`: the vocabulary the session feed's
 `harness` filter accepts. It is served because `harness` narrows a keyset-paged
@@ -45,7 +199,14 @@ feed's own read path gate on. Until then the route returns `503` with
 backfill or overlap audit has not completed. Session summaries stay available
 throughout; only the transcript detail is withheld.
 
-Successful analytics, web-search, and session responses carry
+That sentence covers **both** discovery routes. `/api/v1/sessions` and
+`/api/v1/sessions/search` branch on the same readiness key and hydrate their
+summaries from the pre-cutover projected headers while it is unset, so a
+not-ready backend answers a search with the sessions that matched — never with
+an empty `sessions` array, which would assert that the whole corpus was searched
+and nothing matched.
+
+Successful analytics, web-search, session, and session-search responses carry
 `"read_model":"live"`: their rows are authorized against published source
 generations. Table listing and bounded table preview carry
 `"read_model":"audit"` because they intentionally inspect physical relations,
@@ -83,8 +244,8 @@ The example version values are illustrative. Field semantics are:
   error.
 - `features.analytics` means the analytics collection route is implemented.
 - `features.sessions` means the session collection is implemented. It does not
-  separately advertise the session page route; a build that serves the
-  collection serves the page route too.
+  separately advertise the session page or session search routes; a build that
+  serves the collection serves those too.
 - `features.table_inspection` means table listing and bounded table preview are
   implemented.
 - `features.web_searches` means the normalized web-search collection is
@@ -115,6 +276,9 @@ unsigned integer is a malformed query and returns HTTP `400`.
 | `/api/v1/sessions` | `mode` | none | `chat`, `tool_calling`, `mcp_internal`, or `web_search` |
 | `/api/v1/sessions` | `harness`, `source` | none | any value; trimmed, and blank-after-trim means "no filter" |
 | `/api/v1/sessions` | `cursor` | none | an opaque `next_cursor` from a previous page |
+| `/api/v1/sessions/search` | `q` | none | **required**; trimmed, and blank-after-trim is HTTP `400` |
+| `/api/v1/sessions/search` | `limit` | `10` | clamped to `1..=50`, then to the backend's configured `[mcp] max_results` |
+| `/api/v1/sessions/search` | `harness`, `source` | none | any value; trimmed, and blank-after-trim means "no filter" |
 | `/api/v1/sessions/:id/page` | `limit` | `50` | clamped to `1..=200` |
 | `/api/v1/sessions/:id/page` | `cursor` | none | an opaque `next_cursor` from a previous page of the **same** session |
 | `/api/v1/web-searches` | `limit` | `100` | clamped to `1..=1000` |
@@ -140,7 +304,10 @@ question with a wider result set. A `cursor` that is present but blank is also
 The session `limit` is clamped twice. The route's own bound is `1..=200`; the
 backend then applies its configured `[mcp] max_results`. The response's `limit`
 field reports the second, effective value — the number of sessions the page was
-actually allowed to contain.
+actually allowed to contain. `/api/v1/sessions/search` clamps the same way with
+a lower route bound of `1..=50`, because a relevance ranking's value is
+concentrated in its head and each ranked session costs a hydration slot in the
+same bounded budget the feed spends.
 
 ### Session Paging
 
@@ -277,20 +444,25 @@ details; clients should branch on the HTTP status and `code`, not match
 arbitrary message text.
 
 A failure that the server can classify also carries an additive machine-readable
-`code`: `deadline_exceeded`, `resource_exhausted`, `invalid_cursor`, or
-`canonical_reader_unavailable`. The field is absent when the failure has no
-classification, so clients must tolerate its absence.
+`code`: `deadline_exceeded`, `resource_exhausted`, `invalid_cursor`,
+`invalid_argument`, or `canonical_reader_unavailable`. The field is absent when
+the failure has no classification, so clients must tolerate its absence.
+
+`invalid_argument` and `invalid_cursor` are the two classifications that mean
+*the request is at fault*: they are permanent for that request and retrying is
+useless. Every other classification describes the store or its budgets and may
+succeed on retry. Clients must not render a `400` as a service outage.
 
 | Status | Meaning |
 | --- | --- |
 | `200 OK` | The request completed. Inspect diagnostic fields such as `clickhouse.healthy`; `200` does not mean every component is healthy. |
-| `400 Bad Request` | The query could not be deserialized, a table identifier was rejected, a filter value was not recognized, or a continuation cursor was refused. Every refused cursor carries `code: "invalid_cursor"`, whether the route or the backend refused it. A rejected table identifier uses `{"ok":false,"error":"invalid table name"}`. Framework-generated malformed-query responses are not guaranteed to use the application JSON envelope. |
+| `400 Bad Request` | The query could not be deserialized, a table identifier was rejected, a filter value was not recognized, a required `q` was missing or blank, a repository operation rejected an argument the route could not validate itself, or a continuation cursor was refused. Every refused cursor carries `code: "invalid_cursor"`, whether the route or the backend refused it; a backend-rejected argument carries `code: "invalid_argument"` — most commonly a `q` the indexing tokenizer cannot split into any searchable term (see *Known limitation: the query tokenizer is ASCII-only*). A rejected table identifier uses `{"ok":false,"error":"invalid table name"}`. Framework-generated malformed-query responses are not guaranteed to use the application JSON envelope. |
 | `403 Forbidden` | Static-file path traversal or a path that resolves outside the configured static root. The JSON error is `{"ok":false,"error":"forbidden"}`. |
 | `404 Not Found` | No requested static file exists, or a requested session is unknown or outside this backend's configured scope. The JSON error is `{"ok":false,"error":"not found"}` or `{"ok":false,"error":"session not found"}`. |
 | `405 Method Not Allowed` | The path exists but does not support the requested HTTP method. A JSON error envelope is not guaranteed. |
 | `429 Too Many Requests` | Concurrent-read admission overflow, or a repository read that exhausted a non-time query budget. Carries `code: "resource_exhausted"`. |
 | `500 Internal Server Error` | The static root cannot be resolved or a selected static file cannot be read. |
-| `503 Service Unavailable` | A required repository or ClickHouse read failed with no budget classification, or `/api/v1/sessions/:id/page` was called on a backend that has not published its canonical read indexes — the latter carries `code: "canonical_reader_unavailable"`. Handler-generated responses use the JSON error envelope. |
+| `503 Service Unavailable` | A required repository or ClickHouse read failed with no budget classification **and was not the caller's fault** — a rejected argument or cursor is a `400`, not this — or `/api/v1/sessions/:id/page` was called on a backend that has not published its canonical read indexes, which carries `code: "canonical_reader_unavailable"`. Handler-generated responses use the JSON error envelope. |
 | `504 Gateway Timeout` | A repository read exceeded its query-budget deadline. Carries `code: "deadline_exceeded"`. |
 
 `/api/v1/health` returns `503` when the required store-health read, ping, or
@@ -333,7 +505,8 @@ build are used according to the server's static-directory resolution rules.
 Because unmatched paths enter static-file handling, an unknown path under
 `/api/v1` is not evidence that an API resource exists. Clients must use the
 routes in the matrix above rather than inferring paths from them; in particular
-`/api/v1/sessions/:id` is not a route, while `/api/v1/sessions/:id/page` is.
+`/api/v1/sessions/:id` is not a route, while `/api/v1/sessions/:id/page` and
+`/api/v1/sessions/search` are.
 
 ## MCP Protocol Is Unchanged
 

--- a/docs/operations/canonical-read-indexes.md
+++ b/docs/operations/canonical-read-indexes.md
@@ -81,6 +81,20 @@ cross-surface switch. As of this build:
   candidate page from `mcp_event_navigation` plus the metadata-bearing `events`
   rows. It reads no `mcp_open_*` relation and no `v_session_summary` /
   `v_conversation_trace` / `v_turn_summary` view.
+  - **Discovery by CONTENT shares the same hydration.** The monitor's
+    `/api/v1/sessions/search` route picks candidates with issue #597's bounded
+    postings ranking and then runs the identical hydration and fold, so the
+    project-scope re-check, the exact `harness`/`source` re-check, the tombstone
+    rule, and the title/summary precedence are single-sourced across both
+    discovery surfaces. Having no keyset page of its own, it also issues one
+    `mcp_session_directory` point-range read over the ids it ranked, so the
+    `updated_at` it reports is the same `max(max_observed_event_time)` the feed
+    orders, pages and renders by rather than a second aggregate of its own —
+    which is what lets both surfaces derive the same `status` for one session at
+    one instant. It branches on the readiness gate below exactly as the
+    feed does and falls back to the same projected headers, so a not-ready store
+    answers a search with the sessions that matched rather than with an empty
+    result set that would read as "the whole corpus was searched".
   - **Readiness gate.** The shared operation selects the directory path only
     when the `open_v2` key reads ready — the same key `open` consults — and
     otherwise serves the pre-#599 `mcp_open_publication_headers` page. The

--- a/web/monitor/e2e/monitor.smoke.spec.ts
+++ b/web/monitor/e2e/monitor.smoke.spec.ts
@@ -62,6 +62,15 @@ const STATIC_PATHNAMES = ['/', '/app.js', '/styles.css'] as const;
 const SESSION_FIXTURE_ID = 'session-monitor-fixture';
 const SESSIONS_PAGE_TWO_CURSOR = 'cursor-page-2';
 const SESSION_PAGE_PATHNAME = `/api/v1/sessions/${SESSION_FIXTURE_ID}/page`;
+const SESSION_SEARCH_PATHNAME = '/api/v1/sessions/search';
+/**
+ * A session the FEED never returns, whose title shares no substring with the
+ * search term. It is reachable only because the server ranked message content
+ * across the whole corpus — which is exactly what WI-09 replaced the page-local
+ * filter with, and what no client-side predicate could produce.
+ */
+const SEARCH_ONLY_SESSION_ID = 'session-only-findable-by-content';
+const SEARCH_TERM = 'projection';
 
 function sessionSummaryFixture(id: string, title: string) {
   return {
@@ -217,6 +226,38 @@ async function setupMockMonitorApi(page: Page): Promise<void> {
     });
   });
 
+  // Registered before the `:id/page` route below; Playwright gives priority to
+  // the most recently registered matching handler, and this path must never be
+  // read as a session whose id is "search".
+  await page.route('**/api/v1/sessions/search?*', async (route) => {
+    const url = new URL(route.request().url());
+    const q = (url.searchParams.get('q') ?? '').trim();
+    const matches =
+      q === SEARCH_TERM
+        ? [
+            sessionSummaryFixture(
+              SEARCH_ONLY_SESSION_ID,
+              'Retire the read-model rebuild',
+            ),
+          ]
+        : [];
+    await route.fulfill({
+      json: {
+        ok: true,
+        read_model: 'live',
+        query: q,
+        terms: q ? q.split(/\s+/) : [],
+        sessions: matches,
+        limit: 25,
+        result_count: matches.length,
+        truncated: false,
+        hits_truncated: false,
+        incomplete: false,
+        dropped: false,
+      },
+    });
+  });
+
   await page.route('**/api/v1/sessions/*/page?*', async (route) => {
     const url = new URL(route.request().url());
     const sessionId = decodeURIComponent(url.pathname.split('/').slice(-2)[0]);
@@ -351,14 +392,15 @@ test('loads dashboard and handles core interactions', async ({ page }) => {
   await expect(counter).toHaveText('2 loaded');
   await expect(page.getByRole('button', { name: 'Load more sessions' })).toHaveCount(0);
 
-  // Filter bar: searching narrows the loaded sessions
+  // Filter bar: the input is a whole-corpus server search, and says so.
   await expect(page.locator('.mv-search-input')).toHaveAttribute(
     'placeholder',
-    'Filter loaded sessions by title or id',
+    'Search all sessions by content',
   );
   await page.locator('.mv-search-input').fill('nothing-should-match-xyz');
-  await expect(page.locator('.mv-empty')).toContainText('No sessions match');
+  await expect(page.locator('#sessionsPanel .mv-empty')).toContainText('No sessions match');
   await page.locator('.mv-search-clear').click();
+  await expect(counter).toHaveText('2 loaded');
 
   // Theme segmented switch
   const htmlThemeBefore = await page.locator('html').getAttribute('data-theme');
@@ -403,4 +445,152 @@ test('keeps dashboard and detail views inside the mobile viewport', async ({ pag
   await expect(page.locator('.mv-sidepanel')).toBeVisible();
   await expect(page.locator('.mv-nodes')).toBeVisible();
   await expectNoPageOverflow(page);
+});
+
+test('search reaches the server and opens a result no local filter could find', async ({
+  page,
+}) => {
+  const runtimeTraffic = trackRuntimeTraffic(page);
+  await page.goto('/');
+  await expect(page.locator('#sessionsPanel')).toBeVisible();
+  await expect(page.locator('.mv-card')).toHaveCount(1);
+
+  // The searched term appears in no loaded row's title, id, slug or label. The
+  // deleted page-local filter matched exactly those fields, so it could only
+  // have produced an empty list here.
+  await expect(page.locator('.mv-card-title').first()).toHaveText('Inspect the repository');
+  // Typed one character at a time, which is the only input shape a debounce can
+  // be observed through: `fill()` emits a single event and would report one
+  // request whether or not the debounce exists.
+  await page.locator('.mv-search-input').pressSequentially(SEARCH_TERM, { delay: 20 });
+
+  await expect
+    .poll(() => runtimeTraffic.apiPathnames.filter((p) => p === SESSION_SEARCH_PATHNAME).length, {
+      message: 'expected the query to reach the server-side search route',
+    })
+    .toBeGreaterThan(0);
+  await expect(page.locator('.mv-card-title')).toHaveText(['Retire the read-model rebuild']);
+  await expect(page.locator('.mv-filter-count')).toHaveText('1 result');
+  // A ranking is bounded, not paged: the feed's continuation affordance must
+  // not offer to extend a result set its cursor does not describe.
+  await expect(page.getByRole('button', { name: 'Load more sessions' })).toHaveCount(0);
+
+  // The count and the server's bounded-answer flags describe two different
+  // populations as soon as a LOCAL filter narrows the ranked set. `status`
+  // is client-side, so selecting `active` hides the (completed) result — and
+  // the bar must then report both numbers rather than presenting a local
+  // narrowing as the ranking's own answer. This is the wiring the pure
+  // `sessionCountLabel` unit tests cannot reach.
+  const statusSelect = page.locator('.mv-filter select').first();
+  await statusSelect.selectOption('active');
+  await expect(page.locator('.mv-filter-count')).toHaveText('0 of 1 results');
+  await expect(page.locator('.mv-card')).toHaveCount(0);
+  await statusSelect.selectOption('all');
+  await expect(page.locator('.mv-filter-count')).toHaveText('1 result');
+
+  // Every search is a real BM25 ranking over the whole corpus, so typing must
+  // settle before one is issued. The bound is 2, not "fewer than the number of
+  // keystrokes": a debounce degraded to one request per keystroke minus one
+  // would satisfy the looser bound while issuing nine rankings for ten
+  // characters. Two allows for the settle boundary landing mid-word once.
+  const searchRequests = runtimeTraffic.apiPathnames.filter(
+    (p) => p === SESSION_SEARCH_PATHNAME,
+  ).length;
+  expect(
+    searchRequests,
+    `${SEARCH_TERM.length} keystrokes issued ${searchRequests} searches`,
+  ).toBeLessThanOrEqual(2);
+
+  // A result is a session summary, so it opens through the same lazy reader a
+  // listed session does — no search-specific detail path.
+  await page.locator('.mv-card').first().click();
+  await expect(page.locator('.mv-sidepanel')).toBeVisible();
+  await expect
+    .poll(() =>
+      runtimeTraffic.apiPathnames.filter(
+        (p) => p === `/api/v1/sessions/${SEARCH_ONLY_SESSION_ID}/page`,
+      ).length,
+    )
+    .toBe(1);
+  await page.locator('.mv-sidepanel .mv-iconbtn').click();
+
+  // Clearing the query returns the panel to the time-ordered feed rather than
+  // leaving an empty result set on screen.
+  await page.locator('.mv-search-clear').click();
+  await expect(page.locator('.mv-card-title').first()).toHaveText('Inspect the repository');
+  await expect(page.locator('.mv-filter-count')).toHaveText('1 loaded');
+});
+
+test('a failed search is reported, never answered from the loaded page', async ({ page }) => {
+  const runtimeTraffic = trackRuntimeTraffic(page);
+  await page.route('**/api/v1/sessions/search?*', async (route) => {
+    await route.fulfill({
+      status: 504,
+      json: { ok: false, error: 'session search failed: deadline', code: 'deadline_exceeded' },
+    });
+  });
+
+  await page.goto('/');
+  await expect(page.locator('#sessionsPanel')).toBeVisible();
+  // Typed, not `fill()`ed: a failing search must go through the same debounced
+  // path a succeeding one does, or this never exercises the code that runs in
+  // production.
+  await page.locator('.mv-search-input').pressSequentially('repository', { delay: 20 });
+  await expect
+    .poll(() =>
+      runtimeTraffic.apiPathnames.filter((p) => p === SESSION_SEARCH_PATHNAME).length,
+    )
+    .toBeGreaterThan(0);
+
+  // "repository" IS in the loaded row's title. A fallback to the deleted local
+  // filter would therefore render that row and look like a working search.
+  await expect(page.locator('#sessionsPanel .mv-empty').first()).toContainText(
+    'Search unavailable',
+  );
+  await expect(page.locator('.mv-card')).toHaveCount(0);
+
+  // THE POINT OF THE GUARD. The banner alone is also true of the broken
+  // behaviour this replaced, which additionally printed "No sessions match this
+  // search." and "0 results" — a corpus-wide claim the request never
+  // established, beside a banner saying it could not be established.
+  const panel = page.locator('#sessionsPanel');
+  await expect(panel).not.toContainText('No sessions match');
+  await expect(panel).not.toContainText('0 results');
+  await expect(page.locator('.mv-filter-count')).toHaveText('search did not run');
+  // A ranking's continuation affordance must not appear either: there is
+  // nothing to continue.
+  await expect(page.getByRole('button', { name: 'Load more sessions' })).toHaveCount(0);
+
+  // Clearing returns the panel to the feed, so the failure is not sticky.
+  await page.locator('.mv-search-clear').click();
+  await expect(page.locator('.mv-card-title').first()).toHaveText('Inspect the repository');
+  await expect(page.locator('.mv-filter-count')).toHaveText('1 loaded');
+});
+
+test('a query the server cannot tokenize is a hint, not an outage', async ({ page }) => {
+  // The backend owns the tokenizer, so it decides that a one-character or
+  // non-ASCII query carries no searchable term. Reported as `503` this rendered
+  // "Search unavailable" — an outage banner for a typo, with a retry that could
+  // never succeed.
+  await page.route('**/api/v1/sessions/search?*', async (route) => {
+    await route.fulfill({
+      status: 400,
+      json: {
+        ok: false,
+        error:
+          'session search failed: query has no searchable terms (tokens shorter than 2 characters are excluded)',
+        code: 'invalid_argument',
+      },
+    });
+  });
+
+  await page.goto('/');
+  await expect(page.locator('#sessionsPanel')).toBeVisible();
+  await page.locator('.mv-search-input').pressSequentially('x', { delay: 20 });
+
+  const panel = page.locator('#sessionsPanel');
+  await expect(panel.locator('.mv-empty').first()).toContainText('no searchable terms');
+  await expect(panel).not.toContainText('Search unavailable');
+  await expect(panel).not.toContainText('No sessions match');
+  await expect(panel).not.toContainText('0 results');
 });

--- a/web/monitor/playwright.mocked.config.cjs
+++ b/web/monitor/playwright.mocked.config.cjs
@@ -13,7 +13,7 @@ module.exports = defineConfig({
   workers: 1,
   reporter: [
     ['list'],
-    ['./e2e/expected-cases-reporter.cjs', { expectedCases: 3 }],
+    ['./e2e/expected-cases-reporter.cjs', { expectedCases: 6 }],
   ],
   use: {
     baseURL: 'http://127.0.0.1:4173',

--- a/web/monitor/src/App.svelte
+++ b/web/monitor/src/App.svelte
@@ -6,11 +6,14 @@
   import SessionsPanel from './lib/components/sessions/SessionsPanel.svelte';
   import TopBar from './lib/components/TopBar.svelte';
   import { fetchAnalytics, fetchHealth, fetchStatus } from './lib/api/client';
-  import { fetchSessions } from './lib/api/sessions';
+  import { fetchSessions, searchSessions } from './lib/api/sessions';
   import { FAST_POLL_INTERVAL_MS, SLOW_POLL_INTERVAL_MS } from './lib/constants';
   import { analyticsRangeStore } from './lib/state/monitor';
   import {
+    failedSessionSearch,
     filteredSessionsStore,
+    idleSessionSearch,
+    sessionSearchStore,
     sessionsCursorStore,
     sessionsErrorStore,
     sessionsFilterStore,
@@ -31,6 +34,13 @@
 
   const SESSIONS_POLL_INTERVAL_MS = 30_000;
   const SESSIONS_PAGE_SIZE = 50;
+  /**
+   * Keystroke settle before a search reaches the backend. Every search is a
+   * real BM25 ranking over the whole corpus, so typing must not issue one per
+   * character.
+   */
+  const SEARCH_DEBOUNCE_MS = 250;
+  const SEARCH_RESULT_LIMIT = 25;
 
   /** Whether the reader has paged past page 1. See `refreshSessions`. */
   let sessionsPaged = false;
@@ -51,6 +61,7 @@
   $: sessionsLoadingMore = $sessionsLoadingMoreStore;
   $: sessionsHasMore = $sessionsHasMoreStore;
   $: sessionsError = $sessionsErrorStore;
+  $: sessionSearch = $sessionSearchStore;
 
   // The harness vocabulary is served, not scraped from the loaded page: with a
   // paged feed, options derived from loaded rows would omit every harness whose
@@ -186,14 +197,94 @@
     setTheme(event.detail);
   }
 
+  /**
+   * Whole-corpus search (issue-599 WI-09).
+   *
+   * The search input is no longer a filter over the loaded page — it is a
+   * server-side ranking over every session this backend may serve. A blank
+   * query clears the results back to `null`, which is what returns the panel to
+   * the time-ordered feed; setting `[]` there would render as "nothing matched".
+   */
+  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Bumped by every search so a late response cannot overwrite a newer one. */
+  let searchGeneration = 0;
+
+  function clearSearch(): void {
+    if (searchTimer !== null) {
+      clearTimeout(searchTimer);
+      searchTimer = null;
+    }
+    searchGeneration += 1;
+    sessionSearchStore.set({ ...idleSessionSearch });
+  }
+
+  async function runSearch(query: string): Promise<void> {
+    const generation = ++searchGeneration;
+    const filter = get(sessionsFilterStore);
+    sessionSearchStore.update((state) => ({
+      ...state,
+      query,
+      loading: true,
+      error: null,
+      errorKind: null,
+    }));
+    try {
+      const page = await searchSessions(query, {
+        limit: SEARCH_RESULT_LIMIT,
+        harness: filter.harness === 'all' ? null : filter.harness,
+      });
+      if (generation !== searchGeneration) return;
+      sessionSearchStore.set({
+        query,
+        results: page.sessions,
+        loading: false,
+        error: null,
+        errorKind: null,
+        truncated: page.truncated,
+        hitsTruncated: page.hitsTruncated,
+        incomplete: page.incomplete,
+        dropped: page.dropped,
+      });
+    } catch (error) {
+      if (generation !== searchGeneration) return;
+      // No fallback to a local filter: answering a failed search with a
+      // page-local title match would report a subset of one page as the
+      // corpus-wide answer. `failedSessionSearch` owns what a failure looks
+      // like — in particular that `results` stays `null` — so the rule is
+      // testable rather than living in this `catch`.
+      sessionSearchStore.set(failedSessionSearch(query, error));
+    }
+  }
+
+  function scheduleSearch(query: string): void {
+    if (searchTimer !== null) {
+      clearTimeout(searchTimer);
+    }
+    searchTimer = setTimeout(() => {
+      searchTimer = null;
+      void runSearch(query);
+    }, SEARCH_DEBOUNCE_MS);
+  }
+
   function handleFilterChange(event: CustomEvent<SessionsFilter>): void {
     const previous = get(sessionsFilterStore);
-    sessionsFilterStore.set(event.detail);
+    const next = event.detail;
+    sessionsFilterStore.set(next);
+
+    const query = next.query.trim();
+    const harnessChanged = previous.harness !== next.harness;
     // `harness` narrows the query the server runs, so it cannot be answered
     // from the loaded pages alone: changing it restarts the feed from page 1.
-    // `status` and `query` are page-local and need no round trip.
-    if (previous.harness !== event.detail.harness) {
+    // `status` is the only control still answered locally.
+    if (harnessChanged) {
       void loadSessions();
+    }
+    if (query === '') {
+      clearSearch();
+    } else if (previous.query.trim() !== query || harnessChanged) {
+      // A harness change re-runs the active search too: the server applies it,
+      // so the previous results answer a different question.
+      scheduleSearch(query);
     }
   }
 
@@ -219,6 +310,10 @@
       window.clearInterval(fastInterval);
       window.clearInterval(slowInterval);
       window.clearInterval(sessionsInterval);
+      if (searchTimer !== null) {
+        clearTimeout(searchTimer);
+        searchTimer = null;
+      }
     };
   });
 </script>
@@ -246,6 +341,7 @@
       loadingMore={sessionsLoadingMore}
       hasMore={sessionsHasMore}
       errorMessage={sessionsError}
+      search={sessionSearch}
       on:filterChange={handleFilterChange}
       on:loadMore={loadMoreSessions}
     />

--- a/web/monitor/src/lib/api/sessions.test.ts
+++ b/web/monitor/src/lib/api/sessions.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { SessionSummary, SessionTurn } from '../types/sessions';
-import { MonitorApiError, fetchSessionPage, fetchSessions } from './sessions';
+import { MonitorApiError, fetchSessionPage, fetchSessions, searchSessions } from './sessions';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -233,5 +233,122 @@ describe('fetchSessionPage', () => {
       (rejection: unknown) => rejection,
     );
     expect((error as MonitorApiError).code).toBe('canonical_reader_unavailable');
+  });
+});
+
+
+describe('searchSessions', () => {
+  it('asks the server to rank the whole corpus and returns summary rows', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        ok: true,
+        read_model: 'live',
+        query: 'projection runaway',
+        terms: ['projection', 'runaway'],
+        sessions: [summary('best-match'), summary('second')],
+        limit: 25,
+        result_count: 2,
+        truncated: true,
+        hits_truncated: false,
+        incomplete: false,
+        dropped: false,
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const page = await searchSessions('  projection runaway  ', { limit: 25, harness: 'codex' });
+
+    expect(page.sessions).toEqual([summary('best-match'), summary('second')]);
+    expect(page.query).toBe('projection runaway');
+    expect(page.truncated).toBe(true);
+    expect(page.incomplete).toBe(false);
+
+    const url = requestedUrl(fetchMock);
+    expect(url.pathname).toBe('/api/v1/sessions/search');
+    // The whole point of WI-09: the query goes to the server, not to a
+    // predicate over the loaded page.
+    expect(url.searchParams.get('q')).toBe('projection runaway');
+    expect(url.searchParams.get('limit')).toBe('25');
+    expect(url.searchParams.get('harness')).toBe('codex');
+    // A cleared filter is absent, not an empty value that would match nothing.
+    expect(url.searchParams.has('source')).toBe(false);
+  });
+
+  it('preserves the ranked order the server returned', async () => {
+    // The best match is deliberately the OLDEST session, so any recency sort
+    // sneaking back in would reorder this.
+    const oldest = { ...summary('best-match'), endedAt: 1_500_000_000_000 };
+    const newest = { ...summary('second'), endedAt: 1_900_000_000_000 };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse({ ok: true, sessions: [oldest, newest] })),
+    );
+
+    const page = await searchSessions('projection');
+    expect(page.sessions.map((s) => s.id)).toEqual(['best-match', 'second']);
+  });
+
+  // The four signals mean four different things and have different remedies.
+  // The matrix is exhaustive so a field wired to its neighbour cannot survive.
+  it('carries every bounded-answer signal through independently', async () => {
+    for (let bits = 0; bits < 16; bits += 1) {
+      const wire = {
+        truncated: (bits & 1) !== 0,
+        hits_truncated: (bits & 2) !== 0,
+        incomplete: (bits & 4) !== 0,
+        dropped: (bits & 8) !== 0,
+      };
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(jsonResponse({ ok: true, sessions: [], ...wire })),
+      );
+
+      const page = await searchSessions('projection');
+      expect(page.sessions).toEqual([]);
+      expect(page.truncated, `bits=${bits}`).toBe(wire.truncated);
+      expect(page.hitsTruncated, `bits=${bits}`).toBe(wire.hits_truncated);
+      expect(page.incomplete, `bits=${bits}`).toBe(wire.incomplete);
+      expect(page.dropped, `bits=${bits}`).toBe(wire.dropped);
+    }
+  });
+
+  // A server that has not yet learned these fields must not be read as
+  // "definitely not truncated" — but the honest default for an absent optional
+  // boolean is `false`, and the server always sends them.
+  it('defaults every absent bounded-answer signal to false', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ ok: true, sessions: [] })));
+    const page = await searchSessions('projection');
+    expect(page).toMatchObject({
+      truncated: false,
+      hitsTruncated: false,
+      incomplete: false,
+      dropped: false,
+    });
+  });
+
+  it('throws with the server classification rather than degrading to a local filter', async () => {
+    for (const [status, code] of [
+      [504, 'deadline_exceeded'],
+      [429, 'resource_exhausted'],
+      [400, 'invalid_request'],
+      // The repository owns the tokenizer, so "your query has no searchable
+      // term" arrives as a 400 with its own code — a hint, not an outage.
+      [400, 'invalid_argument'],
+    ] as const) {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(jsonResponse({ ok: false, error: `boom ${code}`, code }, status)),
+      );
+
+      const error = await searchSessions('projection').then(
+        () => {
+          throw new Error(`expected ${status} to reject`);
+        },
+        (rejection: unknown) => rejection,
+      );
+      expect(error).toBeInstanceOf(MonitorApiError);
+      expect((error as MonitorApiError).status).toBe(status);
+      expect((error as MonitorApiError).code).toBe(code);
+    }
   });
 });

--- a/web/monitor/src/lib/api/sessions.ts
+++ b/web/monitor/src/lib/api/sessions.ts
@@ -1,5 +1,6 @@
 import type {
   SessionPageResponse,
+  SessionSearchResponse,
   SessionSummary,
   SessionTranscript,
   SessionTurn,
@@ -47,6 +48,43 @@ export interface FetchSessionPageParams {
   /** A `next_cursor` from a previous page of the same session. */
   cursor?: string | null;
 }
+
+export interface SearchSessionsParams {
+  harness?: string | null;
+  source?: string | null;
+  limit?: number;
+}
+
+/**
+ * The four bounded-answer signals, kept distinct because they have different
+ * remedies. `truncated` is answered by raising `limit`; `hitsTruncated`,
+ * `incomplete` and `dropped` are not.
+ */
+export interface SessionSearchPage {
+  /** The query the server actually ranked, after trimming. */
+  query: string;
+  /** Ranked best-first. The SAME summary objects `fetchSessions` returns. */
+  sessions: SessionSummary[];
+  /** SESSION grain: more ranked sessions existed than the bound returned. */
+  truncated: boolean;
+  /**
+   * HIT grain: the ranking filled its event-hit budget, so matching events
+   * existed that it never examined. A term matching one session thirty times
+   * sets this and leaves `truncated` false.
+   */
+  hitsTruncated: boolean;
+  /** The ranking's bounded candidate window was exhausted first (#597 §1.6). */
+  incomplete: boolean;
+  /**
+   * Ranked sessions were removed by the server's exact post-ranking re-check
+   * and nothing refilled them, so this answer is a strict subset of what was
+   * ranked rather than everything that matched.
+   */
+  dropped: boolean;
+}
+
+/** Ranked sessions per search. The route clamps to `1..=50`, then to the backend's `max_results`. */
+const DEFAULT_SEARCH_LIMIT = 25;
 
 export interface SessionTurnPage {
   /** Absent when the server asked for a reopen. */
@@ -131,6 +169,57 @@ export async function fetchSessions(params: FetchSessionsParams = {}): Promise<S
     hasMore: data.has_more ?? nextCursor !== null,
     window: data.window ?? null,
     limit: data.limit ?? limit,
+  };
+}
+
+/**
+ * Whole-corpus session search.
+ *
+ * This is what replaced the page-local `query` filter (issue-599 WI-09). The
+ * server ranks message content across every session this backend may serve, and
+ * returns session SUMMARIES — no snippets, no transcripts — so the response
+ * stays flat as the corpus grows and a result opens through the same
+ * `fetchSessionPage` reader a listed session does.
+ *
+ * The caller is responsible for debouncing; every call is a real backend
+ * ranking.
+ */
+export async function searchSessions(
+  query: string,
+  params: SearchSessionsParams = {},
+): Promise<SessionSearchPage> {
+  const search = new URLSearchParams({
+    q: query.trim(),
+    limit: String(params.limit ?? DEFAULT_SEARCH_LIMIT),
+  });
+  appendOptional(search, 'harness', params.harness);
+  appendOptional(search, 'source', params.source);
+
+  const response = await fetch(`/api/v1/sessions/search?${search.toString()}`, {
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    throw await failure(response);
+  }
+
+  const data = (await response.json()) as SessionSearchResponse;
+  if (!data.ok || !Array.isArray(data.sessions)) {
+    throw new MonitorApiError(
+      data.error || 'malformed session search response',
+      response.status,
+      data.code ?? null,
+    );
+  }
+
+  return {
+    query: data.query ?? query.trim(),
+    // Ranked order is the server's answer. Never re-sort it here: relevance is
+    // the whole point of the route, and recency ordering would discard it.
+    sessions: data.sessions,
+    truncated: data.truncated ?? false,
+    hitsTruncated: data.hits_truncated ?? false,
+    incomplete: data.incomplete ?? false,
+    dropped: data.dropped ?? false,
   };
 }
 

--- a/web/monitor/src/lib/components/sessions/FilterBar.svelte
+++ b/web/monitor/src/lib/components/sessions/FilterBar.svelte
@@ -1,11 +1,33 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import { sessionCountLabel } from '../../state/sessions';
   import type { SessionsFilter } from '../../types/sessions';
 
   export let filter: SessionsFilter;
   /** The harness vocabulary served by `/api/v1/status`, not scraped from the loaded page. */
   export let harnesses: string[] = [];
+  /** Rows on screen, i.e. AFTER the client-side `status` narrowing. */
   export let count = 0;
+  /**
+   * Rows the SERVER's ranking answered with, before local narrowing; `null`
+   * when no search is in effect.
+   *
+   * This is the population `truncated` / `hitsTruncated` / `incomplete` /
+   * `dropped` all describe, and it is why the count and the qualifier cannot be
+   * derived from the same number.
+   */
+  export let resultCount: number | null = null;
+  export let searchLoading = false;
+  /** A search was attempted and did not answer. Nothing may be counted. */
+  export let searchFailed = false;
+  /** SESSION grain: more ranked sessions existed than the server returned. */
+  export let truncated = false;
+  /** HIT grain: the ranking filled its event-hit budget. */
+  export let hitsTruncated = false;
+  /** The ranking's bounded candidate window was exhausted first (#597 §1.6). */
+  export let incomplete = false;
+  /** The server's exact re-check removed ranked sessions and did not refill. */
+  export let dropped = false;
 
   // The server derives exactly these two (`completed` flag, else the activity
   // window). `cancelled` and `error` were offered here and have never been
@@ -17,17 +39,32 @@
   function update(next: Partial<SessionsFilter>): void {
     dispatch('change', { ...filter, ...next });
   }
+
+  // The label is a pure function in `state/sessions.ts`, not an expression
+  // here: it has to reason about two different populations (rows on screen vs
+  // the server's answer) and that decision deserves a test of its own.
+  $: countLabel = sessionCountLabel({
+    rendered: count,
+    serverResults: resultCount,
+    searchLoading,
+    searchFailed,
+    truncated,
+    hitsTruncated,
+    incomplete,
+    dropped,
+  });
 </script>
 
 <div class="mv-filterbar">
   <div class="mv-search">
     <span class="mv-search-icon" aria-hidden="true">⌕</span>
-    <!-- Honest label: the feed carries no message content, so this narrows the
-         loaded pages by label and id. Whole-corpus search arrives with #597. -->
+    <!-- Whole-corpus search (issue-599 WI-09): the server ranks message content
+         across every session this backend serves, so the label no longer has to
+         confess to being page-local. -->
     <input
       class="mv-search-input"
-      placeholder="Filter loaded sessions by title or id"
-      aria-label="Filter loaded sessions by title or id"
+      placeholder="Search all sessions by content"
+      aria-label="Search all sessions by content"
       value={filter.query}
       on:input={(e) => update({ query: e.currentTarget.value })}
     />
@@ -61,8 +98,6 @@
         </select>
       </label>
     {/if}
-    <!-- "loaded", never "{count} / {total}": the feed is paged and reports no
-         corpus total, so a ratio here would invent a denominator. -->
-    <span class="mv-filter-count mono">{count} loaded</span>
+    <span class="mv-filter-count mono">{countLabel}</span>
   </div>
 </div>

--- a/web/monitor/src/lib/components/sessions/SessionsPanel.svelte
+++ b/web/monitor/src/lib/components/sessions/SessionsPanel.svelte
@@ -2,6 +2,7 @@
   import { createEventDispatcher } from 'svelte';
   import FilterBar from './FilterBar.svelte';
   import V1Library from './variations/V1Library.svelte';
+  import { idleSessionSearch, type SessionSearchState } from '../../state/sessions';
   import type { SessionSummary, SessionsFilter } from '../../types/sessions';
 
   export let sessions: SessionSummary[] = [];
@@ -12,12 +13,31 @@
   export let loadingMore = false;
   export let hasMore = false;
   export let errorMessage: string | null = null;
+  export let search: SessionSearchState = idleSessionSearch;
 
   const dispatch = createEventDispatcher<{ filterChange: SessionsFilter; loadMore: void }>();
 
   function handleFilter(next: SessionsFilter): void {
     dispatch('filterChange', next);
   }
+
+  /** A search is in effect exactly when the server has answered one. */
+  $: searching = search.results !== null;
+  /**
+   * A search was attempted and did not answer.
+   *
+   * This is its own render state, not "a search that returned nothing": the
+   * corpus was never searched, so neither the ranked-results empty state nor
+   * the feed's own empty state may be shown, and no result count may be
+   * printed. Both would assert something about the corpus that this request
+   * never established.
+   */
+  $: searchFailed = search.error !== null;
+  // "Load more" pages the time-ordered feed, and its cursor belongs to that
+  // query. A ranking is bounded rather than paged, so the affordance would
+  // answer a different question; `truncated` is what tells the reader a ranking
+  // was cut off.
+  $: showLoadMore = hasMore && !searching && !search.loading && !searchFailed;
 </script>
 
 <section class="panel mv-root" id="sessionsPanel">
@@ -32,16 +52,40 @@
     <div class="mv-empty" role="status" aria-live="polite">{errorMessage}</div>
   {/if}
 
-  <FilterBar {filter} {harnesses} count={filtered.length} on:change={(e) => handleFilter(e.detail)} />
+  <!-- `count` is what is on screen; `resultCount` is what the server answered
+       with. The bounded-answer flags describe the second, so the bar needs both
+       or it attaches a server fact to a locally narrowed number. -->
+  <FilterBar
+    {filter}
+    {harnesses}
+    count={filtered.length}
+    resultCount={search.results?.length ?? null}
+    searchLoading={search.loading}
+    {searchFailed}
+    truncated={search.truncated}
+    hitsTruncated={search.hitsTruncated}
+    incomplete={search.incomplete}
+    dropped={search.dropped}
+    on:change={(e) => handleFilter(e.detail)}
+  />
 
-  {#if loading && sessions.length === 0}
+  {#if searchFailed}
+    <!-- The dedicated failure state. It replaces the list rather than sitting
+         above it: a rendered list beside "Search unavailable" reads as the
+         search's answer, and the feed's rows are not that. -->
+    <div class="mv-empty mv-search-failure" role="status" aria-live="polite">
+      {search.error}
+    </div>
+  {:else if loading && sessions.length === 0 && !searching}
     <div class="mv-empty">Loading sessions…</div>
+  {:else if search.loading && !searching}
+    <div class="mv-empty">Searching all sessions…</div>
   {:else}
-    <V1Library sessions={filtered} />
+    <V1Library sessions={filtered} {searching} />
     <!-- The feed reports whether more exist; without this affordance a loaded
          page would read as the whole corpus. An empty page with `hasMore` is a
          legal "keep paging" signal, so the button appears even with no rows. -->
-    {#if hasMore}
+    {#if showLoadMore}
       <div class="mv-loadmore">
         <button
           class="mv-loadmore-btn"

--- a/web/monitor/src/lib/components/sessions/variations/V1Library.svelte
+++ b/web/monitor/src/lib/components/sessions/variations/V1Library.svelte
@@ -14,6 +14,8 @@
    * traversal with the cursor the previous page minted.
    */
   export let sessions: SessionSummary[];
+  /** Whether these rows are ranked search results rather than the feed. */
+  export let searching = false;
 
   const TURN_PAGE_SIZE = 25;
 
@@ -135,7 +137,11 @@
 <div class="mv-v1">
   <div class="mv-v1-list mv-list">
     {#if sessions.length === 0}
-      <div class="mv-empty">No sessions match these filters.</div>
+      <div class="mv-empty">
+        {searching
+          ? 'No sessions match this search.'
+          : 'No sessions match these filters.'}
+      </div>
     {/if}
     {#each sessions as session (session.id)}
       <SessionCard

--- a/web/monitor/src/lib/state/sessions.test.ts
+++ b/web/monitor/src/lib/state/sessions.test.ts
@@ -1,6 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { afterEach, describe, expect, it } from 'vitest';
+import { MonitorApiError } from '../api/sessions';
 import type { SessionSummary, SessionsFilter } from '../types/sessions';
-import { filterSessions } from './sessions';
+import {
+  failedSessionSearch,
+  filteredSessionsStore,
+  idleSessionSearch,
+  narrowSessions,
+  sessionCountLabel,
+  sessionSearchStore,
+  sessionsFilterStore,
+  sessionsStore,
+  type SessionCountLabelInput,
+} from './sessions';
 
 function summary(overrides: Partial<SessionSummary> = {}): SessionSummary {
   return {
@@ -27,55 +39,221 @@ function filter(overrides: Partial<SessionsFilter> = {}): SessionsFilter {
   return { query: '', status: 'all', harness: 'all', ...overrides };
 }
 
-describe('filterSessions', () => {
-  it('matches the labels and identifiers the feed actually carries', () => {
-    const sessions = [
-      summary({ id: 'a' }),
-      // No title: the server's synthesized label is the only thing to match on.
-      summary({
-        id: 'b',
-        title: null,
-        displayLabel: 'codex, tool calling, Feb 16 12:00 UTC, 3 turns',
-        sessionSlug: null,
-        sessionSummary: null,
-      }),
-      summary({
-        id: 'sess-9f3',
-        title: 'Unrelated',
-        displayLabel: 'Unrelated',
-        sessionSlug: 'unrelated',
-        sessionSummary: 'ingest backfill',
-      }),
-    ];
+afterEach(() => {
+  sessionsStore.set([]);
+  sessionSearchStore.set({ ...idleSessionSearch });
+  sessionsFilterStore.set(filter());
+});
 
-    expect(filterSessions(sessions, filter({ query: 'repository' })).map((s) => s.id)).toEqual(['a']);
-    expect(filterSessions(sessions, filter({ query: 'tool calling' })).map((s) => s.id)).toEqual(['b']);
-    expect(filterSessions(sessions, filter({ query: 'backfill' })).map((s) => s.id)).toEqual([
-      'sess-9f3',
-    ]);
-    // The id itself is matchable, which is how an operator pastes one in.
-    expect(filterSessions(sessions, filter({ query: '9f3' })).map((s) => s.id)).toEqual(['sess-9f3']);
-  });
-
-  it('cannot match message content, because the feed carries none', () => {
-    // The removed transcript branch searched `turn.steps[].text`. Nothing in a
-    // summary holds message bodies, so a content query matches nothing — which
-    // is why the input is labelled as filtering loaded sessions, not prompts.
-    const sessions = [summary({ id: 'a' })];
-    expect(filterSessions(sessions, filter({ query: 'workspace = true' }))).toEqual([]);
-  });
-
+describe('narrowSessions', () => {
   it('narrows by the two statuses the server can produce', () => {
     const sessions = [
       summary({ id: 'a', status: 'active' }),
       summary({ id: 'b', status: 'completed' }),
     ];
-    expect(filterSessions(sessions, filter({ status: 'active' })).map((s) => s.id)).toEqual(['a']);
-    expect(filterSessions(sessions, filter({ status: 'completed' })).map((s) => s.id)).toEqual(['b']);
+    expect(narrowSessions(sessions, filter({ status: 'active' })).map((s) => s.id)).toEqual(['a']);
+    expect(narrowSessions(sessions, filter({ status: 'completed' })).map((s) => s.id)).toEqual([
+      'b',
+    ]);
   });
 
   it('treats a session with no recorded harness as matching no harness filter', () => {
     const sessions = [summary({ id: 'a', harness: null }), summary({ id: 'b', harness: 'codex' })];
-    expect(filterSessions(sessions, filter({ harness: 'codex' })).map((s) => s.id)).toEqual(['b']);
+    expect(narrowSessions(sessions, filter({ harness: 'codex' })).map((s) => s.id)).toEqual(['b']);
+  });
+
+  it('does not filter on the query, because the query is a server search', () => {
+    // The deleted page-local branch matched title/label/slug/id. Re-applying it
+    // to a ranked result set would drop every session that matched on message
+    // content — precisely the set whole-corpus search exists to find, and whose
+    // matching text appears in no field the client ever receives.
+    const sessions = [
+      summary({ id: 'a', title: 'Inspect the repository' }),
+      summary({
+        id: 'b',
+        title: 'Unrelated title',
+        displayLabel: 'Unrelated title',
+        sessionSlug: null,
+        sessionSummary: null,
+      }),
+    ];
+    expect(
+      narrowSessions(sessions, filter({ query: 'nothing here matches any label' })).map((s) => s.id),
+    ).toEqual(['a', 'b']);
+  });
+});
+
+describe('filteredSessionsStore', () => {
+  it('renders the time-ordered feed, newest first, when no search is in effect', () => {
+    sessionsStore.set([
+      summary({ id: 'older', endedAt: 1_700_000_000_000 }),
+      summary({ id: 'newer', endedAt: 1_700_000_009_000 }),
+    ]);
+    expect(get(filteredSessionsStore).map((s) => s.id)).toEqual(['newer', 'older']);
+  });
+
+  it('renders search results in the order the server ranked them', () => {
+    // The feed sorts by recency. A ranking does not, and re-sorting it would
+    // throw away the relevance the search was issued for: the best match here
+    // is deliberately the OLDEST session.
+    sessionsStore.set([summary({ id: 'feed-row' })]);
+    sessionSearchStore.set({
+      ...idleSessionSearch,
+      query: 'projection',
+      results: [
+        summary({ id: 'best-match', endedAt: 1_600_000_000_000 }),
+        summary({ id: 'second', endedAt: 1_700_000_009_000 }),
+      ],
+    });
+    expect(get(filteredSessionsStore).map((s) => s.id)).toEqual(['best-match', 'second']);
+  });
+
+  it('distinguishes an unsearched panel from a search that matched nothing', () => {
+    sessionsStore.set([summary({ id: 'feed-row' })]);
+
+    // `null` results: no search in effect, so the feed shows.
+    expect(get(filteredSessionsStore).map((s) => s.id)).toEqual(['feed-row']);
+
+    // `[]` results: the corpus WAS searched and nothing matched. Falling back
+    // to the feed here would present unrelated sessions as the answer.
+    sessionSearchStore.set({ ...idleSessionSearch, query: 'nothing', results: [] });
+    expect(get(filteredSessionsStore)).toEqual([]);
+  });
+
+  // A FAILED search searched nothing, so it is neither of the two states above.
+  // Setting `results` to `[]` here is what made the panel print "No sessions
+  // match this search." beside "Search unavailable" — the corpus-wide claim the
+  // server refuses to make even for a blank query.
+  //
+  // MUTATION: return `results: []` from `failedSessionSearch`; this fails.
+  it('a failed search is not a search that matched nothing', () => {
+    const state = failedSessionSearch(
+      'projection',
+      new MonitorApiError('deadline', 504, 'deadline_exceeded'),
+    );
+    expect(state.results).toBeNull();
+    expect(state.error).toBe('Search unavailable: deadline');
+    expect(state.errorKind).toBe('unavailable');
+
+    // And the panel's own "is a search in effect" predicate reads it as "no",
+    // so the ranked-results empty state is unreachable from a failure.
+    sessionsStore.set([summary({ id: 'feed-row' })]);
+    sessionSearchStore.set(state);
+    expect(get(sessionSearchStore).results === null).toBe(true);
+  });
+
+  // The backend owns the tokenizer, so "your query has no searchable term" is
+  // its 400, not an outage. Rendering it as one told a reader the store was
+  // down when they had typed one character, permanently and unrecoverably.
+  //
+  // MUTATION: drop the `error.status === 400` branch in `failedSessionSearch`;
+  // this fails on both the kind and the un-prefixed message.
+  it('classifies a rejected query as a hint and everything else as an outage', () => {
+    const rejected = failedSessionSearch(
+      'x',
+      new MonitorApiError(
+        'session search failed: query has no searchable terms',
+        400,
+        'invalid_argument',
+      ),
+    );
+    expect(rejected.errorKind).toBe('invalid');
+    // Rendered verbatim: the rule belongs to the server and is not restated
+    // here, so no local copy can drift from it.
+    expect(rejected.error).toBe('session search failed: query has no searchable terms');
+    expect(rejected.error).not.toContain('unavailable');
+    expect(rejected.results).toBeNull();
+
+    for (const status of [429, 503, 504]) {
+      const outage = failedSessionSearch('projection', new MonitorApiError('boom', status, null));
+      expect(outage.errorKind, `status=${status}`).toBe('unavailable');
+      expect(outage.error, `status=${status}`).toBe('Search unavailable: boom');
+    }
+
+    // A transport failure is not a `MonitorApiError` at all.
+    const offline = failedSessionSearch('projection', new TypeError('Failed to fetch'));
+    expect(offline.errorKind).toBe('unavailable');
+    expect(offline.error).toBe('Search unavailable: Failed to fetch');
+  });
+
+  it('still applies the client-answerable filters to search results', () => {
+    sessionSearchStore.set({
+      ...idleSessionSearch,
+      query: 'projection',
+      results: [
+        summary({ id: 'active-hit', status: 'active' }),
+        summary({ id: 'completed-hit', status: 'completed' }),
+      ],
+    });
+    sessionsFilterStore.set(filter({ query: 'projection', status: 'active' }));
+    expect(get(filteredSessionsStore).map((s) => s.id)).toEqual(['active-hit']);
+  });
+});
+
+describe('sessionCountLabel', () => {
+  function label(overrides: Partial<SessionCountLabelInput> = {}): string {
+    return sessionCountLabel({
+      rendered: 0,
+      serverResults: null,
+      searchLoading: false,
+      searchFailed: false,
+      truncated: false,
+      hitsTruncated: false,
+      incomplete: false,
+      dropped: false,
+      ...overrides,
+    });
+  }
+
+  it('counts the paged feed as "loaded" and invents no denominator', () => {
+    // The feed reports no corpus total, so a `{count} / {total}` ratio here
+    // would be a number the server never emitted.
+    expect(label({ rendered: 2 })).toBe('2 loaded');
+    expect(label({ rendered: 0 })).toBe('0 loaded');
+  });
+
+  it('qualifies a search only when the qualifier and the count describe one population', () => {
+    // Nothing narrowed locally: the rows on screen ARE the server's answer, so
+    // the server's fact about that answer attaches to the number shown.
+    expect(label({ rendered: 3, serverResults: 3, truncated: true })).toBe('3 results (top matches)');
+    expect(label({ rendered: 1, serverResults: 1, hitsTruncated: true })).toBe('1 result (top matches)');
+    expect(label({ rendered: 4, serverResults: 4, incomplete: true })).toBe('4 results (partial)');
+    expect(label({ rendered: 4, serverResults: 4, dropped: true })).toBe('4 results (partial)');
+    expect(label({ rendered: 2, serverResults: 2 })).toBe('2 results');
+  });
+
+  // THE GUARD. `status` narrows locally; `truncated` is a fact about what the
+  // RANKING returned. Printing "3 results (top matches)" when the server
+  // answered 25 and the status filter hid 22 asserts the ranking found more
+  // than those 3 — against a denominator the ranking never emitted, with a
+  // remedy ("raise the limit") that would not bring the 22 back.
+  //
+  // MUTATION: drop the `rendered !== serverResults` branch from
+  // `sessionCountLabel`; this fails.
+  //
+  // The WIRING is a different mutation with a different guard: passing `count`
+  // for `serverResults` in `FilterBar.svelte` leaves this file green — the
+  // label is a pure function and this test calls it directly — and is caught
+  // instead by `a failed search is reported, never answered from the loaded
+  // page` in the mocked Playwright suite. Both were run; neither covers the
+  // other.
+  it('never attaches a server qualifier to a locally narrowed count', () => {
+    expect(
+      label({ rendered: 3, serverResults: 25, truncated: true, hitsTruncated: true }),
+    ).toBe('3 of 25 results');
+    expect(label({ rendered: 0, serverResults: 25, dropped: true })).toBe('0 of 25 results');
+    // The denominator is the server's own count, so it is not invented.
+    expect(label({ rendered: 1, serverResults: 2, incomplete: true })).toBe('1 of 2 results');
+  });
+
+  it('counts nothing at all for a search that is running or failed', () => {
+    // A failed search searched nothing: "0 results" would be a claim about the
+    // corpus and "N loaded" would label rows that are not on screen.
+    expect(label({ rendered: 7, serverResults: null, searchFailed: true })).toBe(
+      'search did not run',
+    );
+    // …including when a previous answer is still in `results`.
+    expect(label({ rendered: 7, serverResults: 7, searchFailed: true })).toBe('search did not run');
+    expect(label({ rendered: 7, serverResults: 7, searchLoading: true })).toBe('searching…');
   });
 });

--- a/web/monitor/src/lib/state/sessions.ts
+++ b/web/monitor/src/lib/state/sessions.ts
@@ -1,4 +1,5 @@
 import { derived, writable } from 'svelte/store';
+import { MonitorApiError } from '../api/sessions';
 import type { SessionSummary, SessionsFilter } from '../types/sessions';
 
 export const sessionsStore = writable<SessionSummary[]>([]);
@@ -22,46 +23,202 @@ export const sessionsFilterStore = writable<SessionsFilter>({
   harness: 'all',
 });
 
+/**
+ * Why a search produced no results.
+ *
+ * `invalid` is the server rejecting the QUERY (HTTP 400): the backend owns the
+ * tokenizer, so it — not this client — decides that a string carries no
+ * searchable term, and it is a hint to retype, not an outage. `unavailable` is
+ * everything else: a deadline, an exhausted budget, an unreachable store.
+ * Rendering the first as the second told a reader the store was down when they
+ * had typed one character.
+ */
+export type SessionSearchFailure = 'invalid' | 'unavailable';
+
+/**
+ * The state of the whole-corpus search (issue-599 WI-09).
+ *
+ * `results` is `null` when no search is in effect **and when one failed** —
+ * deliberately distinct from `[]`, which means "the corpus was searched and
+ * nothing matched". A failed search that set `[]` would make the panel print
+ * "No sessions match this search." and "0 results" beside the failure banner,
+ * which is exactly the false statement the server's blank-`q` refusal exists to
+ * prevent.
+ */
+export interface SessionSearchState {
+  /** The query these results belong to; empty when no search is in effect. */
+  query: string;
+  results: SessionSummary[] | null;
+  loading: boolean;
+  error: string | null;
+  /** How to render `error`; `null` exactly when `error` is `null`. */
+  errorKind: SessionSearchFailure | null;
+  /** SESSION grain: more ranked sessions existed than the server returned. */
+  truncated: boolean;
+  /** HIT grain: the ranking filled its event-hit budget. */
+  hitsTruncated: boolean;
+  /** The ranking's bounded candidate window was exhausted first (#597 §1.6). */
+  incomplete: boolean;
+  /** The server's exact re-check removed ranked sessions and did not refill. */
+  dropped: boolean;
+}
+
+export const idleSessionSearch: SessionSearchState = {
+  query: '',
+  results: null,
+  loading: false,
+  error: null,
+  errorKind: null,
+  truncated: false,
+  hitsTruncated: false,
+  incomplete: false,
+  dropped: false,
+};
+
+export const sessionSearchStore = writable<SessionSearchState>({ ...idleSessionSearch });
+
+/**
+ * The state a FAILED search must produce.
+ *
+ * Extracted so the two decisions in it are testable rather than buried in a
+ * component's `catch`:
+ *
+ * 1. **`results` stays `null`.** A failed search searched nothing. Setting `[]`
+ *    puts the panel into the "the corpus was searched and nothing matched"
+ *    state, which renders "No sessions match this search." and "0 results"
+ *    beside the failure banner — the corpus-wide claim the server refuses to
+ *    make even for a blank query.
+ * 2. **A `400` is a hint, not an outage.** The backend owns the tokenizer, so
+ *    it decides that a query carries no searchable term, and it is the one that
+ *    writes the message. This client renders that message as-is and does not
+ *    restate or re-derive the rule; a local copy of the tokenizer's rules would
+ *    drift from the server's.
+ */
+export function failedSessionSearch(query: string, error: unknown): SessionSearchState {
+  const invalid = error instanceof MonitorApiError && error.status === 400;
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    ...idleSessionSearch,
+    query,
+    results: null,
+    error: invalid ? message : `Search unavailable: ${message}`,
+    errorKind: invalid ? 'invalid' : 'unavailable',
+  };
+}
+
 export const activeSessionIdStore = writable<string | null>(null);
 
 /**
- * Narrow the sessions ALREADY LOADED.
+ * Narrow a rendered set of sessions by the controls the CLIENT can answer.
  *
- * `query` matches labels and identifiers only. Message content is not in the
- * feed and is not fetched to answer a keystroke, so this cannot search
- * transcripts — the filter input says so. Whole-corpus search arrives with
- * issue #597; until then this is page-local by construction.
+ * `status` is derived from fields the summary already carries, so applying it
+ * here costs nothing and is exact. `harness` is applied here for instant
+ * feedback and is ALSO pushed to the server, which is what makes it correct
+ * beyond the loaded page.
  *
- * `harness` and `status` are applied here too so a filter change is instant on
- * what is loaded; `harness` is additionally pushed to the server, which is what
- * makes it correct across pages.
+ * `query` is deliberately absent. It is a whole-corpus server search
+ * (`/api/v1/sessions/search`), and re-applying it locally would drop exactly
+ * the results the search exists to find: a session that matched on a message
+ * body carries that text in no field the client ever sees.
  */
-export function filterSessions(
+export function narrowSessions(
   sessions: SessionSummary[],
   filter: SessionsFilter,
 ): SessionSummary[] {
-  const q = filter.query.trim().toLowerCase();
   return sessions.filter((session) => {
     if (filter.status !== 'all' && session.status !== filter.status) return false;
     if (filter.harness !== 'all' && (session.harness ?? '') !== filter.harness) return false;
-    if (!q) return true;
-    return [
-      session.title,
-      session.displayLabel,
-      session.sessionSummary,
-      session.sessionSlug,
-      session.id,
-      session.harness,
-      session.source,
-      session.inferenceProvider,
-    ].some((field) => field?.toLowerCase().includes(q));
+    return true;
   });
 }
 
+/**
+ * What the panel renders: the ranked search results when a search is in effect,
+ * otherwise the time-ordered feed.
+ *
+ * Search results keep the server's ranked order — re-sorting them by recency
+ * would discard the relevance the route was called for. The feed keeps its
+ * recency order.
+ */
 export const filteredSessionsStore = derived(
-  [sessionsStore, sessionsFilterStore],
-  ([$sessions, $filter]) => {
-    const filtered = filterSessions($sessions, $filter);
-    return [...filtered].sort((a, b) => b.endedAt - a.endedAt);
+  [sessionsStore, sessionSearchStore, sessionsFilterStore],
+  ([$sessions, $search, $filter]) => {
+    if ($search.results !== null) {
+      return narrowSessions($search.results, $filter);
+    }
+    const narrowed = narrowSessions($sessions, $filter);
+    return [...narrowed].sort((a, b) => b.endedAt - a.endedAt);
   },
 );
+
+/** What the filter bar's count is describing. */
+export interface SessionCountLabelInput {
+  /** Rows actually on screen, i.e. AFTER `narrowSessions`. */
+  rendered: number;
+  /**
+   * Rows the SERVER answered with, before any local narrowing; `null` when no
+   * search is in effect. This is the population every bounded-answer flag below
+   * describes.
+   */
+  serverResults: number | null;
+  searchLoading: boolean;
+  searchFailed: boolean;
+  truncated: boolean;
+  hitsTruncated: boolean;
+  incomplete: boolean;
+  dropped: boolean;
+}
+
+/**
+ * The filter bar's count label, which must never overstate what it counts.
+ *
+ * The feed is paged and reports no corpus total, so "loaded" — never a
+ * `{count} / {total}` ratio, which would invent a denominator.
+ *
+ * A search DOES have a denominator the server emitted: the number of sessions
+ * it answered with. That matters because the four bounded-answer flags are
+ * facts about the SERVER's answer, while the rows on screen have additionally
+ * been narrowed by `status` locally. Attaching a qualifier to a locally
+ * narrowed count asserts something about a population the ranking never
+ * emitted: with `status: 'active'` and a server answer of 25 of which 3 are
+ * active, "3 results (top matches)" claims the ranking found more than those
+ * 3 — but 22 were hidden here, not truncated there. So:
+ *
+ * * nothing narrowed locally — `N results` plus the qualifier, and `N` IS the
+ *   server's answer;
+ * * narrowed locally — `M of N results`, with NO qualifier. The denominator is
+ *   the server's own count rather than an invented one, and the qualifier is
+ *   dropped rather than misattributed.
+ *
+ * The qualifier itself distinguishes the two things the server reports
+ * separately, because they have different remedies:
+ *
+ * * **top matches** — the ranking found more than it returned, at the SESSION
+ *   grain (`truncated`) or the event-HIT grain (`hitsTruncated`). More exists;
+ *   a wider request reaches further into it.
+ * * **partial** — the answer is shorter than it should be: the ranking's
+ *   candidate window was exhausted (`incomplete`) or the server's exact
+ *   re-check removed ranked sessions and refilled nothing (`dropped`). A wider
+ *   request fixes neither, so this must not read as "top matches", which
+ *   invites exactly that.
+ *
+ * A FAILED search counts nothing at all. It never searched the corpus, so
+ * "0 results" would be a claim about the corpus and "N loaded" would label rows
+ * that are not on screen.
+ */
+export function sessionCountLabel(input: SessionCountLabelInput): string {
+  if (input.searchFailed) return 'search did not run';
+  if (input.searchLoading) return 'searching…';
+  if (input.serverResults === null) return `${input.rendered} loaded`;
+
+  if (input.rendered !== input.serverResults) {
+    return `${input.rendered} of ${input.serverResults} results`;
+  }
+  const qualifier =
+    input.truncated || input.hitsTruncated
+      ? ' (top matches)'
+      : input.incomplete || input.dropped
+        ? ' (partial)'
+        : '';
+  return `${input.rendered} result${input.rendered === 1 ? '' : 's'}${qualifier}`;
+}

--- a/web/monitor/src/lib/types/sessions.ts
+++ b/web/monitor/src/lib/types/sessions.ts
@@ -55,6 +55,33 @@ export interface SessionsResponse {
   code?: string;
 }
 
+/**
+ * `/api/v1/sessions/search` — whole-corpus content search.
+ *
+ * `sessions` are the SAME summary objects the feed returns, in ranked order,
+ * so a result opens through `/api/v1/sessions/:id/page` like any other row.
+ * There is no cursor: a relevance ranking is bounded, not paged.
+ */
+export interface SessionSearchResponse {
+  ok: boolean;
+  read_model?: 'live';
+  query?: string;
+  terms?: string[];
+  sessions?: SessionSummary[];
+  limit?: number;
+  result_count?: number;
+  /** SESSION grain: more ranked sessions existed than the bound returned. */
+  truncated?: boolean;
+  /** HIT grain: the ranking filled its event-hit budget. */
+  hits_truncated?: boolean;
+  /** The ranking's bounded candidate window was exhausted first. */
+  incomplete?: boolean;
+  /** Ranked sessions were removed by the exact re-check and not refilled. */
+  dropped?: boolean;
+  error?: string;
+  code?: string;
+}
+
 /** One turn from `/api/v1/sessions/:id/page`: counts, references, summaries. */
 export interface SessionTurn {
   turnSeq: number;
@@ -105,11 +132,13 @@ export interface SessionPageResponse {
 }
 
 /**
- * Client-side narrowing of the sessions already loaded.
+ * The session-panel controls.
  *
- * `harness` and `status` are the two the server can answer; `query` is
- * page-local by construction (see `filterSessions`) until issue #597 ships a
- * server-side search.
+ * `query` is NOT a client-side filter. It is the whole-corpus search the server
+ * runs (`/api/v1/sessions/search`), debounced by the panel; only `status` is
+ * narrowed on what is already rendered, and `harness` is applied both locally
+ * (for instant feedback) and server-side (which is what makes it correct across
+ * pages and across a search).
  */
 export interface SessionsFilter {
   query: string;


### PR DESCRIPTION
## Description

**What.** WI-09, the last work item of #599: the dashboard's search input now ranks the whole permitted corpus server-side instead of filtering the sessions already on screen.

**Why.** WI-06 shipped a deliberate, time-boxed regression — search filtered only the loaded page's title/id/harness/tags, and said so in its placeholder. It was blocked on #597, which has since landed.

## What changed

- **One route, one reader.** `GET /api/v1/sessions/search` ranks through #597's bounded postings path and returns the same summary objects `/api/v1/sessions` serves, so a result opens through the same `/api/v1/sessions/:id/page` reader. No transcript content on the wire.
- **One authority for what a session is.** `hydrated_session_summary` is the single place applying the blank-id rule, the tombstone rule, the exact project-scope re-check and the exact harness/source re-check; LIST and SEARCH both fold through it.
- **One timestamp.** The directory keyset is the value both surfaces order by, page by, and report. Reporting two different aggregates would let one session render `active` in the feed and `completed` in search, because `status` derives from that field against a 60 s window.
- **Debounced client, honest failures.** 250 ms debounce with a generation guard against late responses; a failed search never renders as an empty corpus.

## Review history

Four adversarial rounds, thirty-two findings, all closed. The blocking ones:

- **A not-ready store answered an empty 200.** Both sibling operations fall back when `canonical_list_path_ready()` is false; the new hydration did not, so a store whose backfill had not started returned a confident "the whole corpus was searched and nothing matched" while the feed still worked.
- **A one-character query rendered "Search unavailable".** `RepoError::InvalidArgument` fell through a `_ => 503` catch-all — the store-is-down class — for a typo. Permanent, not transient, for any query with no ASCII-alphanumeric run of length ≥ 2.
- **The two discovery surfaces disagreed twice**: harness/source narrowed per posting but were never re-checked against the hydrated aggregates; and separating the paging value from the rendered one — the fix for the `status` divergence — broke `docs/mcp-search-interface-spec.md`'s normative promise that the response is sorted by the `updated_at` it reports. Both surfaces now report the directory aggregate, so the spec is untouched and true.
- **The over-fetch was inert in the shipped configuration**, and the expression that replaced it disabled its own ceiling at exactly the route's maximum `limit`, making `truncated` structurally unsettable — while the docs advised raising `limit` as the remedy for `truncated`.

## `MUTATION:` docstrings are executed before they are written

Five shipped docstrings stated recipes that left the suite green. That is a guard that cannot fail wearing the instructions for falsifying it: a contributor follows the repo's own convention, sees green, and concludes the guard is proven. Every recipe now present was run and observed to fail, and the two mutations that legitimately survive say so explicitly.

## Validation

- `cargo test --workspace --locked` — 28 targets, 0 failures
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- monitor `typecheck` 374 files, 0 errors; `vitest` 41/41; mocked Playwright 6/6
- Verified on an isolated copy of the tree, because a concurrent agent was building on the same volume

## Operational impact

New route; no migration, no schema change, no config change. `docs/monitor-http-api.md` gains the route, its bounded-answer signals, and what raising `limit` actually buys.

## References

Completes #599. Depends on #597's bounded search and #598's canonical reader.
