### PR TITLE
feat(601): measure SQLite scans, back off failures, stamp poll triggers

### DIFF
--- a/crates/moraine-ingest-core/src/dispatch.rs
+++ b/crates/moraine-ingest-core/src/dispatch.rs
@@ -5,7 +5,7 @@ use crate::sources::claude_code::cowork_session_path;
 use crate::sources::kiro_cli::{load_kiro_session_metadata, KiroSessionMetadata};
 use crate::sources::shared::{format_record_ts, infer_vendor_from_base_url, parse_record_ts};
 use crate::sqlite_poll::VolatilePollMap;
-use crate::{DispatchState, Metrics, SinkMessage, WorkItem};
+use crate::{DispatchState, Metrics, SinkMessage, WorkItem, WorkTrigger};
 use anyhow::{Context, Result};
 use moraine_config::{is_workflow_journal_path, map_tracked_path, AppConfig, SourceFormat};
 use serde::{Deserialize, Serialize};
@@ -857,8 +857,60 @@ pub(crate) fn spawn_debounce_task(
             tokio::select! {
                 maybe_work = rx.recv() => {
                     match maybe_work {
-                        Some(work) => {
-                            pending.insert(work.key(), (work, Instant::now()));
+                        Some(mut work) => {
+                            let key = work.key();
+                            // **This window is watcher-only.** Its receiver is
+                            // `watch_path_rx`, and the only sender is
+                            // `spawn_watcher_threads`, which funnels every
+                            // event through `WorkItem::watcher` — the crate's
+                            // single `WorkTrigger::Watcher` literal. Reconcile
+                            // ticks and startup backfill bypass the debounce
+                            // and call `enqueue_work` directly, so no reconcile
+                            // tick can ever be merged away *here*.
+                            //
+                            // That is what makes `reconcile_owed` have exactly
+                            // **one** creator, `enqueue_work`'s incoming-
+                            // `Reconcile` path, which is the whole reachability
+                            // argument `complete_work` rests on. An earlier
+                            // revision also owed from this window; that path
+                            // could not fire in production and only its own
+                            // synthetic test drove it, so it is gone rather
+                            // than left as a second, untestable creator.
+                            //
+                            // The assertion below is the invariant, not a
+                            // comment about it: route a `Reconcile` producer
+                            // into this channel and the merge would silently
+                            // discard the tick, so such a change has to bring
+                            // a ledger entry with it.
+                            debug_assert_eq!(
+                                work.trigger,
+                                WorkTrigger::Watcher,
+                                "the debounce window is fed only by the watcher \
+                                 threads; a {:?} producer here would have its \
+                                 trigger merged away with nothing recording it",
+                                work.trigger
+                            );
+                            // Coalescing keeps the least reconciliation-
+                            // eligible trigger (§2.4): merging never *raises*
+                            // the cost of an item already queued behind a
+                            // debounce window. `key()` excludes the trigger, so
+                            // the two items still merge into one poll.
+                            //
+                            // Under the invariant asserted above this merge is
+                            // **inert** — every item in this window carries
+                            // `Watcher`, and `Watcher.merge(Watcher)` is
+                            // `Watcher` — so no test can distinguish it from
+                            // the bare `insert` below and none tries to. It is
+                            // kept because the alternative is not "no merge"
+                            // but last-writer-wins, which for a future mixed
+                            // producer would let the *later* event raise the
+                            // cost of a queued poll. Deleting it is safe today
+                            // and wrong the moment the assert above starts
+                            // earning its keep.
+                            if let Some((queued, _)) = pending.get(&key) {
+                                work.trigger = work.trigger.merge(queued.trigger);
+                            }
+                            pending.insert(key, (work, Instant::now()));
                         }
                         None => break,
                     }
@@ -894,6 +946,67 @@ pub(crate) fn spawn_debounce_task(
     })
 }
 
+/// Re-arm a merged-away reconcile tick onto a poll that is about to start,
+/// and settle the debt in the same step.
+///
+/// **This is a disclosed deviation from §2.4.** That section says the dirty
+/// re-enqueue "preserves the original trigger and must never upgrade it to
+/// `Reconcile`"; this function is called from that re-enqueue and does exactly
+/// that upgrade. The deviation is deliberate — §2.4's other bullet makes every
+/// reconcile tick that lands on a busy key merge away, and on a continuously
+/// written database that is *every* tick, so obeying both bullets literally
+/// makes the §4 complete-sweep interval unbounded on the source with the most
+/// history to sweep. What is preserved is the narrower rule the upgrade
+/// actually depends on: no item that has already been handed to a poll is ever
+/// upgraded. Both bullets are restated for WI-10 in
+/// `plans/601-delta-sqlite.md`; the plan text is the thing that must change,
+/// not this comment.
+///
+/// Draining here is what makes the debt settle: the poll that carries the tick
+/// is the poll that pays for it. It is also the **only** remover of a
+/// `reconcile_owed` entry, so "does not arm" and "does not drain" have to stay
+/// the same decision — see the `Startup` refusal below.
+///
+/// `Startup` — and **only** `Startup` — is refused. `WorkTrigger`'s own doc says
+/// startup is the worst moment to add a broad scan, and `merge` encodes that by
+/// keeping `Startup` over `Reconcile`; this function is the one place in the
+/// dispatcher that overrides `merge`'s ranking, so it must not override it
+/// *here* as well. The debt is left standing rather than spent: a poll that does
+/// not carry the tick has not paid for it, and the key's next watcher or
+/// reconcile poll will.
+///
+/// The refusal's **width** matters as much as its existence, and the two are
+/// separately guarded. Widening it by one token — refusing everything that is
+/// not `Watcher` — still refuses every `Startup` poll, so the refusal's own
+/// guard stays green; what it silently drops is the settlement of a standing
+/// debt onto a `Reconcile` carrier, which is a reachable steady state (a tick
+/// owed in the pending window, its poll completing empty, and the next reconcile
+/// firing finding the key idle). The debt would then survive that firing and be
+/// spent by an ordinary watcher event instead, so a filesystem event pays a
+/// sweep slice nothing bought — the §2.4 inversion — and on a path that never
+/// sees another watcher event it never leaves the ledger at all. That direction
+/// is pinned by
+/// `a_standing_debt_is_settled_by_a_reconcile_poll_not_only_a_watcher_one`.
+///
+/// Reachability: no production `Startup` item can hold a debt today. The two
+/// `tee.rs` startup-poll sites call `process_file` directly and never
+/// touch the dispatcher, and `run_ingestor`'s backfill enumerates each path
+/// exactly once — so reaching this refusal needs a path that acquired an unpaid
+/// tick and then went fully idle inside the startup window, before backfill's
+/// round-robin got to it. That race is not structurally impossible (the
+/// reconcile task is spawned before the backfill loop and `tokio::time::interval`
+/// fires immediately), just vanishingly narrow. WI-04 is what makes the branch
+/// worth pinning: it gives the upgrade a cost, and a `Startup` item paying it
+/// is the exact thing §2.4 forbids.
+fn arm_owed_reconcile(state: &mut DispatchState, key: &str, work: &mut WorkItem) {
+    if work.trigger == WorkTrigger::Startup {
+        return;
+    }
+    if state.reconcile_owed.remove(key) {
+        work.trigger = WorkTrigger::Reconcile;
+    }
+}
+
 pub(crate) async fn enqueue_work(
     work: WorkItem,
     process_tx: &mpsc::Sender<WorkItem>,
@@ -904,15 +1017,144 @@ pub(crate) async fn enqueue_work(
         return;
     }
 
+    let mut work = work;
     let key = work.key();
+    let incoming_trigger = work.trigger;
     let mut should_send = false;
     {
         let mut state = dispatch.lock().expect("dispatch mutex poisoned");
-        state.item_by_key.insert(key.clone(), work.clone());
+        // `item_by_key` is what `complete_work`'s dirty re-enqueue replays, so
+        // overwriting it wholesale would let a reconcile tick arriving during
+        // an inflight watcher poll upgrade that poll's trigger. Merge instead:
+        // the trigger can be downgraded to `Watcher`, never upgraded (§2.4).
+        if let Some(queued) = state.item_by_key.get(&key) {
+            work.trigger = work.trigger.merge(queued.trigger);
+        }
         if state.inflight.contains(&key) {
+            state.item_by_key.insert(key.clone(), work.clone());
             state.dirty.insert(key.clone());
         } else if state.pending.insert(key.clone()) {
+            // This send starts the poll, so an owed tick may ride it.
+            arm_owed_reconcile(&mut state, &key, &mut work);
+            state.item_by_key.insert(key.clone(), work.clone());
             should_send = true;
+        } else {
+            state.item_by_key.insert(key.clone(), work.clone());
+        }
+
+        // The debt ledger's **only** creator, and — since `complete_work` no
+        // longer prunes — the only thing that bounds the map at all.
+        //
+        // There is no `remove` to pair with it, and the reason is not "the
+        // debt is always already drained by here": settling is
+        // `arm_owed_reconcile`'s job *alone*, and on the `should_send` paths it
+        // has already made the call. For a `Watcher` or `Reconcile` carrier it
+        // drained; for a `Startup` carrier it deliberately did **not**, and that
+        // entry has to stand. A `remove` here would be redundant in the first
+        // case and would destroy a live tick in the second.
+        //
+        // `carried` is "this call handed the tick to a poll", which is exactly
+        // `should_send`. It is not also worth testing `work.trigger ==
+        // Reconcile`: for a dispatching call the trigger it sends is the trigger
+        // it arrived with, unless `arm_owed_reconcile` raised it to `Reconcile`.
+        // `should_send` is only set where `pending.insert` returned true and the
+        // key was not `inflight`, so the merge above found no `item_by_key`
+        // entry — every insert site (this block and `complete_work`'s dirty
+        // re-enqueue) leaves its key in `pending ∪ inflight ∪ dirty` under this
+        // same lock, and the sole `remove` runs only when the key is in none of
+        // them, so a key absent from `pending` and `inflight` is absent from the
+        // map. The `debug_assert` below is where that invariant is stated in
+        // executable form; a future change that lets a stale entry survive trips
+        // it rather than silently under-owing.
+        //
+        // What remains is bounded in both directions by mutation:
+        //
+        //   * `carried = true` (never owe) is an **under-owe**: a tick landing
+        //     on a busy key is treated as paid and silently dropped — two ticks
+        //     straddling one queued poll become one. Guarded from beneath by
+        //     `two_reconcile_ticks_straddling_one_queued_poll_buy_two_polls`.
+        //   * `carried = false` (always owe) is an **over-owe**: every
+        //     dispatched sweep tick is also recorded, so a single sweep leaves a
+        //     standing debt on every idle path it touched. Because nothing
+        //     prunes, those debts are permanent and upgrade every later watcher
+        //     poll of every path to `Reconcile` — strictly worse than a per-key
+        //     latch. Guarded from above by
+        //     `a_reconcile_sweep_over_idle_paths_leaves_no_standing_debt`.
+        //
+        // `incoming_trigger == Reconcile` needs its **width** pinned too, and at
+        // both neighbours rather than only at `Reconcile`. Each one-token
+        // widening has its own guard, and each guard was checked by running it
+        // against its own mutation rather than by reading the suite:
+        //
+        //   * `!= Watcher` lets a startup backfill enqueue mint a debt that some
+        //     later watcher poll then spends — the §2.4 inversion
+        //     `arm_owed_reconcile` refuses from the other side. Held by
+        //     `a_startup_poll_landing_on_a_queued_poll_owes_nothing`, which
+        //     fails under it on its own.
+        //   * `!= Startup` lets every watcher event landing on a busy key mint
+        //     one, so watcher churn alone manufactures sweep eligibility. Held
+        //     by `one_reconcile_tick_buys_exactly_one_reconcile_eligible_poll`,
+        //     the *only* test in the crate that fails under it.
+        //
+        // An earlier revision of this comment named
+        // `debounce_coalesces_a_watcher_burst_into_one_watcher_poll` for the
+        // second. It cannot bound that width and never could: the debounce
+        // coalesces the burst into a single `enqueue_work` call against an idle
+        // key, so `pending.insert` returns true, `carried` is true, and this owe
+        // branch is unreachable whatever the filter admits. Run alone under
+        // `!= Startup` it passes.
+        //
+        // A debt is deliberately **not** created by observing that a queued
+        // item's trigger got downgraded: `item_by_key`'s entry describes a poll
+        // that is already pending or inflight, so re-owing on its downgrade is
+        // re-owing a tick that was already paid. That is a latch —
+        // `complete_work` arms `Reconcile` into `item_by_key`, the next watcher
+        // event downgrades it and re-owes, `complete_work` re-arms — and it
+        // makes *every* poll of a churning key sweep-eligible at the 50 ms
+        // watcher cadence, which inverts §2.4 in the expensive direction on
+        // precisely the busiest database.
+        //
+        // Nothing is lost by dropping that case: a queued `Reconcile` in
+        // `item_by_key` was itself an incoming tick once, and at that moment it
+        // was either dispatched (paid) or recorded here (owed).
+        //
+        // **The two failure directions are not symmetric, and this assertion is
+        // deliberately the weaker kind.** The `work.trigger == Reconcile`
+        // conjunct that used to sit alongside `should_send` was dead under the
+        // invariant, so dropping it changed no outcome — but it failed *safely*:
+        // if the invariant ever broke it would have over-owed, which is bounded
+        // and self-correcting (one extra reconcile-eligible poll, spent on the
+        // next completion). Bare `carried = should_send` fails the other way; a
+        // break silently under-owes, and a lost tick is exactly the §0/§4
+        // coverage failure the whole D1a analysis exists to prevent.
+        //
+        // It stays a `debug_assert!` even so. A hard `assert!` here panics with
+        // the dispatch mutex held, poisoning it and killing every subsequent
+        // poll for every source — trading a bounded, one-tick coverage loss for
+        // a total ingest outage. The invariant is structural (it is about which
+        // insert sites can leave an entry in `item_by_key`), so any change that
+        // could break it is a code change, and code changes run the suite in
+        // debug where this does fire.
+        debug_assert!(
+            !should_send
+                || incoming_trigger != WorkTrigger::Reconcile
+                || work.trigger == WorkTrigger::Reconcile,
+            "a dispatching call cannot have merged away the tick it arrived \
+             with: `should_send` implies no `item_by_key` entry existed"
+        );
+        //
+        // This `insert` **coalesces** on purpose. `reconcile_owed` is a set, so
+        // several ticks landing on a key that stays pending/inflight/dirty
+        // throughout collapse to one debt and are settled by one sweep slice. A
+        // slice covers everything accumulated since the last one, so the debt
+        // is a flag ("this key owes a sweep") rather than an amount of work,
+        // and §4's complete-sweep interval is bounded by how often the key
+        // polls at all — which coalescing does not change. The declaration-site
+        // doc on `DispatchState::reconcile_owed` carries the full argument;
+        // `reconcile_ticks_landing_on_one_queued_poll_coalesce` pins it.
+        let carried = should_send;
+        if incoming_trigger == WorkTrigger::Reconcile && !carried {
+            state.reconcile_owed.insert(key.clone());
         }
     }
 
@@ -927,12 +1169,72 @@ pub(crate) fn complete_work(key: &str, dispatch: &Arc<Mutex<DispatchState>>) -> 
 
     if state.dirty.remove(key) {
         if state.pending.insert(key.to_string()) {
-            return state.item_by_key.get(key).cloned();
+            let mut item = state.item_by_key.get(key).cloned()?;
+            // The poll that was inflight has finished; this re-enqueue starts
+            // a new one, so it is the first moment an owed reconcile tick can
+            // be honoured without upgrading work already in flight.
+            arm_owed_reconcile(&mut state, key, &mut item);
+            state.item_by_key.insert(key.to_string(), item.clone());
+            return Some(item);
         }
         return None;
     }
 
     if !state.pending.contains(key) && !state.inflight.contains(key) && !state.dirty.contains(key) {
+        // The key has left the dispatcher entirely, so its queued item goes.
+        //
+        // `reconcile_owed` deliberately does **not** follow it out, and this is
+        // not tidiness deferred: pruning the debt here destroys a live
+        // reconcile tick on every firing. The ledger has exactly one production
+        // creator — `enqueue_work`'s incoming-`Reconcile` path — and that path
+        // splits on the key's state:
+        //
+        //   * key **inflight** with a `Watcher` or `Reconcile` item: `dirty` is
+        //     set, so `complete_work` takes the dirty branch above and
+        //     `arm_owed_reconcile` settles the debt onto the re-enqueued poll.
+        //     This branch is never reached.
+        //   * key **inflight** with a `Startup` item: `dirty` is set and the
+        //     dirty branch still runs, but `arm_owed_reconcile` **refuses** to
+        //     upgrade `Startup` (D1c) and leaves the debt standing by design.
+        //     The re-enqueued poll can then complete with nothing dirty behind
+        //     it and arrive *here* holding an unpaid tick, exactly like the
+        //     pending case. D1c added this case after the two-case split above
+        //     was written; it does not weaken the conclusion, it is a third way
+        //     to reach this point with a live debt.
+        //   * key **pending**: the item is already queued for a worker and
+        //     `dirty` is *not* set, so the debt is recorded against a poll that
+        //     still carries `Watcher`. The window is wide — the processor loop
+        //     parks on `sem.acquire_owned()` before draining the next item, so
+        //     a saturated worker pool holds keys in `pending` indefinitely.
+        //     No poll picks that tick up, and when the queued poll finishes
+        //     with nothing dirty behind it, control arrives *here* with the
+        //     debt unpaid.
+        //
+        // So every reachable prune deletes a tick a reconcile firing created
+        // milliseconds earlier — the §0/§4 coverage guarantee failing on
+        // exactly the source with the most history to sweep. A *paid* debt is
+        // already gone by the time this runs (`arm_owed_reconcile` drains on
+        // use), so there is no reachable state in which a prune here collects
+        // anything but a live tick.
+        //
+        // Retention costs one `String` per *indebted* path, and the bound is
+        // worth stating exactly rather than rounding to "the tracked-path set".
+        // For a path that stays tracked the entry is transient: the next
+        // reconcile firing enumerates it and `arm_owed_reconcile` drains the
+        // debt onto that poll. For a path that leaves tracking while holding an
+        // unpaid debt — deleted, rotated out of the glob — nothing enumerates
+        // it again, so its entry persists for the lifetime of the process and
+        // is cleared only by restart. That is the honest bound: one `String`
+        // per such path, unbounded in time but not in rate, against a ledger
+        // whose sole creator fires once per `reconcile_interval_seconds`.
+        //
+        // Since this prune went, `enqueue_work`'s settle/owe condition is the
+        // only thing bounding the map; it is guarded from both directions by
+        // `a_reconcile_sweep_over_idle_paths_leaves_no_standing_debt` (above)
+        // and `two_reconcile_ticks_straddling_one_queued_poll_buy_two_polls`
+        // (beneath). Removing *this* prune is what
+        // `a_tick_landing_on_a_queued_poll_survives_that_polls_completion`
+        // pins, in the pending window that no other test reaches.
         state.item_by_key.remove(key);
     }
 
@@ -2103,15 +2405,15 @@ mod tests {
     use super::{
         complete_work, compose_hermes_model, enqueue_work, enrich_claude_model_latency,
         jsonl_policy_fingerprint, jsonl_source_line_byte_limit, process_file,
-        process_session_json_file, run_work_item, source_inode_for_file, work_item_is_ingestable,
-        work_path_is_canonical, SessionCursor, CLICKHOUSE_JSON_OBJECT_BYTE_LIMIT,
-        ERROR_KIND_NORMALIZED_ROW_TOO_LARGE, ERROR_KIND_SOURCE_LINE_TOO_LARGE,
-        JSONL_PUBLICATION_PROTOCOL_VERSION, SESSION_JSON_GENERATION, SESSION_JSON_INODE,
-        SOURCE_NORMALIZATION_RULES_VERSION,
+        process_session_json_file, run_work_item, source_inode_for_file, spawn_debounce_task,
+        work_item_is_ingestable, work_path_is_canonical, SessionCursor,
+        CLICKHOUSE_JSON_OBJECT_BYTE_LIMIT, ERROR_KIND_NORMALIZED_ROW_TOO_LARGE,
+        ERROR_KIND_SOURCE_LINE_TOO_LARGE, JSONL_PUBLICATION_PROTOCOL_VERSION,
+        SESSION_JSON_GENERATION, SESSION_JSON_INODE, SOURCE_NORMALIZATION_RULES_VERSION,
     };
     use crate::model::{Checkpoint, CheckpointLifecycle};
     use crate::sqlite_poll::VolatilePollMap;
-    use crate::{DispatchState, Metrics, SinkMessage, WorkItem};
+    use crate::{DispatchState, Metrics, SinkMessage, WorkItem, WorkTrigger};
     use moraine_config::SourceFormat;
     use serde_json::{json, Value};
     use sha2::{Digest, Sha256};
@@ -2132,6 +2434,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: path.to_string(),
+            trigger: WorkTrigger::Watcher,
         }
     }
 
@@ -2355,6 +2658,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: path.to_string_lossy().to_string(),
+            trigger: WorkTrigger::Watcher,
         };
         let checkpoints = Arc::new(RwLock::new(HashMap::<String, Checkpoint>::new()));
         if let Some(resume_from) = resume_from {
@@ -2490,6 +2794,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: path.to_string_lossy().to_string(),
+            trigger: WorkTrigger::Watcher,
         };
         let checkpoints = Arc::new(RwLock::new(HashMap::<String, Checkpoint>::new()));
         let metrics = Arc::new(Metrics::default());
@@ -2629,6 +2934,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: path.to_string_lossy().to_string(),
+            trigger: WorkTrigger::Watcher,
         };
         let checkpoints = Arc::new(RwLock::new(HashMap::<String, Checkpoint>::new()));
         let metrics = Arc::new(Metrics::default());
@@ -2765,6 +3071,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: "/tmp/rollout.jsonl".to_string(),
+            trigger: WorkTrigger::Watcher,
         };
 
         let mut exclusions = config.ingest.exclude_project_dirs.clone();
@@ -2817,6 +3124,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: path.to_string_lossy().to_string(),
+            trigger: WorkTrigger::Watcher,
         };
         let key = work.key();
 
@@ -2885,6 +3193,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: "/tmp/x.jsonl".to_string(),
+            trigger: WorkTrigger::Watcher,
         };
         assert!(work_path_is_canonical(&jsonl));
 
@@ -2894,11 +3203,13 @@ mod tests {
             format: SourceFormat::SessionJson,
             source_glob: String::new(),
             path: "/tmp/session_x.json".to_string(),
+            trigger: WorkTrigger::Watcher,
         };
         assert!(work_path_is_canonical(&session));
         // session_json format must NOT pick up .jsonl files
         let wrong = WorkItem {
             path: "/tmp/x.jsonl".to_string(),
+            trigger: WorkTrigger::Watcher,
             ..session.clone()
         };
         assert!(!work_path_is_canonical(&wrong));
@@ -2909,12 +3220,14 @@ mod tests {
             format: SourceFormat::CursorSqlite,
             source_glob: String::new(),
             path: "/tmp/User/state.vscdb".to_string(),
+            trigger: WorkTrigger::Watcher,
         };
         assert!(work_path_is_canonical(&sqlite));
         // Sidecars are canonicalized upstream; a sidecar path reaching the
         // dispatcher directly is dropped rather than processed.
         let sidecar = WorkItem {
             path: "/tmp/User/state.vscdb-wal".to_string(),
+            trigger: WorkTrigger::Watcher,
             ..sqlite.clone()
         };
         assert!(!work_path_is_canonical(&sidecar));
@@ -2929,6 +3242,7 @@ mod tests {
             format: SourceFormat::Infer,
             source_glob: String::new(),
             path: "/tmp/unresolved.jsonl".to_string(),
+            trigger: WorkTrigger::Watcher,
         };
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
         let metrics = Arc::new(Metrics::default());
@@ -2959,6 +3273,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: path.to_string(),
+            trigger: WorkTrigger::Watcher,
         };
         let proj = "/Users/x/.claude/projects/-Users-x-src-moraine";
         let sid = "7e74512d-612b-4406-ae5e-069e73d7f2dc";
@@ -2990,6 +3305,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: format!("{proj}/{sid}/subagents/workflows/wf_x/journal.jsonl"),
+            trigger: WorkTrigger::Watcher,
         };
         assert!(work_item_is_ingestable(&codex_journal));
     }
@@ -3003,6 +3319,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path,
+            trigger: WorkTrigger::Watcher,
         };
         assert!(work_item_is_ingestable(&cowork(format!(
             "{root}/.claude/projects/-sessions-demo/aaaaaaaa-1111-4333-8444-555555555555.jsonl"
@@ -3034,6 +3351,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: format!("{proj}/{sid}/subagents/workflows/wf_12dc2994-7e9/journal.jsonl"),
+            trigger: WorkTrigger::Watcher,
         };
 
         enqueue_work(journal.clone(), &process_tx, &dispatch, &metrics).await;
@@ -3055,6 +3373,7 @@ mod tests {
         // A real session transcript from the same source is forwarded.
         let session = WorkItem {
             path: format!("{proj}/{sid}.jsonl"),
+            trigger: WorkTrigger::Watcher,
             ..journal.clone()
         };
         enqueue_work(session.clone(), &process_tx, &dispatch, &metrics).await;
@@ -3063,6 +3382,1172 @@ mod tests {
             .expect("real session transcript must be forwarded");
         assert_eq!(forwarded.key(), session.key());
         assert_eq!(metrics.queue_depth.load(Ordering::Relaxed), 1);
+    }
+
+    /// Issue #601 §2.4 / WI-03. Trigger provenance exists so a reconciliation
+    /// sweep can be attached to reconcile ticks only; every merge point must
+    /// therefore be able to *downgrade* a trigger and never upgrade one.
+    #[test]
+    fn trigger_merge_keeps_the_least_reconciliation_eligible_trigger() {
+        use WorkTrigger::{Reconcile, Startup, Watcher};
+        assert_eq!(Watcher.merge(Reconcile), Watcher);
+        assert_eq!(Reconcile.merge(Watcher), Watcher);
+        assert_eq!(Startup.merge(Reconcile), Startup);
+        assert_eq!(Reconcile.merge(Startup), Startup);
+        assert_eq!(Watcher.merge(Startup), Watcher);
+        assert_eq!(Reconcile.merge(Reconcile), Reconcile);
+    }
+
+    /// `work.key()` must not carry the trigger: if it did, a watcher event and
+    /// a reconcile tick for the same file would occupy two queue slots and the
+    /// debounce would stop coalescing anything.
+    ///
+    /// Fails for: adding the trigger to `WorkItem::key`.
+    #[test]
+    fn work_key_excludes_the_trigger() {
+        let watcher = sample_work("/tmp/trigger-key.jsonl");
+        let reconcile = WorkItem {
+            trigger: WorkTrigger::Reconcile,
+            ..watcher.clone()
+        };
+        assert_eq!(
+            watcher.key(),
+            reconcile.key(),
+            "the trigger is not part of the coalescing identity"
+        );
+    }
+
+    /// A reconcile tick that lands while a watcher poll is inflight must not
+    /// upgrade that poll — a burst must never retroactively become expensive —
+    /// but it must not be *lost* either. `item_by_key` holds a key while it is
+    /// pending, inflight or dirty, so on a continuously written database almost
+    /// every reconcile tick lands on an occupied key; discarding them starves
+    /// the sweep on exactly the source with the most history to sweep.
+    ///
+    /// So the inflight item stays `Watcher`, and the *next* poll — the dirty
+    /// re-enqueue, which has not started yet — carries the owed tick.
+    ///
+    /// Fails for: dropping `reconcile_owed` (the re-enqueue comes back as
+    /// `Watcher` and the tick is gone), or arming it on the inflight item.
+    #[tokio::test]
+    async fn a_reconcile_tick_landing_on_an_inflight_poll_survives_to_the_next_one() {
+        let dispatch = Arc::new(Mutex::new(DispatchState::default()));
+        let metrics = Arc::new(Metrics::default());
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(8);
+
+        let proj = "/Users/x/.claude/projects/-Users-x-src-moraine";
+        let sid = "7e74512d-612b-4406-ae5e-069e73d7f2dc";
+        let watcher = WorkItem {
+            source_name: "claude".to_string(),
+            harness: "claude-code".to_string(),
+            format: SourceFormat::Jsonl,
+            source_glob: String::new(),
+            path: format!("{proj}/{sid}.jsonl"),
+            trigger: WorkTrigger::Watcher,
+        };
+        let key = watcher.key();
+
+        enqueue_work(watcher.clone(), &process_tx, &dispatch, &metrics).await;
+        let dispatched = process_rx.try_recv().expect("watcher item is forwarded");
+        assert_eq!(dispatched.trigger, WorkTrigger::Watcher);
+        {
+            let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+            state.pending.remove(&key);
+            state.inflight.insert(key.clone());
+        }
+
+        // A reconcile tick arrives mid-poll and only marks the item dirty.
+        let reconcile = WorkItem {
+            trigger: WorkTrigger::Reconcile,
+            ..watcher.clone()
+        };
+        enqueue_work(reconcile, &process_tx, &dispatch, &metrics).await;
+        assert!(
+            process_rx.try_recv().is_err(),
+            "an inflight key is marked dirty, not re-sent"
+        );
+        assert_eq!(
+            dispatch
+                .lock()
+                .expect("dispatch mutex poisoned")
+                .item_by_key
+                .get(&key)
+                .map(|item| item.trigger),
+            Some(WorkTrigger::Watcher),
+            "the inflight poll is never upgraded mid-flight"
+        );
+
+        let rescheduled = complete_work(&key, &dispatch).expect("dirty item is re-enqueued");
+        assert_eq!(
+            rescheduled.trigger,
+            WorkTrigger::Reconcile,
+            "the swallowed reconcile tick rides the next poll instead of being lost"
+        );
+
+        // And it is drained on use: the tick buys one reconcile-eligible poll,
+        // not a permanent upgrade of the key.
+        {
+            let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+            assert!(state.reconcile_owed.is_empty());
+            state.pending.remove(&key);
+            state.inflight.insert(key.clone());
+            state.dirty.insert(key.clone());
+        }
+        let next = complete_work(&key, &dispatch).expect("second dirty re-enqueue");
+        assert_eq!(
+            next.trigger,
+            WorkTrigger::Reconcile,
+            "item_by_key carries the armed trigger forward; nothing re-arms it"
+        );
+        assert!(dispatch
+            .lock()
+            .expect("dispatch mutex poisoned")
+            .reconcile_owed
+            .is_empty());
+    }
+
+    /// Issue #601 §0/§4 — the **lower** bound on `reconcile_owed`. The sweep is
+    /// the only mechanism guaranteeing coverage, and §4 promises a *finite*
+    /// maximum complete-sweep interval. A key under continuous watcher churn is
+    /// pending, inflight or dirty essentially all the time, so if every
+    /// reconcile tick that lands there is discarded the interval on the busiest
+    /// database is unbounded.
+    ///
+    /// Drive 20 churn cycles with one reconcile tick each and assert every tick
+    /// produces exactly one reconcile-eligible poll, within one cycle of
+    /// arriving.
+    ///
+    /// **This test cannot see an over-owing bug**, and saying so is the point:
+    /// it feeds one tick per cycle, so a correct ledger and one that latches
+    /// permanently sweep-eligible both produce 20. The upper bound is
+    /// `one_reconcile_tick_buys_exactly_one_reconcile_eligible_poll`, and
+    /// neither guard is sufficient alone.
+    ///
+    /// Fails for: discarding the merged-away tick (zero reconcile-eligible
+    /// polls in 20 cycles).
+    #[tokio::test]
+    async fn continuous_watcher_churn_still_yields_reconcile_eligible_polls() {
+        let dispatch = Arc::new(Mutex::new(DispatchState::default()));
+        let metrics = Arc::new(Metrics::default());
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(64);
+
+        let proj = "/Users/x/.claude/projects/-Users-x-src-moraine";
+        let sid = "7e74512d-612b-4406-ae5e-069e73d7f2dc";
+        let watcher = WorkItem {
+            source_name: "claude".to_string(),
+            harness: "claude-code".to_string(),
+            format: SourceFormat::Jsonl,
+            source_glob: String::new(),
+            path: format!("{proj}/{sid}.jsonl"),
+            trigger: WorkTrigger::Watcher,
+        };
+        let reconcile = WorkItem {
+            trigger: WorkTrigger::Reconcile,
+            ..watcher.clone()
+        };
+        let key = watcher.key();
+
+        const CYCLES: usize = 20;
+        let mut reconcile_eligible = 0usize;
+        let mut polls = 0usize;
+
+        enqueue_work(watcher.clone(), &process_tx, &dispatch, &metrics).await;
+        let mut next = process_rx.try_recv().ok();
+        while let Some(item) = next.take() {
+            polls += 1;
+            if item.trigger == WorkTrigger::Reconcile {
+                reconcile_eligible += 1;
+            }
+            {
+                let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+                state.pending.remove(&key);
+                state.inflight.insert(key.clone());
+            }
+            if polls <= CYCLES {
+                // The database is written continuously, so the key is busy for
+                // the whole poll and a reconcile tick lands on top of it.
+                enqueue_work(watcher.clone(), &process_tx, &dispatch, &metrics).await;
+                enqueue_work(reconcile.clone(), &process_tx, &dispatch, &metrics).await;
+            }
+            next = complete_work(&key, &dispatch);
+        }
+
+        assert_eq!(
+            polls,
+            CYCLES + 1,
+            "each cycle must reschedule exactly one poll"
+        );
+        assert_eq!(
+            reconcile_eligible, CYCLES,
+            "every reconcile tick that landed on a busy key must still buy one \
+             reconcile-eligible poll; got {reconcile_eligible} in {polls} polls"
+        );
+    }
+
+    /// Issue #601 §2.4 — the **upper** bound on `reconcile_owed`, and the half
+    /// that a lower-bound-only guard let through.
+    ///
+    /// `reconcile_owed` is a debt ledger: one reconcile tick buys one
+    /// reconcile-eligible poll, no more. The failure this pins is not "the tick
+    /// was lost" but "the tick never stops being spent": `complete_work` arms
+    /// `Reconcile` into `item_by_key`, the next watcher event merges it back
+    /// down to `Watcher`, and a ledger that owes on *that* downgrade re-creates
+    /// the debt the arming just settled. `complete_work` re-arms, and the key
+    /// is permanently sweep-eligible — at the 50 ms watcher-debounce cadence
+    /// instead of once per `reconcile_interval_seconds`. That inverts §2.4 in
+    /// the expensive direction on the busiest database, which is the one with
+    /// the most history to sweep and the largest slice cost (§0, WI-04).
+    ///
+    /// One tick on the first cycle, then twenty cycles of pure watcher churn.
+    ///
+    /// Fails for: owing a debt because a stored item's trigger was downgraded
+    /// (21 polls, 20 of them reconcile-eligible, where the answer is 1).
+    #[tokio::test]
+    async fn one_reconcile_tick_buys_exactly_one_reconcile_eligible_poll() {
+        let dispatch = Arc::new(Mutex::new(DispatchState::default()));
+        let metrics = Arc::new(Metrics::default());
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(64);
+
+        let proj = "/Users/x/.claude/projects/-Users-x-src-moraine";
+        let sid = "7e74512d-612b-4406-ae5e-069e73d7f2dc";
+        let watcher = WorkItem {
+            source_name: "claude".to_string(),
+            harness: "claude-code".to_string(),
+            format: SourceFormat::Jsonl,
+            source_glob: String::new(),
+            path: format!("{proj}/{sid}.jsonl"),
+            trigger: WorkTrigger::Watcher,
+        };
+        let reconcile = WorkItem {
+            trigger: WorkTrigger::Reconcile,
+            ..watcher.clone()
+        };
+        let key = watcher.key();
+
+        const CYCLES: usize = 20;
+        let mut reconcile_eligible = 0usize;
+        let mut polls = 0usize;
+
+        enqueue_work(watcher.clone(), &process_tx, &dispatch, &metrics).await;
+        let mut next = process_rx.try_recv().ok();
+        while let Some(item) = next.take() {
+            polls += 1;
+            if item.trigger == WorkTrigger::Reconcile {
+                reconcile_eligible += 1;
+            }
+            {
+                let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+                state.pending.remove(&key);
+                state.inflight.insert(key.clone());
+            }
+            if polls <= CYCLES {
+                enqueue_work(watcher.clone(), &process_tx, &dispatch, &metrics).await;
+                // Exactly one reconcile tick, on the first cycle. Everything
+                // after this is a watcher event on a busy key.
+                if polls == 1 {
+                    enqueue_work(reconcile.clone(), &process_tx, &dispatch, &metrics).await;
+                }
+            }
+            next = complete_work(&key, &dispatch);
+        }
+
+        assert_eq!(
+            polls,
+            CYCLES + 1,
+            "each cycle must reschedule exactly one poll"
+        );
+        assert_eq!(
+            reconcile_eligible, 1,
+            "one reconcile tick must buy exactly one reconcile-eligible poll; \
+             got {reconcile_eligible} in {polls} polls, which means watcher \
+             churn alone is manufacturing sweep eligibility"
+        );
+        assert!(
+            dispatch
+                .lock()
+                .expect("dispatch mutex poisoned")
+                .reconcile_owed
+                .is_empty(),
+            "and the ledger must be settled, not carrying a standing debt"
+        );
+    }
+
+    /// Issue #601 §0/§4 — the **pending window**, which neither existing bound
+    /// exercises: `continuous_watcher_churn_still_yields_reconcile_eligible_polls`
+    /// and `one_reconcile_tick_buys_exactly_one_reconcile_eligible_poll` both
+    /// move the key to `inflight` before the tick arrives, so both take
+    /// `enqueue_work`'s dirty branch. Production has a third state.
+    ///
+    /// A debounced watcher poll is dispatched, so the key sits in `pending` —
+    /// handed to `process_tx` but not yet inflight. The processor loop parks on
+    /// `sem.acquire_owned()` before draining the next item, so a saturated
+    /// worker pool holds keys there indefinitely. A reconcile tick bypasses the
+    /// debounce entirely (`spawn_reconcile_task` calls `enqueue_work` directly),
+    /// lands on the pending key, and takes the third branch: the debt is
+    /// recorded and `dirty` is **not** set. The queued item still carries
+    /// `Watcher`, so no sweep slice rides it, and when it completes there is
+    /// nothing dirty behind it — the key leaves the dispatcher with the tick
+    /// still unpaid.
+    ///
+    /// The tick must survive that, because nothing else in the system will ever
+    /// re-issue it: `spawn_reconcile_task` fires once per
+    /// `reconcile_interval_seconds` and does not remember what it dispatched.
+    ///
+    /// Direction bounded: **lower**, and that half is this test's whole
+    /// contribution. It is the only guard on the pending window — the debt must
+    /// outlive the dispatcher entry — and no other test reaches that window.
+    ///
+    /// The trailing upper-bound half (the revived debt is spent once, not
+    /// latched) is kept for readability but claims nothing new: for any
+    /// single-site mutation it is redundant with
+    /// `one_reconcile_tick_buys_exactly_one_reconcile_eligible_poll` and
+    /// `a_reconcile_tick_landing_on_an_inflight_poll_survives_to_the_next_one`,
+    /// both of which drain through `arm_owed_reconcile` too. It bites only if
+    /// the ledger stops settling in *both* places at once.
+    ///
+    /// Fails for: pruning `reconcile_owed` when a key leaves the dispatcher
+    /// (the debt is destroyed before any poll can carry it); dropping
+    /// `item_by_key`'s prune along with it; or a ledger that never settles, in
+    /// which case the revived poll's drain assertion goes.
+    #[tokio::test]
+    async fn a_tick_landing_on_a_queued_poll_survives_that_polls_completion() {
+        let dispatch = Arc::new(Mutex::new(DispatchState::default()));
+        let metrics = Arc::new(Metrics::default());
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(8);
+
+        let proj = "/Users/x/.claude/projects/-Users-x-src-moraine";
+        let sid = "7e74512d-612b-4406-ae5e-069e73d7f2dc";
+        let watcher = WorkItem {
+            source_name: "claude".to_string(),
+            harness: "claude-code".to_string(),
+            format: SourceFormat::Jsonl,
+            source_glob: String::new(),
+            path: format!("{proj}/{sid}.jsonl"),
+            trigger: WorkTrigger::Watcher,
+        };
+        let reconcile = WorkItem {
+            trigger: WorkTrigger::Reconcile,
+            ..watcher.clone()
+        };
+        let key = watcher.key();
+
+        // The debounce dispatches a watcher poll. It is queued, not inflight:
+        // the worker pool is saturated, so nothing has drained it yet.
+        enqueue_work(watcher.clone(), &process_tx, &dispatch, &metrics).await;
+        let queued = process_rx.try_recv().expect("watcher item is forwarded");
+        assert_eq!(queued.trigger, WorkTrigger::Watcher);
+        assert!(
+            dispatch
+                .lock()
+                .expect("dispatch mutex poisoned")
+                .pending
+                .contains(&key),
+            "the dispatched item is pending until the processor drains it"
+        );
+
+        // The reconcile tick lands on the pending key.
+        enqueue_work(reconcile, &process_tx, &dispatch, &metrics).await;
+        assert!(
+            process_rx.try_recv().is_err(),
+            "a key already pending is not queued a second time"
+        );
+        {
+            let state = dispatch.lock().expect("dispatch mutex poisoned");
+            assert_eq!(
+                state.item_by_key.get(&key).map(|item| item.trigger),
+                Some(WorkTrigger::Watcher),
+                "the queued poll is not upgraded — it has already been sent"
+            );
+            assert!(!state.dirty.contains(&key), "a pending key is not dirtied");
+            assert!(
+                state.reconcile_owed.contains(&key),
+                "so the tick has to be owed instead"
+            );
+        }
+
+        // The worker finally picks the queued item up and runs it. It carries
+        // `Watcher`, so no sweep slice attaches — the tick is still unpaid.
+        {
+            let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+            state.pending.remove(&key);
+            state.inflight.insert(key.clone());
+        }
+        assert!(
+            complete_work(&key, &dispatch).is_none(),
+            "nothing was written during the poll, so there is no re-enqueue"
+        );
+        {
+            let state = dispatch.lock().expect("dispatch mutex poisoned");
+            assert!(
+                !state.item_by_key.contains_key(&key),
+                "the key has left the dispatcher, so its queued item goes"
+            );
+            assert!(
+                state.reconcile_owed.contains(&key),
+                "but the unpaid tick must not go with it — no poll ever carried \
+                 it, and nothing re-issues a reconcile firing"
+            );
+        }
+
+        // The writer comes back. The next poll of that key honours the debt.
+        enqueue_work(watcher.clone(), &process_tx, &dispatch, &metrics).await;
+        let revived = process_rx.try_recv().expect("the key polls again");
+        assert_eq!(
+            revived.trigger,
+            WorkTrigger::Reconcile,
+            "the surviving tick rides the next poll of the key it belongs to"
+        );
+        assert!(
+            dispatch
+                .lock()
+                .expect("dispatch mutex poisoned")
+                .reconcile_owed
+                .is_empty(),
+            "and is drained on use"
+        );
+
+        // Upper bound: one tick, one reconcile-eligible poll. The cycle after
+        // it is ordinary watcher work again.
+        {
+            let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+            state.pending.remove(&key);
+            state.inflight.insert(key.clone());
+        }
+        assert!(complete_work(&key, &dispatch).is_none());
+        enqueue_work(watcher, &process_tx, &dispatch, &metrics).await;
+        let after = process_rx.try_recv().expect("the key polls once more");
+        assert_eq!(
+            after.trigger,
+            WorkTrigger::Watcher,
+            "a surviving debt must be spent once, not latch the key sweep-eligible"
+        );
+        assert!(dispatch
+            .lock()
+            .expect("dispatch mutex poisoned")
+            .reconcile_owed
+            .is_empty());
+    }
+
+    /// Issue #601 §2.4 — `reconcile_owed` is a **set**, and several ticks
+    /// landing on one key that never leaves the pending window between them
+    /// therefore buy one sweep-eligible poll, not one each.
+    ///
+    /// This is a deliberate design choice and the type is where it is made, so
+    /// it gets a guard rather than a comment. A sweep slice covers everything
+    /// accumulated since the previous slice, so the debt is a flag and not an
+    /// amount of work: N flags on one key would buy N identical sweeps of a key
+    /// that needed one, and §4's complete-sweep interval is bounded by the poll
+    /// rate either way.
+    ///
+    /// It is not covered by
+    /// `two_reconcile_ticks_straddling_one_queued_poll_buy_two_polls`, which
+    /// looks adjacent but is the opposite case: its first tick is *dispatched*,
+    /// so only one tick is ever owed and a counting ledger and a set answer
+    /// identically. Nor by
+    /// `a_tick_landing_on_a_queued_poll_survives_that_polls_completion`, which
+    /// lands exactly one tick on the pending window.
+    ///
+    /// Fails for: replacing `HashSet<String>` with a per-key count (the second
+    /// poll after the debt is spent comes back `Reconcile`).
+    #[tokio::test]
+    async fn reconcile_ticks_landing_on_one_queued_poll_coalesce() {
+        let dispatch = Arc::new(Mutex::new(DispatchState::default()));
+        let metrics = Arc::new(Metrics::default());
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(8);
+
+        let proj = "/Users/x/.claude/projects/-Users-x-src-moraine";
+        let sid = "1a5b0c93-3f77-4d2e-9b1c-0d2f6a8e4471";
+        let watcher = WorkItem {
+            source_name: "claude".to_string(),
+            harness: "claude-code".to_string(),
+            format: SourceFormat::Jsonl,
+            source_glob: String::new(),
+            path: format!("{proj}/{sid}.jsonl"),
+            trigger: WorkTrigger::Watcher,
+        };
+        let reconcile = WorkItem {
+            trigger: WorkTrigger::Reconcile,
+            ..watcher.clone()
+        };
+        let key = watcher.key();
+
+        // A watcher poll is dispatched and parks in `pending`: the worker pool
+        // is saturated, so nothing drains it. Two reconcile firings land inside
+        // that one window.
+        enqueue_work(watcher.clone(), &process_tx, &dispatch, &metrics).await;
+        process_rx.try_recv().expect("watcher item is forwarded");
+        enqueue_work(reconcile.clone(), &process_tx, &dispatch, &metrics).await;
+        enqueue_work(reconcile, &process_tx, &dispatch, &metrics).await;
+        assert!(
+            process_rx.try_recv().is_err(),
+            "a key already pending is not queued again"
+        );
+        assert_eq!(
+            dispatch
+                .lock()
+                .expect("dispatch mutex poisoned")
+                .reconcile_owed
+                .len(),
+            1,
+            "two ticks inside one pending window are one debt, not two"
+        );
+
+        // The worker runs the queued watcher poll; the debt is still unpaid.
+        {
+            let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+            state.pending.remove(&key);
+            state.inflight.insert(key.clone());
+        }
+        assert!(complete_work(&key, &dispatch).is_none());
+
+        // The next poll of the key carries the sweep…
+        enqueue_work(watcher.clone(), &process_tx, &dispatch, &metrics).await;
+        assert_eq!(
+            process_rx.try_recv().expect("the key polls again").trigger,
+            WorkTrigger::Reconcile,
+            "the coalesced debt is settled by the next poll"
+        );
+
+        // …and the poll after it is ordinary watcher work. A counting ledger
+        // would make this one `Reconcile` too.
+        {
+            let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+            state.pending.remove(&key);
+            state.inflight.insert(key.clone());
+        }
+        assert!(complete_work(&key, &dispatch).is_none());
+        enqueue_work(watcher, &process_tx, &dispatch, &metrics).await;
+        assert_eq!(
+            process_rx
+                .try_recv()
+                .expect("the key polls once more")
+                .trigger,
+            WorkTrigger::Watcher,
+            "one sweep slice covers everything both ticks would have swept, so \
+             the second tick must not buy a second sweep"
+        );
+        assert!(dispatch
+            .lock()
+            .expect("dispatch mutex poisoned")
+            .reconcile_owed
+            .is_empty());
+    }
+
+    /// Build `count` distinct canonical Claude Code session paths. Distinct
+    /// paths mean distinct `work.key()`s, which is what makes a fleet-wide
+    /// ledger assertion possible.
+    fn sweep_fleet(count: usize) -> Vec<WorkItem> {
+        let proj = "/Users/x/.claude/projects/-Users-x-src-moraine";
+        (0..count)
+            .map(|index| WorkItem {
+                source_name: "claude".to_string(),
+                harness: "claude-code".to_string(),
+                format: SourceFormat::Jsonl,
+                source_glob: String::new(),
+                path: format!("{proj}/7e74512d-612b-4406-ae5e-{index:012}.jsonl"),
+                trigger: WorkTrigger::Watcher,
+            })
+            .collect()
+    }
+
+    /// Issue #601 §2.4 — the **upper** bound on `enqueue_work`'s settle/owe
+    /// condition, which since `complete_work` stopped pruning is the only thing
+    /// bounding `reconcile_owed` at all.
+    ///
+    /// The ordinary case for a reconcile firing is the one this pins: the sweep
+    /// enumerates the whole tracked-path set, and most of those paths are idle,
+    /// so most ticks are handed straight to a poll. Such a tick is *paid on
+    /// dispatch* and must leave no entry behind. Recording it anyway looks
+    /// harmless one key at a time, but a firing touches every path, and with no
+    /// reaper left the debts are permanent: the ledger grows to the full
+    /// tracked-path set and every subsequent watcher poll of every path is
+    /// upgraded to `Reconcile`, attaching a sweep slice to every filesystem
+    /// event forever. That is worse than a per-key latch, and it is invisible to
+    /// the existing bounds — they all drive one key.
+    ///
+    /// So: one sweep over 50 idle paths, then a watcher event on each after it
+    /// has gone idle again.
+    ///
+    /// Not the only test that can *detect* over-owing —
+    /// `two_reconcile_ticks_straddling_one_queued_poll_buy_two_polls` asserts an
+    /// empty ledger after its first carried tick and trips on the same
+    /// single-site mutation. What is unique here is that this test *also* pins
+    /// the **consequence**: it is the only place a debt the sweep should never
+    /// have recorded is shown upgrading an ordinary watcher poll, on every path
+    /// at once, and that closing assertion fails independently of the mid-way
+    /// one. Note the order, though — the mid-way ledger-size assertion runs
+    /// first, so under a single-site over-owe mutation its message is the one a
+    /// developer actually sees; the closing assertion is what that message
+    /// *means*.
+    ///
+    /// Dispatch order is deliberately not asserted. The sweep's coverage claim
+    /// is about which paths are polled, not the sequence they arrive in, and
+    /// WI-04 is free to batch, dedup or reorder sweep dispatch; pinning the
+    /// order here would fail that work for a reason unrelated to
+    /// `reconcile_owed`.
+    ///
+    /// Fails for: owing on every incoming `Reconcile` regardless of whether the
+    /// dispatch carried it — 50 standing debts, and 50 watcher polls that come
+    /// back `Reconcile`.
+    #[tokio::test]
+    async fn a_reconcile_sweep_over_idle_paths_leaves_no_standing_debt() {
+        const PATHS: usize = 50;
+
+        let dispatch = Arc::new(Mutex::new(DispatchState::default()));
+        let metrics = Arc::new(Metrics::default());
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(PATHS * 2);
+        let fleet = sweep_fleet(PATHS);
+
+        // One reconcile firing. Every path is idle, so every tick is handed
+        // straight to a poll.
+        for item in &fleet {
+            let tick = WorkItem {
+                trigger: WorkTrigger::Reconcile,
+                ..item.clone()
+            };
+            enqueue_work(tick, &process_tx, &dispatch, &metrics).await;
+        }
+        let mut swept_paths = std::collections::HashSet::new();
+        for _ in &fleet {
+            let swept = process_rx.try_recv().expect("every idle path is swept");
+            assert_eq!(swept.trigger, WorkTrigger::Reconcile);
+            swept_paths.insert(swept.path);
+        }
+        assert_eq!(
+            swept_paths,
+            fleet.iter().map(|item| item.path.clone()).collect(),
+            "the sweep covers every idle path exactly once, in whatever order"
+        );
+
+        {
+            let state = dispatch.lock().expect("dispatch mutex poisoned");
+            let owed = state.reconcile_owed.len();
+            assert_eq!(
+                owed, 0,
+                "a tick a dispatch carried is paid; {owed} of {PATHS} swept \
+                 paths are carrying a standing debt, and nothing prunes it"
+            );
+        }
+
+        // Each swept poll runs and finishes with nothing behind it, so every
+        // key leaves the dispatcher.
+        for item in &fleet {
+            let key = item.key();
+            {
+                let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+                state.pending.remove(&key);
+                state.inflight.insert(key.clone());
+            }
+            assert!(complete_work(&key, &dispatch).is_none());
+        }
+
+        // The writers come back. Ordinary watcher work must stay ordinary
+        // watcher work: no standing debt means no sweep slice on a filesystem
+        // event.
+        for item in &fleet {
+            enqueue_work(item.clone(), &process_tx, &dispatch, &metrics).await;
+        }
+        let mut upgraded = 0usize;
+        for _ in 0..PATHS {
+            let polled = process_rx.try_recv().expect("every path polls again");
+            if polled.trigger == WorkTrigger::Reconcile {
+                upgraded += 1;
+            }
+        }
+        assert_eq!(
+            upgraded, 0,
+            "{upgraded} of {PATHS} watcher polls were upgraded to Reconcile by a \
+             debt the sweep should never have recorded; a sweep slice on every \
+             watcher event on every path is the cost"
+        );
+    }
+
+    /// Issue #601 §0/§4 — the **lower** bound on `enqueue_work`'s settle/owe
+    /// condition, and the half that its `should_send` conjunct carries alone.
+    ///
+    /// Two reconcile firings can straddle one queued poll. The first tick finds
+    /// the path idle and is dispatched, so `item_by_key` now reads `Reconcile`;
+    /// the worker pool is saturated, so that poll sits in `pending` rather than
+    /// running. The second tick lands on top of it. Its merged trigger is
+    /// `Reconcile` — inherited from the queued item, not carried by this call —
+    /// and a settle condition that inspects the trigger without also requiring
+    /// that *this* call dispatched it reads the second tick as already paid and
+    /// discards it. One firing's worth of sweep coverage vanishes, and nothing
+    /// re-issues it: `spawn_reconcile_task` does not remember what it
+    /// dispatched.
+    ///
+    /// Two ticks must therefore buy two reconcile-eligible polls.
+    ///
+    /// Direction bounded: **lower**, by the closing assertion — the second tick
+    /// must survive. The mid-way assertion that the *first* tick left an empty
+    /// ledger is an incidental upper-bound check on the same condition, and is
+    /// deliberately kept: it is what makes this test trip on an over-owing
+    /// mutation too, so neither conjunct can be moved without something here
+    /// going red.
+    ///
+    /// Fails for: dropping the `should_send` conjunct from the settle condition
+    /// (the second tick takes the settled path and the revived poll comes back
+    /// `Watcher`); or owing on every incoming `Reconcile` (the first tick's
+    /// carried dispatch leaves a debt behind).
+    #[tokio::test]
+    async fn two_reconcile_ticks_straddling_one_queued_poll_buy_two_polls() {
+        let dispatch = Arc::new(Mutex::new(DispatchState::default()));
+        let metrics = Arc::new(Metrics::default());
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(8);
+
+        let watcher = sweep_fleet(1).remove(0);
+        let reconcile = WorkItem {
+            trigger: WorkTrigger::Reconcile,
+            ..watcher.clone()
+        };
+        let key = watcher.key();
+
+        // First firing: the path is idle, so the tick rides the poll it starts.
+        enqueue_work(reconcile.clone(), &process_tx, &dispatch, &metrics).await;
+        let first = process_rx.try_recv().expect("an idle path is swept");
+        assert_eq!(first.trigger, WorkTrigger::Reconcile);
+        {
+            let state = dispatch.lock().expect("dispatch mutex poisoned");
+            assert!(state.pending.contains(&key), "queued, not yet inflight");
+            assert!(
+                state.reconcile_owed.is_empty(),
+                "the dispatch carried it, so nothing is owed"
+            );
+        }
+
+        // Second firing, while the first poll is still queued. The stored item
+        // reads `Reconcile`, but this call handed nothing to a poll.
+        enqueue_work(reconcile, &process_tx, &dispatch, &metrics).await;
+        assert!(
+            process_rx.try_recv().is_err(),
+            "a key already pending is not queued a second time"
+        );
+        assert!(
+            dispatch
+                .lock()
+                .expect("dispatch mutex poisoned")
+                .reconcile_owed
+                .contains(&key),
+            "an incoming tick this call did not dispatch is owed, whatever the \
+             queued item's trigger happens to read"
+        );
+
+        // The queued poll runs and finishes with nothing behind it.
+        {
+            let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+            state.pending.remove(&key);
+            state.inflight.insert(key.clone());
+        }
+        assert!(complete_work(&key, &dispatch).is_none());
+
+        // The second firing's tick is still owed, and the next poll carries it.
+        enqueue_work(watcher, &process_tx, &dispatch, &metrics).await;
+        let second = process_rx.try_recv().expect("the key polls again");
+        assert_eq!(
+            second.trigger,
+            WorkTrigger::Reconcile,
+            "two reconcile firings must buy two reconcile-eligible polls; the \
+             second tick was swallowed by the first tick's queued poll"
+        );
+        assert!(dispatch
+            .lock()
+            .expect("dispatch mutex poisoned")
+            .reconcile_owed
+            .is_empty());
+    }
+
+    /// `arm_owed_reconcile` is the only place in the dispatcher that upgrades a
+    /// trigger, so it is also the only place that can contradict
+    /// `WorkTrigger::merge`. `merge` keeps `Startup` over `Reconcile` because
+    /// `Startup`'s own doc says startup is the worst moment to add a broad
+    /// scan; the arming path must agree.
+    ///
+    /// Direction bounded: **upper**, on which polls may become sweep-eligible —
+    /// a `Startup` poll may not. And the debt is not spent by the refusal:
+    /// refusing to carry a tick is not paying it, so the ledger keeps the entry
+    /// for the key's next ordinary poll. That second assertion is what keeps
+    /// the refusal from silently becoming a *lower*-bound violation.
+    ///
+    /// It does **not** bound the refusal's *width*: this test drives only a
+    /// `Startup` carrier, so a predicate that refused every non-`Watcher`
+    /// carrier would satisfy it. That direction is
+    /// `a_standing_debt_is_settled_by_a_reconcile_poll_not_only_a_watcher_one`,
+    /// immediately below; the pair is what makes the condition exactly
+    /// `== Startup` and not merely "at least `Startup`".
+    ///
+    /// No production `Startup` item can hold a debt today (`arm_owed_reconcile`
+    /// carries the reachability argument), which is exactly why this is a test
+    /// rather than a comment: WI-04 gives the upgrade a real cost, and an
+    /// unpinned branch is one a later change may flip without noticing.
+    ///
+    /// Fails for: dropping the `Startup` refusal (the backfill poll comes back
+    /// `Reconcile`), or refusing while still draining the ledger (the tick is
+    /// destroyed and the following watcher poll comes back `Watcher`).
+    ///
+    /// It also trips if `complete_work`'s deleted second reaper is reinstated,
+    /// because parking a debt on an *idle* key is only reachable through the
+    /// pending window. That is a side effect of the setup, not a claim: the
+    /// prune itself is guarded by
+    /// `a_tick_landing_on_a_queued_poll_survives_that_polls_completion`.
+    #[tokio::test]
+    async fn an_owed_tick_neither_upgrades_a_startup_poll_nor_is_spent_by_it() {
+        let dispatch = Arc::new(Mutex::new(DispatchState::default()));
+        let metrics = Arc::new(Metrics::default());
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(8);
+
+        let watcher = sweep_fleet(1).remove(0);
+        let key = watcher.key();
+        let startup = WorkItem {
+            trigger: WorkTrigger::Startup,
+            ..watcher.clone()
+        };
+
+        // Park an unpaid tick on an otherwise idle key: a reconcile tick lands
+        // on a queued watcher poll, which then completes with nothing behind it.
+        enqueue_work(watcher.clone(), &process_tx, &dispatch, &metrics).await;
+        process_rx.try_recv().expect("watcher item is forwarded");
+        enqueue_work(
+            WorkItem {
+                trigger: WorkTrigger::Reconcile,
+                ..watcher.clone()
+            },
+            &process_tx,
+            &dispatch,
+            &metrics,
+        )
+        .await;
+        {
+            let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+            assert!(state.reconcile_owed.contains(&key), "the tick is owed");
+            state.pending.remove(&key);
+            state.inflight.insert(key.clone());
+        }
+        assert!(complete_work(&key, &dispatch).is_none());
+
+        // The startup backfill reaches the path. It must not pay sweep cost.
+        enqueue_work(startup, &process_tx, &dispatch, &metrics).await;
+        let backfill = process_rx.try_recv().expect("the startup poll is sent");
+        assert_eq!(
+            backfill.trigger,
+            WorkTrigger::Startup,
+            "startup is the worst moment to add a broad scan, and merge already \
+             says so; the arming path must not override it"
+        );
+        assert!(
+            dispatch
+                .lock()
+                .expect("dispatch mutex poisoned")
+                .reconcile_owed
+                .contains(&key),
+            "and refusing to carry the tick is not paying it — the debt stands"
+        );
+
+        // The key's next ordinary poll settles it.
+        {
+            let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+            state.pending.remove(&key);
+            state.inflight.insert(key.clone());
+        }
+        assert!(complete_work(&key, &dispatch).is_none());
+        enqueue_work(watcher, &process_tx, &dispatch, &metrics).await;
+        let after = process_rx.try_recv().expect("the key polls again");
+        assert_eq!(
+            after.trigger,
+            WorkTrigger::Reconcile,
+            "the tick the startup poll declined to carry rides the next one"
+        );
+        assert!(dispatch
+            .lock()
+            .expect("dispatch mutex poisoned")
+            .reconcile_owed
+            .is_empty());
+    }
+
+    /// Issue #601 §2.4 — the **width** of `arm_owed_reconcile`'s refusal, the
+    /// direction its own guard cannot see.
+    ///
+    /// `an_owed_tick_neither_upgrades_a_startup_poll_nor_is_spent_by_it` bounds
+    /// the refusal from both of the usual sides — it must fire for `Startup`,
+    /// and firing must not also spend the debt — but it drives only a `Startup`
+    /// carrier. Widening the condition by one token, from `== Startup` to
+    /// `!= Watcher`, therefore leaves it green, along with every other test in
+    /// the suite. What that widening actually removes is the settlement of a
+    /// standing debt onto a `Reconcile` carrier, and that is an ordinary steady
+    /// state rather than a corner:
+    ///
+    ///   1. a reconcile tick lands on a `pending` key and is owed — the window
+    ///      `a_tick_landing_on_a_queued_poll_survives_that_polls_completion`
+    ///      models;
+    ///   2. that poll completes with nothing behind it, so the key leaves the
+    ///      dispatcher with the debt standing;
+    ///   3. the *next* reconcile firing, one `reconcile_interval_seconds`
+    ///      later, finds the key idle — and its carrier is already `Reconcile`.
+    ///      That poll is the natural place to settle the debt, and this is the
+    ///      step the widened predicate skips.
+    ///
+    /// Skipping it costs twice. The debt survives a firing that should have
+    /// cleared it, so the next ordinary watcher event spends it instead and a
+    /// filesystem event pays for a sweep slice nothing bought — precisely the
+    /// inversion `one_reconcile_tick_buys_exactly_one_reconcile_eligible_poll`
+    /// exists to prevent. And on a path that never sees another watcher event —
+    /// an archived session, a rotated log — no reconcile poll will ever clear
+    /// the entry either, so it is a permanent leak, which the retention
+    /// argument in `complete_work` does not cover: that argument assumes a
+    /// tracked path's next reconcile firing drains its debt.
+    ///
+    /// Direction bounded: **width**. Narrowing the refusal is covered by the
+    /// test above (dropping it makes a `Startup` poll sweep-eligible);
+    /// widening it by one token is covered here and, at the time of writing,
+    /// nowhere else in the suite.
+    ///
+    /// Fails for: refusing to settle on any carrier other than `Watcher` — the
+    /// debt survives step 3 and is spent by the following watcher poll instead.
+    #[tokio::test]
+    async fn a_standing_debt_is_settled_by_a_reconcile_poll_not_only_a_watcher_one() {
+        let dispatch = Arc::new(Mutex::new(DispatchState::default()));
+        let metrics = Arc::new(Metrics::default());
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(8);
+
+        let watcher = sweep_fleet(1).remove(0);
+        let key = watcher.key();
+        let tick = WorkItem {
+            trigger: WorkTrigger::Reconcile,
+            ..watcher.clone()
+        };
+
+        // Step 1-2: a tick lands on a queued watcher poll and is owed; the poll
+        // completes with nothing behind it, so the key leaves the dispatcher
+        // with the debt standing.
+        enqueue_work(watcher.clone(), &process_tx, &dispatch, &metrics).await;
+        process_rx.try_recv().expect("watcher item is forwarded");
+        enqueue_work(tick.clone(), &process_tx, &dispatch, &metrics).await;
+        {
+            let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+            assert!(
+                state.reconcile_owed.contains(&key),
+                "a tick landing on a pending poll is owed"
+            );
+            state.pending.remove(&key);
+            state.inflight.insert(key.clone());
+        }
+        assert!(complete_work(&key, &dispatch).is_none());
+
+        // Step 3: the next reconcile firing finds the key idle. The poll it
+        // starts already carries `Reconcile`, and it is that poll — not some
+        // later watcher event — that settles the standing debt.
+        enqueue_work(tick, &process_tx, &dispatch, &metrics).await;
+        let swept = process_rx.try_recv().expect("the idle key is swept");
+        assert_eq!(swept.trigger, WorkTrigger::Reconcile);
+        assert!(
+            dispatch
+                .lock()
+                .expect("dispatch mutex poisoned")
+                .reconcile_owed
+                .is_empty(),
+            "a reconcile poll settles a standing debt just as a watcher poll \
+             does; refusing to settle on anything but a `Watcher` carrier \
+             leaves the debt to be spent by a filesystem event instead"
+        );
+
+        // Consequence: with the debt already settled, the key's next ordinary
+        // watcher poll is ordinary watcher work. If step 3 had skipped the
+        // settlement this is where the sweep slice would attach.
+        {
+            let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+            state.pending.remove(&key);
+            state.inflight.insert(key.clone());
+        }
+        assert!(complete_work(&key, &dispatch).is_none());
+        enqueue_work(watcher, &process_tx, &dispatch, &metrics).await;
+        let after = process_rx.try_recv().expect("the key polls again");
+        assert_eq!(
+            after.trigger,
+            WorkTrigger::Watcher,
+            "a debt a reconcile poll already paid must not be spent a second \
+             time by a filesystem event"
+        );
+    }
+
+    /// Issue #601 §2.4 — the **width** of the settle/owe condition's *incoming*
+    /// filter, the sibling hole to the one above and found the same way.
+    ///
+    /// `incoming_trigger == Reconcile` names one variant of three, so its
+    /// extent needs pinning at both neighbours, not just at `Reconcile`.
+    /// `debounce_coalesces_a_watcher_burst_into_one_watcher_poll` already
+    /// covers `Watcher` ("watcher churn must not manufacture a reconcile
+    /// debt"); this covers `Startup`, and without it widening the filter by one
+    /// token to `!= Watcher` leaves the whole suite green.
+    ///
+    /// The widened form would let a startup backfill enqueue *create* a debt,
+    /// which is the same §2.4 inversion `arm_owed_reconcile` refuses in the
+    /// other direction — there a `Startup` poll may not *carry* a tick; here a
+    /// `Startup` event may not *mint* one. Refusing only the first while
+    /// permitting the second is strictly worse than permitting both, because
+    /// the minted debt is then spent by some later watcher poll: a filesystem
+    /// event pays sweep cost that a startup event bought.
+    ///
+    /// And it is far more reachable than the carrier case. `run_ingestor`
+    /// spawns the watcher threads *before* the backfill loop, so during startup
+    /// a path can have a queued watcher poll at the moment backfill enumerates
+    /// it — an ordinary race on any harness that is writing while moraine
+    /// starts, not the narrow window `arm_owed_reconcile`'s reachability note
+    /// describes.
+    ///
+    /// Direction bounded: **width**, at the `Startup` neighbour. `Reconcile`
+    /// itself is bounded by the owe path's own lower/upper guards
+    /// (`two_reconcile_ticks_straddling_one_queued_poll_buy_two_polls` and
+    /// `a_reconcile_sweep_over_idle_paths_leaves_no_standing_debt`).
+    ///
+    /// Fails for: owing on any incoming trigger that is not `Watcher` — the
+    /// startup enqueue mints a debt and the following watcher poll spends it.
+    #[tokio::test]
+    async fn a_startup_poll_landing_on_a_queued_poll_owes_nothing() {
+        let dispatch = Arc::new(Mutex::new(DispatchState::default()));
+        let metrics = Arc::new(Metrics::default());
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(8);
+
+        let watcher = sweep_fleet(1).remove(0);
+        let key = watcher.key();
+        let startup = WorkItem {
+            trigger: WorkTrigger::Startup,
+            ..watcher.clone()
+        };
+
+        // A watcher poll is queued for a path the startup backfill has not
+        // reached yet.
+        enqueue_work(watcher.clone(), &process_tx, &dispatch, &metrics).await;
+        let queued = process_rx.try_recv().expect("watcher item is forwarded");
+        assert_eq!(queued.trigger, WorkTrigger::Watcher);
+
+        // Backfill reaches it. The key is already pending, so nothing is
+        // dispatched — and a startup event is not a reconcile tick, so there is
+        // nothing to remember either.
+        enqueue_work(startup, &process_tx, &dispatch, &metrics).await;
+        assert!(
+            process_rx.try_recv().is_err(),
+            "a key already pending is not queued a second time"
+        );
+        assert!(
+            dispatch
+                .lock()
+                .expect("dispatch mutex poisoned")
+                .reconcile_owed
+                .is_empty(),
+            "startup backfill must not manufacture a reconcile debt; only a \
+             reconcile tick may put an entry in the ledger"
+        );
+
+        // Consequence: the key's next poll is ordinary watcher work. This is
+        // where a minted debt would attach its sweep slice.
+        {
+            let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+            state.pending.remove(&key);
+            state.inflight.insert(key.clone());
+        }
+        assert!(complete_work(&key, &dispatch).is_none());
+        enqueue_work(watcher, &process_tx, &dispatch, &metrics).await;
+        let after = process_rx.try_recv().expect("the key polls again");
+        assert_eq!(
+            after.trigger,
+            WorkTrigger::Watcher,
+            "a filesystem event must not pay for a sweep slice that a startup \
+             event bought"
+        );
+    }
+
+    /// The debounce window coalesces by `work.key()`, so a watcher burst on one
+    /// session file becomes **one** poll rather than one poll per event.
+    ///
+    /// Only watcher events are fed, because only watcher events reach this
+    /// window in production: its receiver is `watch_path_rx` and its only
+    /// sender is `spawn_watcher_threads`. The earlier version of this test drove
+    /// `Reconcile` through it to exercise a debt-owing branch that no producer
+    /// could reach; that branch is deleted, and asserting on synthetic input is
+    /// how it survived being dead. `spawn_debounce_task` now `debug_assert`s the
+    /// invariant, so a future `Reconcile` producer trips there instead.
+    ///
+    /// The coalesced poll must stay `Watcher` and the ledger must stay empty:
+    /// watcher churn alone never manufactures sweep eligibility that no
+    /// reconcile tick paid for (the §2.4 upper bound, at the debounce).
+    ///
+    /// Fails for: a window that never drains its ready items (nothing is
+    /// dispatched at all), or owing a debt from this window again — the owed
+    /// tick is armed onto the very poll the burst dispatches, so it comes back
+    /// `Reconcile` and watcher churn has bought itself a sweep slice.
+    ///
+    /// It does **not** falsify the debounce's choice of coalescing key: keying
+    /// the window per-event still yields one poll, because `enqueue_work`'s
+    /// `pending` set dedupes by `work.key()` underneath it (verified by
+    /// mutation — the burst stays one entry). The single-entry assertion is
+    /// therefore a statement about the pair, not about this map alone.
+    ///
+    /// It also does **not** bound the *width* of `enqueue_work`'s settle/owe
+    /// filter, and an earlier revision of that filter's comment claimed it did.
+    /// The burst coalesces into one `enqueue_work` call against an idle key, so
+    /// `pending.insert` returns true, `carried` is true, and the owe branch is
+    /// unreachable regardless of which triggers the filter admits: widening it
+    /// to `incoming_trigger != WorkTrigger::Startup` leaves this test green
+    /// (run alone under that mutation: 1 passed, 0 failed).
+    /// `one_reconcile_tick_buys_exactly_one_reconcile_eligible_poll` is what
+    /// catches that.
+    #[tokio::test]
+    async fn debounce_coalesces_a_watcher_burst_into_one_watcher_poll() {
+        let proj = "/Users/x/.claude/projects/-Users-x-src-moraine";
+        let sid = "7e74512d-612b-4406-ae5e-069e73d7f2dc";
+        let base = WorkItem {
+            source_name: "claude".to_string(),
+            harness: "claude-code".to_string(),
+            format: SourceFormat::Jsonl,
+            source_glob: String::new(),
+            path: format!("{proj}/{sid}.jsonl"),
+            trigger: WorkTrigger::Watcher,
+        };
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.debounce_ms = 10;
+        let dispatch = Arc::new(Mutex::new(DispatchState::default()));
+        let metrics = Arc::new(Metrics::default());
+        let (debounce_tx, debounce_rx) = mpsc::unbounded_channel::<WorkItem>();
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(8);
+        let task = spawn_debounce_task(
+            config,
+            debounce_rx,
+            process_tx,
+            dispatch.clone(),
+            metrics.clone(),
+        );
+
+        for _ in 0..4 {
+            debounce_tx
+                .send(base.clone())
+                .expect("watcher event reaches the debounce");
+        }
+
+        let dispatched = timeout(Duration::from_secs(2), process_rx.recv())
+            .await
+            .expect("debounce must emit within the window")
+            .expect("debounce channel stays open");
+        assert_eq!(
+            dispatched.trigger,
+            WorkTrigger::Watcher,
+            "a burst of watcher events dispatches as watcher work"
+        );
+        assert!(
+            timeout(Duration::from_millis(100), process_rx.recv())
+                .await
+                .is_err(),
+            "the burst must coalesce into one queue entry"
+        );
+        assert!(
+            dispatch
+                .lock()
+                .expect("dispatch mutex poisoned")
+                .reconcile_owed
+                .is_empty(),
+            "watcher churn must not manufacture a reconcile debt"
+        );
+        drop(debounce_tx);
+        task.abort();
     }
 
     #[test]
@@ -3234,6 +4719,7 @@ mod tests {
             format: SourceFormat::KiroSession,
             source_glob: String::new(),
             path: path.to_string_lossy().to_string(),
+            trigger: WorkTrigger::Watcher,
         }
     }
 
@@ -3731,6 +5217,7 @@ mod tests {
                 format: SourceFormat::Jsonl,
                 source_glob: String::new(),
                 path: path.to_string_lossy().to_string(),
+                trigger: WorkTrigger::Watcher,
             };
             process_file(
                 &config,
@@ -3929,6 +5416,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: path.to_string_lossy().to_string(),
+            trigger: WorkTrigger::Watcher,
         };
 
         process_file(
@@ -3990,6 +5478,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: path.to_string_lossy().to_string(),
+            trigger: WorkTrigger::Watcher,
         };
 
         process_file(
@@ -4045,6 +5534,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: source_file,
+            trigger: WorkTrigger::Watcher,
         };
 
         process_file(
@@ -4117,6 +5607,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
         };
 
         // Simulate a restart that already ingested the session header: the
@@ -4213,6 +5704,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: source_file,
+            trigger: WorkTrigger::Watcher,
         };
         let config = moraine_config::AppConfig::default();
         let checkpoints = Arc::new(RwLock::new(HashMap::<String, Checkpoint>::new()));
@@ -4298,6 +5790,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: source_file,
+            trigger: WorkTrigger::Watcher,
         };
 
         process_file(
@@ -4367,6 +5860,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: source_file,
+            trigger: WorkTrigger::Watcher,
         };
 
         process_file(
@@ -4457,6 +5951,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
         };
 
         process_file(
@@ -4618,6 +6113,7 @@ mod tests {
             format: SourceFormat::Jsonl,
             source_glob: String::new(),
             path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
         };
 
         process_file(
@@ -4731,6 +6227,7 @@ mod tests {
             format: SourceFormat::SessionJson,
             source_glob: String::new(),
             path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
         };
 
         process_session_json_file(
@@ -4847,6 +6344,7 @@ mod tests {
             format: SourceFormat::SessionJson,
             source_glob: String::new(),
             path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
         };
 
         process_session_json_file(

--- a/crates/moraine-ingest-core/src/lib.rs
+++ b/crates/moraine-ingest-core/src/lib.rs
@@ -27,7 +27,7 @@ use crate::sink::{spawn_sink_task, SinkAuthorConfig, SinkRole};
 use crate::tee::{
     spawn_tee_router, RedactionContext, RouteResolver, SharedRouteResolver, StatusRegistry,
 };
-use crate::watch::{enumerate_tracked_files, spawn_watcher_threads};
+use crate::watch::{enumerate_startup_work_items, spawn_watcher_threads};
 use anyhow::{bail, Context, Result};
 use moraine_clickhouse::{ClickHouseClient, QueryClass, QueryEnvelope};
 use moraine_config::{
@@ -46,6 +46,40 @@ pub(crate) const WATCHER_BACKEND_NATIVE: u64 = 1;
 pub(crate) const WATCHER_BACKEND_POLL: u64 = 2;
 pub(crate) const WATCHER_BACKEND_MIXED: u64 = 3;
 
+/// Why a `WorkItem` was queued (issue #601 §2.4). Nothing downstream of
+/// `process_file` could previously tell a watcher tick from a reconcile tick,
+/// which is what makes "reconciliation must not run on every watcher event"
+/// unimplementable and untestable.
+///
+/// The variants are ordered by how much expensive reconciliation work a poll
+/// under that trigger may do — least first — and `merge` relies on that
+/// ordering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum WorkTrigger {
+    /// A filesystem watcher event, or a watcher-driven rescan. Latency-
+    /// sensitive and arbitrarily bursty, so never sweep-eligible.
+    #[default]
+    Watcher,
+    /// A one-shot poll outside the steady-state loops: startup backfill and
+    /// the tee router's backend-discovery probe. Not sweep-eligible either —
+    /// startup is the worst moment to add a broad scan.
+    Startup,
+    /// A `reconcile_interval_seconds` tick. The only trigger a reconciliation
+    /// sweep slice may attach to.
+    Reconcile,
+}
+
+impl WorkTrigger {
+    /// Coalescing two queued items keeps the *least* reconciliation-eligible
+    /// trigger, so a watcher burst that swallows a reconcile tick does not
+    /// become sweep-eligible (latency wins). The next reconcile tick is.
+    /// This is also what stops `complete_work`'s dirty re-enqueue from
+    /// upgrading a watcher item to `Reconcile`.
+    pub(crate) fn merge(self, other: Self) -> Self {
+        self.min(other)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct WorkItem {
     pub(crate) source_name: String,
@@ -53,9 +87,56 @@ pub(crate) struct WorkItem {
     pub(crate) format: SourceFormat,
     pub(crate) source_glob: String,
     pub(crate) path: String,
+    pub(crate) trigger: WorkTrigger,
 }
 
 impl WorkItem {
+    /// The **only** place non-test code stamps `WorkTrigger::Watcher`. Both
+    /// watcher paths — the per-event fan-out that every real filesystem event
+    /// takes, and `queue_rescan`'s recovery enumeration — go through here, so
+    /// there is a single literal for `watcher_work_items_are_stamped_as_watcher_triggered`
+    /// to guard. A second literal would be a stamp no test covers, which is
+    /// exactly how the per-event path went unguarded.
+    pub(crate) fn watcher(
+        source_name: &str,
+        harness: &str,
+        format: SourceFormat,
+        source_glob: &str,
+        path: String,
+    ) -> Self {
+        Self {
+            source_name: source_name.to_string(),
+            harness: harness.to_string(),
+            format,
+            source_glob: source_glob.to_string(),
+            path,
+            trigger: WorkTrigger::Watcher,
+        }
+    }
+
+    /// The **only** place non-test code stamps `WorkTrigger::Startup`: the
+    /// startup backfill in `run_ingestor`, the tee router's backend-discovery
+    /// probe, and its replay pass. Same single-literal rule as `watcher`.
+    pub(crate) fn startup(
+        source_name: &str,
+        harness: &str,
+        format: SourceFormat,
+        source_glob: &str,
+        path: String,
+    ) -> Self {
+        Self {
+            source_name: source_name.to_string(),
+            harness: harness.to_string(),
+            format,
+            source_glob: source_glob.to_string(),
+            path,
+            trigger: WorkTrigger::Startup,
+        }
+    }
+
+    /// Deliberately excludes `trigger`: it is the coalescing key, and a
+    /// trigger-bearing key would give every watcher event its own queue entry
+    /// and defeat the debounce entirely.
     pub(crate) fn key(&self) -> String {
         format!("{}\n{}", self.source_name, self.path)
     }
@@ -67,6 +148,73 @@ pub(crate) struct DispatchState {
     pub(crate) inflight: HashSet<String>,
     pub(crate) dirty: HashSet<String>,
     pub(crate) item_by_key: HashMap<String, WorkItem>,
+    /// Keys owed a reconcile tick that arrived while the key was already
+    /// pending, inflight or dirty (issue #601 §2.4, and the starvation defect
+    /// that merge alone creates).
+    ///
+    /// The merge rule is right — an *inflight* poll must never be upgraded to
+    /// `Reconcile` mid-flight — but dropping the tick outright is not: on a
+    /// continuously written database the key is pending or inflight most of
+    /// the time, so every reconcile tick would be downgraded and discarded and
+    /// the sweep would never run on the one source with the most history to
+    /// sweep. That is the coverage hazard §0 exists to prevent, and it would
+    /// make §4's "measured maximum complete-sweep interval" unbounded.
+    ///
+    /// So the tick is remembered here and re-armed onto the *next* poll of that
+    /// key that starts fresh.
+    ///
+    /// **This is a debt ledger with exactly one creator and exactly one
+    /// reaper.** An entry is created only by an incoming `Reconcile` that no
+    /// dispatch carried — `enqueue_work`'s settle/owe condition — and removed
+    /// only by the dispatch that carries one (`arm_owed_reconcile`).
+    ///
+    /// It is specifically **not** removed by the key leaving the dispatcher.
+    /// `complete_work`'s prune used to do that and was deleted, because every
+    /// reachable firing of it destroyed a live tick: a debt can only exist on a
+    /// key that was pending when the tick landed, and such a key reaches the
+    /// prune with the tick still unpaid (`complete_work`'s comment carries the
+    /// case analysis; plan §7.1 D1a records the deviation).
+    ///
+    /// So the creating condition is the *whole* bound on this map, in both
+    /// directions, and neither direction may be weakened without the other
+    /// noticing. Over-owing it — recording a tick that a dispatch did in fact
+    /// carry — is now permanent rather than self-correcting, and grows the map
+    /// to the full tracked-path set while making every later watcher poll of
+    /// every path sweep-eligible. Under-owing it drops ticks outright and
+    /// unbounds §4's complete-sweep interval. The pair
+    /// `a_reconcile_sweep_over_idle_paths_leaves_no_standing_debt` (upper) and
+    /// `two_reconcile_ticks_straddling_one_queued_poll_buy_two_polls` (lower)
+    /// bound that one condition from both sides.
+    ///
+    /// An entry is never created by noticing that a *stored* item's trigger was
+    /// downgraded: that item describes a poll which already exists, so re-owing
+    /// on its downgrade re-owes a paid tick and latches the key permanently
+    /// sweep-eligible under pure watcher churn. Creation is therefore bounded
+    /// by the reconcile cadence, which is what makes "one tick buys **at most**
+    /// one reconcile-eligible poll" true.
+    ///
+    /// The converse — one tick buys *at least* one — deliberately does **not**
+    /// hold, and the type is where that is decided. This is a `HashSet`, so
+    /// several ticks landing on a key that never leaves the
+    /// pending/inflight/dirty window between them collapse into a single debt:
+    /// the second `insert` is a no-op and one sweep slice settles all of them.
+    /// That is the right trade, not an oversight. A sweep slice covers
+    /// everything that has accumulated since the previous one, so the debt is a
+    /// *flag* — "this key owes a sweep" — and not an amount of work; N flags
+    /// would buy N identical sweeps of a key that only ever needed one. §4's
+    /// complete-sweep interval is bounded by the rate at which the key polls at
+    /// all, which coalescing does not change. `two_reconcile_ticks_straddling_
+    /// one_queued_poll_buy_two_polls` shows the other case and does not
+    /// contradict this one: its first tick is *dispatched*, so only one tick is
+    /// ever owed. `reconcile_ticks_landing_on_one_queued_poll_coalesce` pins
+    /// the coalescing itself, which is what a `HashMap<String, u32>` here would
+    /// break.
+    ///
+    /// Retention cost: one `String` per indebted path. A path that stays
+    /// tracked settles on its next poll; a path that leaves tracking while
+    /// still indebted is never enumerated again, so its entry lives until the
+    /// process restarts.
+    pub(crate) reconcile_owed: HashSet<String>,
 }
 
 #[derive(Default)]
@@ -84,6 +232,23 @@ pub(crate) struct Metrics {
     pub(crate) watcher_reset_count: AtomicU64,
     pub(crate) watcher_last_reset_unix_ms: AtomicU64,
     pub(crate) watcher_backend_state: AtomicU64,
+    /// Payload bytes materialized by SQLite polls (issue #601 §2.0). Charged
+    /// from `ScanLedger` at the read site on both the success and the failure
+    /// path, never derived from emitted-record counts.
+    pub(crate) sqlite_poll_payload_bytes_total: AtomicU64,
+    /// Rows whose payload column a SQLite poll materialized.
+    pub(crate) sqlite_poll_payload_rows_total: AtomicU64,
+    /// Census rows walked by SQLite polls. Both ledger axes are folded here,
+    /// not just the payload one: a counter no test can read is an unfailable
+    /// guard, and the OpenCode rewind preflight charges *only* the census
+    /// axis, so a payload-only fold would leave that call site uncoverable.
+    pub(crate) sqlite_poll_census_rows_total: AtomicU64,
+    /// Census bytes materialized by SQLite polls.
+    pub(crate) sqlite_poll_census_bytes_total: AtomicU64,
+    /// Completed SQLite scans that ended in a failure outcome. This is the
+    /// observed-scan denominator the failure-backoff gate asserts on;
+    /// `ingest_errors` rows are rate-limited and cannot count scans.
+    pub(crate) sqlite_scan_failures_total: AtomicU64,
     pub(crate) last_error: Mutex<String>,
 }
 
@@ -533,34 +698,26 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
     if config.ingest.backfill_on_start {
         let mut backfill_sources = Vec::new();
         for source in &enabled_sources {
-            let files = enumerate_tracked_files(&source.glob, source.format)?;
+            // `enumerate_startup_work_items` is the single literal that stamps
+            // `Startup` (see its doc): a `Watcher` stamp here would let
+            // `arm_owed_reconcile` upgrade a backfill poll to `Reconcile`,
+            // which is the one inversion plan §7.1 D1c exists to refuse.
+            let files = enumerate_startup_work_items(source)?;
             info!(
                 "startup backfill queueing {} files for source={} (format={})",
                 files.len(),
                 source.name,
                 source.format
             );
-            backfill_sources.push((source.clone(), files.into_iter()));
+            backfill_sources.push(files.into_iter());
         }
 
         loop {
             let mut queued_any = false;
-            for (source, files) in &mut backfill_sources {
-                if let Some(path) = files.next() {
+            for files in &mut backfill_sources {
+                if let Some(work) = files.next() {
                     queued_any = true;
-                    enqueue_work(
-                        WorkItem {
-                            source_name: source.name.clone(),
-                            harness: source.harness.clone(),
-                            format: source.format,
-                            source_glob: source.glob.clone(),
-                            path,
-                        },
-                        &process_tx,
-                        &dispatch,
-                        &metrics,
-                    )
-                    .await;
+                    enqueue_work(work, &process_tx, &dispatch, &metrics).await;
                 }
             }
 

--- a/crates/moraine-ingest-core/src/reconcile.rs
+++ b/crates/moraine-ingest-core/src/reconcile.rs
@@ -1,6 +1,6 @@
 use crate::dispatch::enqueue_work;
 use crate::watch::enumerate_tracked_files;
-use crate::{DispatchState, Metrics, WorkItem};
+use crate::{DispatchState, Metrics, WorkItem, WorkTrigger};
 use moraine_config::{AppConfig, IngestSource};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -38,6 +38,9 @@ pub(crate) fn spawn_reconcile_task(
                                     format: source.format,
                                     source_glob: source.glob.clone(),
                                     path,
+                                    // The only trigger a reconciliation sweep
+                                    // slice may ever attach to (§2.2, §2.4).
+                                    trigger: WorkTrigger::Reconcile,
                                 },
                                 &process_tx,
                                 &dispatch,
@@ -53,4 +56,59 @@ pub(crate) fn spawn_reconcile_task(
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::spawn_reconcile_task;
+    use crate::{DispatchState, Metrics, WorkTrigger};
+    use moraine_config::{AppConfig, IngestSource, SourceFormat};
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use tokio::sync::mpsc;
+
+    /// Issue #601 §2.4 / WI-03. A reconciliation sweep slice may attach only to
+    /// a reconcile-driven poll, so the reconcile tick has to be the one place
+    /// that stamps `WorkTrigger::Reconcile`. Nothing else may.
+    ///
+    /// Fails for: reverting `spawn_reconcile_task` to the default trigger.
+    #[tokio::test]
+    async fn reconcile_ticks_are_stamped_as_reconcile_triggered() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock before unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("moraine-reconcile-trigger-{nonce}"));
+        std::fs::create_dir_all(&dir).expect("create reconcile fixture dir");
+        let file = dir.join("session.jsonl");
+        std::fs::write(&file, b"{}\n").expect("write reconcile fixture file");
+
+        let source = IngestSource {
+            name: "reconcile-trigger-test".to_string(),
+            harness: "codex".to_string(),
+            format: SourceFormat::Jsonl,
+            glob: dir.join("*.jsonl").to_string_lossy().to_string(),
+            enabled: true,
+            watch_root: dir.to_string_lossy().to_string(),
+        };
+        let (process_tx, mut process_rx) = mpsc::channel(8);
+        let task = spawn_reconcile_task(
+            AppConfig::default(),
+            vec![source],
+            process_tx,
+            Arc::new(Mutex::new(DispatchState::default())),
+            Arc::new(Metrics::default()),
+        );
+
+        // `tokio::time::interval` fires its first tick immediately, so this
+        // does not wait out `reconcile_interval_seconds`.
+        let queued = tokio::time::timeout(Duration::from_secs(5), process_rx.recv())
+            .await
+            .expect("reconcile must enqueue on its first tick")
+            .expect("reconcile channel stays open");
+        assert_eq!(queued.trigger, WorkTrigger::Reconcile);
+        task.abort();
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/crates/moraine-ingest-core/src/sqlite_poll.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll.rs
@@ -140,6 +140,119 @@ impl CursorState {
     }
 }
 
+/// Test-only injection point for the mixed-snapshot bracket.
+///
+/// The bracket only trips when something commits inside the scan's read
+/// window, so the only way to observe that arm without an injection point is
+/// to race a concurrent writer and hope — which made the single guard over
+/// Cursor's one post-read failure arm nondeterministic, and made the *replay*
+/// consequences of a contended scan untestable altogether.
+///
+/// Armings are keyed by database path and each `take` consumes one, so tests
+/// running in parallel threads of the same binary (every path comes from
+/// `unique_db_path`/`fixture_db`) cannot contaminate one another, and an
+/// arming that is never consumed cannot leak into a later test on a different
+/// database.
+#[cfg(test)]
+pub(crate) mod contention_injection {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+
+    fn armed() -> &'static Mutex<HashMap<String, u32>> {
+        static ARMED: OnceLock<Mutex<HashMap<String, u32>>> = OnceLock::new();
+        ARMED.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    /// Force the next `times` scans of `db_path` to fail the mixed-snapshot
+    /// bracket, exactly as a writer committing mid-scan would.
+    pub(crate) fn arm(db_path: &str, times: u32) {
+        armed()
+            .lock()
+            .expect("contention injection mutex poisoned")
+            .insert(db_path.to_string(), times);
+    }
+
+    /// Cancel any remaining armings for `db_path`.
+    pub(crate) fn disarm(db_path: &str) {
+        armed()
+            .lock()
+            .expect("contention injection mutex poisoned")
+            .remove(db_path);
+    }
+
+    /// Consume one arming for `db_path`, if any.
+    pub(crate) fn take(db_path: &str) -> bool {
+        let mut map = armed().lock().expect("contention injection mutex poisoned");
+        let Some(remaining) = map.get_mut(db_path) else {
+            return false;
+        };
+        *remaining -= 1;
+        if *remaining == 0 {
+            map.remove(db_path);
+        }
+        true
+    }
+}
+
+/// True when a test has armed `db_path` for a forced mixed-snapshot rejection.
+/// Compiles to a constant `false` outside the test build.
+#[cfg(test)]
+fn forced_mixed_snapshot(db_path: &str) -> bool {
+    contention_injection::take(db_path)
+}
+
+#[cfg(not(test))]
+#[inline(always)]
+fn forced_mixed_snapshot(_db_path: &str) -> bool {
+    false
+}
+
+/// True when the scan that just finished cannot be trusted to have read one
+/// point-in-time view of the database, so its results are discarded and the
+/// cursor stays where it was.
+///
+/// All three adapters bracket their row scan with this, which is why it is a
+/// function and not three copies of the same expression: the sites are
+/// load-bearing for §3.2 and silent drift between them has no natural guard.
+///
+/// **Known hazard (gate G1d, §3.2).** The stat disjunct compares full
+/// `StatFingerprint`s, `shm_len`/`shm_mtime_ns` included, so it can reject a
+/// scan when `data_version` is unchanged — i.e. when nothing committed at all
+/// and only a concurrent *reader* churned the `-shm` sidecar. That is
+/// load-sensitive rather than theoretical: under a loaded host
+/// `nac::tests::oversized_normalized_rows_fail_before_any_payload_is_sent` has
+/// been observed failing with `sqlite_mixed_snapshot` in place of the error
+/// kind it asserts. §3.2 requires the guard be preserved exactly, so it is;
+/// narrowing it to the sidecars that imply a commit is G1d's job and needs the
+/// sandbox (`/proc/self/io`) to be measured honestly.
+///
+/// **What holds this width, and what does not.** Every *production* rejection
+/// arrives through one of the two real disjuncts and none through the hook —
+/// but until this predicate had its own test, that was true of no test either.
+/// A commit landing between a scan's two `data_version` reads is not
+/// deterministically reachable: the scan runs inside a single function call,
+/// and `forced_mixed_snapshot` is its only seam — a seam that short-circuits
+/// both real disjuncts, so every adapter contention test reached the arm
+/// without ever evaluating them. Racing a concurrent writer would reach them
+/// but only probabilistically, and a second injection hook that performed a
+/// real mid-scan commit would be more production surface than the guard it
+/// checks. So the disjuncts are bounded here instead, separately and
+/// deterministically, by
+/// `the_mixed_snapshot_bracket_fires_on_a_moved_data_version_and_on_a_moved_stat`:
+/// dropping either one, or widening the predicate to fire unconditionally,
+/// fails it. The three *call sites* stay bounded by the adapters' contention
+/// tests, which reach this through the hook.
+fn snapshot_is_mixed(
+    db_path: &str,
+    data_version_before: i64,
+    data_version_after: i64,
+    opened_stat: StatFingerprint,
+) -> bool {
+    forced_mixed_snapshot(db_path)
+        || data_version_before != data_version_after
+        || stat_fingerprint(db_path) != Some(opened_stat)
+}
+
 /// After this many consecutive no-op scans, a database is considered
 /// stat-noisy and rescans are throttled to `NOOP_RESCAN_MIN_INTERVAL`.
 /// Below the threshold every stat change scans immediately, so ordinary
@@ -163,9 +276,62 @@ const NOOP_RESCAN_MIN_INTERVAL: Duration = Duration::from_secs(15);
 /// bounded by the number of distinct watched database paths.
 struct VolatilePollEntry {
     source_generation: u32,
-    stat: StatFingerprint,
+    /// The stat fingerprint a completed no-op scan covered. `None` means no
+    /// scan has covered a fingerprint yet — the state a failed scan leaves
+    /// behind, and deliberately not a sentinel value that a real fingerprint
+    /// could collide with.
+    stat: Option<StatFingerprint>,
     consecutive_noop_scans: u32,
+    consecutive_failed_scans: u32,
     last_scan_at: Instant,
+    /// When the last mixed-snapshot rejection happened, and how many have run
+    /// back to back. Kept **separate from `consecutive_failed_scans`** on
+    /// purpose: contention is not a fault, so it must not climb the 15 s → 15
+    /// min ladder or suppress ordinary scans of an active database. What it
+    /// does have to do is throttle the *durable replay barrier*, which is why
+    /// it exists at all — see `failure_retry_due`.
+    last_contended_at: Option<Instant>,
+    consecutive_contended_scans: u32,
+}
+
+/// Base delay after one failed scan, doubling per consecutive failure.
+const FAILURE_BACKOFF_BASE: Duration = Duration::from_secs(15);
+
+/// Ceiling on the failure backoff: a permanently broken database still retries
+/// every 15 minutes, so recovery from an environmental fault (a lock, a
+/// permission) never needs a restart.
+const FAILURE_BACKOFF_MAX: Duration = Duration::from_secs(15 * 60);
+
+/// `min(15 s * 2^(n-1), 15 min)` for `n` consecutive failures; zero failures
+/// means retry immediately.
+fn failure_backoff(consecutive_failed_scans: u32) -> Duration {
+    if consecutive_failed_scans == 0 {
+        return Duration::ZERO;
+    }
+    let shift = consecutive_failed_scans.saturating_sub(1).min(31);
+    FAILURE_BACKOFF_BASE
+        .saturating_mul(1u32 << shift)
+        .min(FAILURE_BACKOFF_MAX)
+}
+
+/// Base delay before a *contended* replay barrier is re-sent.
+const CONTENTION_BACKOFF_BASE: Duration = Duration::from_secs(15);
+
+/// Ceiling on the contention backoff. Far below `FAILURE_BACKOFF_MAX` on
+/// purpose: contention is transient and self-clearing, and a replacement
+/// database that is merely busy must become visible within a minute of the
+/// writer pausing, not within fifteen.
+const CONTENTION_BACKOFF_MAX: Duration = Duration::from_secs(60);
+
+/// `min(15 s * 2^(n-1), 60 s)` for `n` consecutive mixed-snapshot rejections.
+fn contention_backoff(consecutive_contended_scans: u32) -> Duration {
+    if consecutive_contended_scans == 0 {
+        return Duration::ZERO;
+    }
+    let shift = consecutive_contended_scans.saturating_sub(1).min(31);
+    CONTENTION_BACKOFF_BASE
+        .saturating_mul(1u32 << shift)
+        .min(CONTENTION_BACKOFF_MAX)
 }
 
 /// One map per ingest pipeline, created in `run_ingestor` and threaded
@@ -187,10 +353,11 @@ impl VolatilePollMap {
             .expect("volatile poll state mutex poisoned")
     }
 
-    /// True when a poll should be skipped without scanning: either the last
-    /// no-op scan already covered the current stat fingerprint (the durable
-    /// checkpoint is intentionally stale after a no-op scan), or the database
-    /// is stat-noisy and still inside its rescan backoff window.
+    /// True when a poll should be skipped without scanning: the last no-op
+    /// scan already covered the current stat fingerprint (the durable
+    /// checkpoint is intentionally stale after a no-op scan), the database is
+    /// stat-noisy and still inside its rescan backoff window, or its last scan
+    /// failed and the failure backoff has not expired.
     fn should_skip_poll(
         &self,
         cp_key: &str,
@@ -204,15 +371,60 @@ impl VolatilePollMap {
         if entry.source_generation != source_generation {
             return false;
         }
-        if entry.stat == *current_stat {
+        if entry.stat == Some(*current_stat) {
+            return true;
+        }
+        // The failure arm is independent of the no-op streak: a database whose
+        // first scan fails has no streak to throttle on, which is exactly the
+        // case that re-ran a full failed scan on every tick (issue #601 §2.5).
+        if entry.last_scan_at.elapsed() < failure_backoff(entry.consecutive_failed_scans) {
             return true;
         }
         entry.consecutive_noop_scans >= NOOP_SCAN_BACKOFF_THRESHOLD
             && entry.last_scan_at.elapsed() < NOOP_RESCAN_MIN_INTERVAL
     }
 
+    /// True when a database whose last scan did not succeed is due for another
+    /// attempt. An absent entry (fresh process, or a scan that last succeeded)
+    /// is always due, so a restart never inherits a suppression.
+    ///
+    /// This gates the **durable replay barrier**, which is why it consults the
+    /// contention clock as well as the fault ladder. A mixed-snapshot rejection
+    /// is exempt from the fault ladder (§3.2: contention is not a fault) but it
+    /// must never be exempt from *this*: the `Failed` arm of a replacement
+    /// replay emits `BlockReplay` plus an append-only `ingest_errors` row, and
+    /// the next tick sees `retry_blocked_replay` with `starts_replacement`
+    /// false. With no clock at all that is `BeginReplay` + a full cold scan +
+    /// `BlockReplay` + one error row **per poll, forever** while contention
+    /// persists — at the 30 s reconcile cadence *and* on every 50 ms-debounced
+    /// watcher event. A replacement replay is the longest scan an adapter runs,
+    /// so it is the scan most likely to lose the bracket in the first place.
+    ///
+    /// The contention clock deliberately does *not* appear in
+    /// `should_skip_poll`: throttling ordinary scans of a contended database is
+    /// exactly the active-session freshness regression the exemption exists to
+    /// prevent.
+    fn failure_retry_due(&self, cp_key: &str, source_generation: u32) -> bool {
+        let map = self.lock();
+        let Some(entry) = map.get(cp_key) else {
+            return true;
+        };
+        if entry.source_generation != source_generation {
+            return true;
+        }
+        if entry.last_scan_at.elapsed() < failure_backoff(entry.consecutive_failed_scans) {
+            return false;
+        }
+        match entry.last_contended_at {
+            Some(at) => at.elapsed() >= contention_backoff(entry.consecutive_contended_scans),
+            None => true,
+        }
+    }
+
     /// Record a scan that changed nothing durable: remember the stat
-    /// fingerprint it covered and extend the no-op streak.
+    /// fingerprint it covered and extend the no-op streak. A no-op scan is a
+    /// *successful* scan, so it also clears the failure streak while keeping
+    /// the no-op streak.
     fn record_noop_scan(&self, cp_key: &str, source_generation: u32, stat: StatFingerprint) {
         let mut map = self.lock();
         let entry = map
@@ -224,13 +436,33 @@ impl VolatilePollMap {
             })
             .or_insert(VolatilePollEntry {
                 source_generation,
-                stat,
+                stat: Some(stat),
                 consecutive_noop_scans: 0,
+                consecutive_failed_scans: 0,
                 last_scan_at: Instant::now(),
+                last_contended_at: None,
+                consecutive_contended_scans: 0,
             });
         entry.source_generation = source_generation;
-        entry.stat = stat;
+        entry.stat = Some(stat);
         entry.consecutive_noop_scans = entry.consecutive_noop_scans.saturating_add(1);
+        entry.consecutive_failed_scans = 0;
+        // A scan that completed cleanly is proof the contention has passed, so
+        // the **ladder** resets and not just its clock. Nothing observes the
+        // reset until the next rejection — `consecutive_contended_scans` is
+        // read only inside `failure_retry_due`'s `Some(last_contended_at)` arm
+        // — so a stale streak left here is silent right up to the moment
+        // `record_contended_scan` increments from it, and the barrier throttle
+        // then resumes near the 60 s ceiling instead of at the 15 s base.
+        // `a_clean_scan_resets_the_contention_ladder_not_only_its_clock` fails
+        // if this line goes.
+        //
+        // The `last_contended_at` reset below is, *given* this one, an
+        // equivalent mutant and is deliberately not claimed as pinned:
+        // `contention_backoff(0)` is `Duration::ZERO`, so a zeroed streak
+        // answers `true` through the `Some` arm exactly as `None` does.
+        entry.consecutive_contended_scans = 0;
+        entry.last_contended_at = None;
         entry.last_scan_at = Instant::now();
     }
 
@@ -243,15 +475,451 @@ impl VolatilePollMap {
         self.lock().remove(cp_key);
     }
 
-    /// A failed scan refreshes the backoff clock of an existing no-op streak
-    /// so a persistently failing stat-noisy database retries on the throttled
-    /// cadence instead of every reconcile tick. Without a streak this is a
-    /// no-op and the failure retries exactly as before.
-    fn record_failed_scan(&self, cp_key: &str) {
+    /// Entering a durably blocked replay is a scan failure for backoff
+    /// purposes, and the **only** sanctioned way to record it.
+    ///
+    /// It exists as its own entry point because the obvious-looking
+    /// `clear(); record_failed_scan();` pair is a live defect: `clear` deletes
+    /// the entry, so `record_failed_scan`'s `or_insert` restarts the streak at
+    /// 1 on every retry and pins the path at the 15 s floor forever. The
+    /// trigger is a record failing `normalize_record` during a replacement
+    /// replay — deterministic and content-driven, so it recurs on every retry —
+    /// which means a flat floor re-sends a durable `BeginReplay` barrier and
+    /// re-reads the entire database every 15 s indefinitely.
+    /// `record_failed_scan` already sets `stat` to `None`, which is the only
+    /// suppression the `clear` was there to avoid.
+    fn record_blocked_replay(&self, cp_key: &str, source_generation: u32) {
+        self.record_failed_scan(cp_key, source_generation);
+    }
+
+    /// Record a completed scan that ended in a failure outcome, routing it to
+    /// the fault ladder or the contention exemption by `error_kind`.
+    ///
+    /// **Mixed-snapshot rejections do not escalate.** `ERROR_KIND_MIXED_SNAPSHOT`
+    /// means the database was being written while the scan read it; that is a
+    /// *contention* signal, not a fault, and it happens precisely when the
+    /// source is active — which is when prompt visibility matters most (§6).
+    /// Routing it into the 15 s → 15 min ladder would regress active-session
+    /// freshness by up to 15 minutes, and the mitigation the spec pairs with
+    /// that ("smaller scans make retries rare") is WI-07/WI-08 and does not
+    /// exist yet. So a contended scan retries at the ordinary poll cadence and
+    /// leaves the fault streak untouched — neither extending it nor clearing a
+    /// genuine one underneath it.
+    ///
+    /// **Exempt from the fault ladder is not exempt from the replay throttle.**
+    /// The rejection still routes to `record_contended_scan`, whose clock
+    /// `failure_retry_due` reads, because a replacement replay's `Failed` arm
+    /// emits a durable `BlockReplay` and an append-only `ingest_errors` row —
+    /// recording nothing at all would re-run that on every tick forever. The
+    /// two clocks are read in different places on purpose: `should_skip_poll`
+    /// (ordinary scans) sees only the fault ladder, `failure_retry_due` (the
+    /// replay barrier) sees both.
+    ///
+    /// Every adapter's `Failed` arm goes through this one entry point, so the
+    /// classification cannot drift between them.
+    ///
+    /// **The exemption's width is the whole guard.** One kind is named out of
+    /// five, and naming one more is a one-token edit that no outcome assertion
+    /// can see — `sqlite_scan_error` and `sqlite_cursor_too_large` were both
+    /// admissible with the suite green. `sqlite_scan_error` is the expensive
+    /// one: eleven of the seventeen production failure sites emit it, covering
+    /// the paged read, both `data_version` reads and every adapter's row loop.
+    /// Route it here and no scan failure ever reaches `record_failed_scan`,
+    /// `consecutive_failed_scans` stays 0, `should_skip_poll`'s failure arm
+    /// never fires, and the §2.5 defect this work item exists to remove comes
+    /// straight back — a full failed scan on every reconcile tick and every
+    /// debounced watcher event, forever — while the barrier throttle silently
+    /// drops from `FAILURE_BACKOFF_MAX` to `CONTENTION_BACKOFF_MAX`.
+    /// `each_error_kind_routes_to_exactly_one_backoff_clock` pins the routing
+    /// per kind rather than the outcome, so widening at *any* neighbour fails.
+    fn record_scan_failure_outcome(&self, cp_key: &str, source_generation: u32, error_kind: &str) {
+        if error_kind == ERROR_KIND_MIXED_SNAPSHOT {
+            self.record_contended_scan(cp_key, source_generation);
+            return;
+        }
+        self.record_failed_scan(cp_key, source_generation);
+    }
+
+    /// A failed scan starts (or extends) the failure backoff. It **creates**
+    /// the entry when absent: the previous `get_mut`-only version did nothing
+    /// for a database whose first scan failed, or whose failure followed any
+    /// emitting scan (which clears the entry), so the most common failure
+    /// shapes had no backoff at all and re-ran a full failed scan on every
+    /// reconcile tick and every debounced watcher event, forever.
+    ///
+    /// The entry records **no covered stat**: a failure covered nothing, and
+    /// claiming otherwise would suppress rescans of an unchanged file
+    /// permanently rather than for the backoff window. That is also why the
+    /// blocked-replay path must **not** `clear` before calling this: `clear`
+    /// deletes the entry, so the very next `or_insert` restarts the streak at
+    /// 1 and pins the retry at the 15 s floor forever. Setting `stat` to `None`
+    /// here already removes the only suppression `clear` was there to avoid.
+    fn record_failed_scan(&self, cp_key: &str, source_generation: u32) {
+        let mut map = self.lock();
+        let entry = map
+            .entry(cp_key.to_string())
+            .and_modify(|entry| {
+                if entry.source_generation != source_generation {
+                    entry.consecutive_noop_scans = 0;
+                    entry.consecutive_failed_scans = 0;
+                    entry.consecutive_contended_scans = 0;
+                    entry.last_contended_at = None;
+                }
+            })
+            .or_insert(VolatilePollEntry {
+                source_generation,
+                stat: None,
+                consecutive_noop_scans: 0,
+                consecutive_failed_scans: 0,
+                last_scan_at: Instant::now(),
+                last_contended_at: None,
+                consecutive_contended_scans: 0,
+            });
+        entry.source_generation = source_generation;
+        entry.stat = None;
+        entry.consecutive_failed_scans = entry.consecutive_failed_scans.saturating_add(1);
+        entry.last_scan_at = Instant::now();
+    }
+
+    /// Record a scan the mixed-snapshot bracket rejected.
+    ///
+    /// Contention is **not** a fault (§3.2), so `consecutive_failed_scans` is
+    /// untouched and `should_skip_poll` keeps letting ordinary scans through at
+    /// the full poll cadence — that exemption is what protects active-session
+    /// freshness. What this *does* record is a clock `failure_retry_due` reads,
+    /// so a replacement replay that keeps losing the bracket stops re-sending
+    /// its durable barrier (and appending an `ingest_errors` row) on every tick.
+    ///
+    /// Like `record_failed_scan` it clears the covered stat: a rejected scan
+    /// covered nothing, and a mixed-snapshot rejection means the database moved
+    /// under it, so any fingerprint a previous no-op scan recorded is stale.
+    fn record_contended_scan(&self, cp_key: &str, source_generation: u32) {
+        let mut map = self.lock();
+        let entry = map
+            .entry(cp_key.to_string())
+            .and_modify(|entry| {
+                if entry.source_generation != source_generation {
+                    entry.consecutive_noop_scans = 0;
+                    entry.consecutive_failed_scans = 0;
+                    entry.consecutive_contended_scans = 0;
+                }
+            })
+            .or_insert(VolatilePollEntry {
+                source_generation,
+                stat: None,
+                consecutive_noop_scans: 0,
+                consecutive_failed_scans: 0,
+                last_scan_at: Instant::now(),
+                last_contended_at: None,
+                consecutive_contended_scans: 0,
+            });
+        entry.source_generation = source_generation;
+        entry.stat = None;
+        entry.consecutive_contended_scans = entry.consecutive_contended_scans.saturating_add(1);
+        entry.last_contended_at = Some(Instant::now());
+    }
+
+    /// Consecutive failed scans recorded for `cp_key`; zero when no entry
+    /// exists. Test-only: it is how a backoff test observes escalation without
+    /// sleeping through a 15 s → 30 s → 60 s ladder in real time.
+    #[cfg(test)]
+    fn consecutive_failed_scans(&self, cp_key: &str) -> u32 {
+        self.lock()
+            .get(cp_key)
+            .map_or(0, |entry| entry.consecutive_failed_scans)
+    }
+
+    /// Consecutive mixed-snapshot rejections recorded for `cp_key`. Test-only:
+    /// it is how the contention tests assert that the contention clock moved
+    /// while the fault ladder did not.
+    #[cfg(test)]
+    fn consecutive_contended_scans(&self, cp_key: &str) -> u32 {
+        self.lock()
+            .get(cp_key)
+            .map_or(0, |entry| entry.consecutive_contended_scans)
+    }
+
+    /// Backdate `cp_key`'s last-scan clock so the next poll sees `by` of
+    /// elapsed time. Test-only: without it a backoff test can only drive ticks
+    /// inside the first 15 s window, where a flat floor and an exponential
+    /// ladder are indistinguishable — which is exactly how the blocked-replay
+    /// reset went unnoticed.
+    #[cfg(test)]
+    fn age_for_tests(&self, cp_key: &str, by: Duration) {
         if let Some(entry) = self.lock().get_mut(cp_key) {
-            entry.last_scan_at = Instant::now();
+            entry.last_scan_at = entry
+                .last_scan_at
+                .checked_sub(by)
+                .unwrap_or(entry.last_scan_at);
+            // Both clocks age together, so a test that walks the fault ladder
+            // is never silently held back by a stale contention clock (and
+            // vice versa).
+            entry.last_contended_at = entry
+                .last_contended_at
+                .map(|at| at.checked_sub(by).unwrap_or(at));
         }
     }
+}
+
+/// Per-poll work accounting (issue #601 §2.0). Charged at the exact point
+/// bytes leave SQLite, never derived from emitted-record counts.
+///
+/// **Charging rules.** Every cost gate in this issue is denominated on one of
+/// these axes, so what each one means has to be pinned down here rather than
+/// argued about per call site:
+///
+/// - `census_*` is charged by a row-materializing read whose projection
+///   **excludes** the adapter's payload column(s) — the cheap change-detection
+///   read. An adapter with no such read reports zero, which is the honest
+///   answer, not a rounding of the payload read down.
+/// - `payload_*` is charged by a row-materializing read whose projection
+///   **includes** a payload column. Bytes are every variable-length byte that
+///   read handed to Rust, identity columns included.
+/// - Bytes charged per row are the length of what SQLite actually handed to
+///   Rust, never a SQL-side `length()` expression and never the size of what
+///   was emitted: a row that is read and discarded still costs its bytes.
+/// - Fixed-width scalars (INTEGER/REAL) are 8 bytes and are charged on neither
+///   axis; they cannot move a byte budget.
+/// - **Scalar-aggregate statements materialize no row, so they charge no rows
+///   on either axis.** Their *bytes* follow what SQLite had to decode: an
+///   aggregate over identity or fixed-width columns (`count(*)`, `max(id)`) is
+///   charged nothing, but an aggregate over a payload column
+///   (`sum(length(data))`) forces SQLite to decode every byte of that column —
+///   §1.1 finding 2 measured `length()` on a TEXT-affine column at 48.5 ms /
+///   48 MB, so it is emphatically not a cheap probe — and those bytes are
+///   charged on the payload axis through `charge_aggregate_payload_bytes`.
+///   Without that rule a cold OpenCode scan under-reports its true byte cost by
+///   roughly 2×, and the ledger could be used to argue an aggregate preflight
+///   is free. It is not.
+///
+/// Both axes are always recorded: rows cannot catch content growth, bytes
+/// cannot catch a full scan of narrow rows.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ScanLedger {
+    /// Rows touched by a covering/narrow census.
+    pub(crate) census_rows: u64,
+    /// Key/metadata bytes materialized by the census.
+    pub(crate) census_bytes: u64,
+    /// Rows whose payload column was materialized.
+    pub(crate) payload_rows: u64,
+    /// Payload bytes materialized (the expensive axis).
+    pub(crate) payload_bytes: u64,
+    /// Synthetic records produced by the scan.
+    pub(crate) rows_emitted: u64,
+    // `sweep_rows` / `sweep_bytes` deliberately do **not** exist yet. Nothing
+    // charges a sweep until WI-04 introduces one, so a field carrying a
+    // permanent zero would be a field G6a could assert on and never fail —
+    // the exact unfailable-guard shape this issue is removing. WI-04 adds them
+    // together with the code that charges them.
+}
+
+impl ScanLedger {
+    /// One row materialized by a payload-bearing read. Call once per row,
+    /// before its columns are taken, regardless of how many payload columns
+    /// that row has.
+    pub(crate) fn charge_payload_row(&mut self) {
+        self.payload_rows = self.payload_rows.saturating_add(1);
+    }
+
+    /// One row materialized by a census read that excluded the payload column.
+    pub(crate) fn charge_census_row(&mut self, bytes: usize) {
+        self.census_rows = self.census_rows.saturating_add(1);
+        self.census_bytes = self.census_bytes.saturating_add(bytes as u64);
+    }
+
+    fn charge_payload_bytes(&mut self, bytes: usize) {
+        self.payload_bytes = self.payload_bytes.saturating_add(bytes as u64);
+    }
+
+    /// Bytes a scalar aggregate over a payload column forced SQLite to decode.
+    /// No row is charged — none was materialized — but the bytes were really
+    /// paid, so a byte budget must see them. See the aggregate rule on
+    /// `ScanLedger`.
+    pub(crate) fn charge_aggregate_payload_bytes(&mut self, bytes: u64) {
+        self.payload_bytes = self.payload_bytes.saturating_add(bytes);
+    }
+}
+
+/// The only sanctioned way to materialize a variable-length payload column:
+/// it charges the ledger at the read site, before the value is visible to the
+/// caller. A new `row.get(payload_col)` that bypasses this is a ledger
+/// under-report, and every budget denominated on `payload_bytes` becomes a lie
+/// — reviewers reject it.
+pub(crate) fn take_payload_text(
+    ledger: &mut ScanLedger,
+    row: &rusqlite::Row<'_>,
+    index: usize,
+) -> rusqlite::Result<Option<String>> {
+    let value: Option<String> = row.get(index)?;
+    ledger.charge_payload_bytes(value.as_ref().map_or(0, String::len));
+    Ok(value)
+}
+
+/// `take_payload_text` for a column the schema declares NOT NULL.
+///
+/// A NULL here is **schema drift, and §3.2 wants it surfaced rather than
+/// absorbed**: `row.get::<_, String>` raises `InvalidColumnType`, which fails
+/// the scan and leaves the checkpoint where it was. That is deliberately the
+/// same behaviour these columns had before the ledger existed; the ledger
+/// charge is the only thing this wrapper adds.
+///
+/// Absorbing the NULL instead is not a smaller version of the same thing. An
+/// empty id column manufactures a record whose `source_line_no`/`source_offset`
+/// — and therefore whose `event_uid` — are hashed from nothing (§6 "stable
+/// logical IDs"); an empty timestamp column manufactures an epoch.
+///
+/// This is the default for a text column. `take_payload_nullable_string` is
+/// the per-column exception, and each of its call sites has to name the column
+/// it applies to and why that column tolerates NULL.
+pub(crate) fn take_payload_required_string(
+    ledger: &mut ScanLedger,
+    row: &rusqlite::Row<'_>,
+    index: usize,
+) -> rusqlite::Result<String> {
+    let value: String = row.get(index)?;
+    ledger.charge_payload_bytes(value.len());
+    Ok(value)
+}
+
+/// `take_payload_text` for a column that genuinely tolerates NULL, where the
+/// empty string is the documented default rather than a swallowed defect.
+/// See `take_payload_required_string` for the rule this is the exception to.
+pub(crate) fn take_payload_nullable_string(
+    ledger: &mut ScanLedger,
+    row: &rusqlite::Row<'_>,
+    index: usize,
+) -> rusqlite::Result<String> {
+    Ok(take_payload_text(ledger, row, index)?.unwrap_or_default())
+}
+
+/// `take_payload_text` for a column whose storage class is not trusted:
+/// Cursor writes JSON documents as TEXT into a column declared BLOB, so the
+/// value is taken by reference and charged by its materialized byte length.
+pub(crate) fn take_payload_blob(
+    ledger: &mut ScanLedger,
+    row: &rusqlite::Row<'_>,
+    index: usize,
+) -> rusqlite::Result<Option<Vec<u8>>> {
+    let value = match row.get_ref(index)? {
+        ValueRef::Null => None,
+        ValueRef::Text(text) => Some(text.to_vec()),
+        ValueRef::Blob(blob) => Some(blob.to_vec()),
+        ValueRef::Integer(int) => Some(int.to_string().into_bytes()),
+        ValueRef::Real(real) => Some(real.to_string().into_bytes()),
+    };
+    ledger.charge_payload_bytes(value.as_ref().map_or(0, Vec::len));
+    Ok(value)
+}
+
+/// Fold one poll's ledger into the host-global counters. Called once per poll
+/// that actually scanned, on both the success and the failure path, so a scan
+/// that read 48 MB and then lost the mixed-snapshot race is still charged.
+///
+/// **Both axes are folded, not just the payload one.** A counter nothing can
+/// read is the unfailable-guard pattern this issue exists to remove, and the
+/// OpenCode rewind preflight charges the census axis *only* — folding payload
+/// alone would leave that call site unable to move any observable at all.
+pub(crate) fn record_scan_ledger(metrics: &Arc<Metrics>, ledger: &ScanLedger) {
+    metrics
+        .sqlite_poll_payload_bytes_total
+        .fetch_add(ledger.payload_bytes, std::sync::atomic::Ordering::Relaxed);
+    metrics
+        .sqlite_poll_payload_rows_total
+        .fetch_add(ledger.payload_rows, std::sync::atomic::Ordering::Relaxed);
+    metrics
+        .sqlite_poll_census_rows_total
+        .fetch_add(ledger.census_rows, std::sync::atomic::Ordering::Relaxed);
+    metrics
+        .sqlite_poll_census_bytes_total
+        .fetch_add(ledger.census_bytes, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Reads one table's `CREATE TABLE` text out of `sqlite_master`, charging it
+/// on the census axis.
+///
+/// Schema validation is a row-materializing read whose projection excludes
+/// every payload column, so the ledger's census rule covers it exactly. It ran
+/// uncharged on every poll of all three adapters — a TEXT column pulled into
+/// Rust that neither axis knew about, which is the kind of invisible cost the
+/// ledger exists to expose.
+pub(crate) fn schema_sql_for_table(
+    connection: &Connection,
+    table: &str,
+    ledger: &mut ScanLedger,
+) -> rusqlite::Result<Option<String>> {
+    let sql: Option<String> = connection.query_row(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?1",
+        rusqlite::params![table],
+        |row| row.get(0),
+    )?;
+    ledger.charge_census_row(sql.as_ref().map_or(0, String::len));
+    Ok(sql)
+}
+
+/// `PRAGMA table_info` column names, charged on the census axis for the same
+/// reason as `schema_sql_for_table`: one materialized row per column.
+pub(crate) fn table_column_names(
+    connection: &Connection,
+    table: &str,
+    ledger: &mut ScanLedger,
+) -> Result<Vec<String>> {
+    let mut stmt = connection
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .with_context(|| format!("failed to inspect {table} columns"))?;
+    let names = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<String>, _>>()?;
+    for name in &names {
+        ledger.charge_census_row(name.len());
+    }
+    Ok(names)
+}
+
+/// The census a scan owes for validating `tables`, so every adapter's ledger
+/// test can state its census total as "schema validation **plus** this
+/// adapter's own census read" rather than as an unexplained constant.
+///
+/// Deliberately **does not** call `schema_sql_for_table` /
+/// `table_column_names`: an expectation computed by the very functions under
+/// test moves with them, so dropping a charge would lower both sides equally
+/// and every assertion would stay green. This is an independent oracle — one
+/// `sqlite_master.sql` row per table, one `PRAGMA table_info` row per column,
+/// each charged its own materialized length.
+#[cfg(test)]
+pub(crate) fn expected_schema_census(connection: &Connection, tables: &[&str]) -> ScanLedger {
+    let mut ledger = ScanLedger::default();
+    for table in tables {
+        let sql: Option<String> = connection
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?1",
+                rusqlite::params![table],
+                |row| row.get(0),
+            )
+            .expect("fixture schema row");
+        ledger.census_rows += 1;
+        ledger.census_bytes += sql.as_ref().map_or(0, String::len) as u64;
+
+        let mut stmt = connection
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .expect("fixture column names");
+        let names: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .expect("fixture column names")
+            .map(|row| row.expect("fixture column name"))
+            .collect();
+        ledger.census_rows += names.len() as u64;
+        ledger.census_bytes += names.iter().map(|name| name.len() as u64).sum::<u64>();
+    }
+    ledger
+}
+
+/// One completed scan that ended in `Failed`. Denominated on observed scans,
+/// which is what the failure-backoff gate asserts on — not on `ingest_errors`
+/// rows, which are rate-limited and therefore cannot count scans.
+pub(crate) fn record_scan_failure(metrics: &Arc<Metrics>) {
+    metrics
+        .sqlite_scan_failures_total
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 }
 
 /// One synthetic record ready for `normalize_record`, with the stable
@@ -473,6 +1141,15 @@ pub(crate) async fn process_cursor_sqlite_db(
     let generation_changed = had_committed && checkpoint.source_inode != inode;
     let exclusions_changed =
         had_committed && state.project_exclusions_hash != current_exclusions_hash;
+    // Both disjuncts are load-bearing and they do not cover each other. A
+    // process that dies between `BeginReplay` and `FinalizeReplay` leaves
+    // `replaying` with no error status and no block reason, so dropping the
+    // first disjunct strands that source: the poll becomes ordinary, the
+    // cursor is not reset, the barrier is never re-sent, and the status is
+    // quietly rewritten to `active`.
+    // `a_crash_interrupted_replay_resumes_from_its_replaying_status` fails if
+    // it goes. Widening the *second* disjunct to a bare `status == "error"` is
+    // green at all three adapters and is recorded, unfixed, as plan §7.2 F2.
     let retry_blocked_replay = checkpoint.status == "replaying"
         || (checkpoint.status == "error" && !checkpoint.block_reason.is_empty());
     let starts_replacement = generation_changed || exclusions_changed;
@@ -500,27 +1177,71 @@ pub(crate) async fn process_cursor_sqlite_db(
         .last_offset
         .checked_add(1)
         .context("cursor_sqlite poll sequence exhausted")?;
+    // The failure backoff has to gate the *barrier*, not just the scan:
+    // `begin_database_replay` is durable, so throttling only the scan behind
+    // it would re-send a barrier with nothing behind it on every tick — the
+    // failure mode §2.1(2) warns about. A genuine replacement (new inode,
+    // changed exclusions) bumped the generation above and is never throttled.
+    if retry_blocked_replay
+        && !starts_replacement
+        && !poll_state.failure_retry_due(&cp_key, checkpoint.source_generation)
+    {
+        return Ok(());
+    }
     if replacement_replay {
         begin_database_replay(&sink_tx, &checkpoint, scan_boundary, &policy_fingerprint).await?;
     }
 
     // Cheap no-change short-circuit: nothing touched the database or its WAL
     // sidecars since the last successful poll.
+    //
+    // §2.5 also specifies a `|| !failure_retry_due` disjunct here. **It must
+    // not be added while the contention clock lives in `failure_retry_due`** —
+    // not by WI-04, not as a tidy-up.
+    //
+    // It was once outcome-redundant with `should_skip_poll`'s failure arm
+    // below. §3.2's contention exemption broke that equivalence on purpose:
+    // `failure_retry_due` reads `last_contended_at` as well as the fault
+    // ladder, `should_skip_poll` deliberately does not. After a mixed-snapshot
+    // rejection the two disagree by design — `failure_retry_due` is false for
+    // up to `CONTENTION_BACKOFF_MAX` (60 s) while `should_skip_poll` stays
+    // false, so ordinary scans keep running at the full poll cadence.
+    //
+    // So the disjunct is now outcome-**changing**: it would return early on an
+    // ordinary poll of a contended — i.e. actively written — database for up to
+    // a minute. That is exactly the active-session freshness regression the
+    // exemption exists to prevent, and exactly what `record_contended_scan`'s
+    // doc comment promises does not happen. A pre-`should_skip_poll` throttle
+    // for WI-04's sweep slice must therefore read the fault ladder alone.
+    //
+    // `an_ordinary_poll_of_a_contended_database_is_not_throttled` fails if the
+    // disjunct is added; `a_contended_replacement_replay_throttles_its_barrier`
+    // bounds the other direction (the durable barrier *is* throttled). See the
+    // deviation record in `plans/601-delta-sqlite.md` §7 WI-10.
     if state.stat == current_stat && state.last_error.is_empty() {
         return Ok(());
     }
 
     // Volatile short-circuit + rescan backoff (issue #443): no-op scans leave
     // the durable checkpoint untouched, so their coverage lives here instead.
-    if poll_state.should_skip_poll(&cp_key, checkpoint.source_generation, &current_stat) {
+    // Skipped during a replay: the barrier has already been sent, and a skip
+    // here would leave it with no scan behind it.
+    if !replacement_replay
+        && poll_state.should_skip_poll(&cp_key, checkpoint.source_generation, &current_stat)
+    {
         return Ok(());
     }
 
     let scan_db_path = source_file.clone();
     let scan_state = state.clone();
-    let outcome = tokio::task::spawn_blocking(move || scan_database(&scan_db_path, &scan_state))
-        .await
-        .context("cursor_sqlite scan task panicked")?;
+    let (outcome, ledger) = tokio::task::spawn_blocking(move || {
+        let mut ledger = ScanLedger::default();
+        let outcome = scan_database(&scan_db_path, &scan_state, &mut ledger);
+        (outcome, ledger)
+    })
+    .await
+    .context("cursor_sqlite scan task panicked")?;
+    record_scan_ledger(metrics, &ledger);
 
     match outcome {
         ScanOutcome::Scanned {
@@ -677,7 +1398,7 @@ pub(crate) async fn process_cursor_sqlite_db(
                         ..final_checkpoint
                     };
                     block_database_replay(&sink_tx, &blocked_checkpoint, reason).await?;
-                    poll_state.clear(&cp_key);
+                    poll_state.record_blocked_replay(&cp_key, checkpoint.source_generation);
                     return Ok(());
                 }
                 let active_checkpoint = Checkpoint {
@@ -699,18 +1420,28 @@ pub(crate) async fn process_cursor_sqlite_db(
 
             if emitted > 0 {
                 debug!(
-                    "{}:{} cursor_sqlite emitted {} changed records ({} relevant keys)",
-                    work.source_name, source_file, emitted, relevant_keys
+                    "{}:{} cursor_sqlite emitted {} changed records ({} relevant keys, \
+                     {} payload rows, {} payload bytes)",
+                    work.source_name,
+                    source_file,
+                    emitted,
+                    relevant_keys,
+                    ledger.payload_rows,
+                    ledger.payload_bytes
                 );
             }
-            let _ = metrics;
             Ok(())
         }
         ScanOutcome::Failed {
             error_kind,
             error_text,
         } => {
-            poll_state.record_failed_scan(&cp_key);
+            record_scan_failure(metrics);
+            poll_state.record_scan_failure_outcome(
+                &cp_key,
+                checkpoint.source_generation,
+                error_kind,
+            );
 
             // A repeat of the failure already marked in the committed
             // checkpoint sends nothing: the marker is durable, and reconcile
@@ -793,7 +1524,10 @@ pub(crate) async fn process_cursor_sqlite_db(
 
 /// Blocking phase: open the database read-only, validate schema, scan the
 /// relevant key ranges, and synthesize records for new/changed keys.
-fn scan_database(db_path: &str, prior: &CursorState) -> ScanOutcome {
+///
+/// The caller owns `ledger` so that every early return — including each
+/// failure arm — still reports the bytes this scan had already paid for.
+fn scan_database(db_path: &str, prior: &CursorState, ledger: &mut ScanLedger) -> ScanOutcome {
     let connection = match open_read_only(db_path) {
         Ok(connection) => connection,
         Err(exc) => {
@@ -816,7 +1550,7 @@ fn scan_database(db_path: &str, prior: &CursorState) -> ScanOutcome {
         }
     };
 
-    let schema_fingerprint = match validate_schema(&connection) {
+    let schema_fingerprint = match validate_schema(&connection, ledger) {
         Ok(fingerprint) => fingerprint,
         Err(text) => {
             return ScanOutcome::Failed {
@@ -865,6 +1599,7 @@ fn scan_database(db_path: &str, prior: &CursorState) -> ScanOutcome {
             &mut new_state.kv_hashes,
             &mut records,
             &mut workspace_cache,
+            ledger,
         );
         match scan {
             Ok(seen) => relevant_keys += seen,
@@ -899,7 +1634,12 @@ fn scan_database(db_path: &str, prior: &CursorState) -> ScanOutcome {
             }
         }
     };
-    if data_version_before != data_version_after || stat_fingerprint(db_path) != Some(opened_stat) {
+    if snapshot_is_mixed(
+        db_path,
+        data_version_before,
+        data_version_after,
+        opened_stat,
+    ) {
         return ScanOutcome::Failed {
             error_kind: ERROR_KIND_MIXED_SNAPSHOT,
             error_text:
@@ -941,6 +1681,7 @@ fn scan_database(db_path: &str, prior: &CursorState) -> ScanOutcome {
         rank(a).cmp(&rank(b))
     });
 
+    ledger.rows_emitted = records.len() as u64;
     ScanOutcome::Scanned {
         records,
         new_state,
@@ -1032,14 +1773,12 @@ fn sqlite_immutable_uri(db_path: &str) -> String {
     format!("file:{encoded}?immutable=1")
 }
 
-fn validate_schema(connection: &Connection) -> std::result::Result<u64, String> {
-    let schema_sql: Option<String> = connection
-        .query_row(
-            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'cursorDiskKV'",
-            [],
-            |row| row.get(0),
-        )
-        .map_err(|exc| match exc {
+fn validate_schema(
+    connection: &Connection,
+    ledger: &mut ScanLedger,
+) -> std::result::Result<u64, String> {
+    let schema_sql =
+        schema_sql_for_table(connection, "cursorDiskKV", ledger).map_err(|exc| match exc {
             rusqlite::Error::QueryReturnedNoRows => {
                 "required table cursorDiskKV is missing".to_string()
             }
@@ -1049,22 +1788,15 @@ fn validate_schema(connection: &Connection) -> std::result::Result<u64, String> 
     let schema_sql = schema_sql.unwrap_or_default();
     let mut has_key = false;
     let mut has_value = false;
-    connection
-        .prepare("PRAGMA table_info(cursorDiskKV)")
-        .and_then(|mut stmt| {
-            let names = stmt
-                .query_map([], |row| row.get::<_, String>(1))?
-                .collect::<std::result::Result<Vec<_>, _>>()?;
-            for name in names {
-                match name.as_str() {
-                    "key" => has_key = true,
-                    "value" => has_value = true,
-                    _ => {}
-                }
-            }
-            Ok(())
-        })
-        .map_err(|exc| exc.to_string())?;
+    for name in
+        table_column_names(connection, "cursorDiskKV", ledger).map_err(|exc| format!("{exc:#}"))?
+    {
+        match name.as_str() {
+            "key" => has_key = true,
+            "value" => has_value = true,
+            _ => {}
+        }
+    }
 
     if !has_key || !has_value {
         return Err(format!(
@@ -1074,15 +1806,25 @@ fn validate_schema(connection: &Connection) -> std::result::Result<u64, String> 
     Ok(hash_str(&schema_sql))
 }
 
+/// The relevant-key census, shared with the plan assertion in
+/// `cursor_relevant_key_count_is_a_covering_index_scan` so the statement that
+/// test certifies is the statement this adapter actually runs. A copy in the
+/// test would let the two drift and the certification would mean nothing.
+///
+/// Strictly greater, matching `scan_prefix`'s seed of the bare prefix — a key
+/// exactly equal to the prefix is never scanned and must not count toward the
+/// ceiling. The projection stays `count(*)` over indexed columns only: adding
+/// any reference to `value` costs the covering index and turns a 0.056 ms /
+/// 19 KB read into a 55 ms / 48 MB one (§1.1).
+const CURSOR_RELEVANT_KEY_COUNT_SQL: &str =
+    "SELECT count(*) FROM cursorDiskKV WHERE key > ?1 AND key < ?2";
+
 fn count_relevant_keys(connection: &Connection) -> Result<usize> {
     let mut total = 0usize;
     for prefix in RELEVANT_PREFIXES {
         let count: i64 = connection
             .query_row(
-                // Strictly greater, matching scan_prefix's seed of the bare
-                // prefix — a key exactly equal to the prefix is never scanned
-                // and must not count toward the ceiling.
-                "SELECT count(*) FROM cursorDiskKV WHERE key > ?1 AND key < ?2",
+                CURSOR_RELEVANT_KEY_COUNT_SQL,
                 rusqlite::params![prefix, prefix_range_end(prefix)],
                 |row| row.get(0),
             )
@@ -1106,6 +1848,7 @@ fn scan_prefix(
     new_hashes: &mut BTreeMap<String, String>,
     records: &mut Vec<SyntheticRecord>,
     workspace_cache: &mut HashMap<String, Option<String>>,
+    ledger: &mut ScanLedger,
 ) -> Result<u64> {
     let range_end = prefix_range_end(prefix);
     let mut last_key = prefix.to_string();
@@ -1129,17 +1872,19 @@ fn scan_prefix(
                 ])
                 .context("prefix scan query failed")?;
             while let Some(row) = rows.next().context("prefix scan row failed")? {
-                let key = row.get::<_, String>(0).context("prefix scan key failed")?;
+                // This projection includes `value`, so the whole row is a
+                // payload read: the key bytes are materialized alongside it
+                // and are charged on the same axis. Cursor has no census read
+                // today (issue #601 §3.3 Change 1 adds one), so `census_rows`
+                // stays zero here rather than borrowing this read's rows.
+                ledger.charge_payload_row();
+                let key = take_payload_required_string(ledger, row, 0)
+                    .context("prefix scan key failed")?;
                 // Cursor writes JSON documents as TEXT even though the
                 // column is declared BLOB; accept any storage class instead
                 // of trusting the declared affinity.
-                let value = match row.get_ref(1).context("prefix scan value failed")? {
-                    ValueRef::Null => None,
-                    ValueRef::Text(text) => Some(text.to_vec()),
-                    ValueRef::Blob(blob) => Some(blob.to_vec()),
-                    ValueRef::Integer(int) => Some(int.to_string().into_bytes()),
-                    ValueRef::Real(real) => Some(real.to_string().into_bytes()),
-                };
+                let value =
+                    take_payload_blob(ledger, row, 1).context("prefix scan value failed")?;
                 page_bytes += value.as_ref().map_or(0, Vec::len);
                 page.push((key, value));
                 if page_bytes >= SCAN_PAGE_MAX_BYTES {
@@ -1159,7 +1904,7 @@ fn scan_prefix(
             let unchanged = prior_hashes.get(&key) == Some(&hash);
             if !unchanged && !bytes.is_empty() {
                 if let Some(mut record) = synthesize_cursor_sqlite_record(&key, &bytes) {
-                    stamp_bubble_workspace(connection, workspace_cache, &mut record);
+                    stamp_bubble_workspace(connection, workspace_cache, &mut record, ledger);
                     records.push(record);
                 }
             }
@@ -1388,6 +2133,7 @@ fn stamp_bubble_workspace(
     connection: &Connection,
     cache: &mut HashMap<String, Option<String>>,
     synthetic: &mut SyntheticRecord,
+    ledger: &mut ScanLedger,
 ) {
     let Some(record) = synthetic.record.as_object_mut() else {
         return;
@@ -1399,10 +2145,16 @@ fn stamp_bubble_workspace(
         return;
     };
     let composer_id = composer_id.to_string();
-    let workspace = cache
-        .entry(composer_id.clone())
-        .or_insert_with(|| lookup_composer_workspace(connection, &composer_id))
-        .clone();
+    let workspace = match cache.get(&composer_id) {
+        Some(cached) => cached.clone(),
+        None => {
+            // A cache miss is a real second payload read of the composer blob
+            // (up to 2.4 MB on the reference host) and is charged as one.
+            let resolved = lookup_composer_workspace(connection, &composer_id, ledger);
+            cache.insert(composer_id.clone(), resolved.clone());
+            resolved
+        }
+    };
     if let Some(path) = workspace {
         record.insert("workspacePath".to_string(), json!(path));
     }
@@ -1412,18 +2164,28 @@ fn stamp_bubble_workspace(
 /// parent `composerData:` blob. Works even for composers the synthesizer
 /// defers (no positive `createdAt` yet): Cursor writes the workspace
 /// identifier at creation. Any failure resolves to `None`.
-fn lookup_composer_workspace(connection: &Connection, composer_id: &str) -> Option<String> {
-    let bytes: Vec<u8> = connection
-        .query_row(
-            "SELECT value FROM cursorDiskKV WHERE key = ?1",
-            rusqlite::params![format!("composerData:{composer_id}")],
-            |row| match row.get_ref(0)? {
-                ValueRef::Text(text) => Ok(text.to_vec()),
-                ValueRef::Blob(blob) => Ok(blob.to_vec()),
-                _ => Ok(Vec::new()),
-            },
-        )
-        .ok()?;
+fn lookup_composer_workspace(
+    connection: &Connection,
+    composer_id: &str,
+    ledger: &mut ScanLedger,
+) -> Option<String> {
+    // `query_row` holds the closure's borrow for its whole call, so the read
+    // is charged into a scratch ledger and folded in unconditionally — a row
+    // that materialized bytes and then failed to parse still cost them.
+    let mut row_ledger = ScanLedger::default();
+    let read = connection.query_row(
+        "SELECT value FROM cursorDiskKV WHERE key = ?1",
+        rusqlite::params![format!("composerData:{composer_id}")],
+        |row| {
+            row_ledger.charge_payload_row();
+            Ok(take_payload_blob(&mut row_ledger, row, 0)?.unwrap_or_default())
+        },
+    );
+    ledger.payload_rows = ledger.payload_rows.saturating_add(row_ledger.payload_rows);
+    ledger.payload_bytes = ledger
+        .payload_bytes
+        .saturating_add(row_ledger.payload_bytes);
+    let bytes: Vec<u8> = read.ok()?;
     let parsed: Value = serde_json::from_slice(&bytes).ok()?;
     parsed
         .pointer("/workspaceIdentifier/uri/fsPath")
@@ -1543,6 +2305,7 @@ fn truncate_chars_local(input: &str, max_chars: usize) -> String {
 mod tests {
     use super::*;
     use crate::model::RowBatch;
+    use crate::WorkTrigger;
     use moraine_config::SourceFormat;
     use serde_json::json;
     use std::path::{Path, PathBuf};
@@ -1690,6 +2453,7 @@ mod tests {
             format: SourceFormat::CursorSqlite,
             source_glob: String::new(),
             path: path.to_string_lossy().to_string(),
+            trigger: WorkTrigger::Watcher,
         }
     }
 
@@ -1715,8 +2479,25 @@ mod tests {
         checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
         poll_state: &VolatilePollMap,
     ) -> Vec<RowBatch> {
+        run_poll_with_state_and_metrics(
+            work,
+            checkpoints,
+            poll_state,
+            &Arc::new(Metrics::default()),
+        )
+        .await
+    }
+
+    /// Shares one `Metrics` across several polls so a test can count the scans
+    /// that actually ran (`sqlite_scan_failures_total`) rather than the errors
+    /// that were reported, which are deliberately rate-limited.
+    async fn run_poll_with_state_and_metrics(
+        work: &WorkItem,
+        checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
+        poll_state: &VolatilePollMap,
+        metrics: &Arc<Metrics>,
+    ) -> Vec<RowBatch> {
         let config = moraine_config::AppConfig::default();
-        let metrics = Arc::new(Metrics::default());
         let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(64);
         let process = process_cursor_sqlite_db(
             &config,
@@ -1724,7 +2505,7 @@ mod tests {
             checkpoints.clone(),
             poll_state,
             sink_tx,
-            &metrics,
+            metrics,
         );
         tokio::pin!(process);
         let mut batches = Vec::new();
@@ -1800,6 +2581,648 @@ mod tests {
         for suffix in ["", "-wal", "-shm"] {
             let _ = std::fs::remove_file(format!("{}{}", path.to_string_lossy(), suffix));
         }
+    }
+
+    fn payload_rows(metrics: &Arc<Metrics>) -> u64 {
+        metrics
+            .sqlite_poll_payload_rows_total
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn payload_bytes(metrics: &Arc<Metrics>) -> u64 {
+        metrics
+            .sqlite_poll_payload_bytes_total
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Issue #601 §2.5. The ladder itself — nothing asserted its shape, so
+    /// `failure_backoff` could return `Duration::MAX` for every non-zero `n`
+    /// with the whole suite still green. That is the latch class inverted: a
+    /// permanently broken database would never retry, and §2.5's stated
+    /// purpose for the cap ("recovery from an environmental fault never needs
+    /// a restart") could not fail.
+    ///
+    /// Fails for: replacing the body with a constant, dropping the doubling,
+    /// dropping `.min(31)` (`1u32 << 32` overflows in debug), or removing the
+    /// `FAILURE_BACKOFF_MAX` clamp.
+    #[test]
+    fn failure_backoff_doubles_from_the_base_and_saturates_at_the_cap() {
+        assert_eq!(
+            failure_backoff(0),
+            Duration::ZERO,
+            "no failures means retry immediately"
+        );
+        assert_eq!(failure_backoff(1), Duration::from_secs(15));
+        assert_eq!(failure_backoff(2), Duration::from_secs(30));
+        assert_eq!(failure_backoff(3), Duration::from_secs(60));
+        assert_eq!(failure_backoff(6), Duration::from_secs(15 * 32));
+        // 15 s * 2^6 = 960 s overshoots the 900 s ceiling, so n = 7 is the
+        // first genuinely clamped step rather than a coincidence.
+        assert!(Duration::from_secs(15 * 64) > FAILURE_BACKOFF_MAX);
+        assert_eq!(failure_backoff(7), FAILURE_BACKOFF_MAX);
+        assert_eq!(failure_backoff(60), FAILURE_BACKOFF_MAX);
+        // The shift clamp: without `.min(31)` this panics on overflow.
+        assert_eq!(failure_backoff(u32::MAX), FAILURE_BACKOFF_MAX);
+        assert_eq!(
+            FAILURE_BACKOFF_MAX,
+            Duration::from_secs(15 * 60),
+            "a permanently broken database still retries every 15 minutes"
+        );
+    }
+
+    /// Issue #601 §3.2 — the *contention* ladder's shape. It was mirrored from
+    /// the fault ladder above for its lower bound (it throttles) and its upper
+    /// bound (it does not latch), but not for its **width**, and only the base
+    /// was pinned — incidentally, through
+    /// `a_contended_replacement_replay_throttles_its_barrier`'s single
+    /// `age_for_tests(.., 16 s)` step. That test never reaches
+    /// `consecutive_contended_scans >= 3`, so everything above the first step
+    /// was free: `CONTENTION_BACKOFF_MAX` could be set to `FAILURE_BACKOFF_MAX`
+    /// — literally the fifteen minutes the constant's own doc says must not
+    /// happen — or collapsed onto the base so the ladder cannot grow at all, or
+    /// the doubling removed outright, with the whole suite green.
+    ///
+    /// Fails for: any of those three, moving the base, or dropping `.min(31)`
+    /// (`1u32 << 32` overflows in debug).
+    #[test]
+    fn contention_backoff_doubles_from_the_base_and_saturates_at_a_minute() {
+        assert_eq!(
+            contention_backoff(0),
+            Duration::ZERO,
+            "no contention means retry immediately"
+        );
+        assert_eq!(contention_backoff(1), Duration::from_secs(15));
+        assert_eq!(contention_backoff(2), Duration::from_secs(30));
+        // 15 s * 2^2 = 60 s meets the ceiling exactly, so n = 4 is the first
+        // genuinely clamped step rather than a coincidence.
+        assert_eq!(contention_backoff(3), Duration::from_secs(60));
+        assert!(Duration::from_secs(15 * 8) > CONTENTION_BACKOFF_MAX);
+        assert_eq!(contention_backoff(4), CONTENTION_BACKOFF_MAX);
+        assert_eq!(contention_backoff(60), CONTENTION_BACKOFF_MAX);
+        // The shift clamp: without `.min(31)` this panics on overflow.
+        assert_eq!(contention_backoff(u32::MAX), CONTENTION_BACKOFF_MAX);
+        assert_eq!(
+            CONTENTION_BACKOFF_MAX,
+            Duration::from_secs(60),
+            "a replacement database that is merely busy must become visible \
+             within a minute of the writer pausing"
+        );
+        assert!(
+            CONTENTION_BACKOFF_MAX < FAILURE_BACKOFF_MAX,
+            "…not within fifteen — the two ladders are separate precisely \
+             because contention is transient and self-clearing and a fault is \
+             not, so collapsing the ceilings together erases the distinction"
+        );
+    }
+
+    /// Issue #601 §2.5, the escalation the ladder exists for.
+    ///
+    /// The `clear(); record_failed_scan();` pair the blocked-replay path used
+    /// to run is indistinguishable from a single `record_failed_scan` *inside
+    /// one backoff window*, which is why a test driving ten retries in fifteen
+    /// seconds proved nothing. Backdating the entry's clock makes the
+    /// difference observable: after two failures the window is 30 s, so
+    /// sixteen seconds of elapsed time must **not** be enough.
+    ///
+    /// Fails for: resetting the streak on each failure (every window stays
+    /// 15 s, so the 16 s probe is due), or dropping the escalation entirely.
+    #[test]
+    fn repeated_failures_escalate_the_retry_window() {
+        let map = VolatilePollMap::new();
+        let key = "escalation-key";
+
+        map.record_failed_scan(key, 1);
+        assert_eq!(map.consecutive_failed_scans(key), 1);
+        assert!(
+            !map.failure_retry_due(key, 1),
+            "inside the first 15 s window"
+        );
+        map.age_for_tests(key, Duration::from_secs(16));
+        assert!(map.failure_retry_due(key, 1), "15 s window has expired");
+
+        map.record_failed_scan(key, 1);
+        assert_eq!(map.consecutive_failed_scans(key), 2);
+        map.age_for_tests(key, Duration::from_secs(16));
+        assert!(
+            !map.failure_retry_due(key, 1),
+            "the second window is 30 s, so 16 s is not yet due — this is the \
+             assertion a reset-to-1 bug fails"
+        );
+        map.age_for_tests(key, Duration::from_secs(16));
+        assert!(map.failure_retry_due(key, 1), "32 s > 30 s");
+
+        // And `clear` genuinely does restart the ladder: the defect the
+        // blocked-replay path shipped, pinned here so a reintroduction is a
+        // visible behavioral claim rather than an invisible one.
+        map.record_failed_scan(key, 1);
+        assert_eq!(map.consecutive_failed_scans(key), 3);
+        map.clear(key);
+        map.record_failed_scan(key, 1);
+        assert_eq!(
+            map.consecutive_failed_scans(key),
+            1,
+            "clear() before record_failed_scan() resets the ladder — which is \
+             why `record_blocked_replay` must never do it"
+        );
+    }
+
+    /// Issue #601 §6 / §3.2. A mixed-snapshot rejection means the database was
+    /// being written while the scan read it. That is **contention**, not a
+    /// fault: it happens precisely when the source is active, which is when
+    /// prompt visibility matters most. Routing it into the 15 s → 15 min fault
+    /// ladder would regress active-session freshness by up to fifteen minutes,
+    /// and the mitigation the spec pairs with that ("smaller scans make retries
+    /// rare") is WI-07/WI-08 and does not exist yet.
+    ///
+    /// Fails for: routing `sqlite_mixed_snapshot` through the fault ladder, or
+    /// making the exemption swallow a genuine fault's streak.
+    #[test]
+    fn mixed_snapshot_rejection_does_not_escalate_the_failure_backoff() {
+        let stat = StatFingerprint::default();
+        let map = VolatilePollMap::new();
+        let key = "contended-key";
+
+        for _ in 0..5 {
+            map.record_scan_failure_outcome(key, 1, ERROR_KIND_MIXED_SNAPSHOT);
+        }
+        assert_eq!(
+            map.consecutive_failed_scans(key),
+            0,
+            "contention must not build a fault streak"
+        );
+        assert!(
+            !map.should_skip_poll(key, 1, &stat),
+            "a contended database retries at the ordinary poll cadence"
+        );
+
+        // A genuine fault still escalates, and a contended retry underneath it
+        // neither extends nor clears it.
+        map.record_scan_failure_outcome(key, 1, ERROR_KIND_SCHEMA);
+        map.record_scan_failure_outcome(key, 1, ERROR_KIND_SCHEMA);
+        assert_eq!(map.consecutive_failed_scans(key), 2);
+        map.record_scan_failure_outcome(key, 1, ERROR_KIND_MIXED_SNAPSHOT);
+        assert_eq!(
+            map.consecutive_failed_scans(key),
+            2,
+            "contention leaves a genuine fault ladder exactly where it was"
+        );
+        assert!(
+            map.should_skip_poll(key, 1, &stat),
+            "the fault ladder holds"
+        );
+    }
+
+    /// Issue #601 §3.2 / §2.5 — the classifier's **extent**, per error kind
+    /// rather than per outcome.
+    ///
+    /// `mixed_snapshot_rejection_does_not_escalate_the_failure_backoff` bounds
+    /// the predicate from beneath (the named kind is exempt) and at one
+    /// neighbour (`sqlite_schema_mismatch` is not). It does not bound the
+    /// width, and two of the four neighbours were open: widening to
+    /// `|| error_kind == ERROR_KIND_SCAN` and to
+    /// `|| error_kind == ERROR_KIND_TOO_LARGE` were both green. The first is
+    /// the expensive one — `sqlite_scan_error` is emitted at eleven of the
+    /// seventeen production failure sites — and it silently restores the exact
+    /// §2.5 defect: no fault streak, so `should_skip_poll` never backs off and
+    /// a full failed scan re-runs on every reconcile tick and every debounced
+    /// watcher event, while the durable barrier's throttle collapses from
+    /// fifteen minutes to sixty seconds.
+    ///
+    /// Every kind is asserted on both clocks *and* on the gate the clock
+    /// serves, so there is no neighbour left to widen into and no direction to
+    /// narrow in.
+    ///
+    /// Fails for: routing any fault kind to the contention clock, routing
+    /// `sqlite_mixed_snapshot` to the fault ladder, or collapsing the split.
+    #[test]
+    fn each_error_kind_routes_to_exactly_one_backoff_clock() {
+        let stat = StatFingerprint::default();
+
+        for kind in [
+            ERROR_KIND_OPEN,
+            ERROR_KIND_SCHEMA,
+            ERROR_KIND_TOO_LARGE,
+            ERROR_KIND_SCAN,
+        ] {
+            let map = VolatilePollMap::new();
+            let key = "fault-routing";
+            map.record_scan_failure_outcome(key, 1, kind);
+            assert_eq!(
+                map.consecutive_failed_scans(key),
+                1,
+                "{kind} is a fault and must climb the fault ladder"
+            );
+            assert_eq!(
+                map.consecutive_contended_scans(key),
+                0,
+                "{kind} is not contention and must not move the contention clock"
+            );
+            // The consequence, at the gate §2.5 exists to serve: with no fault
+            // streak the very next tick re-runs the whole failed scan.
+            assert!(
+                map.should_skip_poll(key, 1, &stat),
+                "{kind} must make the next ordinary poll back off"
+            );
+        }
+
+        let map = VolatilePollMap::new();
+        let key = "contention-routing";
+        map.record_scan_failure_outcome(key, 1, ERROR_KIND_MIXED_SNAPSHOT);
+        assert_eq!(
+            map.consecutive_failed_scans(key),
+            0,
+            "contention is the one kind exempt from the fault ladder (§3.2)"
+        );
+        assert_eq!(
+            map.consecutive_contended_scans(key),
+            1,
+            "…and the one kind that moves the contention clock"
+        );
+        assert!(
+            !map.should_skip_poll(key, 1, &stat),
+            "a contended database keeps scanning at the ordinary poll cadence"
+        );
+    }
+
+    /// Issue #601 §3.2 — the mixed-snapshot bracket's **extent**, one disjunct
+    /// at a time.
+    ///
+    /// The bracket is the production trigger for the entire contention
+    /// feature, and no test in any of the three adapters reached it through a
+    /// real disjunct: every one arms `contention_injection`, and
+    /// `forced_mixed_snapshot` short-circuits the rest of the expression. So
+    /// all three brackets could be reduced to the bare `#[cfg(test)]` hook —
+    /// deleting *both* real disjuncts — with the suite green in each adapter,
+    /// and dropping either one alone was green too.
+    ///
+    /// Why the guard is bounded here rather than through a live scan is
+    /// recorded on `snapshot_is_mixed` itself: a commit landing between a
+    /// scan's two `data_version` reads is not deterministically reachable, and
+    /// racing for it would give a probabilistic test that also cannot say which
+    /// disjunct fired.
+    ///
+    /// Fails for: dropping the `data_version` disjunct, dropping the stat
+    /// disjunct, or widening the predicate to fire unconditionally.
+    #[test]
+    fn the_mixed_snapshot_bracket_fires_on_a_moved_data_version_and_on_a_moved_stat() {
+        let path = unique_db_path("mixed-snapshot-extent");
+        std::fs::write(&path, b"a file standing in for a database").expect("seed probe file");
+        let db_path = path.to_string_lossy().to_string();
+        let opened = stat_fingerprint(&db_path).expect("the probe file exists");
+
+        // Upper bound: a quiet database is a clean scan. Widening the predicate
+        // to fire unconditionally dies here, and so does any rewrite that
+        // rejects a scan nothing touched.
+        assert!(
+            !snapshot_is_mixed(&db_path, 7, 7, opened),
+            "an unchanged data_version over an unchanged file is a clean scan"
+        );
+
+        // Lower bound A — a writer committed during the scan. `data_version`
+        // moved while the file did not: the WAL case, where the commit lands in
+        // the `-wal` and a coarse-resolution stat can still compare equal.
+        assert!(
+            snapshot_is_mixed(&db_path, 7, 8, opened),
+            "a data_version that moved during the scan is a torn read"
+        );
+
+        // Lower bound B — the file moved under the scan while `data_version`
+        // did not: a checkpoint, a rotation, or a wholesale replacement.
+        std::fs::write(&path, b"a file standing in for a database, now longer")
+            .expect("grow the probe file");
+        let grown = stat_fingerprint(&db_path).expect("the probe file still exists");
+        assert_ne!(
+            grown, opened,
+            "the probe must actually move the fingerprint, or bound B proves nothing"
+        );
+        assert!(
+            snapshot_is_mixed(&db_path, 7, 7, opened),
+            "a file that changed under the scan is a torn read even when \
+             data_version did not move"
+        );
+
+        cleanup(&path);
+    }
+
+    /// Issue #601 §2.0. The ledger is **caller-owned** precisely so that a scan
+    /// which reads 48 MB and then loses the mixed-snapshot race is still
+    /// charged for what it read. Nothing asserted that: every ledger test
+    /// destructured `Scanned` and panicked otherwise, so resetting the ledger
+    /// on any failure arm left the suite green and the guarantee unverified.
+    ///
+    /// This drives the one post-read failure arm Cursor has. The contention is
+    /// **injected**, not raced for: the bracket sits after the paged read, so
+    /// arming it reproduces exactly the state a writer committing mid-scan
+    /// produces — a full ledger and a rejected outcome — without the retry loop
+    /// the earlier version needed, which could fail for reasons unrelated to
+    /// the code it guards.
+    ///
+    /// Fails for: resetting or rebuilding the ledger on the mixed-snapshot
+    /// return.
+    #[test]
+    fn a_failed_scan_still_reports_the_bytes_it_had_already_read() {
+        let path = unique_db_path("failure-arm-ledger");
+        let db = create_kv_db(&path);
+        db.execute_batch("BEGIN").expect("begin seed");
+        for idx in 0..8 {
+            put(
+                &db,
+                &format!("bubbleId:{COMPOSER_ID}:seed{idx:04}"),
+                &json!({"_v": 3, "type": 1, "bubbleId": USER_BUBBLE_ID,
+                        "createdAt": "2026-05-08T02:04:37.835Z",
+                        "text": "y".repeat(96 * 1024)}),
+            );
+        }
+        db.execute_batch("COMMIT").expect("commit seed");
+        drop(db);
+
+        let db_path = path.to_string_lossy().to_string();
+        contention_injection::arm(&db_path, 1);
+        let mut ledger = ScanLedger::default();
+        let outcome = scan_database(&db_path, &CursorState::fresh(), &mut ledger);
+        assert!(
+            matches!(
+                outcome,
+                ScanOutcome::Failed {
+                    error_kind: ERROR_KIND_MIXED_SNAPSHOT,
+                    ..
+                }
+            ),
+            "the armed scan must reach the mixed-snapshot arm; without observing \
+             the arm this test proves nothing"
+        );
+        assert!(
+            ledger.payload_rows > 0,
+            "the rejected scan had already read rows"
+        );
+        assert!(
+            ledger.payload_bytes > 64 * 1024,
+            "and it must still be charged for the bytes it read; got {}",
+            ledger.payload_bytes
+        );
+
+        // Armings are one-shot and path-keyed: the very next scan of the same
+        // database succeeds, so nothing leaks into another test.
+        let mut clean = ScanLedger::default();
+        assert!(matches!(
+            scan_database(&db_path, &CursorState::fresh(), &mut clean),
+            ScanOutcome::Scanned { .. }
+        ));
+
+        cleanup(&path);
+    }
+
+    /// Issue #601 §2.5 / §3.2. Mixed-snapshot rejections are exempt from the
+    /// **fault ladder**; they must never be exempt from the **replay throttle**.
+    ///
+    /// A replacement replay is the longest scan an adapter runs — cold, whole
+    /// database — so it is the scan most likely to lose the `data_version`/stat
+    /// bracket in the first place. Its `Failed` arm emits a durable
+    /// `BlockReplay` plus an append-only `ingest_errors` row, and the next tick
+    /// sees `retry_blocked_replay` true with `starts_replacement` false (the
+    /// blocked checkpoint carries the current inode and exclusions hash). If
+    /// the exemption leaves no clock behind, `failure_retry_due` says "due" and
+    /// the pre-barrier throttle never fires: `BeginReplay` + full cold scan +
+    /// `BlockReplay` + one error row **per poll, forever**, at the reconcile
+    /// cadence and on every 50 ms-debounced watcher event.
+    ///
+    /// Driven through an actual replay rather than `VolatilePollMap` directly,
+    /// because the barrier — not the map — is what was unguarded.
+    ///
+    /// Fails for: `record_scan_failure_outcome` returning without recording
+    /// anything for `ERROR_KIND_MIXED_SNAPSHOT`, or `failure_retry_due`
+    /// ignoring the contention clock.
+    #[tokio::test]
+    async fn a_contended_replacement_replay_throttles_its_barrier() {
+        let path = unique_db_path("contended-replay-barrier");
+        let _db = seed_fixture_db(&path);
+        let work = sqlite_work(&path);
+        let db_path = work.path.clone();
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+
+        // Cold poll commits a checkpoint under the default exclusion policy.
+        run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
+        assert!(checkpoints.read().await.contains_key(&cp_key));
+
+        // Changing the exclusion set starts a replacement replay. Every scan
+        // from here loses the mixed-snapshot bracket, as a busy database's
+        // cold re-read would.
+        let mut replaying = moraine_config::AppConfig::default();
+        replaying.ingest.exclude_project_dirs = vec!["/no/such/dir/**".to_string()];
+        contention_injection::arm(&db_path, 64);
+        let block_poll = |config: moraine_config::AppConfig| {
+            let work = work.clone();
+            let checkpoints = checkpoints.clone();
+            let poll_state = poll_state.clone();
+            let metrics = metrics.clone();
+            async move { run_replay_poll(&config, &work, &checkpoints, &poll_state, &metrics).await }
+        };
+
+        assert!(
+            block_poll(replaying.clone()).await,
+            "the contended replay blocks durably"
+        );
+        assert_eq!(
+            poll_state.consecutive_failed_scans(&cp_key),
+            0,
+            "contention must not climb the fault ladder (§3.2)"
+        );
+        assert_eq!(
+            poll_state.consecutive_contended_scans(&cp_key),
+            1,
+            "…but it must leave a clock behind"
+        );
+
+        // The retry is throttled: no barrier, no scan, no second error row.
+        let scans_before = payload_rows(&metrics);
+        assert!(
+            !block_poll(replaying.clone()).await,
+            "a contended blocked replay must not re-send BeginReplay/BlockReplay \
+             on the very next tick"
+        );
+        assert_eq!(
+            payload_rows(&metrics),
+            scans_before,
+            "and must not re-read the whole database either"
+        );
+
+        // Ten more ticks change nothing — this is the "per poll, forever" shape.
+        for _ in 0..10 {
+            assert!(!block_poll(replaying.clone()).await);
+        }
+        assert_eq!(payload_rows(&metrics), scans_before);
+
+        // Once the contention window expires the retry runs again, so recovery
+        // is not sacrificed: the clock throttles, it does not latch.
+        poll_state.age_for_tests(&cp_key, Duration::from_secs(16));
+        assert!(
+            block_poll(replaying).await,
+            "an expired contention window must let the replay retry"
+        );
+        assert_eq!(
+            poll_state.consecutive_failed_scans(&cp_key),
+            0,
+            "still not a fault"
+        );
+        assert_eq!(poll_state.consecutive_contended_scans(&cp_key), 2);
+
+        contention_injection::disarm(&db_path);
+        cleanup(&path);
+    }
+
+    /// Issue #601 §3.2/§6 — the direction
+    /// `a_contended_replacement_replay_throttles_its_barrier` does **not**
+    /// bound. That test proves a contended *replay barrier* is throttled; this
+    /// one proves an ordinary poll of the same database is not, which is the
+    /// half the exemption exists for.
+    ///
+    /// The two clocks are read in different places on purpose:
+    /// `failure_retry_due` (the barrier) consults `last_contended_at`,
+    /// `should_skip_poll` (ordinary scans) deliberately does not. A database is
+    /// contended precisely because someone is writing to it, so throttling its
+    /// ordinary polls regresses freshness on the only sessions anyone is
+    /// watching. Nothing pinned that asymmetry at a **call site** — the
+    /// predicates could be asserted directly, but the short-circuits could not
+    /// — which is how the short-circuit comments were able to keep instructing
+    /// WI-04 to add §2.5's `|| !failure_retry_due` disjunct after §3.2 made it
+    /// outcome-changing. That disjunct puts the barrier's clock in front of
+    /// every ordinary poll.
+    ///
+    /// Fails for: adding `|| !poll_state.failure_retry_due(..)` to the cheap
+    /// no-change short-circuit (the second contended scan never runs, and the
+    /// writer's next edit stays invisible for up to 60 s), or moving the
+    /// contention clock into `should_skip_poll`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_ordinary_poll_of_a_contended_database_is_not_throttled() {
+        let path = unique_db_path("contended-ordinary-poll");
+        let db = seed_fixture_db(&path);
+        let work = sqlite_work(&path);
+        let db_path = work.path.clone();
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+
+        let cold =
+            run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
+        assert!(
+            !all_event_rows(&cold).is_empty(),
+            "the cold poll emits the fixture"
+        );
+
+        // The session is live. The writer commits, and the next two scans lose
+        // the mixed-snapshot bracket to it.
+        contention_injection::arm(&db_path, 2);
+        put(
+            &db,
+            &format!("bubbleId:{COMPOSER_ID}:{TOOL_BUBBLE_ID}"),
+            &tool_bubble_value("running", false),
+        );
+        run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            poll_state.consecutive_contended_scans(&cp_key),
+            1,
+            "the first scan is rejected by the bracket"
+        );
+        assert_eq!(
+            poll_state.consecutive_failed_scans(&cp_key),
+            0,
+            "contention is not a fault (§3.2)"
+        );
+
+        // Immediately — far inside the 15 s contention window the barrier is
+        // now serving — the next ordinary poll must still read the database.
+        put(
+            &db,
+            &format!("bubbleId:{COMPOSER_ID}:{THINKING_BUBBLE_ID}"),
+            &thinking_bubble_value(),
+        );
+        run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            poll_state.consecutive_contended_scans(&cp_key),
+            2,
+            "an ordinary poll of a contended database must not be throttled — \
+             the second scan has to run at the ordinary poll cadence"
+        );
+        assert_eq!(
+            metrics
+                .sqlite_scan_failures_total
+                .load(std::sync::atomic::Ordering::Relaxed),
+            2,
+            "…and must reach the scan, not return before it"
+        );
+
+        // The writer's edit lands and the contention clears. This poll is still
+        // well inside the contention window, and it is the poll that makes an
+        // active session visible.
+        contention_injection::disarm(&db_path);
+        put(
+            &db,
+            &format!("bubbleId:{COMPOSER_ID}:{TOOL_BUBBLE_ID}"),
+            &tool_bubble_value("completed", true),
+        );
+        let fresh =
+            run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            event_uid_by_kind(&all_event_rows(&fresh), "tool_result").len(),
+            1,
+            "a contended database's next write must be visible at the ordinary \
+             poll cadence, not after a 60 s barrier backoff"
+        );
+
+        cleanup(&path);
+    }
+
+    /// Issue #601 §1.1. `count_relevant_keys` is Cursor's only census-shaped
+    /// read today: two range scans over the unique `key` index, measured at
+    /// 0.056 ms / 19 KB for 247 keys on the reference host **because the index
+    /// covers them**. Nothing pinned that, so the same statement degrading to
+    /// a table scan — 48 MB and 55 ms on that host — would be invisible.
+    ///
+    /// It stays a scalar aggregate, so by the `ScanLedger` charging rules it
+    /// materializes no row and is charged on neither axis. This plan assertion
+    /// is what keeps that silence honest rather than an unstated cost; see the
+    /// matching note on `ledger_charges_payload_bytes_at_the_read_site`.
+    ///
+    /// Fails for: widening the count's projection or predicate such that
+    /// SQLite stops using the covering index.
+    #[test]
+    fn cursor_relevant_key_count_is_a_covering_index_scan() {
+        let path = unique_db_path("census-plan");
+        let db = seed_fixture_db(&path);
+
+        for prefix in RELEVANT_PREFIXES {
+            let plan: Vec<String> = {
+                let mut stmt = db
+                    .prepare(&format!(
+                        "EXPLAIN QUERY PLAN {CURSOR_RELEVANT_KEY_COUNT_SQL}"
+                    ))
+                    .expect("prepare explain");
+                let rows = stmt
+                    .query_map(rusqlite::params![prefix, prefix_range_end(prefix)], |row| {
+                        row.get::<_, String>(3)
+                    })
+                    .expect("query plan");
+                rows.map(|row| row.expect("plan detail")).collect()
+            };
+            let detail = plan.join("; ");
+            assert!(
+                detail.contains("COVERING INDEX"),
+                "the relevant-key census must stay index-covered for {prefix}; \
+                 plan was: {detail}"
+            );
+            assert!(
+                !detail.contains("SCAN cursorDiskKV"),
+                "the census must never degrade to a table scan for {prefix}; \
+                 plan was: {detail}"
+            );
+        }
+
+        drop(db);
+        cleanup(&path);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2235,26 +3658,71 @@ mod tests {
         cleanup(&path);
     }
 
+    /// Issue #601 §8. `second.is_empty()` alone is satisfied *equally* by the
+    /// cheap stat short-circuit and by a complete re-scan that finds nothing —
+    /// deleting the `state.stat == current_stat` short-circuit left this test
+    /// green, which made it a guard that could not fail for the property it is
+    /// named after. `sqlite_poll_payload_rows_total` is the instrument that
+    /// distinguishes them: a poll that short-circuited read no rows.
+    ///
+    /// **[DIVERGENT FIXTURE]** each poll gets a *fresh* `VolatilePollMap`, so
+    /// the issue-#443 volatile short-circuit cannot stand in for the durable
+    /// one and mask the mutation.
+    ///
+    /// Fails for: deleting the `state.stat == current_stat` short-circuit.
     #[tokio::test(flavor = "multi_thread")]
     async fn unchanged_db_is_a_noop_on_the_next_poll() {
         let path = unique_db_path("noop");
         let _db = seed_fixture_db(&path);
         let work = sqlite_work(&path);
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let metrics = Arc::new(Metrics::default());
 
-        let first = run_poll(&work, &checkpoints).await;
+        let first =
+            run_poll_with_state_and_metrics(&work, &checkpoints, &VolatilePollMap::new(), &metrics)
+                .await;
         assert!(!first.is_empty());
+        let read_after_first = payload_rows(&metrics);
+        let bytes_after_first = payload_bytes(&metrics);
+        assert!(
+            read_after_first > 0 && bytes_after_first > 0,
+            "the cold poll must actually read rows and bytes, or the comparison \
+             below is vacuous"
+        );
 
-        let second = run_poll(&work, &checkpoints).await;
+        let second =
+            run_poll_with_state_and_metrics(&work, &checkpoints, &VolatilePollMap::new(), &metrics)
+                .await;
         assert!(
             second.is_empty(),
             "unchanged database must produce zero batches; got {}",
             second.len()
         );
+        assert_eq!(
+            payload_rows(&metrics),
+            read_after_first,
+            "an unchanged database must not be re-read at all — zero batches is \
+             also what a full re-scan finding nothing produces"
+        );
+        assert_eq!(
+            payload_bytes(&metrics),
+            bytes_after_first,
+            "both axes: rows cannot catch content growth, bytes cannot catch a \
+             scan of narrow rows"
+        );
 
         cleanup(&path);
     }
 
+    /// Issue #601 §8 and issue #443. Every "sends nothing" assertion here is
+    /// also satisfied by a full re-scan that finds nothing, so each step now
+    /// states what it read as well as what it sent — that is the only way the
+    /// two short-circuits (durable stat, volatile stat coverage) become
+    /// mutation-provable at all.
+    ///
+    /// Fails for: deleting the `state.stat == current_stat` short-circuit
+    /// (the fifth poll re-reads), or deleting the `should_skip_poll` call (the
+    /// third poll re-reads).
     #[tokio::test(flavor = "multi_thread")]
     async fn irrelevant_write_scans_but_persists_no_checkpoint() {
         let path = unique_db_path("noop-checkpoint");
@@ -2262,8 +3730,10 @@ mod tests {
         let work = sqlite_work(&path);
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
         let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
 
-        let first = run_poll_with_state(&work, &checkpoints, &poll_state).await;
+        let first =
+            run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
         assert!(!first.is_empty());
         let cp_key = checkpoint_key(&work.source_name, &work.path);
         let baseline = checkpoints
@@ -2272,24 +3742,40 @@ mod tests {
             .get(&cp_key)
             .cloned()
             .expect("committed checkpoint after first poll");
+        let read_after_first = payload_rows(&metrics);
+        assert!(read_after_first > 0);
 
         // Cursor constantly rewrites non-transcript keys (issue #443): the
         // stat fingerprint moves but no relevant key changes.
         put(&db, "agentKv:blob:0000", &json!({"opaque": "blob"}));
 
-        let second = run_poll_with_state(&work, &checkpoints, &poll_state).await;
+        let second =
+            run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
         assert!(
             second.is_empty(),
             "a no-op scan must send nothing durable; got {} batches",
             second.len()
         );
+        let read_after_second = payload_rows(&metrics);
+        assert!(
+            read_after_second > read_after_first,
+            "the stat moved, so this poll genuinely re-scanned — the test name's \
+             'scans but persists no checkpoint' has to be observable"
+        );
 
         // The same stat fingerprint is now covered by volatile state, so a
-        // re-poll without further writes also sends nothing.
-        let third = run_poll_with_state(&work, &checkpoints, &poll_state).await;
+        // re-poll without further writes also sends nothing *and reads
+        // nothing*.
+        let third =
+            run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
         assert!(
             third.is_empty(),
             "volatile stat coverage must short-circuit"
+        );
+        assert_eq!(
+            payload_rows(&metrics),
+            read_after_second,
+            "volatile coverage must skip the scan, not just its output"
         );
 
         // A relevant write below the backoff threshold is picked up
@@ -2299,7 +3785,8 @@ mod tests {
             &format!("bubbleId:{COMPOSER_ID}:{TOOL_BUBBLE_ID}"),
             &tool_bubble_value("completed", true),
         );
-        let fourth = run_poll_with_state(&work, &checkpoints, &poll_state).await;
+        let fourth =
+            run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
         let rows = all_event_rows(&fourth);
         assert_eq!(event_uid_by_kind(&rows, "tool_result").len(), 1);
         let cp = fourth
@@ -2310,6 +3797,20 @@ mod tests {
             cp.last_offset,
             baseline.last_offset + 1,
             "poll sequence advances once for the relevant change, not per WAL touch"
+        );
+
+        // The emitting scan cleared the volatile entry, so only the *durable*
+        // stat short-circuit can suppress this last poll. It is the arm the
+        // volatile map cannot stand in for.
+        let read_after_fourth = payload_rows(&metrics);
+        let fifth =
+            run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
+        assert!(fifth.is_empty());
+        assert_eq!(
+            payload_rows(&metrics),
+            read_after_fourth,
+            "with no volatile entry left, the durable stat short-circuit is the \
+             only thing that can stop the re-read"
         );
 
         cleanup(&path);
@@ -2328,12 +3829,15 @@ mod tests {
             !map.should_skip_poll(key, 1, &stat(1)),
             "no volatile state yet"
         );
-        map.record_failed_scan(key);
+        map.record_failed_scan(key, 1);
         assert!(
-            !map.should_skip_poll(key, 1, &stat(1)),
-            "a failed scan without a streak leaves retries unthrottled"
+            map.should_skip_poll(key, 1, &stat(1)),
+            "a first failed scan, with no prior entry, still starts a backoff \
+             (issue #601 §2.5 — this assertion is the inverse of the one it \
+             replaced, which pinned the unthrottled retry as correct)"
         );
 
+        map.clear(key);
         map.record_noop_scan(key, 1, stat(1));
         assert!(
             map.should_skip_poll(key, 1, &stat(1)),
@@ -2355,24 +3859,674 @@ mod tests {
             "a new generation ignores stale volatile state"
         );
 
-        // A failed scan on an established streak refreshes the backoff clock
-        // (streak and coverage untouched), keeping a persistently failing
-        // stat-noisy database on the throttled cadence.
-        map.record_failed_scan(key);
+        // A failed scan on an established streak keeps the database throttled
+        // and drops the covered stat: a failure covered nothing, so claiming
+        // coverage would suppress rescans of an unchanged file permanently
+        // instead of for the backoff window.
+        map.record_failed_scan(key, 1);
         assert!(
             map.should_skip_poll(key, 1, &stat(5)),
             "failed scan keeps the throttle window open"
         );
+        // Asserted on the entry directly, because both a retained coverage
+        // claim and the failure backoff produce the same `should_skip_poll`
+        // answer here — a behavioral assertion could not tell them apart, and
+        // the difference is that the stat-covered arm has no time bound at all.
         assert!(
-            map.should_skip_poll(key, 1, &stat(3)),
-            "failed scan does not invalidate the covered stat"
+            map.lock()
+                .get(key)
+                .expect("failed scan creates an entry")
+                .stat
+                .is_none(),
+            "a failed scan covered nothing, so it must drop any covered stat: \
+             keeping one would suppress rescans of an unchanged file forever \
+             instead of for the backoff window, and an environmental failure \
+             (a lock, a permission) would never recover without a restart"
+        );
+        assert!(
+            !map.failure_retry_due(key, 1),
+            "a fresh failure is not due for another attempt"
+        );
+        assert!(
+            map.failure_retry_due(key, 2),
+            "a new generation is always due"
+        );
+
+        map.record_noop_scan(key, 1, stat(6));
+        assert!(
+            map.failure_retry_due(key, 1),
+            "a successful no-op scan clears the failure streak"
         );
 
         map.clear(key);
         assert!(
+            map.failure_retry_due(key, 1),
+            "an absent entry is always due, so a restart inherits no suppression"
+        );
+        assert!(
             !map.should_skip_poll(key, 1, &stat(4)),
             "a durable checkpoint write clears the throttle"
         );
+    }
+
+    /// Issue #601 §3.2 — the **width** of `record_noop_scan`'s contention
+    /// reset. A clean scan proves the contention passed, so it must clear the
+    /// contention *ladder*, not only the clock the ladder is measured from.
+    ///
+    /// The reset is unobservable at the moment it happens:
+    /// `consecutive_contended_scans` is read in exactly one place —
+    /// `failure_retry_due`'s `Some(last_contended_at)` arm — and that arm is
+    /// unreachable while the clock is `None`. So deleting the reset changes
+    /// nothing until contention returns, at which point `record_contended_scan`
+    /// increments from a **stale** streak and the durable replay barrier
+    /// resumes part-way up the ladder (here: the 60 s ceiling) instead of at
+    /// its 15 s base. A replacement replay of a store that was busy an hour ago
+    /// and is busy again now would wait a minute per attempt from the first
+    /// rejection.
+    ///
+    /// **[DIVERGENT FIXTURE]** the streak is walked to 3 before the clean scan,
+    /// so the base window and the ceiling are distinguishable; from a streak of
+    /// 1 a reset and a stale value give the same answer.
+    ///
+    /// Fails for: dropping `entry.consecutive_contended_scans = 0` from
+    /// `record_noop_scan`.
+    #[test]
+    fn a_clean_scan_resets_the_contention_ladder_not_only_its_clock() {
+        let map = VolatilePollMap::new();
+        let key = "cursor-sqlite-test:contention-ladder-reset";
+        let stat = |db_len: u64| StatFingerprint {
+            db_len,
+            ..Default::default()
+        };
+
+        // Three consecutive rejections: the next barrier window is the 60 s
+        // ceiling, which is what makes a stale streak visible.
+        map.record_contended_scan(key, 1);
+        map.record_contended_scan(key, 1);
+        map.record_contended_scan(key, 1);
+        assert_eq!(map.consecutive_contended_scans(key), 3);
+        map.age_for_tests(key, Duration::from_secs(31));
+        assert!(
+            !map.failure_retry_due(key, 1),
+            "the fixture must sit deep enough in the ladder that the base \
+             window and the ceiling differ, or this guard cannot fail"
+        );
+
+        map.record_noop_scan(key, 1, stat(1));
+        assert_eq!(
+            map.consecutive_contended_scans(key),
+            0,
+            "a scan that completed cleanly resets the ladder, not only its clock"
+        );
+
+        // …so the next rejection is a first rejection, and its window is the
+        // 15 s base rather than the ceiling the stale streak would have kept.
+        map.record_contended_scan(key, 1);
+        assert!(
+            !map.failure_retry_due(key, 1),
+            "a fresh rejection still throttles the durable barrier"
+        );
+        map.age_for_tests(key, Duration::from_secs(16));
+        assert!(
+            map.failure_retry_due(key, 1),
+            "one rejection buys a 15 s window; resuming from a stale streak \
+             would hold the barrier for up to CONTENTION_BACKOFF_MAX instead"
+        );
+    }
+
+    /// Issue #601 §2.1(2) — the **narrowing** width of `retry_blocked_replay`,
+    /// at the Cursor site. Plan §7.2 F2 records the widening (dropping
+    /// `&& !block_reason.is_empty()`); this is the other direction, and it is
+    /// the worse one.
+    ///
+    /// `checkpoint.status == "replaying"` is not covered by the `"error"`
+    /// disjunct: a process that dies between `BeginReplay` and
+    /// `FinalizeReplay` leaves a checkpoint that is `replaying` with **no**
+    /// error status and **no** block reason. Delete the disjunct and that
+    /// checkpoint is treated as an ordinary poll — `replacement_replay` is
+    /// false, the cursor is not reset, no barrier is re-sent, the status is
+    /// quietly rewritten to `active`, and the interrupted replay never
+    /// completes. Since round 8 this predicate also feeds the blocked-replay
+    /// throttle gates, so its width is load-bearing for code this PR adds.
+    ///
+    /// **[DIVERGENT FIXTURE]** the stat is deliberately left unchanged since
+    /// the cold poll, so the cheap short-circuit is armed. That is what a
+    /// crashed replay actually looks like — nothing wrote to the database while
+    /// the process was down — and it is what makes the two behaviours diverge:
+    /// with the disjunct the state is reset and the scan runs, without it the
+    /// unchanged stat returns early.
+    ///
+    /// Fails for: dropping the `checkpoint.status == "replaying"` disjunct from
+    /// `retry_blocked_replay`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_crash_interrupted_replay_resumes_from_its_replaying_status() {
+        let path = unique_db_path("replaying-status-resume");
+        let _db = seed_fixture_db(&path);
+        let work = sqlite_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+
+        run_poll_with_state(&work, &checkpoints, &poll_state).await;
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+
+        // Exactly what a crash between `BeginReplay` and `FinalizeReplay`
+        // leaves behind: `replaying`, no error, no block reason.
+        {
+            let mut map = checkpoints.write().await;
+            let checkpoint = map
+                .get_mut(&cp_key)
+                .expect("first poll commits a checkpoint");
+            checkpoint.status = "replaying".to_string();
+            checkpoint.block_reason.clear();
+            checkpoint.final_scan_complete = false;
+        }
+
+        run_poll_with_state(&work, &checkpoints, &poll_state).await;
+
+        let after = checkpoints
+            .read()
+            .await
+            .get(&cp_key)
+            .cloned()
+            .expect("checkpoint survives the retry");
+        assert_eq!(
+            after.status, "active",
+            "an interrupted replay must resume and finish, not be relabelled"
+        );
+        assert!(
+            after.final_scan_complete,
+            "a resumed replay finalizes; without the `replaying` disjunct the \
+             poll returns on the unchanged stat and the source is stuck"
+        );
+
+        cleanup(&path);
+    }
+
+    fn scan_failures(metrics: &Arc<Metrics>) -> u64 {
+        metrics
+            .sqlite_scan_failures_total
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Gate G6b, issue #601 §2.5. A database whose **first** scan fails has
+    /// **no prior volatile entry** — precisely the case `record_failed_scan`
+    /// was a no-op for, so the full failed scan re-ran on every reconcile tick
+    /// and every debounced watcher event, forever.
+    ///
+    /// Denominated on an **observed scan count**, never on absence of
+    /// `ingest_errors` rows: those are rate-limited by `state.last_error`, so a
+    /// test asserting on them (as
+    /// `schema_mismatch_emits_one_error_and_preserves_cursor` does) stays green
+    /// no matter how many scans ran.
+    ///
+    /// Fails for: reverting `record_failed_scan` to its `get_mut`-only form, or
+    /// dropping the failure arm from `should_skip_poll`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn failed_scan_backs_off_instead_of_rescanning_every_tick() {
+        let path = unique_db_path("failure-backoff-first-scan");
+        let db = Connection::open(&path).expect("create db");
+        db.execute_batch("CREATE TABLE unrelated (id INTEGER PRIMARY KEY);")
+            .expect("create unrelated table");
+        drop(db);
+
+        let work = sqlite_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+
+        for _ in 0..10 {
+            run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
+        }
+
+        assert!(
+            scan_failures(&metrics) >= 1,
+            "the first tick must actually attempt the scan"
+        );
+        assert!(
+            scan_failures(&metrics) <= 2,
+            "10 ticks against a database whose first scan fails must not run 10 \
+             scans; observed {}",
+            scan_failures(&metrics)
+        );
+
+        cleanup(&path);
+    }
+
+    /// The second shape `record_failed_scan` was a no-op for: a successful
+    /// emitting scan calls `poll_state.clear`, deleting the entry, so a failure
+    /// that follows one starts from no volatile state at all.
+    ///
+    /// Fails for: reverting `record_failed_scan` to its `get_mut`-only form.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn failure_after_a_successful_scan_still_backs_off() {
+        let path = unique_db_path("failure-backoff-after-success");
+        let db = seed_fixture_db(&path);
+        let work = sqlite_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+
+        let first =
+            run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
+        assert!(
+            !all_event_rows(&first).is_empty(),
+            "the first poll must emit, so the volatile entry is cleared"
+        );
+        assert_eq!(scan_failures(&metrics), 0);
+
+        // Same inode, so this is a schema failure rather than a replacement.
+        db.execute_batch("DROP TABLE cursorDiskKV;")
+            .expect("drop the relevant table");
+        drop(db);
+
+        for _ in 0..10 {
+            run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
+        }
+
+        assert!(scan_failures(&metrics) >= 1);
+        assert!(
+            scan_failures(&metrics) <= 2,
+            "a failure following an emitting scan must still back off; observed {}",
+            scan_failures(&metrics)
+        );
+
+        cleanup(&path);
+    }
+
+    /// Issue #601 §2.1(2): a durable `BeginReplay` barrier must never be sent
+    /// with no scan behind it. `should_skip_poll` runs *after* the barrier, and
+    /// a blocked-replay retry reuses its generation, so a volatile entry
+    /// covering the current stat could skip the scan while the barrier had
+    /// already been persisted — leaving the source stuck in `replaying`
+    /// forever, one barrier per tick.
+    ///
+    /// **[DIVERGENT FIXTURE]** the volatile entry must genuinely cover the
+    /// current stat; with an uncovered stat the skip never triggers and the two
+    /// behaviors coincide.
+    ///
+    /// Fails for: dropping the `!replacement_replay` guard on the
+    /// `should_skip_poll` call.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn blocked_replay_scans_behind_its_barrier() {
+        let path = unique_db_path("blocked-replay-scan");
+        let _db = seed_fixture_db(&path);
+        let work = sqlite_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+
+        run_poll_with_state(&work, &checkpoints, &poll_state).await;
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+
+        // Durably block the source, exactly as a failed replacement would.
+        let generation = {
+            let mut map = checkpoints.write().await;
+            let checkpoint = map
+                .get_mut(&cp_key)
+                .expect("first poll commits a checkpoint");
+            checkpoint.status = "error".to_string();
+            checkpoint.block_reason = "seeded blocked replay".to_string();
+            checkpoint.final_scan_complete = false;
+            checkpoint.source_generation
+        };
+
+        // And make the volatile entry claim the current stat as covered, which
+        // is the only state in which the post-barrier skip can fire.
+        let current_stat = stat_fingerprint(&work.path).expect("fixture stat");
+        poll_state.record_noop_scan(&cp_key, generation, current_stat);
+        assert!(
+            poll_state.should_skip_poll(&cp_key, generation, &current_stat),
+            "the fixture must actually reach the skip condition, or this guard \
+             cannot fail"
+        );
+
+        run_poll_with_state(&work, &checkpoints, &poll_state).await;
+
+        let after = checkpoints
+            .read()
+            .await
+            .get(&cp_key)
+            .cloned()
+            .expect("checkpoint survives the retry");
+        assert_eq!(
+            after.status, "active",
+            "a blocked replay retry must run its scan and finalize, not send a \
+             barrier and skip"
+        );
+        assert!(after.final_scan_complete);
+        assert!(after.block_reason.is_empty());
+
+        cleanup(&path);
+    }
+
+    /// Issue #601 §2.5. A replacement replay whose records cannot be normalized
+    /// enters a durably blocked state, and the retry that follows must climb
+    /// the failure ladder like any other repeat failure.
+    ///
+    /// It did not: the block arm ran `clear()` and then `record_failed_scan()`,
+    /// and `clear` deletes the entry so the `or_insert` beneath it restarted
+    /// the streak at 1 every single time. Because the trigger is a record
+    /// failing `normalize_record` — deterministic and content-driven, so it
+    /// recurs on every retry — the path was pinned at the 15 s floor forever:
+    /// a durable `BeginReplay` barrier plus a full re-read of the database,
+    /// every fifteen seconds, indefinitely.
+    ///
+    /// **[DIVERGENT FIXTURE]** an unknown harness makes `normalize_record` fail
+    /// for *every* record, which is what reaches the `replay_block_reason` arm
+    /// rather than the ordinary `Failed` arm; and the volatile clock is
+    /// backdated so the second and third windows are observable without
+    /// sleeping through 15 s + 30 s of real time.
+    ///
+    /// Fails for: restoring the `clear()` before the blocked-replay failure
+    /// record (the third probe becomes due and the retry runs).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn blocked_replay_retries_climb_the_failure_ladder() {
+        let path = unique_db_path("blocked-replay-ladder");
+        let _db = seed_fixture_db(&path);
+        // `normalize_record` rejects an unregistered harness outright, so every
+        // synthesized record fails and a replacement replay blocks durably.
+        let work = WorkItem {
+            harness: "not-a-registered-harness".to_string(),
+            ..sqlite_work(&path)
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+
+        // Cold poll commits a checkpoint under the default exclusion policy.
+        run_poll_with_state_and_metrics(&work, &checkpoints, &poll_state, &metrics).await;
+        assert!(checkpoints.read().await.contains_key(&cp_key));
+
+        // Changing the exclusion set starts a replacement replay, which cannot
+        // finish because nothing normalizes.
+        let mut replaying = moraine_config::AppConfig::default();
+        replaying.ingest.exclude_project_dirs = vec!["/no/such/dir/**".to_string()];
+        let block_poll = |config: moraine_config::AppConfig| {
+            let work = work.clone();
+            let checkpoints = checkpoints.clone();
+            let poll_state = poll_state.clone();
+            let metrics = metrics.clone();
+            async move { run_replay_poll(&config, &work, &checkpoints, &poll_state, &metrics).await }
+        };
+
+        let blocked = block_poll(replaying.clone()).await;
+        assert!(blocked, "the replacement replay must block durably");
+        assert_eq!(
+            poll_state.consecutive_failed_scans(&cp_key),
+            1,
+            "entering the blocked state starts the ladder"
+        );
+
+        // Inside the first 15 s window the retry is suppressed entirely.
+        let scans_before = payload_rows(&metrics);
+        assert!(!block_poll(replaying.clone()).await);
+        assert_eq!(
+            payload_rows(&metrics),
+            scans_before,
+            "throttled, no re-read"
+        );
+        assert_eq!(poll_state.consecutive_failed_scans(&cp_key), 1);
+
+        // 16 s later the first window has expired: the retry runs and the
+        // ladder climbs to 2, which means a 30 s window.
+        poll_state.age_for_tests(&cp_key, Duration::from_secs(16));
+        assert!(block_poll(replaying.clone()).await);
+        assert_eq!(
+            poll_state.consecutive_failed_scans(&cp_key),
+            2,
+            "a repeat block must extend the streak, not restart it"
+        );
+
+        // 16 s is no longer enough. This is the probe a reset-to-1 bug fails:
+        // pinned at the floor, the retry would be due and would run.
+        poll_state.age_for_tests(&cp_key, Duration::from_secs(16));
+        let scans_before = payload_rows(&metrics);
+        assert!(!block_poll(replaying.clone()).await);
+        assert_eq!(
+            payload_rows(&metrics),
+            scans_before,
+            "the second window is 30 s; a blocked replay must not re-read the \
+             whole database every 15 s forever"
+        );
+
+        // And it does recover once the wider window expires.
+        poll_state.age_for_tests(&cp_key, Duration::from_secs(20));
+        assert!(block_poll(replaying).await);
+        assert_eq!(poll_state.consecutive_failed_scans(&cp_key), 3);
+
+        cleanup(&path);
+    }
+
+    /// Runs one poll, acknowledging replay barriers, and reports whether the
+    /// poll sent a `BlockReplay` transition (i.e. whether it actually ran).
+    async fn run_replay_poll(
+        config: &moraine_config::AppConfig,
+        work: &WorkItem,
+        checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
+        poll_state: &VolatilePollMap,
+        metrics: &Arc<Metrics>,
+    ) -> bool {
+        let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(64);
+        let process = process_cursor_sqlite_db(
+            config,
+            work,
+            checkpoints.clone(),
+            poll_state,
+            sink_tx,
+            metrics,
+        );
+        tokio::pin!(process);
+        let mut blocked = None;
+        loop {
+            tokio::select! {
+                result = &mut process => {
+                    result.expect("cursor_sqlite replay poll should succeed");
+                    break;
+                }
+                message = sink_rx.recv() => match message.expect("replay sink remains open") {
+                    SinkMessage::Batch(_) => {}
+                    SinkMessage::BlockReplay { transition, ack } => {
+                        blocked = Some(transition.checkpoint.clone());
+                        let _ = ack.send(Ok(crate::publication::ReplayBarrierAck {
+                            checkpoint_revision: 1,
+                            operation_id: transition.checkpoint.operation_id,
+                        }));
+                    }
+                    SinkMessage::BeginReplay { transition, ack }
+                    | SinkMessage::MirrorCaughtUp { transition, ack } => {
+                        let _ = ack.send(Ok(crate::publication::ReplayBarrierAck {
+                            checkpoint_revision: 1,
+                            operation_id: transition.checkpoint.operation_id,
+                        }));
+                    }
+                    SinkMessage::FinalizeReplay { transition: _, ack } => {
+                        let _ = ack.send(Ok(
+                            crate::publication::FinalizeReplayOutcome::Published(
+                                crate::publication::PublicationAck {
+                                    checkpoint_revision: 2,
+                                    publication_revision: 1,
+                                    already_published: false,
+                                },
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+        while let Ok(SinkMessage::Batch(_)) = sink_rx.try_recv() {}
+        if let Some(cp) = blocked.clone() {
+            let key = checkpoint_key(&cp.source_name, &cp.source_file);
+            checkpoints.write().await.insert(key, cp);
+        }
+        blocked.is_some()
+    }
+
+    /// Issue #601 §2.0 / WI-01. Every cost budget in this issue is denominated
+    /// on `ScanLedger.payload_bytes`, so a ledger that charges anywhere other
+    /// than the point SQLite hands the bytes over makes all of them lies.
+    ///
+    /// **[DIVERGENT FIXTURE]** — every convenient proxy for "bytes read" is
+    /// made to disagree with the truth:
+    ///
+    /// - the composer's bulk sits in a field the synthesizer never copies, so
+    ///   emitted bytes are a small fraction of read bytes;
+    /// - one relevant key holds non-JSON ballast, so it is read in full and
+    ///   emits nothing — read rows and emitted rows genuinely differ;
+    /// - the second poll re-reads every byte and emits nothing, so a ledger
+    ///   charged at the emit site (or only on the changed branch) reports zero
+    ///   where the truth is unchanged.
+    ///
+    /// Fails for: charging from emitted records, charging only changed rows,
+    /// charging from a SQL-side `length()` expression, or dropping either the
+    /// row charge or the byte charge.
+    #[test]
+    fn ledger_charges_payload_bytes_at_the_read_site() {
+        let path = unique_db_path("ledger-read-site");
+        let db = create_kv_db(&path);
+
+        // 64 KiB the synthesizer reads and then throws away: `copy_fields`
+        // only lifts a fixed field list, and this is not on it.
+        let composer = json!({
+            "composerId": COMPOSER_ID,
+            "name": "Ledger read-site fixture",
+            "createdAt": 1_780_000_000_000i64,
+            "fullConversationHeadersOnly": [{"bubbleId": USER_BUBBLE_ID, "type": 1}],
+            "unreadBallast": "z".repeat(64 * 1024),
+        });
+        let composer_key = format!("composerData:{COMPOSER_ID}");
+        put(&db, &composer_key, &composer);
+
+        // A relevant key whose value is not JSON at all: read in full,
+        // synthesizes nothing. Emitted rows can never equal read rows here.
+        let junk = format!("not-json-{}", "q".repeat(32 * 1024));
+        let junk_key = format!("bubbleId:{COMPOSER_ID}:{TOOL_BUBBLE_ID}");
+        db.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            rusqlite::params![junk_key, junk],
+        )
+        .expect("insert non-JSON kv row");
+        drop(db);
+
+        let composer_text = serde_json::to_string(&composer).expect("serialize composer");
+        let expected_bytes =
+            (composer_key.len() + composer_text.len() + junk_key.len() + junk.len()) as u64;
+        let db_path = path.to_string_lossy().to_string();
+
+        let mut ledger = ScanLedger::default();
+        let ScanOutcome::Scanned { new_state, .. } =
+            scan_database(&db_path, &CursorState::fresh(), &mut ledger)
+        else {
+            panic!("cold ledger scan should succeed");
+        };
+
+        assert_eq!(
+            ledger.payload_bytes, expected_bytes,
+            "payload bytes must be the exact key+value length SQLite materialized"
+        );
+        assert_eq!(ledger.payload_rows, 2, "both relevant keys were read");
+        assert_eq!(
+            ledger.rows_emitted, 1,
+            "only the composer synthesizes a record; the ballast key emits nothing"
+        );
+        assert!(
+            ledger.payload_bytes > 90 * 1024,
+            "the fixture must read far more than it emits, or the two axes are \
+             interchangeable and neither is tested"
+        );
+        // The census axis carries exactly one thing today: schema validation.
+        // Cursor *also* runs a census-shaped read on every poll —
+        // `count_relevant_keys` walks both relevant key ranges over the unique
+        // `key` index (0.056 ms / 19 KB / 247 keys on the reference host,
+        // §1.1) — but it is a scalar aggregate, so by the charging rules on
+        // `ScanLedger` it materializes no row and is charged on neither axis.
+        //
+        // That silence is deliberate and it is **not** a claim the aggregate is
+        // free: `cursor_relevant_key_count_is_a_covering_index_scan` is what
+        // keeps it honest. WI-08 replaces the aggregate with a
+        // row-materializing census and retires `MAX_RELEVANT_KEYS`; until it
+        // does, G1a's `census_rows == 201` may not be read as Cursor's total
+        // census cost.
+        let schema_census = {
+            let connection = open_read_only(&db_path).expect("reopen for schema census");
+            expected_schema_census(&connection, &["cursorDiskKV"])
+        };
+        assert!(schema_census.census_rows > 0);
+        assert_eq!(
+            ledger.census_rows, schema_census.census_rows,
+            "schema validation is the only charged census read; the payload \
+             read must not be miscounted as one"
+        );
+        assert_eq!(ledger.census_bytes, schema_census.census_bytes);
+
+        // Nothing changed, so nothing is emitted — but every byte is still
+        // read. This is the assertion an emit-site ledger cannot survive.
+        let mut second = ScanLedger::default();
+        let ScanOutcome::Scanned { .. } = scan_database(&db_path, &new_state, &mut second) else {
+            panic!("warm ledger scan should succeed");
+        };
+        assert_eq!(
+            second.rows_emitted, 0,
+            "an unchanged database emits nothing on the second poll"
+        );
+        assert_eq!(
+            second.payload_bytes, expected_bytes,
+            "an unchanged database is still fully re-read today, and the ledger \
+             must say so"
+        );
+        assert_eq!(second.payload_rows, 2);
+
+        cleanup(&path);
+    }
+
+    /// A bubble's workspace stamp issues a *second* payload read of the parent
+    /// composer blob. It is easy to miss because it hides behind a cache, and
+    /// a ledger that misses it under-reports by a whole composer value
+    /// (2.4 MB on the reference host).
+    #[test]
+    fn ledger_charges_the_composer_workspace_lookup() {
+        let path = unique_db_path("ledger-workspace-lookup");
+        let db = create_kv_db(&path);
+        let composer = json!({
+            "composerId": COMPOSER_ID,
+            "workspaceIdentifier": {"uri": {"fsPath": "/work/ledger"}},
+            "ballast": "w".repeat(16 * 1024),
+        });
+        let composer_key = format!("composerData:{COMPOSER_ID}");
+        put(&db, &composer_key, &composer);
+        let bubble_key = format!("bubbleId:{COMPOSER_ID}:{USER_BUBBLE_ID}");
+        put(&db, &bubble_key, &user_bubble_value());
+        drop(db);
+
+        let composer_text = serde_json::to_string(&composer).expect("serialize composer");
+        let bubble_text = serde_json::to_string(&user_bubble_value()).expect("serialize bubble");
+        // The composer value is materialized twice: once by the prefix scan,
+        // once by the workspace lookup the bubble triggers.
+        let expected_bytes = (composer_key.len()
+            + composer_text.len()
+            + bubble_key.len()
+            + bubble_text.len()
+            + composer_text.len()) as u64;
+
+        let mut ledger = ScanLedger::default();
+        let ScanOutcome::Scanned { records, .. } =
+            scan_database(&path.to_string_lossy(), &CursorState::fresh(), &mut ledger)
+        else {
+            panic!("workspace-lookup scan should succeed");
+        };
+        assert!(
+            records.iter().any(
+                |record| record.record.get("workspacePath").and_then(Value::as_str)
+                    == Some("/work/ledger")
+            ),
+            "the fixture must actually take the lookup path"
+        );
+        assert_eq!(
+            ledger.payload_rows, 3,
+            "two scanned keys plus the composer re-read the workspace lookup performs"
+        );
+        assert_eq!(ledger.payload_bytes, expected_bytes);
+
+        cleanup(&path);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/moraine-ingest-core/src/sqlite_poll/nac.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/nac.rs
@@ -18,9 +18,11 @@ use tracing::{debug, warn};
 use url::Origin;
 
 use super::{
-    hash_str, open_read_only, sqlite_data_version, stat_fingerprint, truncate_chars_local,
-    StatFingerprint, SyntheticRecord, VolatilePollMap, ERROR_KIND_MIXED_SNAPSHOT, ERROR_KIND_OPEN,
-    ERROR_KIND_SCAN, ERROR_KIND_SCHEMA, ERROR_KIND_TOO_LARGE, SCAN_PAGE_MAX_BYTES, SCAN_PAGE_SIZE,
+    hash_str, open_read_only, record_scan_failure, record_scan_ledger, sqlite_data_version,
+    stat_fingerprint, take_payload_nullable_string, take_payload_required_string,
+    take_payload_text, truncate_chars_local, ScanLedger, StatFingerprint, SyntheticRecord,
+    VolatilePollMap, ERROR_KIND_MIXED_SNAPSHOT, ERROR_KIND_OPEN, ERROR_KIND_SCAN,
+    ERROR_KIND_SCHEMA, ERROR_KIND_TOO_LARGE, SCAN_PAGE_MAX_BYTES, SCAN_PAGE_SIZE,
 };
 
 const NAC_CURSOR_VERSION: u32 = 1;
@@ -210,6 +212,11 @@ pub(crate) async fn process_nac_sqlite_db(
     let generation_changed = had_committed && checkpoint.source_inode != inode;
     let exclusions_changed =
         had_committed && committed_state.project_exclusions_hash != current_exclusions_hash;
+    // The `replaying` disjunct resumes a replay a crash interrupted between
+    // `BeginReplay` and `FinalizeReplay`; the `error` disjunct cannot cover it,
+    // because a crash never wrote a block reason. Width note at the Cursor
+    // site; `a_crash_interrupted_nac_replay_resumes_from_its_replaying_status`
+    // fails if it goes.
     let retry_blocked_replay = checkpoint.status == "replaying"
         || (checkpoint.status == "error" && !checkpoint.block_reason.is_empty());
     let starts_replacement = generation_changed || exclusions_changed;
@@ -240,15 +247,39 @@ pub(crate) async fn process_nac_sqlite_db(
         .last_offset
         .checked_add(1)
         .context("nac_sqlite poll sequence exhausted")?;
+    // A NAC database stuck in `retry_blocked_replay` previously re-scanned the
+    // whole store and re-sent `BeginReplay` on every tick with zero throttle,
+    // because the volatile check was skipped during replay. Throttle *before*
+    // the durable barrier so the barrier always has a scan behind it
+    // (issue #601 §2.1(2), §2.5); a genuine replacement bumped the generation
+    // above and is never throttled.
+    if retry_blocked_replay
+        && !starts_replacement
+        && !poll_state.failure_retry_due(&cp_key, source_generation)
+    {
+        return Ok(());
+    }
     if replacement_replay {
         super::begin_database_replay(&sink_tx, &checkpoint, scan_boundary, &policy_fingerprint)
             .await?;
     }
+    // §2.5's `|| !failure_retry_due` disjunct is absent and **must stay absent
+    // while the contention clock lives in `failure_retry_due`** — WI-04 must
+    // not add it. It is no longer outcome-redundant with `should_skip_poll`'s
+    // failure arm below: §3.2's contention exemption keeps that clock out of
+    // `should_skip_poll` on purpose, so after a mixed-snapshot rejection
+    // `failure_retry_due` is false for up to 60 s while `should_skip_poll`
+    // stays false. The disjunct would skip ordinary polls of an actively
+    // written NAC store for that whole window — the §6 prompt-visibility
+    // regression the exemption exists to prevent. A pre-`should_skip_poll`
+    // throttle for the sweep slice must read the fault ladder alone.
+    // `an_ordinary_poll_of_a_contended_nac_store_is_not_throttled` fails if it
+    // is added. See `plans/601-delta-sqlite.md` §7 WI-10.
     if !starts_replacement
         && !retry_blocked_replay
         && scan_state.stat == current_stat
-        && scan_state.last_error.is_empty()
         && scan_state.schema_fingerprint != 0
+        && scan_state.last_error.is_empty()
     {
         return Ok(());
     }
@@ -260,18 +291,22 @@ pub(crate) async fn process_nac_sqlite_db(
     let scan_path = source_file.clone();
     let scan_source_name = work.source_name.clone();
     let prior_scan_state = scan_state.clone();
-    let mut outcome = tokio::task::spawn_blocking(move || {
-        scan_nac_database(
+    let (mut outcome, ledger) = tokio::task::spawn_blocking(move || {
+        let mut ledger = ScanLedger::default();
+        let outcome = scan_nac_database(
             &scan_path,
             &scan_source_name,
             source_generation,
             inode,
             current_stat,
             &prior_scan_state,
-        )
+            &mut ledger,
+        );
+        (outcome, ledger)
     })
     .await
     .context("nac_sqlite scan task panicked")?;
+    record_scan_ledger(metrics, &ledger);
 
     let oversized_row = match &mut outcome {
         NacScanOutcome::Scanned { records, .. } => {
@@ -458,7 +493,7 @@ pub(crate) async fn process_nac_sqlite_db(
                         ..final_checkpoint
                     };
                     super::block_database_replay(&sink_tx, &blocked_checkpoint, reason).await?;
-                    poll_state.clear(&cp_key);
+                    poll_state.record_blocked_replay(&cp_key, source_generation);
                     return Ok(());
                 }
                 let active_checkpoint = Checkpoint {
@@ -479,18 +514,24 @@ pub(crate) async fn process_nac_sqlite_db(
             poll_state.clear(&cp_key);
             if emitted > 0 {
                 debug!(
-                    "{}:{} nac_sqlite emitted {} changed records ({} relevant rows)",
-                    work.source_name, source_file, emitted, relevant_rows
+                    "{}:{} nac_sqlite emitted {} changed records ({} relevant rows, \
+                     {} payload rows, {} payload bytes)",
+                    work.source_name,
+                    source_file,
+                    emitted,
+                    relevant_rows,
+                    ledger.payload_rows,
+                    ledger.payload_bytes
                 );
             }
-            let _ = metrics;
             Ok(())
         }
         NacScanOutcome::Failed {
             error_kind,
             error_text,
         } => {
-            poll_state.record_failed_scan(&cp_key);
+            record_scan_failure(metrics);
+            poll_state.record_scan_failure_outcome(&cp_key, source_generation, error_kind);
             if !replacement_replay && committed_state.last_error == error_kind {
                 return Ok(());
             }
@@ -553,6 +594,9 @@ pub(crate) async fn process_nac_sqlite_db(
     }
 }
 
+/// The caller owns `ledger` so that every early return — including each
+/// failure arm — still reports the bytes this scan had already paid for.
+#[allow(clippy::too_many_arguments)]
 fn scan_nac_database(
     db_path: &str,
     source_name: &str,
@@ -560,6 +604,7 @@ fn scan_nac_database(
     expected_inode: u64,
     pre_scan_stat: StatFingerprint,
     prior: &NacState,
+    ledger: &mut ScanLedger,
 ) -> NacScanOutcome {
     let connection = match open_read_only(db_path) {
         Ok(connection) => connection,
@@ -593,7 +638,7 @@ fn scan_nac_database(
     // fingerprint would misclassify every scan as concurrent writer churn on
     // platforms where SQLite removes the sidecars after the last close.
     let opened_stat = stat_fingerprint(db_path).unwrap_or(pre_scan_stat);
-    let schema = match inspect_schema(&connection) {
+    let schema = match inspect_schema(&connection, ledger) {
         Ok(schema) => schema,
         Err(error_text) => {
             return NacScanOutcome::Failed {
@@ -618,6 +663,7 @@ fn scan_nac_database(
         source_generation,
         &schema,
         prior,
+        ledger,
     );
     let (records, mut state, relevant_rows) = match result {
         Ok(value) => value,
@@ -643,7 +689,12 @@ fn scan_nac_database(
             }
         }
     };
-    if data_version_before != data_version_after || stat_fingerprint(db_path) != Some(opened_stat) {
+    if super::snapshot_is_mixed(
+        db_path,
+        data_version_before,
+        data_version_after,
+        opened_stat,
+    ) {
         return NacScanOutcome::Failed {
             error_kind: ERROR_KIND_MIXED_SNAPSHOT,
             error_text:
@@ -674,20 +725,18 @@ struct NacSchema {
     fingerprint: u64,
 }
 
-fn inspect_schema(connection: &Connection) -> std::result::Result<NacSchema, String> {
+fn inspect_schema(
+    connection: &Connection,
+    ledger: &mut ScanLedger,
+) -> std::result::Result<NacSchema, String> {
     let mut material = String::new();
     let mut session_columns = BTreeSet::new();
     for (table, required) in [
         ("sessions", REQUIRED_SESSION_COLUMNS),
         ("episodes", REQUIRED_EPISODE_COLUMNS),
     ] {
-        let sql: Option<String> = connection
-            .query_row(
-                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?1",
-                params![table],
-                |row| row.get(0),
-            )
-            .map_err(|exc| match exc {
+        let sql =
+            super::schema_sql_for_table(connection, table, ledger).map_err(|exc| match exc {
                 rusqlite::Error::QueryReturnedNoRows => {
                     format!("required table {table} is missing")
                 }
@@ -695,7 +744,10 @@ fn inspect_schema(connection: &Connection) -> std::result::Result<NacSchema, Str
             })?;
         material.push_str(&sql.unwrap_or_default());
         material.push('\n');
-        let columns = table_columns(connection, table).map_err(|exc| exc.to_string())?;
+        let columns: BTreeSet<String> = super::table_column_names(connection, table, ledger)
+            .map_err(|exc| format!("{exc:#}"))?
+            .into_iter()
+            .collect();
         for column in required {
             if !columns.contains(*column) {
                 return Err(format!("table {table} is missing required column {column}"));
@@ -709,16 +761,6 @@ fn inspect_schema(connection: &Connection) -> std::result::Result<NacSchema, Str
         session_columns,
         fingerprint: hash_str(&material),
     })
-}
-
-fn table_columns(connection: &Connection, table: &str) -> Result<BTreeSet<String>> {
-    let mut stmt = connection
-        .prepare(&format!("PRAGMA table_info({table})"))
-        .with_context(|| format!("failed to inspect {table} columns"))?;
-    let columns = stmt
-        .query_map([], |row| row.get::<_, String>(1))?
-        .collect::<std::result::Result<BTreeSet<_>, _>>()?;
-    Ok(columns)
 }
 
 #[derive(Debug)]
@@ -739,6 +781,7 @@ impl From<rusqlite::Error> for NacScanError {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn scan_nac_rows(
     connection: &Connection,
     db_path: &str,
@@ -746,6 +789,7 @@ fn scan_nac_rows(
     source_generation: u32,
     schema: &NacSchema,
     prior: &NacState,
+    ledger: &mut ScanLedger,
 ) -> std::result::Result<(Vec<SyntheticRecord>, NacState, u64), NacScanError> {
     let canonical_db = std::fs::canonicalize(db_path)
         .unwrap_or_else(|_| std::path::PathBuf::from(db_path))
@@ -773,7 +817,7 @@ fn scan_nac_rows(
         let mut rows = stmt.query(params![&last_session_id, SCAN_PAGE_SIZE as i64])?;
         let mut page_rows = 0usize;
         while let Some(row) = rows.next()? {
-            let session = read_session_row(row, &schema.session_columns)?;
+            let session = read_session_row(row, &schema.session_columns, ledger)?;
             page_rows += 1;
             total_rows = total_rows.saturating_add(1);
             if total_rows > MAX_NAC_SESSIONS {
@@ -854,18 +898,32 @@ fn scan_nac_rows(
         let mut rows = stmt.query(params![last_episode_id, SCAN_PAGE_SIZE as i64])?;
         let mut page_rows = 0usize;
         while let Some(row) = rows.next()? {
+            // This projection includes `content`, so the whole episode row is
+            // charged on the payload axis where SQLite hands it over. The row
+            // charge lands **before** the oversize check, matching
+            // `read_session_row`: SQLite had already decoded every column to
+            // evaluate `estimated_bytes`, so a ceiling arm reporting zero rows
+            // would contradict the ledger's headline guarantee. Bytes are
+            // still not charged from `estimated_bytes` — the guarded
+            // projection hands Rust NULL for an oversized row, and the ledger
+            // reports what was materialized, not what SQLite touched.
             let id: i64 = row.get(0)?;
+            ledger.charge_payload_row();
             let row_bytes = checked_row_bytes(row.get(6)?, "NAC episode", id)?;
             if row_bytes > SCAN_PAGE_MAX_BYTES {
                 return Err(NacScanError::TooLarge(format!(
                     "NAC episode {id} is {row_bytes} bytes, exceeding the {SCAN_PAGE_MAX_BYTES} byte row ceiling"
                 )));
             }
-            let thread_name: String = row.get(1)?;
-            let raw_session_id: String = row.get(2)?;
-            let action: String = row.get(3)?;
-            let content: String = row.get(4)?;
-            let created_at_raw: String = row.get(5)?;
+            // Every one of these is NOT NULL in the live `episodes` schema and
+            // load-bearing downstream (thread/session identity, the action tag
+            // the record type is derived from, the payload, the timestamp), so
+            // a NULL fails the scan rather than materializing as `""`.
+            let thread_name = take_payload_required_string(ledger, row, 1)?;
+            let raw_session_id = take_payload_required_string(ledger, row, 2)?;
+            let action = take_payload_required_string(ledger, row, 3)?;
+            let content = take_payload_required_string(ledger, row, 4)?;
+            let created_at_raw = take_payload_required_string(ledger, row, 5)?;
             page_rows += 1;
             total_rows = total_rows.saturating_add(1);
             if total_rows > MAX_NAC_SESSIONS.saturating_add(MAX_NAC_EPISODES) {
@@ -934,6 +992,7 @@ fn scan_nac_rows(
         }
     }
 
+    ledger.rows_emitted = records.len() as u64;
     Ok((records, next_state, total_rows))
 }
 
@@ -1007,30 +1066,44 @@ fn session_projection(columns: &BTreeSet<String>) -> String {
     .join(", ")
 }
 
+/// Reads one session row. The projection includes `messages_json`, so every
+/// variable-length column it materializes is charged on the payload axis —
+/// deliberately *not* from the projection's own `estimated_bytes` expression,
+/// which SQLite computes over the pre-guard column values and which therefore
+/// reports bytes that were never handed to Rust for an oversized row.
 fn read_session_row(
     row: &rusqlite::Row<'_>,
     columns: &BTreeSet<String>,
+    ledger: &mut ScanLedger,
 ) -> std::result::Result<NacSessionRow, NacScanError> {
+    ledger.charge_payload_row();
     let estimated_bytes = checked_row_bytes(row.get(15)?, "NAC session row", 0)?;
     if estimated_bytes > SCAN_PAGE_MAX_BYTES {
         return Err(NacScanError::TooLarge(format!(
             "NAC session row is {estimated_bytes} bytes, exceeding the {SCAN_PAGE_MAX_BYTES} byte row ceiling"
         )));
     }
-    let raw_session_id: String = row.get(0)?;
-    let cwd: String = row.get(1)?;
-    let model: String = row.get(2)?;
-    let base_url = sanitize_base_url(&row.get::<_, String>(3)?);
-    let backend = row.get::<_, Option<String>>(4)?.unwrap_or_default();
-    let reasoning_effort = row.get::<_, Option<String>>(5)?.unwrap_or_default();
-    let sandbox_raw: Option<String> = row.get(6)?;
-    let messages_raw: String = row.get(7)?;
+    // NOT NULL in the live `sessions` schema; a NULL is schema drift and must
+    // fail the scan. `session_id` and `created_at`/`updated_at` below feed
+    // logical-ID and timestamp derivation directly (§6), so absorbing a NULL
+    // here would mint records keyed on the empty string.
+    let raw_session_id = take_payload_required_string(ledger, row, 0)?;
+    let cwd = take_payload_required_string(ledger, row, 1)?;
+    let model = take_payload_required_string(ledger, row, 2)?;
+    let base_url = sanitize_base_url(&take_payload_required_string(ledger, row, 3)?);
+    // `backend` and `reasoning_effort` are the two columns that genuinely
+    // tolerate NULL: they are absent on older stores and the empty string is
+    // the documented default (this is what the pre-ledger code did too).
+    let backend = take_payload_nullable_string(ledger, row, 4)?;
+    let reasoning_effort = take_payload_nullable_string(ledger, row, 5)?;
+    let sandbox_raw = take_payload_text(ledger, row, 6)?;
+    let messages_raw = take_payload_required_string(ledger, row, 7)?;
     let last_response_duration_ms = row.get::<_, Option<i64>>(8)?.map(|v| v.max(0) as u64);
     let previous_response_duration_ms = row.get::<_, Option<i64>>(9)?.map(|v| v.max(0) as u64);
-    let durations_raw: Option<String> = row.get(10)?;
-    let usages_raw: Option<String> = row.get(11)?;
-    let created_at: String = row.get(12)?;
-    let updated_at: String = row.get(13)?;
+    let durations_raw = take_payload_text(ledger, row, 10)?;
+    let usages_raw = take_payload_text(ledger, row, 11)?;
+    let created_at = take_payload_required_string(ledger, row, 12)?;
+    let updated_at = take_payload_required_string(ledger, row, 13)?;
     let remote: Option<i64> = row.get(14)?;
     let parse_json = |label: &str, raw: Option<&str>, default: Value| {
         let Some(raw) = raw.filter(|raw| !raw.trim().is_empty()) else {
@@ -1672,6 +1745,7 @@ fn enforce_record_limit(records: usize) -> std::result::Result<(), NacScanError>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::WorkTrigger;
     use std::path::Path;
 
     async fn drive_nac_poll(
@@ -1680,7 +1754,25 @@ mod tests {
         checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
         poll_state: &VolatilePollMap,
     ) -> (Vec<RowBatch>, Vec<crate::CheckpointTransition>) {
-        let metrics = Arc::new(Metrics::default());
+        drive_nac_poll_with_metrics(
+            config,
+            work,
+            checkpoints,
+            poll_state,
+            &Arc::new(Metrics::default()),
+        )
+        .await
+    }
+
+    /// Shares one `Metrics` across several polls so a test can count the scans
+    /// that actually ran rather than the errors that were reported.
+    async fn drive_nac_poll_with_metrics(
+        config: &AppConfig,
+        work: &WorkItem,
+        checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
+        poll_state: &VolatilePollMap,
+        metrics: &Arc<Metrics>,
+    ) -> (Vec<RowBatch>, Vec<crate::CheckpointTransition>) {
         let (sink_tx, mut sink_rx) = mpsc::channel(8);
         let process = process_nac_sqlite_db(
             config,
@@ -1688,7 +1780,7 @@ mod tests {
             checkpoints.clone(),
             poll_state,
             sink_tx,
-            &metrics,
+            metrics,
         );
         tokio::pin!(process);
         let mut batches = Vec::new();
@@ -1744,6 +1836,317 @@ mod tests {
         (batches, transitions)
     }
 
+    /// Issue #601 §2.5. `record_blocked_replay` exists to stop
+    /// `clear(); record_failed_scan();` from pinning a blocked replay at the
+    /// 15 s floor forever, and it is guarded at its implementation — but NAC's
+    /// **call site** was not. `blocked_replay_backs_off_instead_of_resending_the_barrier`
+    /// reaches the `Failed` arm (an unreadable file), never
+    /// `record_blocked_replay`, so inserting a `poll_state.clear()` before
+    /// nac.rs's call left the suite green.
+    ///
+    /// This drives the other block path: the scan *succeeds*, and a record
+    /// fails `normalize_record`, which is deterministic and content-driven and
+    /// therefore recurs on every retry — exactly the shape a flat floor turns
+    /// into a full re-read of the whole store every 15 s indefinitely.
+    ///
+    /// Fails for: `clear`ing volatile state before `record_blocked_replay`, or
+    /// dropping the call entirely.
+    #[tokio::test]
+    async fn a_normalization_blocked_nac_replay_climbs_the_failure_ladder() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        // `normalize_record` rejects an unregistered harness outright, so every
+        // synthesized record fails and a replacement replay blocks durably.
+        let work = WorkItem {
+            source_name: "nac-block-ladder".to_string(),
+            harness: "not-a-registered-harness".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+
+        let config = AppConfig::default();
+        drive_nac_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert!(checkpoints.read().await.contains_key(&cp_key));
+
+        // Changing the exclusion set starts a replacement replay that cannot
+        // finish, because nothing normalizes.
+        let mut replaying = AppConfig::default();
+        replaying.ingest.exclude_project_dirs = vec!["/no/such/dir/**".to_string()];
+        let block_poll = |config: AppConfig| {
+            let work = work.clone();
+            let checkpoints = checkpoints.clone();
+            let poll_state = poll_state.clone();
+            let metrics = metrics.clone();
+            async move {
+                let (_, transitions) = drive_nac_poll_with_metrics(
+                    &config,
+                    &work,
+                    &checkpoints,
+                    &poll_state,
+                    &metrics,
+                )
+                .await;
+                transitions
+                    .iter()
+                    .any(|transition| transition.checkpoint.status == "error")
+            }
+        };
+
+        assert!(
+            block_poll(replaying.clone()).await,
+            "the replacement replay must block durably"
+        );
+        assert_eq!(
+            poll_state.consecutive_failed_scans(&cp_key),
+            1,
+            "entering the blocked state starts the ladder"
+        );
+
+        // Inside the first 15 s window the retry is suppressed entirely.
+        assert!(!block_poll(replaying.clone()).await, "throttled");
+
+        // 16 s later the window has expired and the ladder must climb to 2 —
+        // a 30 s window, not another 15 s one.
+        poll_state.age_for_tests(&cp_key, std::time::Duration::from_secs(16));
+        assert!(block_poll(replaying.clone()).await);
+        assert_eq!(
+            poll_state.consecutive_failed_scans(&cp_key),
+            2,
+            "a repeat block must extend the streak, not restart it — a \
+             `clear()` before `record_blocked_replay` pins it at 1"
+        );
+
+        // This is the probe a reset-to-1 bug fails: pinned at the floor, the
+        // retry would be due and would run.
+        poll_state.age_for_tests(&cp_key, std::time::Duration::from_secs(16));
+        assert!(
+            !block_poll(replaying).await,
+            "the second window is 30 s; a blocked replay must not re-read the \
+             whole store every 15 s forever"
+        );
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(format!("{}-wal", path.display())).ok();
+        std::fs::remove_file(format!("{}-shm", path.display())).ok();
+    }
+
+    /// Issue #601 §2.5/§3.2. NAC's `Failed` arm must route through
+    /// `record_scan_failure_outcome`, not straight into the fault ladder:
+    /// mixed-snapshot means the store was being written while the scan read
+    /// it, and a 15 s → 15 min suppression of an active NAC store is the §6
+    /// prompt-visibility regression the exemption exists to prevent. The
+    /// contention clock still has to move, because it is what throttles a
+    /// contended replay's durable barrier.
+    ///
+    /// Fails for: calling `record_failed_scan` directly from the `Failed` arm,
+    /// or dropping the classification entirely.
+    #[tokio::test]
+    async fn a_contended_nac_scan_moves_the_contention_clock_not_the_fault_ladder() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-contention".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let config = AppConfig::default();
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+
+        super::super::contention_injection::arm(&source_file, 1);
+        drive_nac_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            metrics
+                .sqlite_scan_failures_total
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "the armed scan must actually reach the mixed-snapshot arm"
+        );
+        assert_eq!(
+            poll_state.consecutive_failed_scans(&cp_key),
+            0,
+            "contention must not climb NAC's fault ladder"
+        );
+        assert_eq!(
+            poll_state.consecutive_contended_scans(&cp_key),
+            1,
+            "…but it must leave the clock that throttles the replay barrier"
+        );
+
+        super::super::contention_injection::disarm(&source_file);
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(format!("{}-wal", path.display())).ok();
+        std::fs::remove_file(format!("{}-shm", path.display())).ok();
+    }
+
+    /// Issue #601 §3.2/§6 — NAC's half of the call-site guard. The classifier
+    /// test above proves the clock *moves*; this proves the clock does not
+    /// reach ordinary polls.
+    ///
+    /// §2.5's `|| !failure_retry_due` disjunct on the cheap short-circuit was
+    /// outcome-redundant with `should_skip_poll` until §3.2 put the contention
+    /// clock inside `failure_retry_due` and deliberately left it out of
+    /// `should_skip_poll`. Adding it now would stop scanning an actively
+    /// written NAC store for up to 60 s — the prompt-visibility regression the
+    /// exemption exists to prevent. A NAC store is contended precisely while a
+    /// worker is writing episodes into it.
+    ///
+    /// The end-to-end delivery half of this rule is
+    /// `an_ordinary_poll_of_a_contended_database_is_not_throttled` on the
+    /// Cursor adapter; this one pins the throttle at NAC's own call site.
+    ///
+    /// Fails for: adding `|| !poll_state.failure_retry_due(..)` to the cheap
+    /// short-circuit (the second scan never runs), or moving the contention
+    /// clock into `should_skip_poll`.
+    #[tokio::test]
+    async fn an_ordinary_poll_of_a_contended_nac_store_is_not_throttled() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-contended-ordinary".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let config = AppConfig::default();
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+
+        // Cold poll commits a checkpoint over the fixture.
+        let (cold, _) =
+            drive_nac_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert!(!cold.is_empty(), "the cold poll emits the fixture");
+
+        // A worker is writing episodes, so the next two scans lose the bracket.
+        super::super::contention_injection::arm(&source_file, 2);
+        append_worker_episode(&path, "contended follow-up one", "2026-07-18 12:18:00");
+        drive_nac_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(poll_state.consecutive_contended_scans(&cp_key), 1);
+        assert_eq!(
+            poll_state.consecutive_failed_scans(&cp_key),
+            0,
+            "contention is not a fault (§3.2)"
+        );
+
+        // The very next tick, far inside the contention window the barrier is
+        // now serving, must still read the store.
+        append_worker_episode(&path, "contended follow-up two", "2026-07-18 12:18:01");
+        drive_nac_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            poll_state.consecutive_contended_scans(&cp_key),
+            2,
+            "an ordinary poll of a contended NAC store must not be throttled — \
+             the second scan has to run at the ordinary poll cadence"
+        );
+        assert_eq!(
+            metrics
+                .sqlite_scan_failures_total
+                .load(std::sync::atomic::Ordering::Relaxed),
+            2,
+            "…and must reach the scan, not return before it"
+        );
+
+        super::super::contention_injection::disarm(&source_file);
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(format!("{}-wal", path.display())).ok();
+        std::fs::remove_file(format!("{}-shm", path.display())).ok();
+    }
+
+    /// Issue #601 §2.1(2) — NAC's half of the `retry_blocked_replay` narrowing
+    /// width. See the Cursor twin
+    /// `a_crash_interrupted_replay_resumes_from_its_replaying_status` for the
+    /// argument: `replaying` with no error status and no block reason is what a
+    /// crash between `BeginReplay` and `FinalizeReplay` leaves, and the `error`
+    /// disjunct cannot cover it.
+    ///
+    /// **[DIVERGENT FIXTURE]** the stat is unchanged since the cold poll, which
+    /// is what a crashed replay looks like and what makes the two behaviours
+    /// diverge: with the disjunct the cursor is reset and the scan runs,
+    /// without it NAC's cheap short-circuit returns on the unchanged stat.
+    ///
+    /// Fails for: dropping the `checkpoint.status == "replaying"` disjunct.
+    #[tokio::test]
+    async fn a_crash_interrupted_nac_replay_resumes_from_its_replaying_status() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-replaying-resume".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let config = AppConfig::default();
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+
+        let (cold, _) = drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        assert!(!cold.is_empty(), "the cold poll emits the fixture");
+
+        {
+            let mut map = checkpoints.write().await;
+            let checkpoint = map
+                .get_mut(&cp_key)
+                .expect("the cold poll commits a checkpoint");
+            checkpoint.status = "replaying".to_string();
+            checkpoint.block_reason.clear();
+            checkpoint.final_scan_complete = false;
+        }
+
+        drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+
+        let after = checkpoints
+            .read()
+            .await
+            .get(&cp_key)
+            .cloned()
+            .expect("the checkpoint survives the retry");
+        assert_eq!(
+            after.status, "active",
+            "an interrupted replay must resume and finish, not be relabelled"
+        );
+        assert!(
+            after.final_scan_complete,
+            "a resumed replay finalizes; without the `replaying` disjunct the \
+             poll returns on the unchanged stat and the source is stuck"
+        );
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(format!("{}-wal", path.display())).ok();
+        std::fs::remove_file(format!("{}-shm", path.display())).ok();
+    }
+
+    /// Appends one worker episode, exactly as a live NAC writer would, so a
+    /// poll sees a changed stat fingerprint rather than the unchanged-file
+    /// short-circuit.
+    fn append_worker_episode(path: &Path, content: &str, created_at: &str) {
+        let connection = Connection::open(path).expect("open NAC fixture for append");
+        connection
+            .execute(
+                "INSERT INTO episodes (thread_name, session_id, action, content, created_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params!["worker-a", "session-local", "inspect", content, created_at],
+            )
+            .expect("append worker episode");
+    }
+
     #[test]
     fn normalizes_both_nac_timestamp_precisions() {
         assert_eq!(
@@ -1794,6 +2197,156 @@ mod tests {
         assert!(projection.contains("COALESCE(host_id, '') AS BLOB"));
     }
 
+    /// Issue #601 §3.2/§6. The `ScanLedger` refactor replaced
+    /// `row.get::<_, String>(..)` with a helper that did
+    /// `row.get::<Option<String>>(..).unwrap_or_default()` on every text column
+    /// at once, which silently turned a NULL in a schema-required column from a
+    /// failed scan into `""`. §3.2 wants schema drift **surfaced, not
+    /// absorbed**: an empty `session_id` flows straight into logical-ID
+    /// derivation and an empty `created_at`/`updated_at` into timestamp
+    /// derivation (§6 "stable logical IDs"), so the record is not merely
+    /// lossy — it is misattributed.
+    ///
+    /// Drives every column of the session projection that was strict before the
+    /// refactor, and both columns that deliberately were not.
+    ///
+    /// Fails for: reading any of the seven required columns through
+    /// `take_payload_nullable_string`, or making `backend`/`reasoning_effort`
+    /// strict (older stores genuinely lack them).
+    #[test]
+    fn a_null_in_a_required_session_column_fails_the_scan() {
+        // Positional, matching `session_projection`'s output order.
+        let baseline = [
+            "'ses-null-probe'",      // 0  session_id      required
+            "'/work/moraine'",       // 1  cwd             required
+            "'glm-5.2'",             // 2  model           required
+            "'https://api.example'", // 3  base_url        required
+            "'zai-coding-plan'",     // 4  backend         nullable
+            "'high'",                // 5  reasoning_effort nullable
+            "NULL",                  // 6  sandbox_json    nullable
+            "'[]'",                  // 7  messages_json   required
+            "NULL",                  // 8  last_response_duration_ms
+            "NULL",                  // 9  previous_response_duration_ms
+            "NULL",                  // 10 response_durations_json
+            "NULL",                  // 11 token_usages_json
+            "'2026-05-08 02:04:37'", // 12 created_at      required
+            "'2026-05-08 02:04:38'", // 13 updated_at      required
+            "0",                     // 14 is_remote
+            "64",                    // 15 estimated_bytes
+        ];
+        let columns: BTreeSet<String> = ["host_id"].into_iter().map(str::to_string).collect();
+        let connection = Connection::open_in_memory().expect("in-memory probe database");
+        let read = |values: &[&str]| {
+            let sql = format!("SELECT {}", values.join(", "));
+            connection.query_row(&sql, [], |row| {
+                let mut ledger = ScanLedger::default();
+                Ok(read_session_row(row, &columns, &mut ledger).map(|_| ()))
+            })
+        };
+
+        read(&baseline)
+            .expect("probe query")
+            .expect("the baseline row must read cleanly");
+
+        for (index, name) in [
+            (0, "session_id"),
+            (1, "cwd"),
+            (2, "model"),
+            (3, "base_url"),
+            (7, "messages_json"),
+            (12, "created_at"),
+            (13, "updated_at"),
+        ] {
+            let mut values = baseline;
+            values[index] = "NULL";
+            let outcome = read(&values).expect("probe query");
+            let error = outcome
+                .err()
+                .unwrap_or_else(|| panic!("a NULL {name} must fail the scan, not become \"\""));
+            let NacScanError::Scan(error) = error else {
+                panic!("a NULL {name} is schema drift, not an oversized row");
+            };
+            assert!(
+                format!("{error:#}").contains("Invalid column type"),
+                "a NULL {name} must surface as a column-type error; got {error:#}"
+            );
+        }
+
+        for (index, name) in [(4, "backend"), (5, "reasoning_effort")] {
+            let mut values = baseline;
+            values[index] = "NULL";
+            read(&values).expect("probe query").unwrap_or_else(|_| {
+                panic!("{name} is absent on older stores and must tolerate NULL")
+            });
+        }
+    }
+
+    /// Issue #601 §3.2. Same rule for the episode loop, which reads five
+    /// NOT NULL columns and is the other half of what the ledger refactor
+    /// loosened. Driven through a real scan because the loop is inline in
+    /// `scan_nac_database`.
+    ///
+    /// The fixture's `episodes` table is rebuilt without its NOT NULL
+    /// constraints so the NULL can be inserted at all — the column *set* is
+    /// unchanged, which is what the adapter's schema check looks at.
+    ///
+    /// Fails for: reading `thread_name`/`session_id`/`action`/`content`/
+    /// `created_at` through `take_payload_nullable_string`.
+    #[test]
+    fn a_null_in_a_required_episode_column_fails_the_scan() {
+        let path = fixture_db();
+        {
+            let connection = Connection::open(&path).expect("open fixture for schema relaxation");
+            connection
+                .execute_batch(
+                    r#"
+                    ALTER TABLE episodes RENAME TO episodes_strict;
+                    CREATE TABLE episodes (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        thread_name TEXT,
+                        session_id TEXT,
+                        action TEXT,
+                        content TEXT,
+                        created_at TEXT
+                    );
+                    INSERT INTO episodes SELECT * FROM episodes_strict;
+                    DROP TABLE episodes_strict;
+                    UPDATE episodes SET content = NULL
+                      WHERE id = (SELECT MIN(id) FROM episodes);
+                    "#,
+                )
+                .expect("relax episodes schema and null a required column");
+        }
+
+        let stat = stat_fingerprint(path.to_str().expect("UTF-8 fixture path"))
+            .expect("fixture stat fingerprint");
+        let metadata = std::fs::metadata(&path).expect("fixture metadata");
+        let inode = source_inode_for_file(path.to_str().expect("UTF-8 fixture path"), &metadata);
+        let mut ledger = ScanLedger::default();
+        let outcome = scan_nac_database(
+            path.to_str().expect("UTF-8 fixture path"),
+            "nac-null-episode",
+            1,
+            inode,
+            stat,
+            &NacState::default(),
+            &mut ledger,
+        );
+        match outcome {
+            NacScanOutcome::Failed { error_text, .. } => assert!(
+                error_text.contains("Invalid column type"),
+                "a NULL episode column must surface as a column-type error; got {error_text}"
+            ),
+            NacScanOutcome::Scanned { .. } => {
+                panic!("a NULL in a NOT NULL episode column must fail the scan, not become \"\"")
+            }
+        }
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(format!("{}-wal", path.display())).ok();
+        std::fs::remove_file(format!("{}-shm", path.display())).ok();
+    }
+
     #[test]
     fn base_url_persistence_omits_credentials_paths_and_queries() {
         assert_eq!(
@@ -1824,10 +2377,19 @@ mod tests {
     }
 
     fn scan_fixture(path: &Path, prior: &NacState) -> (Vec<SyntheticRecord>, NacState, u64) {
+        let (records, state, relevant_rows, _) = scan_fixture_with_ledger(path, prior);
+        (records, state, relevant_rows)
+    }
+
+    fn scan_fixture_with_ledger(
+        path: &Path,
+        prior: &NacState,
+    ) -> (Vec<SyntheticRecord>, NacState, u64, ScanLedger) {
         let stat = stat_fingerprint(path.to_str().expect("UTF-8 fixture path"))
             .expect("fixture stat fingerprint");
         let metadata = std::fs::metadata(path).expect("fixture metadata");
         let inode = source_inode_for_file(path.to_str().expect("UTF-8 fixture path"), &metadata);
+        let mut ledger = ScanLedger::default();
         match scan_nac_database(
             path.to_str().expect("UTF-8 fixture path"),
             "nac-fixture",
@@ -1835,13 +2397,14 @@ mod tests {
             inode,
             stat,
             prior,
+            &mut ledger,
         ) {
             NacScanOutcome::Scanned {
                 records,
                 state,
                 relevant_rows,
                 ..
-            } => (records, state, relevant_rows),
+            } => (records, state, relevant_rows, ledger),
             NacScanOutcome::Failed {
                 error_kind,
                 error_text,
@@ -1868,6 +2431,228 @@ mod tests {
             updated_at: "2026-07-18 12:00:00.000000000".to_string(),
             estimated_bytes: 0,
         }
+    }
+
+    /// Issue #601 §2.0. The ledger is **caller-owned** exactly so that a scan
+    /// which reads and then fails is still charged for what it read — the
+    /// stated guarantee being "a scan that reads 48 MB and then loses the
+    /// mixed-snapshot race is charged". Nothing asserted it: every NAC ledger
+    /// test destructured `Scanned` and panicked otherwise, and the one test
+    /// that does reach a failure arm
+    /// (`scanner_rejects_a_database_replaced_before_open`) throws the ledger
+    /// away with `&mut ScanLedger::default()`.
+    ///
+    /// **[DIVERGENT FIXTURE]** the failing session sorts *last* by
+    /// `session_id`, so the scan has already paid for real rows before it
+    /// fails; a fixture whose only session fails would report zero bytes for an
+    /// honest reason and prove nothing.
+    ///
+    /// Fails for: resetting or rebuilding the ledger on any
+    /// `scan_nac_database` failure arm.
+    #[test]
+    fn a_failed_nac_scan_still_reports_the_bytes_it_had_already_read() {
+        let path = fixture_db();
+        let connection = Connection::open(&path).expect("open fixture");
+        // A row that reads fine and then fails to parse: `read_session_row`
+        // charges every column it materialized before it validates the JSON.
+        connection
+            .execute(
+                "INSERT INTO sessions (session_id, cwd, model, base_url, backend, \
+                 reasoning_effort, sandbox_json, messages_json, response_durations_json, \
+                 token_usages_json, created_at, updated_at) \
+                 VALUES ('zzz-broken-json', '/tmp', 'm', '', '', '', NULL, ?1, NULL, NULL, \
+                 '2026-07-18 12:00:00', '2026-07-18 12:00:00')",
+                ["this is not json at all"],
+            )
+            .expect("insert unparseable session");
+        drop(connection);
+
+        let stat = stat_fingerprint(path.to_str().expect("UTF-8 path")).expect("fixture stat");
+        let metadata = std::fs::metadata(&path).expect("fixture metadata");
+        let inode = source_inode_for_file(path.to_str().expect("UTF-8 path"), &metadata);
+        let mut ledger = ScanLedger::default();
+        let outcome = scan_nac_database(
+            path.to_str().expect("UTF-8 path"),
+            "nac-fixture",
+            1,
+            inode,
+            stat,
+            &NacState::default(),
+            &mut ledger,
+        );
+        let NacScanOutcome::Failed { error_kind, .. } = outcome else {
+            panic!("an unparseable messages_json must fail the scan");
+        };
+        assert_eq!(error_kind, ERROR_KIND_SCAN);
+        assert!(
+            ledger.payload_rows > 1,
+            "the sessions read before the failure are still charged; got {}",
+            ledger.payload_rows
+        );
+        assert!(
+            ledger.payload_bytes > 0,
+            "a failed scan must still report the bytes it paid for"
+        );
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(format!("{}-wal", path.display())).ok();
+        std::fs::remove_file(format!("{}-shm", path.display())).ok();
+    }
+
+    /// Issue #601 §2.0, the episode arm. `read_session_row` charges its row
+    /// *before* the oversize check; the episode loop charged it *after*, so the
+    /// `TooLarge` arm reported zero rows and zero bytes for a row SQLite had
+    /// already fully decoded to compute `estimated_bytes` — contradicting the
+    /// headline guarantee on the very ceiling the ledger is meant to denominate.
+    ///
+    /// **[DIVERGENT FIXTURE]** the oversized episode is not the first row read,
+    /// so the byte axis is non-zero for reasons independent of the row charge,
+    /// and the two axes stay distinguishable.
+    ///
+    /// Fails for: moving the episode `charge_payload_row` back below the
+    /// ceiling check.
+    #[test]
+    fn an_oversized_episode_still_charges_the_row_it_decoded() {
+        let path = fixture_db();
+        let connection = Connection::open(&path).expect("open fixture");
+        // One byte past the row ceiling, computed the way the scan computes it.
+        let oversized = "e".repeat(SCAN_PAGE_MAX_BYTES + 1);
+        connection
+            .execute(
+                "INSERT INTO episodes (thread_name, session_id, action, content, created_at) \
+                 VALUES ('zzz-oversized-thread', 'session-local', 'run', ?1, \
+                 '2026-07-18 12:30:00')",
+                [&oversized],
+            )
+            .expect("insert oversized episode");
+        drop(connection);
+
+        let stat = stat_fingerprint(path.to_str().expect("UTF-8 path")).expect("fixture stat");
+        let metadata = std::fs::metadata(&path).expect("fixture metadata");
+        let inode = source_inode_for_file(path.to_str().expect("UTF-8 path"), &metadata);
+        let mut ledger = ScanLedger::default();
+        let outcome = scan_nac_database(
+            path.to_str().expect("UTF-8 path"),
+            "nac-fixture",
+            1,
+            inode,
+            stat,
+            &NacState::default(),
+            &mut ledger,
+        );
+        let NacScanOutcome::Failed { error_kind, .. } = outcome else {
+            panic!("an episode past the row ceiling must fail the scan");
+        };
+        assert_eq!(error_kind, ERROR_KIND_TOO_LARGE);
+
+        // Every session, every earlier episode, **and** the rejected episode.
+        let expected_rows = {
+            let connection = Connection::open(&path).expect("reopen fixture for counting");
+            let sessions: i64 = connection
+                .query_row("SELECT count(*) FROM sessions", [], |row| row.get(0))
+                .expect("count sessions");
+            let episodes: i64 = connection
+                .query_row("SELECT count(*) FROM episodes", [], |row| row.get(0))
+                .expect("count episodes");
+            (sessions + episodes) as u64
+        };
+        assert_eq!(
+            ledger.payload_rows, expected_rows,
+            "the rejected episode was decoded in full to evaluate its size, so \
+             the ceiling arm must charge it like any other row"
+        );
+        assert!(
+            ledger.payload_bytes > 0,
+            "and the rows read before it are still charged"
+        );
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(format!("{}-wal", path.display())).ok();
+        std::fs::remove_file(format!("{}-shm", path.display())).ok();
+    }
+
+    /// Issue #601 §2.0 / WI-01, NAC arm. **[DIVERGENT FIXTURE]** the second
+    /// scan carries the first scan's cursor, so it emits nothing while reading
+    /// exactly the same bytes — a ledger charged at the emit site reports zero
+    /// there, and a ledger charged only on the changed branch reports zero too.
+    ///
+    /// Fails for: charging from emitted records, charging only changed rows,
+    /// or dropping the row/byte charge from `read_session_row` or the episode
+    /// loop.
+    #[test]
+    fn nac_ledger_charges_payload_bytes_at_the_read_site() {
+        let path = fixture_db();
+        let connection = Connection::open(&path).expect("open fixture for counting");
+        let sessions: i64 = connection
+            .query_row("SELECT count(*) FROM sessions", [], |row| row.get(0))
+            .expect("count sessions");
+        let episodes: i64 = connection
+            .query_row("SELECT count(*) FROM episodes", [], |row| row.get(0))
+            .expect("count episodes");
+        let messages_bytes: i64 = connection
+            .query_row(
+                "SELECT coalesce(sum(length(CAST(messages_json AS BLOB))), 0) FROM sessions",
+                [],
+                |row| row.get(0),
+            )
+            .expect("sum messages bytes");
+        drop(connection);
+
+        let (records, state, _, ledger) = scan_fixture_with_ledger(&path, &NacState::default());
+        assert!(!records.is_empty(), "the cold scan must emit something");
+        assert_eq!(
+            ledger.payload_rows,
+            (sessions + episodes) as u64,
+            "every session and episode row is a payload read"
+        );
+        assert_eq!(ledger.rows_emitted, records.len() as u64);
+        assert!(
+            ledger.payload_bytes > messages_bytes as u64,
+            "payload bytes must cover messages_json plus the other materialized \
+             columns; got {} against {messages_bytes} of messages alone",
+            ledger.payload_bytes
+        );
+        // Schema validation is the only charged census read today; §3.2's
+        // `updated_at` fast path adds NAC's own. The payload read must not be
+        // miscounted as one.
+        let schema_census = {
+            let connection =
+                super::open_read_only(&path.to_string_lossy()).expect("reopen for schema census");
+            crate::sqlite_poll::expected_schema_census(&connection, &["sessions", "episodes"])
+        };
+        assert!(schema_census.census_rows > 0);
+        assert_eq!(ledger.census_rows, schema_census.census_rows);
+        assert_eq!(ledger.census_bytes, schema_census.census_bytes);
+
+        let (second_records, second_state, _, second) = scan_fixture_with_ledger(&path, &state);
+        assert!(
+            second_records.is_empty(),
+            "the warm scan must emit nothing, or the divergence is not exercised"
+        );
+        assert_eq!(second.rows_emitted, 0);
+        assert_eq!(
+            second.payload_rows, sessions as u64,
+            "every session is still re-read on an unchanged store; only episodes \
+             are spared, by the existing append-only `episode_high_water`"
+        );
+        assert!(
+            second.payload_bytes >= messages_bytes as u64,
+            "a scan that emits nothing still pays for every session it read"
+        );
+
+        let (third_records, _, _, third) = scan_fixture_with_ledger(&path, &second_state);
+        assert!(third_records.is_empty());
+        assert_eq!(third.rows_emitted, 0);
+        assert_eq!(
+            third.payload_bytes, second.payload_bytes,
+            "two consecutive scans that emit nothing must charge identical, \
+             non-zero bytes — an emit-site ledger reports zero for both"
+        );
+        assert_eq!(third.payload_rows, second.payload_rows);
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(format!("{}-wal", path.display())).ok();
+        std::fs::remove_file(format!("{}-shm", path.display())).ok();
     }
 
     #[test]
@@ -1993,6 +2778,7 @@ mod tests {
             format: moraine_config::SourceFormat::NacSqlite,
             source_glob: source_file.clone(),
             path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
         };
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
         let poll_state = VolatilePollMap::new();
@@ -2034,6 +2820,7 @@ mod tests {
                 inode ^ 1,
                 stat,
                 &NacState::default(),
+                &mut ScanLedger::default(),
             ),
             NacScanOutcome::Failed {
                 error_kind: ERROR_KIND_MIXED_SNAPSHOT,
@@ -2055,6 +2842,7 @@ mod tests {
             format: moraine_config::SourceFormat::NacSqlite,
             source_glob: source_file.clone(),
             path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
         };
         let config = AppConfig::default();
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
@@ -2098,6 +2886,120 @@ mod tests {
         std::fs::remove_file(format!("{}-shm", path.display())).ok();
     }
 
+    /// Issue #601 §2.5, the NAC-specific aggravation: the volatile check was
+    /// skipped entirely during replay (`!replacement_replay && should_skip_poll`),
+    /// so a store stuck in `retry_blocked_replay` re-scanned the whole database
+    /// **and re-sent a durable `BeginReplay` barrier** on every tick, forever.
+    ///
+    /// The throttle has to sit *before* the barrier: gating only the scan would
+    /// leave a barrier with nothing behind it, which is the failure mode
+    /// §2.1(2) warns about.
+    ///
+    /// Denominated on durable transitions emitted and on observed scans — not
+    /// on `ingest_errors` rows, which the `last_error` marker already
+    /// suppresses.
+    #[tokio::test]
+    async fn blocked_replay_backs_off_instead_of_resending_the_barrier() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-fixture".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let config = AppConfig::default();
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        drive_nac_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        // The cold poll's ledger must reach the shared counters: `Metrics` is
+        // how every observation below is denominated, and a `record_scan_ledger`
+        // that folds nothing would make all of them unfailable.
+        assert!(
+            metrics
+                .sqlite_poll_payload_rows_total
+                .load(std::sync::atomic::Ordering::Relaxed)
+                > 0,
+            "the NAC scan's ledger must be folded into the shared metrics"
+        );
+
+        // Replace the store in place so the next poll starts a replacement
+        // replay that cannot succeed, leaving the checkpoint durably blocked.
+        let replacement = path.with_extension("replacement");
+        std::fs::write(&replacement, b"not a sqlite database").expect("write invalid replacement");
+        std::fs::remove_file(&path).expect("remove fixture database");
+        std::fs::rename(&replacement, &path).expect("install invalid replacement");
+        let (_, blocking) =
+            drive_nac_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(blocking.len(), 2, "begin then durable block");
+        let failures_after_block = metrics
+            .sqlite_scan_failures_total
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(failures_after_block, 1);
+
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        assert_eq!(
+            poll_state.consecutive_failed_scans(&cp_key),
+            1,
+            "the block starts the failure ladder"
+        );
+
+        let scan_failures = || {
+            metrics
+                .sqlite_scan_failures_total
+                .load(std::sync::atomic::Ordering::Relaxed)
+        };
+
+        // Ten ticks inside the first 15 s window: nothing runs.
+        let mut retry_transitions = 0usize;
+        for _ in 0..10 {
+            let (_, transitions) =
+                drive_nac_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics)
+                    .await;
+            retry_transitions += transitions.len();
+        }
+        assert_eq!(
+            retry_transitions, 0,
+            "a durably blocked replay must not re-send BeginReplay on every tick"
+        );
+        assert_eq!(
+            scan_failures(),
+            failures_after_block,
+            "and must not re-run the failing scan either"
+        );
+
+        // Ten ticks inside one window cannot distinguish a flat 15 s floor from
+        // an exponential ladder, which is what let the floor-pinning reset ship.
+        // Backdating the clock does: after the first retry the window is 30 s,
+        // so a further 16 s must **not** be enough.
+        poll_state.age_for_tests(&cp_key, std::time::Duration::from_secs(16));
+        let (_, retried) =
+            drive_nac_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(retried.len(), 2, "the due retry re-sends begin then block");
+        assert_eq!(scan_failures(), failures_after_block + 1);
+        assert_eq!(
+            poll_state.consecutive_failed_scans(&cp_key),
+            2,
+            "a repeat failure extends the ladder"
+        );
+
+        poll_state.age_for_tests(&cp_key, std::time::Duration::from_secs(16));
+        let (_, throttled) =
+            drive_nac_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert!(
+            throttled.is_empty(),
+            "the second window is 30 s; 16 s of elapsed time is not yet due"
+        );
+        assert_eq!(scan_failures(), failures_after_block + 1);
+
+        std::fs::remove_file(&path).ok();
+        std::fs::remove_file(format!("{}-wal", path.display())).ok();
+        std::fs::remove_file(format!("{}-shm", path.display())).ok();
+    }
+
     #[tokio::test]
     async fn oversized_normalized_rows_fail_before_any_payload_is_sent() {
         let path = fixture_db();
@@ -2133,21 +3035,52 @@ mod tests {
             format: moraine_config::SourceFormat::NacSqlite,
             source_glob: source_file.clone(),
             path: source_file,
+            trigger: WorkTrigger::Watcher,
         };
-        let (sink_tx, mut sink_rx) = mpsc::channel(2);
-        process_nac_sqlite_db(
-            &AppConfig::default(),
-            &work,
-            Arc::new(RwLock::new(HashMap::new())),
-            &VolatilePollMap::new(),
-            sink_tx,
-            &Arc::new(Metrics::default()),
-        )
-        .await
-        .expect("oversized scan reports an ingest error");
-        let SinkMessage::Batch(batch) = sink_rx.recv().await.expect("oversized failure batch")
-        else {
-            panic!("expected oversized failure batch");
+        // **Known hazard, gate G1d (§3.2).** The mixed-snapshot bracket's second
+        // disjunct compares full `StatFingerprint`s including `shm_len` /
+        // `shm_mtime_ns`, so it can reject a scan when `data_version` is
+        // unchanged — no commit happened at all, only sidecar churn. Under a
+        // loaded host (running the whole suite in parallel, or alongside the
+        // Cursor mixed-snapshot reproducer) this poll therefore sometimes
+        // reports `sqlite_mixed_snapshot` instead of the ceiling it is about.
+        // That is not noise and it is not this test's bug: it is exactly the
+        // rejection G1d exists to characterize.
+        //
+        // A mixed-snapshot rejection means "retry without advancing the
+        // cursor", so the test does what production does — retries — and
+        // requires the ceiling to be reported within a bounded number of
+        // attempts. Attributing it this way keeps the assertion sharp instead
+        // of loosening it to "either error kind is fine".
+        let mut rejections = 0usize;
+        let batch = loop {
+            let (sink_tx, mut sink_rx) = mpsc::channel(2);
+            process_nac_sqlite_db(
+                &AppConfig::default(),
+                &work,
+                Arc::new(RwLock::new(HashMap::new())),
+                &VolatilePollMap::new(),
+                sink_tx,
+                &Arc::new(Metrics::default()),
+            )
+            .await
+            .expect("oversized scan reports an ingest error");
+            let SinkMessage::Batch(batch) = sink_rx.recv().await.expect("oversized failure batch")
+            else {
+                panic!("expected oversized failure batch");
+            };
+            if batch.error_rows.first().map(|row| &row["error_kind"])
+                == Some(&Value::from(ERROR_KIND_MIXED_SNAPSHOT))
+            {
+                rejections += 1;
+                assert!(
+                    rejections < 20,
+                    "20 consecutive mixed-snapshot rejections against a database \
+                     nothing is writing is the G1d hazard escalating, not a flake"
+                );
+                continue;
+            }
+            break batch;
         };
         assert!(batch.raw_rows.is_empty());
         assert!(batch.event_rows.is_empty());

--- a/crates/moraine-ingest-core/src/sqlite_poll/opencode.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/opencode.rs
@@ -14,11 +14,20 @@ use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, warn};
 
 use super::{
-    hash_str, open_read_only, sqlite_data_version, stat_fingerprint, truncate_chars_local,
+    hash_str, open_read_only, record_scan_failure, record_scan_ledger, sqlite_data_version,
+    stat_fingerprint, take_payload_required_string, truncate_chars_local, ScanLedger,
     StatFingerprint, SyntheticRecord, VolatilePollMap, CURSOR_STATE_VERSION,
     ERROR_KIND_MIXED_SNAPSHOT, ERROR_KIND_OPEN, ERROR_KIND_SCAN, ERROR_KIND_SCHEMA,
     ERROR_KIND_TOO_LARGE, SCAN_PAGE_MAX_BYTES, SCAN_PAGE_SIZE,
 };
+
+/// The paged event read, shared with the fixture-plan assertion in
+/// `opencode_fixture_uses_the_production_event_index` so the plan that test
+/// certifies is the plan this adapter actually runs. A copy in the test would
+/// let the two drift and the certification would become meaningless.
+const OPENCODE_EVENT_PAGE_SQL: &str = "SELECT id, aggregate_id, seq, type, data FROM event \
+     WHERE aggregate_id = ?1 AND seq > ?2 AND seq <= ?3 \
+     ORDER BY seq LIMIT ?4";
 
 const MAX_OPENCODE_RELEVANT_ROWS: u64 = 10_000;
 const MAX_OPENCODE_SCAN_BYTES: u64 = 128 * 1024 * 1024;
@@ -192,24 +201,67 @@ pub(crate) async fn process_opencode_sqlite_db(
     let policy_fingerprint =
         super::sqlite_policy_fingerprint(SOURCE_FORMAT_OPENCODE_SQLITE, current_exclusions_hash);
 
-    let sequence_rewound = if had_committed && current_stat != state.stat {
-        let scan_db_path = source_file.clone();
-        let prior = state.clone();
-        tokio::task::spawn_blocking(move || opencode_sequences_rewound(&scan_db_path, &prior))
-            .await
-            .context("opencode_sqlite sequence preflight panicked")?
-            .unwrap_or(false)
-    } else {
-        false
-    };
-
     // Replaced databases restart logical identities. Changed exclusions replay
     // the event history so rows skipped under the prior policy can return.
     let generation_changed = had_committed && checkpoint.source_inode != inode;
     let exclusions_changed =
         had_committed && state.project_exclusions_hash != current_exclusions_hash;
+    // The `replaying` disjunct resumes a replay a crash interrupted between
+    // `BeginReplay` and `FinalizeReplay`; the `error` disjunct cannot cover it,
+    // because a crash never wrote a block reason. Width note at the Cursor
+    // site; `a_crash_interrupted_opencode_replay_resumes_from_its_replaying_status`
+    // fails if it goes. It also feeds the throttle gate immediately below, so
+    // its width is load-bearing for that gate too.
     let retry_blocked_replay = checkpoint.status == "replaying"
         || (checkpoint.status == "error" && !checkpoint.block_reason.is_empty());
+
+    // The failure backoff gates the **whole poll**, not just the barrier and
+    // the scan behind it (issue #601 §2.1(2), §2.5). The rewind preflight below
+    // opens the database and walks `event_sequence`, and it used to run ahead
+    // of this return, so a durably blocked database still paid for a read — and
+    // still charged metrics — on every single tick while everything downstream
+    // was throttled. `starts_replacement` is not known yet, but its other two
+    // disjuncts are, and they are the only ones that may bypass the throttle: a
+    // rewind discovered by the preflight cannot be a reason to have run the
+    // preflight.
+    //
+    // **Both bypass conjuncts are genuinely load-bearing here, unlike the
+    // `!starts_replacement` conjunct on the Cursor and NAC gates.** There the
+    // gate sits *below* the generation bump, so `failure_retry_due` is asked
+    // about a generation the volatile entry has never seen and answers `true`
+    // whatever the conjunct says — an equivalent mutant. This gate has to sit
+    // *above* the bump (the bump depends on `sequence_rewound`, which is what
+    // the preflight computes), so `checkpoint.source_generation` is still the
+    // old value and `failure_retry_due` genuinely answers `false`. Drop either
+    // conjunct and an OpenCode store whose file was replaced, or whose
+    // exclusion set changed, is ignored for up to `FAILURE_BACKOFF_MAX`.
+    // `a_replaced_opencode_database_bypasses_the_blocked_replay_throttle` and
+    // `an_exclusion_change_bypasses_the_opencode_blocked_replay_throttle` fail,
+    // one per conjunct.
+    if retry_blocked_replay
+        && !generation_changed
+        && !exclusions_changed
+        && !poll_state.failure_retry_due(&cp_key, checkpoint.source_generation)
+    {
+        return Ok(());
+    }
+
+    let sequence_rewound = if had_committed && current_stat != state.stat {
+        let scan_db_path = source_file.clone();
+        let prior = state.clone();
+        let (rewound, preflight_ledger) = tokio::task::spawn_blocking(move || {
+            let mut ledger = ScanLedger::default();
+            let rewound = opencode_sequences_rewound(&scan_db_path, &prior, &mut ledger);
+            (rewound, ledger)
+        })
+        .await
+        .context("opencode_sqlite sequence preflight panicked")?;
+        record_scan_ledger(metrics, &preflight_ledger);
+        rewound.unwrap_or(false)
+    } else {
+        false
+    };
+
     let starts_replacement = generation_changed || exclusions_changed || sequence_rewound;
     if starts_replacement {
         checkpoint.source_inode = inode;
@@ -249,22 +301,49 @@ pub(crate) async fn process_opencode_sqlite_db(
     // Cheap no-change short-circuit: nothing touched the database or its WAL
     // sidecars since the last poll. `event_scan_complete` also forces one real
     // scan after upgrading from the earlier projection cursor state.
-    if state.stat == current_stat && state.last_error.is_empty() && state.event_scan_complete {
+    // §2.5's `|| !failure_retry_due` disjunct is absent and **must stay absent
+    // while the contention clock lives in `failure_retry_due`** — WI-04 must
+    // not add it. It is no longer outcome-redundant with `should_skip_poll`'s
+    // failure arm below: §3.2's contention exemption keeps that clock out of
+    // `should_skip_poll` on purpose, so after a mixed-snapshot rejection
+    // `failure_retry_due` is false for up to 60 s while `should_skip_poll`
+    // stays false. The disjunct would skip ordinary polls of an actively
+    // written OpenCode store for that whole window — the §6 prompt-visibility
+    // regression the exemption exists to prevent. A pre-`should_skip_poll`
+    // throttle for the sweep slice must read the fault ladder alone.
+    // `an_ordinary_poll_of_a_contended_opencode_store_is_not_throttled` fails
+    // if it is added. See `plans/601-delta-sqlite.md` §7 WI-10.
+    if state.stat == current_stat && state.event_scan_complete && state.last_error.is_empty() {
         return Ok(());
     }
 
     // Volatile short-circuit + rescan backoff (issue #443): no-op scans leave
     // the durable checkpoint untouched, so their coverage lives here instead.
-    if poll_state.should_skip_poll(&cp_key, checkpoint.source_generation, &current_stat) {
+    // Skipped during a replay so the barrier always has a scan behind it.
+    //
+    // Both halves are pinned, one test each, mirroring the Cursor site:
+    // `an_opencode_blocked_replay_scans_behind_its_barrier` fails if the
+    // `!replacement_replay` guard goes (the durable barrier is sent and the
+    // skip then fires behind it, one barrier per tick forever), and
+    // `a_failed_opencode_scan_backs_off_instead_of_rescanning_every_tick` fails
+    // if the call goes (a database whose scan fails re-runs the whole failed
+    // scan on every reconcile tick and every debounced watcher event).
+    if !replacement_replay
+        && poll_state.should_skip_poll(&cp_key, checkpoint.source_generation, &current_stat)
+    {
         return Ok(());
     }
 
     let scan_db_path = source_file.clone();
     let scan_state = state.clone();
-    let outcome =
-        tokio::task::spawn_blocking(move || scan_opencode_database(&scan_db_path, &scan_state))
-            .await
-            .context("opencode_sqlite scan task panicked")?;
+    let (outcome, ledger) = tokio::task::spawn_blocking(move || {
+        let mut ledger = ScanLedger::default();
+        let outcome = scan_opencode_database(&scan_db_path, &scan_state, &mut ledger);
+        (outcome, ledger)
+    })
+    .await
+    .context("opencode_sqlite scan task panicked")?;
+    record_scan_ledger(metrics, &ledger);
 
     match outcome {
         OpenCodeScanOutcome::Scanned {
@@ -412,7 +491,7 @@ pub(crate) async fn process_opencode_sqlite_db(
                         ..final_checkpoint
                     };
                     super::block_database_replay(&sink_tx, &blocked_checkpoint, reason).await?;
-                    poll_state.clear(&cp_key);
+                    poll_state.record_blocked_replay(&cp_key, checkpoint.source_generation);
                     return Ok(());
                 }
                 let active_checkpoint = Checkpoint {
@@ -434,18 +513,28 @@ pub(crate) async fn process_opencode_sqlite_db(
 
             if emitted > 0 {
                 debug!(
-                    "{}:{} opencode_sqlite emitted {} changed records ({} relevant rows)",
-                    work.source_name, source_file, emitted, relevant_rows
+                    "{}:{} opencode_sqlite emitted {} changed records ({} relevant rows, \
+                     {} payload rows, {} payload bytes)",
+                    work.source_name,
+                    source_file,
+                    emitted,
+                    relevant_rows,
+                    ledger.payload_rows,
+                    ledger.payload_bytes
                 );
             }
-            let _ = metrics;
             Ok(())
         }
         OpenCodeScanOutcome::Failed {
             error_kind,
             error_text,
         } => {
-            poll_state.record_failed_scan(&cp_key);
+            record_scan_failure(metrics);
+            poll_state.record_scan_failure_outcome(
+                &cp_key,
+                checkpoint.source_generation,
+                error_kind,
+            );
 
             // Emit each failure mode once per state change, not once per
             // reconcile tick: the marker is durable and reconcile re-polls every
@@ -515,7 +604,13 @@ pub(crate) async fn process_opencode_sqlite_db(
     }
 }
 
-fn scan_opencode_database(db_path: &str, prior: &OpenCodeState) -> OpenCodeScanOutcome {
+/// The caller owns `ledger` so that every early return — including each
+/// failure arm — still reports the bytes this scan had already paid for.
+fn scan_opencode_database(
+    db_path: &str,
+    prior: &OpenCodeState,
+    ledger: &mut ScanLedger,
+) -> OpenCodeScanOutcome {
     let connection = match open_read_only(db_path) {
         Ok(connection) => connection,
         Err(exc) => {
@@ -538,7 +633,7 @@ fn scan_opencode_database(db_path: &str, prior: &OpenCodeState) -> OpenCodeScanO
         }
     };
 
-    let schema_fingerprint = match validate_opencode_schema(&connection) {
+    let schema_fingerprint = match validate_opencode_schema(&connection, ledger) {
         Ok(fingerprint) => fingerprint,
         Err(text) => {
             return OpenCodeScanOutcome::Failed {
@@ -548,7 +643,7 @@ fn scan_opencode_database(db_path: &str, prior: &OpenCodeState) -> OpenCodeScanO
         }
     };
 
-    match opencode_relevant_stats(&connection, prior) {
+    match opencode_relevant_stats(&connection, prior, ledger) {
         Ok(stats) if stats.rows > MAX_OPENCODE_RELEVANT_ROWS => {
             return OpenCodeScanOutcome::Failed {
                 error_kind: ERROR_KIND_TOO_LARGE,
@@ -585,7 +680,7 @@ fn scan_opencode_database(db_path: &str, prior: &OpenCodeState) -> OpenCodeScanO
         }
     }
 
-    let result = scan_opencode_rows(&connection, prior);
+    let result = scan_opencode_rows(&connection, prior, ledger);
     let data_version_after = match sqlite_data_version(&connection) {
         Ok(value) => value,
         Err(exc) => {
@@ -595,7 +690,12 @@ fn scan_opencode_database(db_path: &str, prior: &OpenCodeState) -> OpenCodeScanO
             }
         }
     };
-    if data_version_before != data_version_after || stat_fingerprint(db_path) != Some(opened_stat) {
+    if super::snapshot_is_mixed(
+        db_path,
+        data_version_before,
+        data_version_after,
+        opened_stat,
+    ) {
         return OpenCodeScanOutcome::Failed {
             error_kind: ERROR_KIND_MIXED_SNAPSHOT,
             error_text:
@@ -622,19 +722,17 @@ fn scan_opencode_database(db_path: &str, prior: &OpenCodeState) -> OpenCodeScanO
     }
 }
 
-fn validate_opencode_schema(connection: &Connection) -> std::result::Result<u64, String> {
+fn validate_opencode_schema(
+    connection: &Connection,
+    ledger: &mut ScanLedger,
+) -> std::result::Result<u64, String> {
     let mut schema_material = String::new();
     for (table, required_columns) in [
         ("event", EVENT_COLUMNS),
         ("event_sequence", EVENT_SEQUENCE_COLUMNS),
     ] {
-        let schema_sql: Option<String> = connection
-            .query_row(
-                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?1",
-                rusqlite::params![table],
-                |row| row.get(0),
-            )
-            .map_err(|exc| match exc {
+        let schema_sql =
+            super::schema_sql_for_table(connection, table, ledger).map_err(|exc| match exc {
                 rusqlite::Error::QueryReturnedNoRows => {
                     format!("required table {table} is missing")
                 }
@@ -643,7 +741,8 @@ fn validate_opencode_schema(connection: &Connection) -> std::result::Result<u64,
         schema_material.push_str(&schema_sql.unwrap_or_default());
         schema_material.push('\n');
 
-        let names = table_columns(connection, table).map_err(|exc| exc.to_string())?;
+        let names = super::table_column_names(connection, table, ledger)
+            .map_err(|exc| format!("{exc:#}"))?;
         for column in required_columns {
             if !names.iter().any(|name| name == column) {
                 return Err(format!("table {table} is missing required column {column}"));
@@ -653,16 +752,6 @@ fn validate_opencode_schema(connection: &Connection) -> std::result::Result<u64,
     Ok(hash_str(&schema_material))
 }
 
-fn table_columns(connection: &Connection, table: &str) -> Result<Vec<String>> {
-    let mut stmt = connection
-        .prepare(&format!("PRAGMA table_info({table})"))
-        .with_context(|| format!("failed to inspect {table} columns"))?;
-    let names = stmt
-        .query_map([], |row| row.get::<_, String>(1))?
-        .collect::<std::result::Result<Vec<_>, _>>()?;
-    Ok(names)
-}
-
 #[derive(Default)]
 struct OpenCodeRelevantStats {
     rows: u64,
@@ -670,17 +759,38 @@ struct OpenCodeRelevantStats {
     max_row_bytes: u64,
 }
 
+/// Preflight sizing, and an honest account of what it costs.
+///
+/// The per-aggregate statement below is a scalar aggregate, so it materializes
+/// no row — but `sum(length(coalesce(data, '')))` makes SQLite decode every
+/// byte of `data` in the range (§1.1 finding 2). Those bytes are charged on the
+/// payload axis, which is why a cold OpenCode scan's `payload_bytes` is roughly
+/// **twice** its `data` size: once here and once in the page loop. That is the
+/// truth, and it is what makes the duplication visible to a byte budget instead
+/// of leaving it "real and invisible".
+///
+/// Issue #601 §3.1 Change 5 folds this O(#aggregates) preflight into the single
+/// `event_sequence` read, at which point the doubling disappears;
+/// `opencode_ledger_charges_payload_bytes_at_the_read_site` pins the current
+/// number so that change cannot land silently.
 fn opencode_relevant_stats(
     connection: &Connection,
     prior: &OpenCodeState,
+    ledger: &mut ScanLedger,
 ) -> Result<OpenCodeRelevantStats> {
     let mut stats = OpenCodeRelevantStats::default();
-    for aggregate in opencode_aggregate_sequences(connection)? {
+    for aggregate in opencode_aggregate_sequences(connection, ledger)? {
         let prior_seq = opencode_scan_from_seq(prior, &aggregate);
         let (rows, total_bytes, max_row_bytes): (i64, i64, i64) = connection
             .query_row(
-                "SELECT count(*), coalesce(sum(length(coalesce(data, ''))), 0), \
-                 coalesce(max(length(coalesce(data, ''))), 0) \
+                // `CAST(… AS BLOB)` on purpose: bare `length()` over a TEXT
+                // value counts *characters*, and both results are compared
+                // against byte ceilings and charged to a byte axis. The
+                // in-scan check (`build_event_row`) measures real bytes, so
+                // the character form also made the preflight and the loop
+                // disagree on any non-ASCII payload.
+                "SELECT count(*), coalesce(sum(length(CAST(coalesce(data, '') AS BLOB))), 0), \
+                 coalesce(max(length(CAST(coalesce(data, '') AS BLOB))), 0) \
                  FROM event WHERE aggregate_id = ?1 AND seq > ?2 AND seq <= ?3",
                 rusqlite::params![&aggregate.aggregate_id, prior_seq, aggregate.seq],
                 |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
@@ -694,6 +804,10 @@ fn opencode_relevant_stats(
         stats.rows = stats.rows.saturating_add(rows.max(0) as u64);
         stats.total_bytes = stats.total_bytes.saturating_add(total_bytes.max(0) as u64);
         stats.max_row_bytes = stats.max_row_bytes.max(max_row_bytes.max(0) as u64);
+        // `sum(length(data))` is exactly the count of bytes SQLite decoded to
+        // answer this statement, so it is also exactly what the payload axis
+        // owes for it.
+        ledger.charge_aggregate_payload_bytes(total_bytes.max(0) as u64);
     }
     Ok(stats)
 }
@@ -701,6 +815,7 @@ fn opencode_relevant_stats(
 fn scan_opencode_rows(
     connection: &Connection,
     prior: &OpenCodeState,
+    ledger: &mut ScanLedger,
 ) -> std::result::Result<(Vec<SyntheticRecord>, OpenCodeState, u64), OpenCodeScanError> {
     let mut records = Vec::new();
     let mut accumulated = OpenCodeAccumulated::default();
@@ -711,7 +826,7 @@ fn scan_opencode_rows(
     let mut context_events = 0u64;
     let mut context_bytes = 0u64;
 
-    for aggregate in opencode_aggregate_sequences(connection)? {
+    for aggregate in opencode_aggregate_sequences(connection, ledger)? {
         let scan_from_seq = opencode_scan_from_seq(prior, &aggregate);
         if aggregate.seq <= scan_from_seq {
             aggregate_sequences.insert(aggregate.aggregate_id.clone(), scan_from_seq);
@@ -725,11 +840,7 @@ fn scan_opencode_rows(
             let mut page_bytes = 0usize;
             let mut page_capped = false;
             {
-                let mut stmt = connection.prepare_cached(
-                    "SELECT id, aggregate_id, seq, type, data FROM event \
-                     WHERE aggregate_id = ?1 AND seq > ?2 AND seq <= ?3 \
-                     ORDER BY seq LIMIT ?4",
-                )?;
+                let mut stmt = connection.prepare_cached(OPENCODE_EVENT_PAGE_SQL)?;
                 let mut rows = stmt.query(rusqlite::params![
                     &aggregate.aggregate_id,
                     last_seq,
@@ -737,7 +848,7 @@ fn scan_opencode_rows(
                     SCAN_PAGE_SIZE as i64
                 ])?;
                 while let Some(row) = rows.next()? {
-                    let event = build_event_row(row)?;
+                    let event = build_event_row(row, ledger)?;
                     if event.data_bytes > SCAN_PAGE_MAX_BYTES {
                         return Err(OpenCodeScanError::TooLarge(format!(
                             "largest OpenCode event is {} bytes, exceeding the {} byte row ceiling",
@@ -811,15 +922,22 @@ fn scan_opencode_rows(
     new_state.project_exclusions_hash = prior.project_exclusions_hash;
     new_state.event_scan_complete = true;
     new_state.aggregate_sequences = aggregate_sequences;
+    ledger.rows_emitted = records.len() as u64;
     Ok((records, new_state, relevant_events))
 }
 
-fn opencode_sequences_rewound(db_path: &str, prior: &OpenCodeState) -> Result<bool> {
+fn opencode_sequences_rewound(
+    db_path: &str,
+    prior: &OpenCodeState,
+    ledger: &mut ScanLedger,
+) -> Result<bool> {
     if prior.aggregate_sequences.is_empty() {
         return Ok(false);
     }
     let connection = open_read_only(db_path)?;
-    let current = opencode_aggregate_sequences(&connection)?
+    // A preflight on its own connection, before the scan's ledger exists; its
+    // census is charged into a scratch ledger that is folded in by the caller.
+    let current = opencode_aggregate_sequences(&connection, ledger)?
         .into_iter()
         .map(|aggregate| (aggregate.aggregate_id, aggregate.seq))
         .collect::<BTreeMap<_, _>>();
@@ -846,28 +964,47 @@ fn opencode_scan_from_seq(prior: &OpenCodeState, aggregate: &OpenCodeAggregateSe
     }
 }
 
-fn opencode_aggregate_sequences(connection: &Connection) -> Result<Vec<OpenCodeAggregateSequence>> {
+/// The one narrow read in this adapter: `event_sequence` carries no payload
+/// column, so it is charged on the census axis. It runs more than once per
+/// poll today (issue #601 §3.1 Change 5) and the ledger now shows that.
+fn opencode_aggregate_sequences(
+    connection: &Connection,
+    ledger: &mut ScanLedger,
+) -> Result<Vec<OpenCodeAggregateSequence>> {
     let mut stmt = connection
         .prepare_cached("SELECT aggregate_id, seq FROM event_sequence ORDER BY aggregate_id")?;
-    let aggregates = stmt
-        .query_map([], |row| {
-            Ok(OpenCodeAggregateSequence {
-                aggregate_id: row.get(0)?,
-                seq: row.get(1)?,
-            })
-        })?
-        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let mut rows = stmt.query([])?;
+    let mut aggregates = Vec::new();
+    while let Some(row) = rows.next()? {
+        let aggregate_id: String = row.get(0)?;
+        ledger.charge_census_row(aggregate_id.len());
+        aggregates.push(OpenCodeAggregateSequence {
+            aggregate_id,
+            seq: row.get(1)?,
+        });
+    }
     Ok(aggregates)
 }
 
-fn build_event_row(row: &rusqlite::Row<'_>) -> Result<OpenCodeEventRow> {
-    let data_text = row.get::<_, String>(4)?;
+fn build_event_row(row: &rusqlite::Row<'_>, ledger: &mut ScanLedger) -> Result<OpenCodeEventRow> {
+    // This projection includes `data`, so the whole row is charged on the
+    // payload axis at the point SQLite hands it over.
+    ledger.charge_payload_row();
+    // All four are NOT NULL in OpenCode's `event` table, and `id` /
+    // `aggregate_id` are the material behind `source_line_no`/`source_offset`
+    // and therefore behind `event_uid` (§6). A NULL is schema drift: fail the
+    // scan instead of minting a record keyed on the empty string with
+    // `data_bytes = 0`.
+    let id = take_payload_required_string(ledger, row, 0)?;
+    let aggregate_id = take_payload_required_string(ledger, row, 1)?;
+    let event_type = take_payload_required_string(ledger, row, 3)?;
+    let data_text = take_payload_required_string(ledger, row, 4)?;
     let data = serde_json::from_str::<Value>(&data_text).unwrap_or_else(|_| json!(data_text));
     Ok(OpenCodeEventRow {
-        id: row.get(0)?,
-        aggregate_id: row.get(1)?,
+        id,
+        aggregate_id,
         seq: row.get(2)?,
-        event_type: row.get(3)?,
+        event_type,
         data,
         data_bytes: data_text.len(),
     })

--- a/crates/moraine-ingest-core/src/sqlite_poll/opencode/tests.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/opencode/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::checkpoint::checkpoint_key;
 use crate::model::{Checkpoint, RowBatch};
+use crate::WorkTrigger;
 use moraine_config::SourceFormat;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -93,6 +94,16 @@ fn create_opencode_db(path: &PathBuf) -> Connection {
                   time_created integer NOT NULL,
                   time_updated integer NOT NULL
                 );
+                -- Verbatim from a live `~/.local/share/opencode/opencode.db`.
+                -- Without them every scan the unit tests measure is a full
+                -- table scan, so any cost budget calibrated here would be
+                -- calibrated against a plan production never runs
+                -- (issue #601 §1.2). Asserted by
+                -- `opencode_fixture_uses_the_production_event_index`.
+                CREATE UNIQUE INDEX `event_aggregate_seq_idx`
+                  ON `event` (`aggregate_id`,`seq`);
+                CREATE INDEX `event_aggregate_type_seq_idx`
+                  ON `event` (`aggregate_id`,`type`,`seq`);
                 "#,
         )
         .expect("create opencode tables");
@@ -490,6 +501,7 @@ fn opencode_sqlite_work(path: &Path) -> WorkItem {
         format: SourceFormat::OpenCodeSqlite,
         source_glob: String::new(),
         path: path.to_string_lossy().to_string(),
+        trigger: WorkTrigger::Watcher,
     }
 }
 
@@ -515,7 +527,25 @@ async fn drive_opencode_poll(
     checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
     poll_state: &VolatilePollMap,
 ) -> Vec<RowBatch> {
-    let metrics = Arc::new(Metrics::default());
+    drive_opencode_poll_with_metrics(
+        config,
+        work,
+        checkpoints,
+        poll_state,
+        &Arc::new(Metrics::default()),
+    )
+    .await
+}
+
+/// Shares one `Metrics` across several polls so a test can observe what a poll
+/// actually read (`sqlite_poll_*_total`) rather than only what it emitted.
+async fn drive_opencode_poll_with_metrics(
+    config: &moraine_config::AppConfig,
+    work: &WorkItem,
+    checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
+    poll_state: &VolatilePollMap,
+    metrics: &Arc<Metrics>,
+) -> Vec<RowBatch> {
     let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(64);
     let process = process_opencode_sqlite_db(
         config,
@@ -523,7 +553,7 @@ async fn drive_opencode_poll(
         checkpoints.clone(),
         poll_state,
         sink_tx,
-        &metrics,
+        metrics,
     );
     tokio::pin!(process);
     let mut batches = Vec::new();
@@ -572,6 +602,278 @@ async fn drive_opencode_poll(
         checkpoints.write().await.insert(key, cp);
     }
     batches
+}
+
+/// Runs one poll, acknowledging every barrier, and reports whether it emitted
+/// a `BlockReplay`. Unlike `drive_opencode_poll_with_metrics` it persists the
+/// checkpoint a barrier carried, which is the only way a *blocked* replay's
+/// state reaches the next poll.
+async fn drive_opencode_block_poll(
+    config: &moraine_config::AppConfig,
+    work: &WorkItem,
+    checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
+    poll_state: &VolatilePollMap,
+    metrics: &Arc<Metrics>,
+) -> bool {
+    let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(64);
+    let process = process_opencode_sqlite_db(
+        config,
+        work,
+        checkpoints.clone(),
+        poll_state,
+        sink_tx,
+        metrics,
+    );
+    tokio::pin!(process);
+    let mut batches = Vec::new();
+    let mut committed = None;
+    let mut blocked = false;
+    loop {
+        tokio::select! {
+            result = &mut process => {
+                result.expect("opencode_sqlite replay poll should succeed");
+                break;
+            }
+            message = sink_rx.recv() => match message.expect("opencode test sink remains open") {
+                SinkMessage::Batch(batch) => batches.push(batch),
+                SinkMessage::BlockReplay { transition, ack } => {
+                    blocked = true;
+                    committed = Some(transition.checkpoint.clone());
+                    let _ = ack.send(Ok(crate::publication::ReplayBarrierAck {
+                        checkpoint_revision: 1,
+                        operation_id: transition.checkpoint.operation_id,
+                    }));
+                }
+                SinkMessage::BeginReplay { transition, ack }
+                | SinkMessage::MirrorCaughtUp { transition, ack } => {
+                    committed = Some(transition.checkpoint.clone());
+                    let _ = ack.send(Ok(crate::publication::ReplayBarrierAck {
+                        checkpoint_revision: 1,
+                        operation_id: transition.checkpoint.operation_id,
+                    }));
+                }
+                SinkMessage::FinalizeReplay { transition, ack } => {
+                    committed = Some(transition.checkpoint.clone());
+                    let _ = ack.send(Ok(
+                        crate::publication::FinalizeReplayOutcome::Published(
+                            crate::publication::PublicationAck {
+                                checkpoint_revision: 2,
+                                publication_revision: 1,
+                                already_published: false,
+                            },
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+    while let Ok(message) = sink_rx.try_recv() {
+        if let SinkMessage::Batch(batch) = message {
+            batches.push(batch);
+        }
+    }
+    if let Some(cp) = committed.or_else(|| batches.last().and_then(|b| b.checkpoint.clone())) {
+        let key = checkpoint_key(&cp.source_name, &cp.source_file);
+        checkpoints.write().await.insert(key, cp);
+    }
+    blocked
+}
+
+/// Issue #601 §2.5. The OpenCode half of the `record_blocked_replay` call-site
+/// gap: `record_blocked_replay` is guarded at its implementation, and Cursor's
+/// call site is guarded by `blocked_replay_retries_climb_the_failure_ladder`,
+/// but inserting a `poll_state.clear()` before opencode.rs's call passed the
+/// whole suite. A `clear` there restarts the streak on every retry, which pins
+/// the path at the 15 s floor and re-reads the entire event history — plus a
+/// durable `BeginReplay`/`BlockReplay` pair — every 15 s indefinitely, because
+/// the trigger (a record failing `normalize_record`) is deterministic.
+///
+/// Fails for: `clear`ing volatile state before `record_blocked_replay`, or
+/// dropping the call entirely.
+#[tokio::test]
+async fn a_normalization_blocked_opencode_replay_climbs_the_failure_ladder() {
+    let path = unique_opencode_db_path("block-ladder");
+    let _db = seed_opencode_db(&path);
+    // `normalize_record` rejects an unregistered harness outright, so every
+    // synthesized record fails and a replacement replay blocks durably.
+    let work = WorkItem {
+        harness: "not-a-registered-harness".to_string(),
+        ..opencode_sqlite_work(&path)
+    };
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let poll_state = VolatilePollMap::new();
+    let metrics = Arc::new(Metrics::default());
+
+    let config = moraine_config::AppConfig::default();
+    drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+    assert!(checkpoints.read().await.contains_key(&cp_key));
+
+    // Changing the exclusion set starts a replacement replay that cannot
+    // finish, because nothing normalizes.
+    let mut replaying = moraine_config::AppConfig::default();
+    replaying.ingest.exclude_project_dirs = vec!["/no/such/dir/**".to_string()];
+    let block_poll = |config: moraine_config::AppConfig| {
+        let work = work.clone();
+        let checkpoints = checkpoints.clone();
+        let poll_state = poll_state.clone();
+        let metrics = metrics.clone();
+        async move {
+            drive_opencode_block_poll(&config, &work, &checkpoints, &poll_state, &metrics).await
+        }
+    };
+
+    assert!(
+        block_poll(replaying.clone()).await,
+        "the replacement replay must block durably"
+    );
+    assert_eq!(
+        poll_state.consecutive_failed_scans(&cp_key),
+        1,
+        "entering the blocked state starts the ladder"
+    );
+
+    assert!(!block_poll(replaying.clone()).await, "throttled");
+
+    poll_state.age_for_tests(&cp_key, std::time::Duration::from_secs(16));
+    assert!(block_poll(replaying.clone()).await);
+    assert_eq!(
+        poll_state.consecutive_failed_scans(&cp_key),
+        2,
+        "a repeat block must extend the streak, not restart it — a `clear()` \
+         before `record_blocked_replay` pins it at 1"
+    );
+
+    poll_state.age_for_tests(&cp_key, std::time::Duration::from_secs(16));
+    assert!(
+        !block_poll(replaying).await,
+        "the second window is 30 s; a blocked replay must not re-read the whole \
+         event history every 15 s forever"
+    );
+
+    cleanup(&path);
+}
+
+/// Issue #601 §2.5/§3.2. The OpenCode half of the same rule: its `Failed` arm
+/// must classify a mixed-snapshot rejection as contention (no fault streak, so
+/// no 15-minute suppression of an actively written store) while still moving
+/// the clock that throttles a contended replay's durable barrier.
+///
+/// Fails for: calling `record_failed_scan` directly from the `Failed` arm, or
+/// dropping the classification entirely.
+#[tokio::test]
+async fn a_contended_opencode_scan_moves_the_contention_clock_not_the_fault_ladder() {
+    let path = unique_opencode_db_path("contention-classification");
+    let _db = seed_opencode_db(&path);
+    let work = opencode_sqlite_work(&path);
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let config = moraine_config::AppConfig::default();
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let poll_state = VolatilePollMap::new();
+    let metrics = Arc::new(Metrics::default());
+
+    crate::sqlite_poll::contention_injection::arm(&work.path, 1);
+    drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+    assert_eq!(
+        metrics
+            .sqlite_scan_failures_total
+            .load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "the armed scan must actually reach the mixed-snapshot arm"
+    );
+    assert_eq!(
+        poll_state.consecutive_failed_scans(&cp_key),
+        0,
+        "contention must not climb OpenCode's fault ladder"
+    );
+    assert_eq!(
+        poll_state.consecutive_contended_scans(&cp_key),
+        1,
+        "…but it must leave the clock that throttles the replay barrier"
+    );
+
+    crate::sqlite_poll::contention_injection::disarm(&work.path);
+    cleanup(&path);
+}
+
+/// Issue #601 §3.2/§6 — OpenCode's half of the call-site guard. The classifier
+/// test above proves the contention clock *moves*; this proves the clock does
+/// not reach ordinary polls.
+///
+/// §2.5's `|| !failure_retry_due` disjunct on the cheap short-circuit was
+/// outcome-redundant with `should_skip_poll` until §3.2 put the contention
+/// clock inside `failure_retry_due` and deliberately left it out of
+/// `should_skip_poll`. Adding it now would stop scanning an actively written
+/// OpenCode store for up to 60 s — the prompt-visibility regression the
+/// exemption exists to prevent, on a store that is contended precisely because
+/// a session is streaming parts into it.
+///
+/// The end-to-end delivery half of this rule is
+/// `an_ordinary_poll_of_a_contended_database_is_not_throttled` on the Cursor
+/// adapter; this one pins the throttle at OpenCode's own call site.
+///
+/// Fails for: adding `|| !poll_state.failure_retry_due(..)` to the cheap
+/// short-circuit (the second scan never runs), or moving the contention clock
+/// into `should_skip_poll`.
+#[tokio::test]
+async fn an_ordinary_poll_of_a_contended_opencode_store_is_not_throttled() {
+    let path = unique_opencode_db_path("contended-ordinary-poll");
+    let db = seed_opencode_db(&path);
+    let work = opencode_sqlite_work(&path);
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let config = moraine_config::AppConfig::default();
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let poll_state = VolatilePollMap::new();
+    let metrics = Arc::new(Metrics::default());
+
+    let cold =
+        drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+    assert!(!cold.is_empty(), "the cold poll emits the fixture");
+
+    // The session is live, so the next two scans lose the bracket to the
+    // writer. Each poll is preceded by a real write, as a contended store's
+    // would be.
+    crate::sqlite_poll::contention_injection::arm(&work.path, 2);
+    touch_opencode_store(&db, "cred_contended_one");
+    drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+    assert_eq!(poll_state.consecutive_contended_scans(&cp_key), 1);
+    assert_eq!(
+        poll_state.consecutive_failed_scans(&cp_key),
+        0,
+        "contention is not a fault (§3.2)"
+    );
+
+    // The very next tick, far inside the contention window the barrier is now
+    // serving, must still read the store.
+    touch_opencode_store(&db, "cred_contended_two");
+    drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+    assert_eq!(
+        poll_state.consecutive_contended_scans(&cp_key),
+        2,
+        "an ordinary poll of a contended OpenCode store must not be throttled — \
+         the second scan has to run at the ordinary poll cadence"
+    );
+    assert_eq!(
+        metrics
+            .sqlite_scan_failures_total
+            .load(std::sync::atomic::Ordering::Relaxed),
+        2,
+        "…and must reach the scan, not return before it"
+    );
+
+    crate::sqlite_poll::contention_injection::disarm(&work.path);
+    cleanup(&path);
+}
+
+/// Writes a row no event cursor can advance on, so the stat fingerprint moves
+/// without changing what a scan would emit.
+fn touch_opencode_store(db: &Connection, credential_id: &str) {
+    db.execute(
+        "INSERT INTO credential (id, value, time_created, time_updated) \
+         VALUES (?1, 'rotated', 1780000004000, 1780000004000)",
+        rusqlite::params![credential_id],
+    )
+    .expect("write non-event row");
 }
 
 async fn capture_begin_replay_checkpoint(
@@ -624,91 +926,26 @@ fn cleanup(path: &Path) {
     let _ = std::fs::remove_file(format!("{}-shm", path.to_string_lossy()));
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn opencode_sqlite_real_db_smoke_from_env() {
-    let Some(path) = std::env::var_os("MORAINE_OPENCODE_REAL_DB") else {
-        return;
-    };
-    let path = PathBuf::from(path);
-    let work = opencode_sqlite_work(&path);
-    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
-
-    let batches = run_opencode_poll(&work, &checkpoints).await;
-    let errors: Vec<Value> = batches
-        .iter()
-        .flat_map(|batch| batch.error_rows.iter().cloned())
-        .collect();
-    assert!(
-        errors.is_empty(),
-        "real OpenCode DB smoke errors: {errors:?}"
-    );
-
-    let raw_rows: Vec<Value> = batches
-        .iter()
-        .flat_map(|batch| batch.raw_rows.iter().cloned())
-        .collect();
-    assert!(
-        !raw_rows.is_empty(),
-        "real OpenCode DB smoke should emit synthetic raw rows"
-    );
-
-    let event_rows = all_event_rows(&batches);
-    assert!(
-        !event_rows.is_empty(),
-        "real OpenCode DB smoke should normalize at least one event row"
-    );
-    assert!(
-        event_rows
-            .iter()
-            .any(|row| row.get("harness").and_then(Value::as_str) == Some("opencode")),
-        "normalized rows should retain the opencode harness"
-    );
-
-    let checkpoint = batches
-        .last()
-        .and_then(|batch| batch.checkpoint.clone())
-        .expect("real OpenCode smoke checkpoint");
-    let cursor: Value = serde_json::from_str(&checkpoint.cursor_json).expect("cursor_json parses");
-    let expected_sequences = {
-        let connection = Connection::open(&path).expect("open real OpenCode smoke db");
-        let mut stmt = connection
-            .prepare("SELECT aggregate_id, seq FROM event_sequence ORDER BY aggregate_id")
-            .expect("prepare event_sequence query");
-        stmt.query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-        })
-        .expect("query event_sequence")
-        .collect::<std::result::Result<BTreeMap<_, _>, _>>()
-        .expect("read event_sequence")
-    };
-    let cursor_sequences = cursor
-        .get("aggregate_sequences")
-        .and_then(Value::as_object)
-        .expect("cursor has aggregate sequences")
-        .iter()
-        .map(|(key, value)| {
-            (
-                key.clone(),
-                value.as_i64().expect("aggregate sequence is an integer"),
-            )
-        })
-        .collect::<BTreeMap<_, _>>();
-    assert_eq!(
-        cursor_sequences, expected_sequences,
-        "real OpenCode smoke should scan each aggregate through event_sequence"
-    );
-    assert!(
-        cursor
-            .get("aggregate_sequences")
-            .and_then(Value::as_object)
-            .is_some_and(|seqs| !seqs.is_empty()),
-        "real OpenCode smoke should persist aggregate sequence cursors"
-    );
-    assert!(
-        cursor.get("session_contexts").is_none() && cursor.get("message_contexts").is_none(),
-        "real OpenCode smoke cursor should stay bounded"
-    );
-}
+// `opencode_sqlite_real_db_smoke_from_env` lived here and is **deleted**
+// (issue #601 §3.1 Change 6, open question 6).
+//
+// It opened with `let Some(path) = std::env::var_os("MORAINE_OPENCODE_REAL_DB")
+// else { return; };` and that variable appeared exactly once in the entire
+// repository — that read. Every one of its 83 lines was dead and the test had
+// always been green: the eighth instance of this epic's signature bug, a guard
+// that cannot fail. The plan is explicit that it must be resolved rather than
+// left, and gives two options: wire the variable into a live gate that fails
+// when unset, or delete it.
+//
+// Deleted, because the fixture-based gates cover the same ground more
+// precisely and without needing a real OpenCode database on the host:
+//
+// - per-aggregate watermark persistence → `opencode_sqlite_second_poll_is_a_noop`
+//   and `opencode_incremental_scan_currently_re_reads_the_whole_aggregate`;
+// - normalization and harness attribution → the first-poll row assertions below;
+// - the "cursor stays bounded" assertion it ended on → restated by §3.1 Change 4
+//   as a size budget, because WI-06 *requires* persisting reconstruction
+//   context and an absence check would directly contradict it.
 
 #[tokio::test(flavor = "multi_thread")]
 async fn opencode_sqlite_first_poll_emits_allowlisted_conversation_rows() {
@@ -1075,8 +1312,11 @@ fn opencode_sqlite_scan_paginates_past_single_event_page() {
         .expect("insert many-event sequence");
     drop(connection);
 
-    let outcome =
-        scan_opencode_database(path.to_str().expect("utf-8 path"), &OpenCodeState::fresh());
+    let outcome = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &OpenCodeState::fresh(),
+        &mut ScanLedger::default(),
+    );
     let (records, new_state, relevant_rows) = match outcome {
         OpenCodeScanOutcome::Scanned {
             records,
@@ -1142,8 +1382,11 @@ fn opencode_sqlite_project_dir_stays_on_first_absolute_session_directory() {
         .expect("advance event sequence");
     drop(connection);
 
-    let outcome =
-        scan_opencode_database(path.to_str().expect("utf-8 path"), &OpenCodeState::fresh());
+    let outcome = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &OpenCodeState::fresh(),
+        &mut ScanLedger::default(),
+    );
     let records = match outcome {
         OpenCodeScanOutcome::Scanned { records, .. } => records,
         OpenCodeScanOutcome::Failed {
@@ -1525,4 +1768,956 @@ fn opencode_long_string_sanitizer_preserves_text_and_elides_binary_like_payloads
         "binary-like payload should be elided, got {} bytes",
         sanitized.len()
     );
+}
+
+/// Issue #601 §1.2 / WI-01. The live `opencode.db` carries
+/// `event_aggregate_seq_idx` and `event_aggregate_type_seq_idx`; the fixture
+/// carried neither, so every scan these unit tests measured was a full table
+/// scan and any cost budget calibrated here would have been miscalibrated in
+/// both directions.
+///
+/// Asserting on the query plan rather than on `sqlite_master` alone is what
+/// makes this a guard: dropping either index from the fixture flips `SEARCH …
+/// USING INDEX` to `SCAN event` and fails here — the calibration mutation the
+/// plan's checklist names for G3. **Both** indexes are plan-asserted; asserting
+/// one by `EXPLAIN` and the other only by its presence in `sqlite_master` would
+/// leave the type-scoped read (§3.1 Change 3's bounded context rebuild)
+/// uncalibrated, which is what shipped first.
+///
+/// The paged statement comes from `OPENCODE_EVENT_PAGE_SQL`, the constant the
+/// adapter itself pages with — a copy here could drift from the query that
+/// actually runs and certify a plan nothing uses.
+///
+/// Note what §1 corrects about the second index: on the live database SQLite
+/// picks `event_aggregate_seq_idx` even for the type-scoped form, because the
+/// `IN` list is not a leading-column equality. So the type-scoped assertion
+/// below requires *an* index, not specifically the type-scoped one; what it
+/// rules out is the full table scan the fixture used to force. The second index
+/// is present because production has it, not because it is load-bearing here.
+/// Issue #601 §3.2/§6. `build_event_row` reads four columns OpenCode declares
+/// NOT NULL. The `ScanLedger` refactor routed all four through a helper that
+/// absorbed NULL into `""`, which for `id`/`aggregate_id` is not a lossy field
+/// but a **broken identity**: they are the material behind
+/// `source_line_no`/`source_offset` and therefore behind `event_uid` (§6), so
+/// two drifted rows would synthesize records that collide. `data` going empty
+/// additionally reports `data_bytes = 0`, under-charging the ledger every
+/// budget in §2.1 is denominated on.
+///
+/// Fails for: reading any of the four through a NULL-absorbing helper.
+#[test]
+fn a_null_in_a_required_event_column_fails_the_scan() {
+    // Positional, matching the `event` projection: id, aggregate_id, seq,
+    // type, data.
+    let baseline = ["'evt_1'", "'ses_demo'", "1", "'session.created.1'", "'{}'"];
+    let connection = Connection::open_in_memory().expect("in-memory probe database");
+    let read = |values: &[&str]| {
+        let sql = format!("SELECT {}", values.join(", "));
+        connection.query_row(&sql, [], |row| {
+            let mut ledger = ScanLedger::default();
+            Ok(build_event_row(row, &mut ledger).map(|_| ()))
+        })
+    };
+
+    read(&baseline)
+        .expect("probe query")
+        .expect("the baseline row must read cleanly");
+
+    for (index, name) in [(0, "id"), (1, "aggregate_id"), (3, "type"), (4, "data")] {
+        let mut values = baseline;
+        values[index] = "NULL";
+        let error = read(&values)
+            .expect("probe query")
+            .err()
+            .unwrap_or_else(|| panic!("a NULL {name} must fail the scan, not become \"\""));
+        assert!(
+            format!("{error:#}").contains("Invalid column type"),
+            "a NULL {name} must surface as a column-type error; got {error:#}"
+        );
+    }
+}
+
+#[test]
+fn opencode_fixture_uses_the_production_event_index() {
+    let path = unique_opencode_db_path("fixture-index");
+    let connection = create_opencode_db(&path);
+
+    let mut indexes: Vec<String> = {
+        let mut stmt = connection
+            .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'event'")
+            .expect("prepare index query");
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .expect("query indexes");
+        rows.map(|row| row.expect("index name")).collect()
+    };
+    indexes.sort();
+    assert!(
+        indexes.iter().any(|name| name == "event_aggregate_seq_idx"),
+        "fixture must carry the production event index; found {indexes:?}"
+    );
+    assert!(
+        indexes
+            .iter()
+            .any(|name| name == "event_aggregate_type_seq_idx"),
+        "fixture must carry the production type-scoped index; found {indexes:?}"
+    );
+
+    // The exact statement `scan_opencode_rows` pages with, taken from the
+    // adapter's own constant.
+    let plan: Vec<String> = {
+        let mut stmt = connection
+            .prepare(&format!(
+                "EXPLAIN QUERY PLAN {}",
+                super::OPENCODE_EVENT_PAGE_SQL
+            ))
+            .expect("prepare explain");
+        let rows = stmt
+            .query_map(rusqlite::params!["ses_demo", -1_i64, 1_i64, 8_i64], |row| {
+                row.get::<_, String>(3)
+            })
+            .expect("query plan");
+        rows.map(|row| row.expect("plan detail")).collect()
+    };
+    let detail = plan.join("; ");
+    assert!(
+        detail.contains("USING INDEX event_aggregate_seq_idx"),
+        "the paged event scan must use the production index, not a table scan; \
+         plan was: {detail}"
+    );
+    assert!(
+        !detail.contains("SCAN event"),
+        "the paged event scan must not degrade to a full table scan; plan was: {detail}"
+    );
+
+    // The type-scoped read §3.1 Change 3 introduces for the bounded context
+    // rebuild. Presence in `sqlite_master` says nothing about the plan, so this
+    // is exercised rather than assumed: the measurement that justifies the
+    // rebuild (95 rows / 47 KB / 0.51 ms versus 639 / 6.9 MB / 32.8 ms) is only
+    // meaningful against an index-driven plan.
+    let type_scoped_plan: Vec<String> = {
+        let mut stmt = connection
+            .prepare(
+                "EXPLAIN QUERY PLAN SELECT id, aggregate_id, seq, type, data FROM event \
+                 WHERE aggregate_id = ?1 \
+                 AND type IN ('session.created.1','session.updated.1','message.updated.1') \
+                 ORDER BY seq",
+            )
+            .expect("prepare type-scoped explain");
+        let rows = stmt
+            .query_map(rusqlite::params!["ses_demo"], |row| row.get::<_, String>(3))
+            .expect("type-scoped plan");
+        rows.map(|row| row.expect("plan detail")).collect()
+    };
+    let type_scoped = type_scoped_plan.join("; ");
+    assert!(
+        type_scoped.contains("USING INDEX event_aggregate_seq_idx")
+            || type_scoped.contains("USING INDEX event_aggregate_type_seq_idx"),
+        "the type-scoped context rebuild must be index-driven; plan was: {type_scoped}"
+    );
+    assert!(
+        !type_scoped.contains("SCAN event"),
+        "the type-scoped context rebuild must not degrade to a full table scan; \
+         plan was: {type_scoped}"
+    );
+
+    drop(connection);
+    cleanup(&path);
+}
+
+/// Issue #601 §2.0 / WI-01, OpenCode arm. Payload bytes are the exact lengths
+/// of what SQLite materialized *plus* what its aggregate preflight forced it to
+/// decode; the census axis carries schema validation and the narrow
+/// `event_sequence` read.
+///
+/// Both totals record duplication the ledger exists to expose, so neither is an
+/// arbitrary constant:
+///
+/// - `opencode_aggregate_sequences` runs **twice** per scan (preflight + page
+///   loop), so the census is `2 ×` the `event_sequence` read;
+/// - `opencode_relevant_stats`'s `sum(length(data))` decodes every `data` byte
+///   in the range before the page loop reads the same rows again, so a cold
+///   scan's payload bytes are the row bytes **plus a second full pass over
+///   `data`** — the ~2× §1.1 finding 2 predicts, made visible instead of
+///   "real and invisible".
+///
+/// Issue #601 §3.1 Change 5 removes both duplications; these assertions are
+/// what force that to be restated rather than silently drifting.
+#[test]
+fn opencode_ledger_charges_payload_bytes_at_the_read_site() {
+    let path = unique_opencode_db_path("ledger-read-site");
+    let connection = seed_opencode_db(&path);
+    let expected_bytes: i64 = connection
+        .query_row(
+            "SELECT coalesce(sum(length(CAST(e.id AS BLOB)) \
+             + length(CAST(e.aggregate_id AS BLOB)) \
+             + length(CAST(e.type AS BLOB)) \
+             + length(CAST(e.data AS BLOB))), 0) \
+             FROM event e JOIN event_sequence s ON s.aggregate_id = e.aggregate_id \
+             WHERE e.seq <= s.seq",
+            [],
+            |row| row.get(0),
+        )
+        .expect("sum event payload bytes");
+    let expected_rows: i64 = connection
+        .query_row(
+            "SELECT count(*) FROM event e JOIN event_sequence s \
+             ON s.aggregate_id = e.aggregate_id WHERE e.seq <= s.seq",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count read events");
+    let aggregate_id_bytes: i64 = connection
+        .query_row(
+            "SELECT coalesce(sum(length(CAST(aggregate_id AS BLOB))), 0) FROM event_sequence",
+            [],
+            |row| row.get(0),
+        )
+        .expect("sum aggregate id bytes");
+    let aggregates: i64 = connection
+        .query_row("SELECT count(*) FROM event_sequence", [], |row| row.get(0))
+        .expect("count aggregates");
+    // What the preflight aggregate decodes: `data` only, over the same range.
+    let preflight_data_bytes: i64 = connection
+        .query_row(
+            "SELECT coalesce(sum(length(CAST(coalesce(e.data, '') AS BLOB))), 0) \
+             FROM event e JOIN event_sequence s ON s.aggregate_id = e.aggregate_id \
+             WHERE e.seq <= s.seq",
+            [],
+            |row| row.get(0),
+        )
+        .expect("sum preflight decoded bytes");
+    drop(connection);
+
+    let mut ledger = ScanLedger::default();
+    let outcome = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &OpenCodeState::fresh(),
+        &mut ledger,
+    );
+    let records = match outcome {
+        OpenCodeScanOutcome::Scanned { records, .. } => records,
+        OpenCodeScanOutcome::Failed {
+            error_kind,
+            error_text,
+        } => panic!("ledger scan failed: {error_kind}: {error_text}"),
+    };
+
+    assert!(
+        expected_rows > 0 && expected_bytes > 0,
+        "fixture must have events"
+    );
+    assert!(preflight_data_bytes > 0);
+    assert_eq!(
+        ledger.payload_bytes,
+        (expected_bytes + preflight_data_bytes) as u64,
+        "payload bytes are the materialized column lengths plus the bytes the \
+         aggregate preflight forced SQLite to decode; charging only the former \
+         under-reports a cold scan by ~2×"
+    );
+    assert_eq!(ledger.payload_rows, expected_rows as u64);
+    assert_eq!(ledger.rows_emitted, records.len() as u64);
+    assert_ne!(
+        ledger.rows_emitted, ledger.payload_rows,
+        "[DIVERGENT FIXTURE] events read and records emitted must differ, or the \
+         two axes are interchangeable and neither is tested"
+    );
+    // Census = schema validation + the `event_sequence` read, and the latter
+    // runs **twice** per scan today (preflight + page loop). Issue #601 §3.1
+    // Change 5 folds it to one; this assertion is what forces that number to
+    // be restated rather than silently drifting.
+    let schema_census = {
+        let connection = crate::sqlite_poll::open_read_only(path.to_str().expect("utf-8 path"))
+            .expect("reopen for schema census");
+        crate::sqlite_poll::expected_schema_census(&connection, &["event", "event_sequence"])
+    };
+    assert!(schema_census.census_rows > 0);
+    assert_eq!(
+        ledger.census_rows,
+        schema_census.census_rows + 2 * aggregates as u64,
+    );
+    assert_eq!(
+        ledger.census_bytes,
+        schema_census.census_bytes + 2 * aggregate_id_bytes as u64
+    );
+
+    cleanup(&path);
+}
+
+/// Calibration baseline for gates G1b/G3 (issue #601 §3.1). Today
+/// `scan_opencode_rows` starts its page loop at `last_seq = -1`, so appending
+/// one event re-reads the aggregate's entire history — 639 events / 6.9 MB on
+/// the reference host to normalize one new event.
+///
+/// This test *records* that, so that WI-06's fix has a measured "before" and
+/// so nobody can claim the fix without this assertion changing. When the
+/// watermark start lands, the incremental scan's payload bytes must collapse
+/// to the appended event and this assertion must be inverted.
+#[test]
+fn opencode_incremental_scan_currently_re_reads_the_whole_aggregate() {
+    let path = unique_opencode_db_path("incremental-baseline");
+    let connection = seed_opencode_db(&path);
+
+    // The cold scan pays for `data` twice: once in the aggregate preflight and
+    // once in the page loop. Measure the preflight's share so the warm
+    // comparison below is denominated on the page loop alone.
+    let cold_preflight_data_bytes: i64 = connection
+        .query_row(
+            "SELECT coalesce(sum(length(CAST(coalesce(e.data, '') AS BLOB))), 0) \
+             FROM event e JOIN event_sequence s ON s.aggregate_id = e.aggregate_id \
+             WHERE e.seq <= s.seq",
+            [],
+            |row| row.get(0),
+        )
+        .expect("measure cold preflight bytes");
+
+    let mut ledger = ScanLedger::default();
+    let cold = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &OpenCodeState::fresh(),
+        &mut ledger,
+    );
+    let OpenCodeScanOutcome::Scanned { new_state, .. } = cold else {
+        panic!("cold scan should succeed");
+    };
+
+    let next_seq: i64 = connection
+        .query_row(
+            "SELECT seq + 1 FROM event_sequence WHERE aggregate_id = 'ses_demo'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read next sequence");
+    connection
+        .execute(
+            "INSERT INTO event (id, aggregate_id, seq, type, data) \
+             VALUES ('evt_baseline_append', 'ses_demo', ?1, 'session.updated.1', ?2)",
+            rusqlite::params![
+                next_seq,
+                serde_json::to_string(&json!({
+                    "info": {
+                        "id": "ses_demo",
+                        "directory": "/work/opencode-demo",
+                        "title": "OpenCode DB fixture",
+                        "time": {"created": 1780000000000_i64, "updated": 1780000009000_i64}
+                    }
+                }))
+                .unwrap()
+            ],
+        )
+        .expect("append one event");
+    connection
+        .execute(
+            "UPDATE event_sequence SET seq = ?1 WHERE aggregate_id = 'ses_demo'",
+            rusqlite::params![next_seq],
+        )
+        .expect("advance sequence");
+    let appended_bytes: i64 = connection
+        .query_row(
+            "SELECT length(CAST(id AS BLOB)) + length(CAST(aggregate_id AS BLOB)) \
+             + length(CAST(type AS BLOB)) + length(CAST(data AS BLOB)) \
+             FROM event WHERE id = 'evt_baseline_append'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("measure appended event");
+    // The preflight aggregate is denominated on `seq > prior_seq`, so on the
+    // warm scan it decodes only the appended event's `data` — while the page
+    // loop below still replays the whole aggregate. That asymmetry is §3.1
+    // Change 5's "the two axes must converge"; until they do, the warm total is
+    // the sum of both.
+    let appended_data_bytes: i64 = connection
+        .query_row(
+            "SELECT length(CAST(data AS BLOB)) FROM event WHERE id = 'evt_baseline_append'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("measure appended data");
+    drop(connection);
+
+    let mut incremental = ScanLedger::default();
+    let warm = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &new_state,
+        &mut incremental,
+    );
+    assert!(matches!(warm, OpenCodeScanOutcome::Scanned { .. }));
+
+    // Cold = preflight(all data) + page loop(all rows). Warm = preflight(the
+    // appended event's data only) + page loop(all rows + the appended row).
+    let cold_page_loop_bytes = ledger.payload_bytes - cold_preflight_data_bytes as u64;
+    assert_eq!(
+        incremental.payload_bytes,
+        appended_data_bytes as u64 + cold_page_loop_bytes + appended_bytes as u64,
+        "BASELINE, NOT A TARGET: one appended event currently costs the whole \
+         aggregate's history because the page loop starts at seq = -1. Issue \
+         #601 WI-06 must make this collapse to the appended event alone (G1b/G3); \
+         when it does, invert this assertion rather than deleting it."
+    );
+    assert!(
+        incremental.payload_bytes > 4 * appended_bytes as u64,
+        "the fixture must make the replay cost visibly dominate the append"
+    );
+
+    cleanup(&path);
+}
+
+fn census_rows(metrics: &Arc<Metrics>) -> u64 {
+    metrics
+        .sqlite_poll_census_rows_total
+        .load(std::sync::atomic::Ordering::Relaxed)
+}
+
+fn poll_payload_rows(metrics: &Arc<Metrics>) -> u64 {
+    metrics
+        .sqlite_poll_payload_rows_total
+        .load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Issue #601 §2.0. The ledger is caller-owned so that a scan which reads and
+/// then fails is still charged. Every OpenCode ledger test destructured
+/// `Scanned` and panicked otherwise, so the guarantee was unverified on every
+/// failure arm.
+///
+/// The ceiling arm is reached through `opencode_relevant_stats`, whose
+/// `sum(length(data))` has already made SQLite decode the whole range — so
+/// "the bytes this scan had already paid for" is a real, non-zero number even
+/// though the page loop never ran.
+///
+/// Fails for: resetting or rebuilding the ledger on a `scan_opencode_database`
+/// failure arm, or dropping the aggregate byte charge from the preflight.
+#[test]
+fn a_failed_opencode_scan_still_reports_the_bytes_it_had_already_read() {
+    let path = unique_opencode_db_path("failure-arm-ledger");
+    let connection = seed_opencode_db(&path);
+    let base_seq: i64 = connection
+        .query_row(
+            "SELECT seq FROM event_sequence WHERE aggregate_id = 'ses_demo'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read base sequence");
+
+    // One event past `MAX_OPENCODE_RELEVANT_ROWS`, so the preflight ceiling
+    // fires before the page loop reads anything.
+    let overflow = 10_001i64;
+    connection
+        .execute_batch("BEGIN")
+        .expect("begin bulk insert");
+    {
+        let mut stmt = connection
+            .prepare(
+                "INSERT INTO event (id, aggregate_id, seq, type, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            )
+            .expect("prepare bulk insert");
+        for idx in 0..overflow {
+            stmt.execute(rusqlite::params![
+                format!("evt_ceiling_{idx:06}"),
+                "ses_demo",
+                base_seq + 1 + idx,
+                "message.part.updated.1",
+                r#"{"id":"prt_ceiling","messageID":"msg_demo","sessionID":"ses_demo"}"#,
+            ])
+            .expect("insert ceiling event");
+        }
+    }
+    connection
+        .execute(
+            "UPDATE event_sequence SET seq = ?1 WHERE aggregate_id = 'ses_demo'",
+            rusqlite::params![base_seq + overflow],
+        )
+        .expect("advance sequence");
+    connection.execute_batch("COMMIT").expect("commit");
+    drop(connection);
+
+    let mut ledger = ScanLedger::default();
+    let outcome = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &OpenCodeState::fresh(),
+        &mut ledger,
+    );
+    let OpenCodeScanOutcome::Failed { error_kind, .. } = outcome else {
+        panic!("crossing the relevant-row ceiling must fail the scan");
+    };
+    assert_eq!(error_kind, crate::sqlite_poll::ERROR_KIND_TOO_LARGE);
+    assert!(
+        ledger.payload_bytes > 0,
+        "the preflight had already decoded the whole range; a failure arm that \
+         reports zero bytes contradicts the ledger's headline guarantee"
+    );
+    assert!(
+        ledger.census_rows > 0,
+        "and schema validation plus the event_sequence census are charged too"
+    );
+
+    cleanup(&path);
+}
+
+/// Issue #601 §2.0. `record_scan_ledger` folds every poll's ledger into the
+/// host-global counters, and until now nothing read those counters — no-opping
+/// all four call sites left the suite green, which is the exact
+/// unfailable-counter pattern this issue exists to remove.
+///
+/// **[DIVERGENT FIXTURE]** the third poll is arranged so the *rewind preflight*
+/// runs and the scan does not: the durable cursor's stat is stale (so the
+/// preflight is due) while the volatile entry covers the current stat (so
+/// `should_skip_poll` returns before the scan). That isolates
+/// `process_opencode_sqlite_db`'s preflight `record_scan_ledger` — the one call
+/// site a payload-only counter could never observe.
+///
+/// Fails for: no-opping either `record_scan_ledger` call site in the OpenCode
+/// adapter, or folding only the payload axis into `Metrics`.
+#[tokio::test(flavor = "multi_thread")]
+async fn opencode_poll_charges_its_ledger_to_the_shared_metrics() {
+    let path = unique_opencode_db_path("metrics-wiring");
+    let connection = seed_opencode_db(&path);
+    let work = opencode_sqlite_work(&path);
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let poll_state = VolatilePollMap::new();
+    let metrics = Arc::new(Metrics::default());
+    let config = moraine_config::AppConfig::default();
+
+    let first =
+        drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+    assert!(!first.is_empty(), "the cold poll must emit");
+    assert!(
+        poll_payload_rows(&metrics) > 0,
+        "the scan's ledger must reach the shared counters"
+    );
+    assert!(census_rows(&metrics) > 0);
+
+    // Move the stat without changing any event, so the durable cursor is stale
+    // and the rewind preflight becomes due on the next poll.
+    connection
+        .execute(
+            "INSERT INTO credential (id, value, time_created, time_updated) \
+             VALUES ('cred_churn', 'x', 1, 1)",
+            [],
+        )
+        .expect("irrelevant write");
+    drop(connection);
+
+    let generation = checkpoints
+        .read()
+        .await
+        .get(&cp_key)
+        .map(|cp| cp.source_generation)
+        .expect("committed checkpoint");
+    let current_stat =
+        crate::sqlite_poll::stat_fingerprint(&work.path).expect("fixture stat fingerprint");
+    poll_state.record_noop_scan(&cp_key, generation, current_stat);
+
+    let payload_before = poll_payload_rows(&metrics);
+    let census_before = census_rows(&metrics);
+    let third =
+        drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+    assert!(third.is_empty(), "the volatile entry must skip the scan");
+    assert_eq!(
+        poll_payload_rows(&metrics),
+        payload_before,
+        "the scan really was skipped, so nothing charged the payload axis"
+    );
+    assert!(
+        census_rows(&metrics) > census_before,
+        "but the rewind preflight still ran and still owes its census; a poll \
+         that reads must never be invisible to the counters"
+    );
+
+    cleanup(&path);
+}
+
+/// Issue #601 §2.1(2) / §2.5. The failure backoff has to gate the **whole
+/// poll**, not just the barrier and the scan behind it.
+///
+/// The rewind preflight opens the database and walks `event_sequence`, and it
+/// used to run *ahead* of the blocked-replay throttle — so a durably blocked
+/// OpenCode database still paid for a read, and still charged metrics, on every
+/// tick while the barrier and the scan were correctly suppressed. Cheap today,
+/// but "gate the barrier, not just the scan" has to apply to the whole poll or
+/// the next read added ahead of the throttle inherits the same hole.
+///
+/// **[DIVERGENT FIXTURE]** the durable cursor's stat is stale, so the preflight
+/// is genuinely due; without that the preflight would not run either way and
+/// the two behaviours would coincide.
+///
+/// Fails for: moving the throttle back below the preflight.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_throttled_blocked_replay_does_not_run_the_rewind_preflight() {
+    let path = unique_opencode_db_path("throttled-preflight");
+    let connection = seed_opencode_db(&path);
+    let work = opencode_sqlite_work(&path);
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let poll_state = VolatilePollMap::new();
+    let metrics = Arc::new(Metrics::default());
+    let config = moraine_config::AppConfig::default();
+
+    drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+
+    // Move the stat without touching any event, so the preflight is due.
+    connection
+        .execute(
+            "INSERT INTO credential (id, value, time_created, time_updated) \
+             VALUES ('cred_churn', 'x', 1, 1)",
+            [],
+        )
+        .expect("irrelevant write");
+    drop(connection);
+
+    // Durably block the source and start its failure backoff, exactly as a
+    // failed replacement replay would.
+    let generation = {
+        let mut map = checkpoints.write().await;
+        let checkpoint = map.get_mut(&cp_key).expect("committed checkpoint");
+        checkpoint.status = "error".to_string();
+        checkpoint.block_reason = "seeded blocked replay".to_string();
+        checkpoint.final_scan_complete = false;
+        checkpoint.source_generation
+    };
+    poll_state.record_failed_scan(&cp_key, generation);
+    assert!(
+        !poll_state.failure_retry_due(&cp_key, generation),
+        "the fixture must actually be inside the backoff window, or this guard \
+         cannot fail"
+    );
+
+    let census_before = census_rows(&metrics);
+    let payload_before = poll_payload_rows(&metrics);
+    let batches =
+        drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+    assert!(batches.is_empty(), "a throttled poll sends nothing");
+    assert_eq!(
+        poll_payload_rows(&metrics),
+        payload_before,
+        "the scan is throttled"
+    );
+    assert_eq!(
+        census_rows(&metrics),
+        census_before,
+        "and so is the preflight — a throttled poll must not open the database \
+         at all"
+    );
+
+    cleanup(&path);
+}
+
+/// Drives one poll against a durably blocked OpenCode source that is inside its
+/// failure-backoff window, and returns the checkpoint afterwards.
+///
+/// `mutate` seeds the blocked state and may adjust the checkpoint further (a
+/// replaced inode, say). The volatile entry is put into the backoff window
+/// *after* it runs, and the fixture asserts the window is real, so a test built
+/// on this cannot pass by accident.
+async fn poll_a_throttled_blocked_replay(
+    config: &moraine_config::AppConfig,
+    work: &WorkItem,
+    checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
+    mutate: impl FnOnce(&mut Checkpoint),
+) -> Checkpoint {
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let poll_state = VolatilePollMap::new();
+    let metrics = Arc::new(Metrics::default());
+    let cold_config = moraine_config::AppConfig::default();
+
+    drive_opencode_poll_with_metrics(&cold_config, work, checkpoints, &poll_state, &metrics).await;
+
+    let generation = {
+        let mut map = checkpoints.write().await;
+        let checkpoint = map
+            .get_mut(&cp_key)
+            .expect("the cold poll commits a checkpoint");
+        checkpoint.status = "error".to_string();
+        checkpoint.block_reason = "seeded blocked replay".to_string();
+        checkpoint.final_scan_complete = false;
+        mutate(checkpoint);
+        checkpoint.source_generation
+    };
+    poll_state.record_failed_scan(&cp_key, generation);
+    assert!(
+        !poll_state.failure_retry_due(&cp_key, generation),
+        "the fixture must actually be inside the backoff window, or these \
+         guards cannot fail"
+    );
+
+    drive_opencode_poll_with_metrics(config, work, checkpoints, &poll_state, &metrics).await;
+
+    checkpoints
+        .read()
+        .await
+        .get(&cp_key)
+        .cloned()
+        .expect("the checkpoint survives the retry")
+}
+
+/// Issue #601 §2.1(2)/§2.5 — the **width** of OpenCode's blocked-replay
+/// throttle gate, first conjunct.
+///
+/// This gate is not the redundant one it looks like. The Cursor and NAC gates
+/// carry `&& !starts_replacement` *below* the generation bump, so
+/// `failure_retry_due` is asked about a generation the volatile entry has never
+/// seen and returns `true` whatever the conjunct says — dropping it there is an
+/// equivalent mutant. OpenCode's gate has to sit **above** the bump, because
+/// the bump depends on `sequence_rewound` and that is what the rewind preflight
+/// this gate exists to suppress computes. So `checkpoint.source_generation` is
+/// still the old value here and `failure_retry_due` genuinely returns `false`.
+///
+/// Consequence of dropping `&& !generation_changed`: an OpenCode store that was
+/// durably blocked and is then **replaced** — a new inode, so every logical
+/// identity and every event UID starts over — is ignored for up to
+/// `FAILURE_BACKOFF_MAX` (15 minutes) instead of replaying on the next tick.
+///
+/// **[DIVERGENT FIXTURE]** the volatile entry is genuinely inside the backoff
+/// window (asserted), so the gate's last conjunct is true and the first is the
+/// only thing holding the poll open.
+///
+/// Fails for: dropping `&& !generation_changed` from the throttle gate.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_replaced_opencode_database_bypasses_the_blocked_replay_throttle() {
+    let path = unique_opencode_db_path("replaced-under-throttle");
+    let _db = seed_opencode_db(&path);
+    let work = opencode_sqlite_work(&path);
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let config = moraine_config::AppConfig::default();
+
+    let mut generation_before = 0;
+    let after = poll_a_throttled_blocked_replay(&config, &work, &checkpoints, |checkpoint| {
+        generation_before = checkpoint.source_generation;
+        // The database was replaced under the block. Recording a different
+        // inode is what a replacement looks like to the poll, and is
+        // deterministic where deleting and recreating the file is not.
+        checkpoint.source_inode = checkpoint.source_inode.wrapping_add(1);
+    })
+    .await;
+
+    assert_eq!(
+        after.source_generation,
+        generation_before + 1,
+        "a replaced database is a new logical identity and must start its \
+         generation at once, not after a 15-minute backoff"
+    );
+    assert_eq!(after.status, "active");
+    assert!(after.final_scan_complete);
+    assert!(after.block_reason.is_empty());
+
+    cleanup(&path);
+}
+
+/// Issue #601 §2.1(2)/§2.5 — the same gate's **second** conjunct.
+///
+/// Consequence of dropping `&& !exclusions_changed`: an operator who widens or
+/// narrows `exclude_project_dirs` to unblock a source waits out the failure
+/// backoff before the policy takes effect, up to 15 minutes after the config
+/// change. The width argument is the same as its sibling above — this gate runs
+/// above the generation bump, so the fall-through conjunct cannot cover it.
+///
+/// Fails for: dropping `&& !exclusions_changed` from the throttle gate.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_exclusion_change_bypasses_the_opencode_blocked_replay_throttle() {
+    let path = unique_opencode_db_path("exclusions-under-throttle");
+    let _db = seed_opencode_db(&path);
+    let work = opencode_sqlite_work(&path);
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+
+    // The cold poll inside the helper runs under the default policy; the
+    // throttled retry runs under a changed one.
+    let mut changed = moraine_config::AppConfig::default();
+    changed.ingest.exclude_project_dirs = vec!["/no/such/dir/**".to_string()];
+
+    let mut generation_before = 0;
+    let after = poll_a_throttled_blocked_replay(&changed, &work, &checkpoints, |checkpoint| {
+        generation_before = checkpoint.source_generation;
+    })
+    .await;
+
+    assert_eq!(
+        after.source_generation,
+        generation_before + 1,
+        "a changed exclusion policy replays immediately; rows skipped under \
+         the prior policy must not wait out a failure backoff"
+    );
+    assert_eq!(after.status, "active");
+    assert!(after.final_scan_complete);
+    assert!(after.block_reason.is_empty());
+
+    cleanup(&path);
+}
+
+/// Issue #601 §2.1(2) — OpenCode's half of "a durable `BeginReplay` barrier is
+/// never sent with no scan behind it". The Cursor site is pinned by
+/// `blocked_replay_scans_behind_its_barrier`; the identical guard at OpenCode
+/// was not, and dropping `!replacement_replay` there was green.
+///
+/// `should_skip_poll` runs *after* the barrier, and a blocked-replay retry
+/// reuses its generation, so a volatile entry covering the current stat skips
+/// the scan while the barrier has already been persisted — the source stays in
+/// `replaying` forever, one barrier per tick.
+///
+/// **[DIVERGENT FIXTURE]** the volatile entry must genuinely cover the current
+/// stat; with an uncovered stat the skip never triggers and the two behaviours
+/// coincide.
+///
+/// Fails for: dropping the `!replacement_replay` guard on the
+/// `should_skip_poll` call.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_opencode_blocked_replay_scans_behind_its_barrier() {
+    let path = unique_opencode_db_path("blocked-replay-scan");
+    let _db = seed_opencode_db(&path);
+    let work = opencode_sqlite_work(&path);
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let config = moraine_config::AppConfig::default();
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let poll_state = VolatilePollMap::new();
+    let metrics = Arc::new(Metrics::default());
+
+    drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+
+    let generation = {
+        let mut map = checkpoints.write().await;
+        let checkpoint = map
+            .get_mut(&cp_key)
+            .expect("the cold poll commits a checkpoint");
+        checkpoint.status = "error".to_string();
+        checkpoint.block_reason = "seeded blocked replay".to_string();
+        checkpoint.final_scan_complete = false;
+        checkpoint.source_generation
+    };
+
+    // And make the volatile entry claim the current stat as covered, which is
+    // the only state in which the post-barrier skip can fire.
+    let current_stat = stat_fingerprint(&work.path).expect("fixture stat");
+    poll_state.record_noop_scan(&cp_key, generation, current_stat);
+    assert!(
+        poll_state.should_skip_poll(&cp_key, generation, &current_stat),
+        "the fixture must actually reach the skip condition, or this guard \
+         cannot fail"
+    );
+
+    drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+
+    let after = checkpoints
+        .read()
+        .await
+        .get(&cp_key)
+        .cloned()
+        .expect("the checkpoint survives the retry");
+    assert_eq!(
+        after.status, "active",
+        "a blocked replay retry must run its scan and finalize, not send a \
+         barrier and skip"
+    );
+    assert!(after.final_scan_complete);
+    assert!(after.block_reason.is_empty());
+
+    cleanup(&path);
+}
+
+/// Issue #601 §2.5 — the other direction on the same call. Cursor's
+/// `failed_scan_backs_off_instead_of_rescanning_every_tick` fails when the
+/// `should_skip_poll` call is removed outright; OpenCode had no equivalent, so
+/// disabling its call was green and the §2.5 defect could come straight back
+/// on this adapter alone.
+///
+/// Denominated on an **observed scan count**, never on absence of
+/// `ingest_errors` rows: those are rate-limited by `state.last_error`, so
+/// `opencode_sqlite_schema_mismatch_emits_one_error_and_preserves_cursor` stays
+/// green no matter how many scans ran.
+///
+/// Fails for: removing the `should_skip_poll` call, or reverting
+/// `record_failed_scan` to its `get_mut`-only form (a first failing scan has no
+/// prior entry to modify).
+#[tokio::test(flavor = "multi_thread")]
+async fn a_failed_opencode_scan_backs_off_instead_of_rescanning_every_tick() {
+    let path = unique_opencode_db_path("failure-backoff-first-scan");
+    let db = Connection::open(&path).expect("create db");
+    db.execute_batch(
+        "CREATE TABLE session (id TEXT PRIMARY KEY);
+         CREATE TABLE message (id TEXT PRIMARY KEY);
+         CREATE TABLE part (id TEXT PRIMARY KEY);
+         CREATE TABLE session_message (id TEXT PRIMARY KEY);",
+    )
+    .expect("create incomplete opencode schema");
+    drop(db);
+
+    let work = opencode_sqlite_work(&path);
+    let config = moraine_config::AppConfig::default();
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let poll_state = VolatilePollMap::new();
+    let metrics = Arc::new(Metrics::default());
+
+    for _ in 0..10 {
+        drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+    }
+
+    let failures = metrics
+        .sqlite_scan_failures_total
+        .load(std::sync::atomic::Ordering::Relaxed);
+    assert!(
+        failures >= 1,
+        "the first tick must actually attempt the scan"
+    );
+    assert!(
+        failures <= 2,
+        "10 ticks against an OpenCode database whose first scan fails must not \
+         run 10 scans; observed {failures}"
+    );
+
+    cleanup(&path);
+}
+
+/// Issue #601 §2.1(2) — OpenCode's half of the `retry_blocked_replay` narrowing
+/// width. See the Cursor twin
+/// `a_crash_interrupted_replay_resumes_from_its_replaying_status` for the
+/// argument; here the predicate additionally feeds the blocked-replay throttle
+/// gate, so its width is load-bearing for code this PR adds.
+///
+/// **[DIVERGENT FIXTURE]** the stat is unchanged since the cold poll, which is
+/// what a crashed replay looks like and what makes the two behaviours diverge:
+/// with the disjunct the cursor is reset and the scan runs, without it the
+/// unchanged stat and `event_scan_complete` return early.
+///
+/// Fails for: dropping the `checkpoint.status == "replaying"` disjunct.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_crash_interrupted_opencode_replay_resumes_from_its_replaying_status() {
+    let path = unique_opencode_db_path("replaying-status-resume");
+    let _db = seed_opencode_db(&path);
+    let work = opencode_sqlite_work(&path);
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let config = moraine_config::AppConfig::default();
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let poll_state = VolatilePollMap::new();
+    let metrics = Arc::new(Metrics::default());
+
+    drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+
+    // Exactly what a crash between `BeginReplay` and `FinalizeReplay` leaves:
+    // `replaying`, no error, no block reason.
+    {
+        let mut map = checkpoints.write().await;
+        let checkpoint = map
+            .get_mut(&cp_key)
+            .expect("the cold poll commits a checkpoint");
+        checkpoint.status = "replaying".to_string();
+        checkpoint.block_reason.clear();
+        checkpoint.final_scan_complete = false;
+    }
+
+    drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+
+    let after = checkpoints
+        .read()
+        .await
+        .get(&cp_key)
+        .cloned()
+        .expect("the checkpoint survives the retry");
+    assert_eq!(
+        after.status, "active",
+        "an interrupted replay must resume and finish, not be relabelled"
+    );
+    assert!(
+        after.final_scan_complete,
+        "a resumed replay finalizes; without the `replaying` disjunct the poll \
+         returns on the unchanged stat and the source is stuck"
+    );
+
+    cleanup(&path);
 }

--- a/crates/moraine-ingest-core/src/tee.rs
+++ b/crates/moraine-ingest-core/src/tee.rs
@@ -17,7 +17,7 @@ use crate::model::{Checkpoint, RowBatch};
 use crate::publication_identity::PublicationIdentity;
 use crate::redaction::{RedactionAudit, SecretRedactor};
 use crate::sink::{spawn_sink_task, SinkAuthorConfig, SinkRole};
-use crate::watch::enumerate_tracked_files;
+use crate::watch::enumerate_startup_work_items;
 use crate::{Metrics, SinkMessage, WorkItem};
 use moraine_clickhouse::{enforce_remote_schema_policy, ClickHouseClient};
 use moraine_config::{AppConfig, ClickHouseConfig, IngestSource, DEFAULT_BACKEND_NAME};
@@ -611,7 +611,10 @@ async fn discover_startup_backend_targets(context: &TeeRouterContext) -> BTreeSe
 
     let metrics = Arc::new(Metrics::default());
     for source in context.sources.iter() {
-        let files = match enumerate_tracked_files(&source.glob, source.format) {
+        // A one-shot backend-discovery probe. Never reconciliation: it must
+        // not pay sweep cost, which is why the stamp comes from
+        // `enumerate_startup_work_items` rather than a local literal.
+        let files = match enumerate_startup_work_items(source) {
             Ok(files) => files,
             Err(exc) => {
                 warn!(
@@ -622,8 +625,8 @@ async fn discover_startup_backend_targets(context: &TeeRouterContext) -> BTreeSe
             }
         };
 
-        for path in files {
-            match discover_file_backend_targets(context, source, path, metrics.clone()).await {
+        for work in files {
+            match discover_file_backend_targets(context, &work, metrics.clone()).await {
                 Ok(file_targets) => targets.extend(file_targets),
                 Err(exc) => warn!(
                     source = %source.name,
@@ -637,23 +640,15 @@ async fn discover_startup_backend_targets(context: &TeeRouterContext) -> BTreeSe
 
 async fn discover_file_backend_targets(
     context: &TeeRouterContext,
-    source: &IngestSource,
-    path: String,
+    work: &WorkItem,
     metrics: Arc<Metrics>,
 ) -> Result<BTreeSet<String>, anyhow::Error> {
     let checkpoints = Arc::new(RwLock::new(HashMap::<String, Checkpoint>::new()));
     let poll_state = crate::sqlite_poll::VolatilePollMap::new();
     let (tx, mut rx) = mpsc::channel::<SinkMessage>(16);
-    let work = WorkItem {
-        source_name: source.name.clone(),
-        harness: source.harness.clone(),
-        format: source.format,
-        source_glob: source.glob.clone(),
-        path,
-    };
     let process = process_file(
         &context.config,
-        &work,
+        work,
         checkpoints,
         &poll_state,
         tx,
@@ -1007,7 +1002,9 @@ async fn run_replay_pass(
         }
     }
     for source in sources {
-        let files = match enumerate_tracked_files(&source.glob, source.format) {
+        // One-shot catch-up polls, so `Startup` — same single-literal rule as
+        // the discovery probe above.
+        let files = match enumerate_startup_work_items(source) {
             Ok(files) => files,
             Err(exc) => {
                 pass_complete = false;
@@ -1026,7 +1023,7 @@ async fn run_replay_pass(
         // host-filtered), so teammates' files on a shared backend never
         // trip this warning.
         {
-            let enumerated: HashSet<&str> = files.iter().map(String::as_str).collect();
+            let enumerated: HashSet<&str> = files.iter().map(|work| work.path.as_str()).collect();
             let map = floor.read().await;
             for cp in map.values() {
                 if cp.source_name == source.name && !enumerated.contains(cp.source_file.as_str()) {
@@ -1047,14 +1044,7 @@ async fn run_replay_pass(
         // Replay reads against this backend's own floor, not the live
         // pipeline's, so it gets a fresh volatile map: every file scans.
         let poll_state = crate::sqlite_poll::VolatilePollMap::new();
-        for path in files {
-            let work = WorkItem {
-                source_name: source.name.clone(),
-                harness: source.harness.clone(),
-                format: source.format,
-                source_glob: source.glob.clone(),
-                path,
-            };
+        for work in files {
             let key = crate::checkpoint::checkpoint_key(&work.source_name, &work.path);
             let placeholder = floor.read().await.get(&key).cloned().unwrap_or_else(|| {
                 let source_inode = std::fs::metadata(&work.path)

--- a/crates/moraine-ingest-core/src/watch.rs
+++ b/crates/moraine-ingest-core/src/watch.rs
@@ -177,6 +177,34 @@ fn tracked_path_identity(format: SourceFormat, path: &str) -> String {
         .unwrap_or_else(|_| path.to_string())
 }
 
+/// Queues one poll per tracked path a watcher event touched.
+///
+/// This is the path **100 % of real filesystem events take**; `queue_rescan`
+/// only covers watcher *recovery*. Both funnel through `WorkItem::watcher`, so
+/// the crate holds exactly one `WorkTrigger::Watcher` literal and
+/// `watcher_work_items_are_stamped_as_watcher_triggered` guards both paths.
+/// Extracting this out of the receive loop is what makes the primary path
+/// reachable from a test at all — inline in the loop it could only be exercised
+/// through a live `notify` backend.
+fn queue_watcher_event(
+    event: &Event,
+    glob_pattern: &str,
+    source_name: &str,
+    harness: &str,
+    format: SourceFormat,
+    tx: &mpsc::UnboundedSender<WorkItem>,
+) {
+    for path in event_tracked_paths(event, format, glob_pattern) {
+        let _ = tx.send(WorkItem::watcher(
+            source_name,
+            harness,
+            format,
+            glob_pattern,
+            path,
+        ));
+    }
+}
+
 fn queue_rescan(
     glob_pattern: &str,
     source_name: &str,
@@ -189,13 +217,14 @@ fn queue_rescan(
     match enumerate_tracked_files(glob_pattern, format) {
         Ok(paths) => {
             for path in paths {
-                let _ = tx.send(WorkItem {
-                    source_name: source_name.to_string(),
-                    harness: harness.to_string(),
+                // A rescan is watcher-driven recovery, not reconciliation.
+                let _ = tx.send(WorkItem::watcher(
+                    source_name,
+                    harness,
                     format,
-                    source_glob: glob_pattern.to_string(),
+                    glob_pattern,
                     path,
-                });
+                ));
             }
         }
         Err(exc) => {
@@ -352,15 +381,14 @@ pub(crate) fn spawn_watcher_threads(
                             continue;
                         }
 
-                        for path in event_tracked_paths(&event, format, &glob_pattern) {
-                            let _ = tx_clone.send(WorkItem {
-                                source_name: source_name.clone(),
-                                harness: harness.clone(),
-                                format,
-                                source_glob: glob_pattern.clone(),
-                                path,
-                            });
-                        }
+                        queue_watcher_event(
+                            &event,
+                            &glob_pattern,
+                            &source_name,
+                            &harness,
+                            format,
+                            &tx_clone,
+                        );
                     }
                     Ok(Err(exc)) => {
                         eprintln!("[moraine-rust] watcher event error ({source_name}): {exc}");
@@ -413,10 +441,43 @@ pub(crate) fn enumerate_tracked_files(
     Ok(files)
 }
 
+/// Enumerate a source's tracked files as one-shot **startup** polls.
+///
+/// This is the crate's only path from an `IngestSource` to a
+/// `WorkTrigger::Startup` item, and all three producers go through it: the
+/// startup backfill in `run_ingestor`, the tee router's backend-discovery
+/// probe, and the tee router's targeted replay pass. Each of those used to
+/// enumerate and then stamp inline, which left the *stamp* guarded and the
+/// *choice of stamp* unguarded: `startup_work_items_are_stamped_as_startup_triggered`
+/// pinned `WorkItem::startup` itself, so all three call sites could be
+/// repointed at `WorkItem::watcher` with the whole suite green. That matters
+/// most at the backfill site, where the item reaches `enqueue_work` and a
+/// `Watcher` stamp is exactly what `arm_owed_reconcile`'s `Startup` refusal
+/// (plan §7.1 D1c) exists to prevent — a startup poll made sweep-eligible by an
+/// owed reconcile tick.
+///
+/// Same rule, and the same reason, as `queue_watcher_event`: fold the
+/// enumeration and the stamp into one function so the crate holds one literal
+/// per trigger and one test can hold it.
+pub(crate) fn enumerate_startup_work_items(source: &IngestSource) -> Result<Vec<WorkItem>> {
+    Ok(enumerate_tracked_files(&source.glob, source.format)?
+        .into_iter()
+        .map(|path| {
+            WorkItem::startup(
+                &source.name,
+                &source.harness,
+                source.format,
+                &source.glob,
+                path,
+            )
+        })
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Metrics;
+    use crate::{Metrics, WorkTrigger};
     use notify::{
         event::{CreateKind, DataChange, Flag, ModifyKind, RenameMode},
         EventKind,
@@ -424,6 +485,129 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::atomic::Ordering;
     use tokio::sync::mpsc;
+
+    /// Issue #601 §2.4 / WI-03. A reconciliation sweep must never attach to a
+    /// watcher-driven poll, so **both** watcher entry points have to stamp
+    /// `Watcher`:
+    ///
+    /// - `queue_watcher_event` — the per-event fan-out that 100 % of real
+    ///   filesystem events take;
+    /// - `queue_rescan` — watcher *recovery* only (registration failure, event
+    ///   error, or a backend rescan flag).
+    ///
+    /// The earlier version of this test covered the recovery path alone, so
+    /// the stamp on the primary path was unguarded and could be flipped to
+    /// `Reconcile` with the whole suite still green. Both now funnel through
+    /// `WorkItem::watcher`.
+    ///
+    /// Fails for: stamping either path with anything but `Watcher`.
+    #[test]
+    fn watcher_work_items_are_stamped_as_watcher_triggered() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock before unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("moraine-watch-trigger-{nonce}"));
+        std::fs::create_dir_all(&dir).expect("create watcher fixture dir");
+        let file = dir.join("session.jsonl");
+        std::fs::write(&file, b"{}\n").expect("write watcher fixture file");
+        let glob_pattern = dir.join("*.jsonl").to_string_lossy().to_string();
+
+        // The primary path: a data-change event naming the tracked file, the
+        // exact shape `spawn_watcher_threads` forwards on every write.
+        let (tx, mut rx) = mpsc::unbounded_channel::<WorkItem>();
+        let event =
+            Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Any))).add_path(file.clone());
+        assert!(
+            event_is_relevant(&event.kind) && !event_requires_rescan(&event),
+            "the fixture event must reach the per-event fan-out, or this guard \
+             cannot fail"
+        );
+        queue_watcher_event(
+            &event,
+            &glob_pattern,
+            "watch-trigger-test",
+            "codex",
+            SourceFormat::Jsonl,
+            &tx,
+        );
+        let queued = rx
+            .try_recv()
+            .expect("a watcher event must enqueue the tracked file");
+        assert_eq!(queued.trigger, WorkTrigger::Watcher);
+        assert_eq!(queued.path, file.to_string_lossy());
+        assert!(rx.try_recv().is_err(), "one event, one queued poll");
+
+        // The recovery path.
+        let (tx, mut rx) = mpsc::unbounded_channel::<WorkItem>();
+        queue_rescan(
+            &glob_pattern,
+            "watch-trigger-test",
+            "codex",
+            SourceFormat::Jsonl,
+            &tx,
+            &Arc::new(Metrics::default()),
+        );
+
+        let queued = rx.try_recv().expect("rescan must enqueue the tracked file");
+        assert_eq!(queued.trigger, WorkTrigger::Watcher);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Issue #601 §2.4 / WI-03. The startup backfill, the tee router's
+    /// backend-discovery probe and its replay pass all queue one-shot polls
+    /// that must not pay sweep cost — `Startup` is documented as never
+    /// sweep-eligible and nothing enforced that.
+    ///
+    /// An earlier revision of this test asserted on `WorkItem::startup`
+    /// directly, which pins the **constructor** and not which constructor each
+    /// site calls: all three sites were swappable to `WorkItem::watcher` with
+    /// the whole suite green. It now drives `enumerate_startup_work_items`,
+    /// which is the single path from a source to a startup item and the only
+    /// thing those three sites call.
+    ///
+    /// Fails for: stamping anything but `Startup` in
+    /// `enumerate_startup_work_items` — and therefore at every site that
+    /// enumerates through it.
+    #[test]
+    fn startup_work_items_are_stamped_as_startup_triggered() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock before unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("moraine-startup-trigger-{nonce}"));
+        std::fs::create_dir_all(&dir).expect("create startup fixture dir");
+        std::fs::write(dir.join("first.jsonl"), b"{}\n").expect("write first fixture file");
+        std::fs::write(dir.join("second.jsonl"), b"{}\n").expect("write second fixture file");
+        let glob_pattern = dir.join("*.jsonl").to_string_lossy().to_string();
+
+        let source = IngestSource {
+            name: "startup-trigger-test".to_string(),
+            harness: "codex".to_string(),
+            enabled: true,
+            glob: glob_pattern.clone(),
+            watch_root: dir.to_string_lossy().to_string(),
+            format: SourceFormat::Jsonl,
+        };
+        let items = enumerate_startup_work_items(&source).expect("enumerate startup work items");
+
+        assert_eq!(items.len(), 2, "both fixture files must be enumerated");
+        for work in &items {
+            assert_eq!(work.trigger, WorkTrigger::Startup);
+            assert_eq!(work.source_name, "startup-trigger-test");
+            assert_eq!(work.source_glob, glob_pattern);
+            // And it is still not sweep-eligible after coalescing with a
+            // reconcile tick, which is the property the trigger exists to
+            // carry.
+            assert_eq!(
+                work.trigger.merge(WorkTrigger::Reconcile),
+                WorkTrigger::Startup
+            );
+        }
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 
     #[test]
     fn rescan_events_require_reconcile() {


### PR DESCRIPTION
# feat(601): measure SQLite scans, back off failures, stamp poll triggers

Work items **WI-01, WI-02 and WI-03** of #601, per `plans/601-delta-sqlite.md`. Nothing in this PR
changes what gets ingested; it changes what a poll *costs*, what happens when one fails, and whether
the dispatcher can tell why a poll was scheduled. The later work items (sweep budget, ceiling
degradation, per-adapter watermarks) are all denominated against the seam this lands, so it goes
first.

## What changed and why

### WI-01 — a measurement seam that cannot be fudged (`ScanLedger`)

The three SQLite-backed adapters re-read whole databases on every poll and there was no honest way
to say how much that costs. `ScanLedger` charges rows and bytes **at the point the data leaves
SQLite**, split on two axes:

* **census** — a row-materializing read whose projection *excludes* the adapter's payload columns
  (the cheap change-detection read).
* **payload** — a row-materializing read whose projection *includes* one.

Bytes are what SQLite handed to Rust, never the size of what was emitted: a row that is read and
discarded still costs its bytes. Scalar aggregates materialize no row, so they charge no rows — but
an aggregate over a payload column still forces SQLite to decode every byte of it (§1.1 measured
`length()` on a TEXT-affine column at 48.5 ms / 48 MB), so those bytes are charged. Without that
rule a cold OpenCode scan under-reports by roughly 2× and the ledger could be used to argue an
aggregate preflight is free. It is not.

There is exactly one place a SQL-side `length()` supplies a byte figure, and it is that aggregate:
OpenCode's `opencode_relevant_stats` preflight, where `sum(length(...))` *is* the count of bytes
SQLite decoded to answer the statement, so it is also exactly what the payload axis owes. Its SQL
changes here from `length(coalesce(data, ''))` to `length(CAST(coalesce(data, '') AS BLOB))`,
which is a **production behaviour change**: bare `length()` over a TEXT value counts characters, and
the result is compared against byte ceilings and charged to a byte axis. The in-scan check
(`build_event_row`) has always measured real bytes, so on any non-ASCII payload the preflight and
the loop disagreed, and the ceiling comparison moved with the encoding. The rationale is at the
statement.

The ledger is **caller-owned**, so a scan that reads 48 MB and then loses the mixed-snapshot race is
still charged for what it read. **Five** counters land on `Metrics` and WI-09 must surface all five:
`sqlite_poll_{payload,census}_{rows,bytes}_total`, plus `sqlite_scan_failures_total`. The fifth is a
different observable class — a count of completed scans that ended in failure, not a volume — and it
exists because it is the only honest denominator for the failure-backoff gate: `ingest_errors` rows
are rate-limited by `state.last_error`, so a test that counts them cannot count scans. Nine tests
denominate on it, across all three adapters.

The OpenCode test fixture now creates the two indexes the production database has. Without them the
fixture forced a full `SCAN event` where production does an indexed seek, so every plan-shaped gate
measured against it was measuring the wrong plan.

### WI-02 — failed scans back off; contended scans do not

`record_failed_scan` now **creates** the volatile entry when it is absent. The `get_mut`-only version
did nothing for a database whose first scan failed, or whose failure followed any emitting scan
(which clears the entry) — so the most common failure shapes had no backoff at all and re-ran a
complete failed scan on every reconcile tick and every 50 ms-debounced watcher event, indefinitely.
Failures now climb `min(15 s * 2^(n-1), 15 min)`; the ceiling is what makes recovery from an
environmental fault (a lock, a permission) never require a restart.

It makes a **second** behaviour change worth calling out: the entry it writes carries
`stat: None`, and the modify path clears any stat already there. A failure covered nothing, so
claiming coverage would suppress rescans of an unchanged file *permanently* rather than for the
backoff window. The visible consequence is the opposite of the first change's direction — a rescan
after a failure is no longer suppressed by the no-op arm on an unchanged file, it is suppressed by
the backoff window and then allowed through. That is deliberate: an environmental fault that clears
without touching the file must be noticed.

Relatedly, the blocked-replay path no longer clears the volatile entry before recording a failure.
At HEAD that path is a bare `poll_state.clear(&cp_key)`, so no streak survived it at all; an early
revision of this branch reintroduced the same effect by pairing `clear()` with `record_failed_scan()`,
where the following `or_insert` restarted the streak at 1 on every retry and pinned the path at the
15 s floor. Both are now gone. It matters because the trigger — a record failing `normalize_record`
during a replacement replay — is deterministic and recurs on every attempt.

**Mixed-snapshot rejections are exempt from the fault ladder and only from that.** A rejection means
the database was written while the scan read it. That is contention, not a fault, and it happens
precisely when the source is active — which is when prompt visibility matters most. Routing it into
a 15-minute ladder would regress active-session freshness, and the mitigation the spec pairs with
that ("smaller scans make retries rare") is WI-07/WI-08 and does not exist yet. So contention gets
its own `min(15 s * 2^(n-1), 60 s)` clock, and the two clocks are read in **different places**:

| | fault ladder | contention clock |
|---|---|---|
| `should_skip_poll` (ordinary scans) | yes | **no** |
| `failure_retry_due` (durable replay barrier) | yes | yes |

That asymmetry is the whole design. Exempting contention from the *barrier* throttle as well was a
live defect: a replacement replay's `Failed` arm emits a durable `BlockReplay` plus an append-only
`ingest_errors` row, and with no clock behind it that repeats on every poll for as long as the writer
is active — on the longest, coldest scan an adapter runs, which is the one most likely to lose the
bracket in the first place.

The `data_version`/stat bracket that triggers all of this is now a single function,
`snapshot_is_mixed`, rather than three identical inline copies. §3.2 requires the expression be
preserved exactly, which makes three copies a liability: they can drift and nothing would notice.
The expression is unchanged token for token.

### WI-03 — the dispatcher knows why a poll was scheduled

`WorkTrigger` (`Startup` / `Watcher` / `Reconcile`) is stamped at the three producers and threaded
through the watcher, the debounce window, the reconcile task and `complete_work`'s dirty re-enqueue.
WI-04's sweep eligibility reads it. Every *producer* of a trigger goes through one function, so the
crate holds one stamping literal per trigger — `WorkItem::watcher` for both watcher paths,
`watch::enumerate_startup_work_items` for the startup backfill and the tee router's two one-shot
passes, and the reconcile task's own literal — because a stamp with a second literal is a stamp no
test covers. (`arm_owed_reconcile` also writes `Reconcile`, but it *upgrades* an existing item
rather than producing one, and has its own guards.)

Two §2.4 rules are in tension — the debounce must merge to `Watcher` (latency wins), and the dirty
re-enqueue must never upgrade a trigger — and obeying both literally makes the §4 complete-sweep
interval **unbounded** on a continuously written database: essentially every reconcile tick merges
away and no later poll can carry it. The implementation keeps a `reconcile_owed` debt ledger: a
swallowed tick is owed forward and honoured by the next poll that has not started yet. The narrower
invariant preserved is *no item already handed to a poll is upgraded*. `arm_owed_reconcile` also
refuses to upgrade a `Startup` item — `WorkTrigger::merge` deliberately ranks `Startup` above
`Reconcile` because startup is the worst moment to add a broad scan — and leaves the debt standing
rather than spending it, since declining to carry a tick is not paying it.

The ledger **coalesces**, and the declaration doc now says so instead of claiming otherwise. It is a
`HashSet`, so several reconcile ticks landing on a key that stays queued throughout collapse into one
debt. That is the right trade — a sweep slice covers everything accumulated since the previous one,
so a debt is a flag and not an amount of work, and N flags would buy N identical sweeps of a key that
needed one — and it is now pinned deliberately rather than left as a property of the type
(`reconcile_ticks_landing_on_one_queued_poll_coalesce`).

## Operational impact

* **No config keys, no migrations, no schema changes, no API changes.** `sql/` is untouched.
* **Behaviour changes are all in the direction of less work.** A database whose scans fail now backs
  off instead of rescanning on every tick; a blocked replacement replay stops re-emitting its
  barrier and its `ingest_errors` row on every tick. Expect fewer `ingest_errors` rows and fewer
  checkpoint writes from a host with a broken or permission-denied database.
* **Freshness is unchanged for healthy and for busy databases.** The fault ladder never gates a
  database that is scanning cleanly, and the contention clock deliberately never reaches
  `should_skip_poll`, so an actively written database is still polled at the ordinary cadence. A
  permanently broken one still retries every 15 minutes without a restart. A replaced database, or
  one whose exclusion policy just changed, bypasses the backoff entirely and replays on the next
  tick.
* **Five new `Metrics` counters**: `sqlite_poll_{payload,census}_{rows,bytes}_total` and
  `sqlite_scan_failures_total`. They are process-internal on this branch; WI-09 puts them on the
  status surface — all five, including the failure counter, which is a different observable class
  from the four volume counters.
* **One production SQL change**: OpenCode's preflight aggregate moves from `length(...)` to
  `length(CAST(... AS BLOB))`, i.e. from a character count to a byte count. It shifts a ceiling
  comparison on non-ASCII payloads, in the direction that makes the preflight agree with the in-scan
  measurement.
* **Test-surface change**: the OpenCode fixture now carries production indexes (test-only), and
  `opencode_sqlite_real_db_smoke_from_env` (85 lines) is **deleted**. Its `MORAINE_OPENCODE_REAL_DB`
  environment variable appeared exactly once in the whole repository — its own read — so every line
  of it was dead and it had always been green. §3.1 Change 6 requires it be resolved rather than
  left; an in-code tombstone at the deletion site names the three fixture gates that inherit each
  piece of its coverage.

## Validation

Run on this branch, in this worktree, after the round-8 edits and after rebasing onto
`origin/epic/canonical-first-refactor` (`6e3795b`):

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets --locked -- -D warnings` | clean — exit 0, 10 crates re-checked, 0 warnings |
| `cargo test --workspace --locked` | **1466 passed, 0 failed, 22 ignored** |
| `cargo test -p moraine-ingest-core --lib --locked` | **335 passed, 0 failed** |

The clippy run was forced (every `.rs` under `apps/` and `crates/` touched first) so the result is
against the current tree and not a cached fingerprint. Both tests previously flagged as pre-existing
flakes (`managed_clickhouse::tests::termination_force_kills_child_that_ignores_sigterm`,
`…::high_volume_child_output_rotates_while_child_remains_live`) passed on this run.

**Sandbox QA did not run, and it should before this reaches `main`.** This branch changes production
ingest behaviour — a failure/contention backoff that gates whole polls, a blocked-replay throttle that
sits above OpenCode's generation bump, and a production SQL change from `length(...)` to
`length(CAST(... AS BLOB))` — so `CLAUDE.md`'s guidance is that it is validated in a dev sandbox rather
than on unit tests alone. The Docker daemon on the authoring host became unresponsive and did not
recover, so the gate could not be run. Unit coverage is thorough (335 tests in `moraine-ingest-core`,
every new predicate mutation-pinned) but it cannot show that the stack still ingests end to end.
Reviewer or a later run should execute `scripts/dev/sandbox/moraine-sandbox up` against this branch and
confirm ingest reaches ClickHouse under a real poll cycle.

Also not run: WI-11's dedicated ingest gate arms, which do not exist yet — `run-live-test` hard-wires
`cargo test -p moraine-conversations --test live_clickhouse` for all of its modes, and adding an ingest
arm is WI-11's own work item.

### Mutation ledger

A predicate needs three bounds: it fires when it must, it does not fire when it must not, and its
**extent** is exactly right — widening or narrowing by one token must break a named test. Mutations
are applied to an isolated copy of the tree (never the worktree), each with a verified recompile and
a content-plus-mtime restore, and the copy is `diff -r`'d against the worktree afterwards.

Round 7 — sixty-two mutations applied, thirty-eight RED, summarized:

| Mutation | Named test that fails |
|---|---|
| `record_scan_failure_outcome` widened by `\|\| == ERROR_KIND_SCAN` / `_OPEN` / `_TOO_LARGE`, or to `!= ERROR_KIND_SCHEMA` | `each_error_kind_routes_to_exactly_one_backoff_clock` |
| …narrowed so nothing reaches the contention clock | the six adapter contention tests |
| `snapshot_is_mixed` drops the `data_version` disjunct, the stat disjunct, both, or the injection hook | `the_mixed_snapshot_bracket_fires_on_a_moved_data_version_and_on_a_moved_stat` (+ contention tests for the hook) |
| …widened to fire unconditionally | 40 tests |
| The `snapshot_is_mixed` call disabled in Cursor / NAC / OpenCode | that adapter's contention tests |
| `CONTENTION_BACKOFF_MAX` → `FAILURE_BACKOFF_MAX`, → the base, doubling removed, `.min(31)` dropped, base 15 s → 30 s | `contention_backoff_doubles_from_the_base_and_saturates_at_a_minute` |
| `incoming_trigger == Reconcile` → `!= Startup` | `one_reconcile_tick_buys_exactly_one_reconcile_eligible_poll` |
| `incoming_trigger == Reconcile` → `!= Watcher` | `a_startup_poll_landing_on_a_queued_poll_owes_nothing` |

Round 8 widened the sweep from 62 mutations to 182, which found **eleven unpinned extents on lines
this PR introduces** — plus one property (`reconcile_owed`'s coalescing) the declaration doc denied
having. All eleven are now pinned by nine new tests. Nine of the mutations below are evidenced by the saved post-rebase ledger; the coalescing mutation was
verified RED with the named test as the **only** failure:

| Mutation | Named test that fails |
|---|---|
| Drop `&& !generation_changed` from OpenCode's blocked-replay throttle gate | `a_replaced_opencode_database_bypasses_the_blocked_replay_throttle` |
| Drop `&& !exclusions_changed` from the same gate | `an_exclusion_change_bypasses_the_opencode_blocked_replay_throttle` |
| Drop `!replacement_replay &&` from OpenCode's `should_skip_poll` call | `an_opencode_blocked_replay_scans_behind_its_barrier` |
| Remove OpenCode's `should_skip_poll` call outright | `a_failed_opencode_scan_backs_off_instead_of_rescanning_every_tick` |
| `enumerate_startup_work_items` stamps `Watcher` (covers all three startup sites at once) | `startup_work_items_are_stamped_as_startup_triggered` |
| Delete `entry.consecutive_contended_scans = 0` from `record_noop_scan` | `a_clean_scan_resets_the_contention_ladder_not_only_its_clock` |
| Drop the `status == "replaying"` disjunct from `retry_blocked_replay`, per adapter | `a_crash_interrupted_replay_resumes_from_its_replaying_status` / `…_nac_…` / `…_opencode_…` |
| `reconcile_owed: HashSet<String>` → a per-key count | `reconcile_ticks_landing_on_one_queued_poll_coalesce` |

Both tables are in `plans/601-delta-sqlite.md` so later work items inherit them.

Two nearby mutations are **equivalent** and are explicitly *not* claimed as pinned:
`entry.last_contended_at = None` in `record_noop_scan` (redundant given the streak reset beside it —
`contention_backoff(0)` is `Duration::ZERO`, so a zeroed streak answers `true` through the `Some`
arm exactly as `None` does), and `&& !starts_replacement` on the **Cursor and NAC** throttle gates.
The latter is worth being precise about because it looks like the same conjunct as OpenCode's two:
those two gates sit *below* the generation bump, so `failure_retry_due` is asked about a generation
the volatile entry has never seen and answers `true` whatever the conjunct says. OpenCode's gate has
to sit *above* the bump — the bump depends on the rewind preflight this gate exists to suppress — so
there the same conjuncts are load-bearing, which is why they got tests and their twins did not.

## What this PR does *not* prove

Stated plainly because eight rounds of review were spent finding claims that were not backed:

* **The mixed-snapshot bracket has no end-to-end coverage through a real mid-scan commit, and cannot
  get one deterministically.** The scan runs inside a single function call and the `#[cfg(test)]`
  `forced_mixed_snapshot` hook is its only seam — a seam that short-circuits both real disjuncts. So
  every adapter contention test reaches the rejection arm without ever evaluating the guard that
  fires in production. Racing a concurrent writer would reach it but only probabilistically, and
  could not attribute the rejection to a disjunct. The disjuncts are therefore bounded separately at
  the unit level, and the call sites by the adapters' contention tests. This is written on
  `snapshot_is_mixed` itself and recorded as deviation D4 in the plan; WI-10 should not restate it as
  end-to-end coverage.
* **`enqueue_work`'s `carried = should_send` under-owes if its invariant breaks**, where the dead
  conjunct it replaced would have over-owed. Over-owing is bounded and self-correcting (one extra
  reconcile-eligible poll); under-owing silently drops a tick, which is the §0/§4 coverage failure
  the whole D1a analysis exists to prevent. The invariant is stated as a `debug_assert!` and stays
  one deliberately: a hard `assert!` there panics with the dispatch mutex held, poisoning it and
  killing every subsequent poll for every source — a total ingest outage traded for a one-tick
  coverage loss. The invariant is structural, so anything that could break it is a code change, and
  code changes run the suite in debug. The reasoning is at the assertion.
* **The width holes on code this PR does not touch are recorded, not fixed** (plan §7.2, each with
  its mutation evidence and its owning work item). The round-8 superset sweep left 69 survivors;
  eleven were on new lines and are fixed above, and the rest are these:
  * **F1 — `scan_is_noop` has no discriminating test at all.** Every conjunct at every adapter is
    droppable-green (8/8 Cursor, 7/7 NAC, 7/7 OpenCode). Fifteen of the 22 are mutually implied;
    **seven across three files are genuinely load-bearing** — `new_state == prior_state_covered` at
    all three, `schema_fingerprint` at all three, `relevant_keys` at Cursor. The case to name is a
    **key deletion**: it moves the adapter state while emitting no record, so every other conjunct
    reads "no-op" and only the structural comparison notices, and dropping it suppresses the
    checkpoint that would have recorded the deletion. WI-08 owns it.
  * **F2 — `retry_blocked_replay`'s error arm is three sites wide**, and widening it to the bare
    `status == "error"` is green at all three (WI-04). The *narrowing* direction of the same
    predicate is fixed here rather than recorded, because it feeds the throttle gates this PR adds
    and is not covered by the surviving disjunct.
  * **F3 — thirty-three survivors across the poll path with one root cause**: the ceilings, intervals and
    short-circuits are pinned by tests denominated on what a poll *emitted*, and none of those
    quantities changes what a healthy poll emits. `SCAN_PAGE_SIZE`, `SCAN_PAGE_MAX_BYTES` and
    `MAX_RELEVANT_KEYS` are each scalable in **both** directions with the suite green, as is
    `NOOP_RESCAN_MIN_INTERVAL`; NAC's extra short-circuit conjuncts and Cursor's
    `last_error.is_empty()` are individually droppable. The guard they need is a **ledger**
    assertion, which is what WI-01's seam is for. The one thing already pinned here holds: the §3.2
    G1d documented hazard is guarded at both NAC and Cursor — it is the conjuncts around it that are
    free.
  * **F4 — the startup stamp is pinned at the enumerator, not at the three sites that call it.**
    Re-introducing a local constructor at a call site is still green. It is no longer a one-token
    edit, and it is unobservable today (the tee sites hand the item straight to `process_file`,
    which ignores the trigger, and `Watcher` is no more sweep-eligible than `Startup`); WI-04 is
    what gives it a cost.

## Review history

This went through eight review rounds before being proposed for merge, and it is worth being blunt
that most of them found a defect rather than polish. The `record_failed_scan` no-backoff bug, the
`clear()`-before-record latch, a `reconcile_owed` prune whose every reachable firing destroyed a live
reconcile tick, a second debt creator in the debounce window that no production path could reach and
only its own test exercised, and the §2.5 short-circuit disjunct that became outcome-changing the
moment the contention clock existed — all of those were found by review, not by the suite, and each
is now pinned by a test that fails when it is reintroduced. The plan's §7.1 records each as a
disclosed deviation rather than letting a narrowed doc comment make the code look compliant.

The last three rounds were about a different failure mode: guards that were bounded from beneath and
above but whose **extent** was free. Round 6 mirrored the fault ladder's lower and upper bounds onto
the new contention ladder but not its width test, so the contention ceiling could be set to exactly
the fifteen minutes its own doc comment forbids with the suite green. Round 7's width sweep found
that, the failure classifier open at two of its four neighbours (including `sqlite_scan_error`, which
eleven of the seventeen production failure sites emit — routing it to the contention clock silently
restores the exact defect WI-02 exists to remove), and the mixed-snapshot bracket with no coverage in
any of the three adapters.

Round 8 widened the sweep from 62 mutations to 182 on the assumption that a sweep sized to the
guards you already wrote can only confirm them. It found eleven unpinned extents — eight on lines this PR introduces, three on pre-existing `retry_blocked_replay` text that this PR newly makes load-bearing — on lines this PR
introduces — including two conjuncts whose own comment declared them "the only ones that may bypass
the throttle", a guard present at Cursor and absent at OpenCode, and a `WorkTrigger::startup` stamp
whose test pinned the constructor rather than which constructor each of three sites called. It also
found that `reconcile_owed`'s declaration doc claimed a property the type does not have. Everything
in that list is fixed; everything found on code this PR does not touch is in §7.2 with its evidence
and its owner.

Closes nothing on its own. Refs #601.
