### PR TITLE
feat(603): classify storage ownership and gate reclamation

### DIFF
--- a/apps/moraine-mcp/src/rpc.rs
+++ b/apps/moraine-mcp/src/rpc.rs
@@ -119,6 +119,9 @@ fn repository_config(cfg: &AppConfig, session_scope: Option<SessionOriginScope>)
         bm25_default_min_should_match: cfg.bm25.default_min_should_match,
         bm25_max_query_terms: cfg.bm25.max_query_terms,
         session_scope,
+        // Issue #603 WI-03: carry the effective policy so `/api/v1/health`
+        // reports what the operator configured, not the built-in default.
+        retention: cfg.retention,
     }
 }
 

--- a/apps/moraine/src/cli.rs
+++ b/apps/moraine/src/cli.rs
@@ -156,6 +156,57 @@ pub(crate) enum DbCommand {
     Doctor,
     /// Inspect and operate the canonical read indexes (issue #598).
     CoreIndex(CoreIndexArgs),
+    /// Inspect storage ownership and plan physical reclamation (issue #603).
+    Reclaim(ReclaimArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ReclaimArgs {
+    #[command(subcommand)]
+    pub(crate) command: ReclaimCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ReclaimCommand {
+    /// Print per-bucket storage, disk headroom, the effective retention
+    /// policy, and the reclaim ledger. Never destructive.
+    Status(ReclaimStatusArgs),
+    /// Dry run: the claim set and row/byte ESTIMATES for each scope. Writes
+    /// nothing.
+    Plan(ReclaimPlanArgs),
+    /// Claim and execute a bounded reclaim. Refuses without --confirm, and
+    /// refuses a scope that deletes user history unless the matching
+    /// `[retention]` key is configured.
+    Run(ReclaimRunArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ReclaimStatusArgs {
+    #[arg(long)]
+    pub(crate) json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ReclaimPlanArgs {
+    /// Limit the dry run to one scope (`mcp_open_orphan`,
+    /// `read_index_generation`, `canonical_generation`). Omit for all.
+    #[arg(long)]
+    pub(crate) scope: Option<String>,
+    #[arg(long)]
+    pub(crate) json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ReclaimRunArgs {
+    /// The scope to reclaim. Required: there is deliberately no "everything".
+    #[arg(long)]
+    pub(crate) scope: String,
+    /// Acknowledge the deletion. Without it the command prints exactly what
+    /// would be deleted and exits non-zero.
+    #[arg(long)]
+    pub(crate) confirm: bool,
+    #[arg(long)]
+    pub(crate) json: bool,
 }
 
 #[derive(Debug, Args)]
@@ -356,6 +407,69 @@ mod tests {
                     }),
             }) => assert!(args.force),
             _ => panic!("expected forced core-index promote command"),
+        }
+    }
+
+    #[test]
+    fn clap_parses_reclaim_subcommands() {
+        let status = Cli::parse_from(["moraine", "db", "reclaim", "status"]);
+        match status.command {
+            CliCommand::Db(DbArgs {
+                command:
+                    DbCommand::Reclaim(ReclaimArgs {
+                        command: ReclaimCommand::Status(args),
+                    }),
+            }) => assert!(!args.json),
+            _ => panic!("expected reclaim status command"),
+        }
+
+        let plan = Cli::parse_from([
+            "moraine",
+            "db",
+            "reclaim",
+            "plan",
+            "--scope",
+            "mcp_open_orphan",
+            "--json",
+        ]);
+        match plan.command {
+            CliCommand::Db(DbArgs {
+                command:
+                    DbCommand::Reclaim(ReclaimArgs {
+                        command: ReclaimCommand::Plan(args),
+                    }),
+            }) => {
+                assert_eq!(args.scope.as_deref(), Some("mcp_open_orphan"));
+                assert!(args.json);
+            }
+            _ => panic!("expected reclaim plan command"),
+        }
+
+        // `run` must not be invocable without a scope: there is deliberately
+        // no "reclaim everything".
+        assert!(Cli::try_parse_from(["moraine", "db", "reclaim", "run"]).is_err());
+
+        // And --confirm defaults off, so the ceremony cannot be skipped by
+        // omission.
+        let run = Cli::parse_from([
+            "moraine",
+            "db",
+            "reclaim",
+            "run",
+            "--scope",
+            "canonical_generation",
+        ]);
+        match run.command {
+            CliCommand::Db(DbArgs {
+                command:
+                    DbCommand::Reclaim(ReclaimArgs {
+                        command: ReclaimCommand::Run(args),
+                    }),
+            }) => {
+                assert_eq!(args.scope, "canonical_generation");
+                assert!(!args.confirm);
+            }
+            _ => panic!("expected reclaim run command"),
         }
     }
 

--- a/apps/moraine/src/commands.rs
+++ b/apps/moraine/src/commands.rs
@@ -8,9 +8,10 @@ mod up;
 
 use anyhow::{bail, Context, Result};
 use moraine_clickhouse::{
-    ClickHouseClient, CoreIndexAuditOutcome, CoreIndexBackfillProgress, DoctorReport,
+    reclaim, ClickHouseClient, CoreIndexAuditOutcome, CoreIndexBackfillProgress, DoctorReport,
     MigrationProgress, OpenV2PromotionOutcome, PublicationDiagnostics, QueryClass, QueryEnvelope,
-    ReadIndexState, OPEN_V2_PROVENANCE_OPERATOR_PROMOTE, STATE_KEY_CORE_INDEXES, STATE_KEY_OPEN_V2,
+    ReadIndexState, ReclaimPlan, ReclaimScope, ReclaimStatusReport, StorageReport,
+    OPEN_V2_PROVENANCE_OPERATOR_PROMOTE, STATE_KEY_CORE_INDEXES, STATE_KEY_OPEN_V2,
 };
 use moraine_config::{
     AppConfig, OpenReaderMode, OpenReaderResolution, QueryBudgetsConfig, ValidatedQueryBudgets,
@@ -22,7 +23,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::cli::{
     Cli, CliCommand, ClickhouseCommand, ConfigCommand, CoreIndexCommand, DbCommand, ExportCommand,
-    OutputFormat, RunArgs, SchemaCommand,
+    OutputFormat, ReclaimCommand, RunArgs, SchemaCommand,
 };
 use crate::managed_clickhouse::{
     cmd_clickhouse_install, cmd_clickhouse_status, cmd_clickhouse_uninstall,
@@ -32,7 +33,8 @@ use crate::paths::{load_cfg, runtime_paths};
 use crate::process::{require_service_binary, service_args_with_defaults};
 use crate::render::{
     render_clickhouse_status, render_core_index_status, render_db_doctor, render_db_migrate,
-    render_logs, state_label, CliOutput, CoreIndexReport, MigrationOutcome,
+    render_logs, render_reclaim_plan, render_reclaim_refusal, render_reclaim_status, state_label,
+    CliOutput, CoreIndexReport, MigrationOutcome,
 };
 use crate::service::Service;
 
@@ -89,13 +91,23 @@ pub(crate) async fn dispatch(cli: Cli, output: CliOutput) -> Result<ExitCode> {
                 DbCommand::Doctor => {
                     let report = cmd_db_doctor(&cfg).await?;
                     let core_index = gather_core_index_report(&cfg).await;
-                    render_db_doctor(&output, &report, &core_index)?;
+                    let storage = gather_storage_report(&cfg).await;
+                    render_db_doctor(&output, &report, &core_index, storage.as_ref())?;
                     if doctor_is_healthy(&report) {
                         Ok(ExitCode::SUCCESS)
                     } else {
                         Ok(ExitCode::from(1))
                     }
                 }
+                DbCommand::Reclaim(args) => match args.command {
+                    ReclaimCommand::Status(status) => {
+                        let report = gather_reclaim_status(&cfg).await;
+                        render_reclaim_status(&output, &report, status.json)?;
+                        Ok(ExitCode::SUCCESS)
+                    }
+                    ReclaimCommand::Plan(plan) => cmd_db_reclaim_plan(&cfg, &output, plan).await,
+                    ReclaimCommand::Run(run) => cmd_db_reclaim_run(&cfg, &output, run).await,
+                },
                 DbCommand::CoreIndex(args) => match args.command {
                     CoreIndexCommand::Status => {
                         let report = gather_core_index_report(&cfg).await;
@@ -452,6 +464,145 @@ pub(super) async fn gather_core_index_report(cfg: &AppConfig) -> CoreIndexReport
     }
 }
 
+/// Best-effort gather of the issue #603 storage/reclaim surface for operator
+/// display (`status`, `db doctor`, `db reclaim status`).
+///
+/// Never fails: an unreachable ClickHouse yields `available: false` with the
+/// error attached, so the surrounding command still renders. Storage state is
+/// transient and must not fail the doctor exit code — the same contract
+/// `gather_core_index_report` established.
+pub(super) async fn gather_reclaim_status(cfg: &AppConfig) -> ReclaimStatusReport {
+    let Ok(ch) = ClickHouseClient::new(cfg.clickhouse.clone()) else {
+        return unavailable_reclaim_status("ClickHouse client could not be constructed");
+    };
+    let budgets = query_budgets(cfg);
+    ch.reclaim_status(&cfg.retention, &budgets.background, &budgets.administrative)
+        .await
+}
+
+fn unavailable_reclaim_status(message: &str) -> ReclaimStatusReport {
+    ReclaimStatusReport {
+        available: false,
+        storage: None,
+        ledger: Default::default(),
+        reclaimable: Vec::new(),
+        registered_executors: reclaim::registered_executors(),
+        denomination: reclaim::estimated_bytes_note(),
+        error: Some(message.to_string()),
+    }
+}
+
+/// The storage half of the reclaim status, for the `status` panel and the
+/// doctor block. `None` when the backend is unreachable.
+pub(super) async fn gather_storage_report(cfg: &AppConfig) -> Option<StorageReport> {
+    gather_reclaim_status(cfg).await.storage
+}
+
+/// Resolve a `--scope` argument, listing the valid values on a typo rather
+/// than falling back to "all" — silently widening a destructive command's
+/// scope is the one failure this parser must not have.
+fn parse_reclaim_scope(raw: &str) -> Result<ReclaimScope> {
+    ReclaimScope::parse(raw.trim()).ok_or_else(|| {
+        anyhow::anyhow!(
+            "unknown reclaim scope `{raw}`; valid scopes: {}",
+            ReclaimScope::ALL
+                .iter()
+                .map(|scope| scope.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    })
+}
+
+async fn cmd_db_reclaim_plan(
+    cfg: &AppConfig,
+    output: &CliOutput,
+    args: crate::cli::ReclaimPlanArgs,
+) -> Result<ExitCode> {
+    let scopes = match args.scope.as_deref() {
+        Some(raw) => vec![parse_reclaim_scope(raw)?],
+        None => ReclaimScope::ALL.to_vec(),
+    };
+    let ch = ClickHouseClient::new(cfg.clickhouse.clone())?;
+    let budgets = query_budgets(cfg);
+    let plan: ReclaimPlan = QueryEnvelope::new_batch(
+        "reclaim-plan",
+        QueryClass::Background,
+        &budgets.background,
+        &budgets.administrative,
+        reclaim::PLAN_STATEMENT_CAP,
+    )
+    .scope(ch.reclaim_plan(&cfg.retention, &scopes))
+    .await?;
+    render_reclaim_plan(output, &plan, args.json)?;
+    Ok(ExitCode::SUCCESS)
+}
+
+/// `moraine db reclaim run`.
+///
+/// Two refusals, in this order:
+///
+/// 1. **Unconfirmed.** The unforced path prints exactly which scope and which
+///    tables would be touched and exits non-zero, following the `--force`
+///    ceremony precedent. `moraine export events --format jsonl` is named as
+///    the pre-destructive safety valve.
+/// 2. **Unauthorized.** A bucket-1/2 scope additionally refuses unless the
+///    matching `[retention]` key is present, and says which key is missing.
+///
+/// In this build every scope then refuses again for a third reason: no
+/// executor is registered. Nothing is deleted by any path.
+///
+/// All three of the ceremony's parts — the `--confirm` gate, the authority
+/// gate reached through `reclaim_run`, and the non-zero exit — are guarded by
+/// `tests::the_unconfirmed_run_ceremony_is_enforced_end_to_end` and
+/// `tests::a_refusal_exits_non_zero`, which drive this function rather than
+/// re-deriving its decisions. `cli::tests::clap_parses_reclaim_subcommands`
+/// proves only that `--confirm` parses and defaults to false; it says nothing
+/// about whether anything reads it.
+async fn cmd_db_reclaim_run(
+    cfg: &AppConfig,
+    output: &CliOutput,
+    args: crate::cli::ReclaimRunArgs,
+) -> Result<ExitCode> {
+    let scope = parse_reclaim_scope(&args.scope)?;
+    if !args.confirm {
+        render_reclaim_refusal(output, scope, args.json)?;
+        return Ok(ExitCode::from(RECLAIM_REFUSAL_EXIT_CODE));
+    }
+    let ch = ClickHouseClient::new(cfg.clickhouse.clone())?;
+    let budgets = query_budgets(cfg);
+    let outcome = QueryEnvelope::new_batch(
+        "reclaim-run",
+        QueryClass::Background,
+        &budgets.background,
+        &budgets.administrative,
+        reclaim::UNIT_STATEMENT_CAP,
+    )
+    .scope(ch.reclaim_run(&cfg.retention, scope))
+    .await?;
+    crate::render::render_reclaim_outcome(output, &outcome, args.json)?;
+    Ok(ExitCode::from(reclaim_run_exit_code(&outcome)))
+}
+
+/// Exit status of a `moraine db reclaim run` that never reached an executor.
+pub(crate) const RECLAIM_REFUSAL_EXIT_CODE: u8 = 1;
+
+/// Exit status for a rendered reclaim outcome.
+///
+/// A refusal is not a success: `NoExecutor` exits non-zero so a script that
+/// expects reclamation to have happened notices that it did not. `Blocked` is
+/// the same case — hazard H9 is precisely that "blocked" and "nothing to do"
+/// were indistinguishable, and an exit code that cannot tell them apart is
+/// that bug at the process boundary.
+pub(crate) fn reclaim_run_exit_code(outcome: &moraine_clickhouse::ReclaimOutcome) -> u8 {
+    match outcome {
+        moraine_clickhouse::ReclaimOutcome::NoExecutor { .. }
+        | moraine_clickhouse::ReclaimOutcome::Blocked { .. } => RECLAIM_REFUSAL_EXIT_CODE,
+        moraine_clickhouse::ReclaimOutcome::Idle { .. }
+        | moraine_clickhouse::ReclaimOutcome::Settled { .. } => 0,
+    }
+}
+
 fn unavailable_core_index_report(configured: OpenReaderMode) -> CoreIndexReport {
     CoreIndexReport {
         available: false,
@@ -793,6 +944,159 @@ mod tests {
             verbose: false,
             unicode: false,
             width: 100,
+        }
+    }
+
+    /// A config whose ClickHouse endpoint is a port nothing listens on, so any
+    /// path that reaches the network fails loudly rather than passing.
+    fn offline_config(retention: moraine_config::RetentionConfig) -> AppConfig {
+        let mut cfg = AppConfig::default();
+        cfg.clickhouse.url = "http://127.0.0.1:1".to_string();
+        cfg.clickhouse.timeout_seconds = 1.0;
+        cfg.retention = retention;
+        cfg
+    }
+
+    fn reclaim_run_args(scope: &str, confirm: bool) -> crate::cli::ReclaimRunArgs {
+        crate::cli::ReclaimRunArgs {
+            scope: scope.to_string(),
+            confirm,
+            json: false,
+        }
+    }
+
+    /// **G-CONFIRM.** Fails for: an unconfirmed `moraine db reclaim run`
+    /// proceeding.
+    /// Denomination: end-to-end behaviour of `cmd_db_reclaim_run`, not a
+    /// re-derivation of its decision.
+    ///
+    /// The probe is `--scope canonical_generation` under a stock config,
+    /// because that is the one scope whose two outcomes are distinguishable
+    /// from outside: refused it returns `Ok`, proceeded it reaches
+    /// `reclaim_run`'s authority check and returns `Err` naming the missing
+    /// key. No stdout capture is needed, and nothing touches the network on
+    /// either path.
+    ///
+    /// MUTATION (executed 2026-07-27): change `if !args.confirm` to
+    /// `if false` in `cmd_db_reclaim_run` => FAILS here (the unconfirmed call
+    /// returns `Err`). Before this test, that mutation left the CLI suite at
+    /// 229/0 and an unconfirmed run against user history proceeded with no
+    /// test noticing. **Lower bound.**
+    ///
+    /// MUTATION (executed 2026-07-27): change it to `if true` (refuse even a
+    /// confirmed run) => FAILS on the confirmed half below, which requires the
+    /// authority refusal to be reached. **Upper bound.**
+    ///
+    /// MUTATION (executed 2026-07-27): change it to `if !args.json` => FAILS
+    /// on both halves. **Width: the gate reads `confirm` and nothing else.**
+    #[tokio::test(flavor = "multi_thread")]
+    async fn the_unconfirmed_run_ceremony_is_enforced_end_to_end() {
+        let cfg = offline_config(moraine_config::RetentionConfig::default());
+
+        // Unconfirmed: refused locally, exit non-zero, no authority check and
+        // no client construction.
+        let code = cmd_db_reclaim_run(
+            &cfg,
+            &plain_output(),
+            reclaim_run_args("canonical_generation", false),
+        )
+        .await
+        .expect("an unconfirmed run must refuse, not error");
+        assert_eq!(code, ExitCode::from(RECLAIM_REFUSAL_EXIT_CODE));
+
+        // Confirmed: the gate lets it through to `reclaim_run`, whose S2
+        // authority check refuses this scope under a stock config and names
+        // the key. This is what proves the gate above is `confirm` and not a
+        // blanket refusal.
+        let error = cmd_db_reclaim_run(
+            &cfg,
+            &plain_output(),
+            reclaim_run_args("canonical_generation", true),
+        )
+        .await
+        .expect_err("a confirmed run of an unconfigured bucket-1 scope must refuse");
+        assert!(
+            error
+                .to_string()
+                .contains("retention.canonical_history_horizon_days"),
+            "{error:#}"
+        );
+    }
+
+    /// **G-EXITCODE.** Fails for: a reclaim refusal exiting zero.
+    /// Denomination: the `ExitCode` the command actually returns.
+    ///
+    /// The report's claim — "a script expecting reclamation notices it did not
+    /// happen" — had no test behind it.
+    ///
+    /// MUTATION (executed 2026-07-27): change `ExitCode::from(1)` on the
+    /// unconfirmed path to `ExitCode::SUCCESS` => FAILS in
+    /// `the_unconfirmed_run_ceremony_is_enforced_end_to_end`.
+    ///
+    /// MUTATION (executed 2026-07-27): make `reclaim_run_exit_code` return `0`
+    /// for `NoExecutor` => FAILS here, on the end-to-end call and on the pure
+    /// mapping. **Lower bound.**
+    ///
+    /// MUTATION (executed 2026-07-27): make it return `1` for every variant =>
+    /// FAILS on the `Idle`/`Settled` rows, so "always fail" is not a passing
+    /// "fix". **Upper bound, and width: each variant is named.**
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_refusal_exits_non_zero() {
+        // End to end: a confirmed run of an authorized scope still refuses for
+        // the missing executor, and that refusal is not a success.
+        let cfg = offline_config(moraine_config::RetentionConfig::default());
+        let code = cmd_db_reclaim_run(
+            &cfg,
+            &plain_output(),
+            reclaim_run_args("mcp_open_orphan", true),
+        )
+        .await
+        .expect("no executor is a refusal, not an error");
+        assert_eq!(code, ExitCode::from(1));
+        assert_ne!(code, ExitCode::SUCCESS);
+
+        // And the mapping itself, variant by variant.
+        use moraine_clickhouse::ReclaimOutcome;
+        let scope = moraine_clickhouse::ReclaimScope::McpOpenOrphan;
+        assert_eq!(
+            reclaim_run_exit_code(&ReclaimOutcome::NoExecutor {
+                scope,
+                message: String::new()
+            }),
+            1
+        );
+        assert_eq!(
+            reclaim_run_exit_code(&ReclaimOutcome::Blocked {
+                scope,
+                pending_mutations: 3
+            }),
+            1,
+            "H9: a blocked run must not be indistinguishable from a successful one at the process \
+             boundary either"
+        );
+        assert_eq!(reclaim_run_exit_code(&ReclaimOutcome::Idle { scope }), 0);
+        assert_eq!(
+            reclaim_run_exit_code(&ReclaimOutcome::Settled {
+                scope,
+                units: 0,
+                reclaimed_rows: 0,
+                denomination: String::new()
+            }),
+            0
+        );
+    }
+
+    /// An unknown `--scope` must not widen to "everything".
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unknown_scope_is_an_error_rather_than_a_default() {
+        let cfg = offline_config(moraine_config::RetentionConfig::default());
+        let error = cmd_db_reclaim_run(&cfg, &plain_output(), reclaim_run_args("everything", true))
+            .await
+            .expect_err("an unknown scope must not run");
+        let rendered = error.to_string();
+        assert!(rendered.contains("unknown reclaim scope"), "{rendered}");
+        for scope in moraine_clickhouse::ReclaimScope::ALL {
+            assert!(rendered.contains(scope.as_str()), "{rendered}");
         }
     }
 

--- a/apps/moraine/src/commands/status.rs
+++ b/apps/moraine/src/commands/status.rs
@@ -561,6 +561,9 @@ pub(super) async fn cmd_status(
     // a direct-DB read that yields "unavailable" when ClickHouse is unreachable,
     // so it never blocks or fails the status snapshot.
     let core_index = super::gather_core_index_report(cfg).await;
+    // Storage ownership and effective retention policy (issue #603 WI-02).
+    // Same best-effort contract: `None` when ClickHouse is unreachable.
+    let storage = super::gather_storage_report(cfg).await;
 
     Ok(StatusSnapshot {
         services,
@@ -577,6 +580,7 @@ pub(super) async fn cmd_status(
         doctor: report,
         heartbeat,
         core_index: Some(core_index),
+        storage,
     })
 }
 

--- a/apps/moraine/src/managed_clickhouse.rs
+++ b/apps/moraine/src/managed_clickhouse.rs
@@ -1745,6 +1745,77 @@ pub(crate) fn cmd_clickhouse_uninstall(paths: &RuntimePaths) -> Result<String> {
 mod tests {
     use super::*;
     use moraine_config::AppConfig;
+
+    /// The server config template must be well-formed XML.
+    ///
+    /// `CLICKHOUSE_TEMPLATE` is rendered as the whole server config, so a
+    /// malformed template does not degrade anything — the server refuses to
+    /// start, the supervisor exhausts its five replacements, and the stack is
+    /// dead. Nothing else in the suite parses this file, which is how #603's
+    /// WI-08 comment shipped a `--` inside an XML comment (illegal per the
+    /// spec, `SAXParseException: Invalid token`) with every unit test green;
+    /// only `e2e-stack` caught it, and only by launching a real server.
+    ///
+    /// This checks the two properties a hand-edited XML file actually loses:
+    /// balanced tags, and no `--` inside a comment. The second is the one that
+    /// bites, because prose about command-line flags is exactly what belongs
+    /// in a config comment.
+    ///
+    /// MUTATION: put `--config-file` back into any comment in
+    /// `config/clickhouse.xml` and this fails.
+    #[test]
+    fn the_clickhouse_config_template_is_well_formed_xml() {
+        let mut rest = CLICKHOUSE_TEMPLATE;
+        while let Some(open) = rest.find("<!--") {
+            let after = &rest[open + 4..];
+            let close = after.find("-->").expect(
+                "an unterminated XML comment in config/clickhouse.xml: the server refuses to \
+                 start and the supervisor exhausts its replacements",
+            );
+            let body = &after[..close];
+            assert!(
+                !body.contains("--"),
+                "config/clickhouse.xml has a comment containing `--`, which XML forbids; \
+                 ClickHouse fails with `SAXParseException: Invalid token` and never starts. \
+                 Offending comment body: {body:?}"
+            );
+            rest = &after[close + 3..];
+        }
+
+        let mut depth = 0i32;
+        let mut scan = CLICKHOUSE_TEMPLATE;
+        while let Some(lt) = scan.find('<') {
+            let tail = &scan[lt..];
+            if tail.starts_with("<!--") {
+                let close = tail[4..]
+                    .find("-->")
+                    .expect("comment termination checked above");
+                scan = &tail[4 + close + 3..];
+                continue;
+            }
+            if tail.starts_with("<?") {
+                let close = tail.find("?>").expect("an unterminated XML declaration");
+                scan = &tail[close + 2..];
+                continue;
+            }
+            let close = tail.find('>').expect("an unterminated XML tag");
+            let inner = &tail[1..close];
+            if inner.starts_with('/') {
+                depth -= 1;
+            } else if !inner.ends_with('/') {
+                depth += 1;
+            }
+            assert!(
+                depth >= 0,
+                "config/clickhouse.xml closes a tag it never opened"
+            );
+            scan = &tail[close + 1..];
+        }
+        assert_eq!(
+            depth, 0,
+            "config/clickhouse.xml leaves {depth} tag(s) unclosed; the server would refuse to start"
+        );
+    }
     use std::net::{SocketAddr, TcpListener, TcpStream};
     use std::sync::{
         atomic::{AtomicBool, Ordering},

--- a/apps/moraine/src/managed_clickhouse.rs
+++ b/apps/moraine/src/managed_clickhouse.rs
@@ -1786,11 +1786,9 @@ mod tests {
         let mut scan = CLICKHOUSE_TEMPLATE;
         while let Some(lt) = scan.find('<') {
             let tail = &scan[lt..];
-            if tail.starts_with("<!--") {
-                let close = tail[4..]
-                    .find("-->")
-                    .expect("comment termination checked above");
-                scan = &tail[4 + close + 3..];
+            if let Some(body) = tail.strip_prefix("<!--") {
+                let close = body.find("-->").expect("comment termination checked above");
+                scan = &body[close + 3..];
                 continue;
             }
             if tail.starts_with("<?") {

--- a/apps/moraine/src/render.rs
+++ b/apps/moraine/src/render.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use moraine_clickhouse::{CoreIndexAuditOutcome, DoctorReport};
+use moraine_clickhouse::{
+    reclaim, CoreIndexAuditOutcome, DoctorReport, ReclaimOutcome, ReclaimPlan, ReclaimScope,
+    ReclaimStatusReport, StorageReport,
+};
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -106,6 +109,11 @@ pub(crate) struct StatusSnapshot {
     /// on the legacy status paths that do not gather it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) core_index: Option<CoreIndexReport>,
+    /// Storage ownership, bytes, and effective retention policy (issue #603
+    /// WI-02). `None` when ClickHouse was unreachable; the panel then omits
+    /// the line rather than reporting zeroes as facts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) storage: Option<StorageReport>,
 }
 
 /// Canonical read-index (issue #598) readiness surfaced by `moraine status`,
@@ -608,6 +616,19 @@ pub(crate) fn render_status(output: &CliOutput, snapshot: &StatusSnapshot) -> Re
     if output.verbose && !snapshot.doctor.errors.is_empty() {
         doctor_lines.push(format!("  errors: {}", snapshot.doctor.errors.join(" | ")));
     }
+    if let Some(storage) = &snapshot.storage {
+        doctor_lines.push(status_storage_line(storage));
+        // A destructive policy is never invisible, even in the concise view.
+        if let Some(warning) = status_retention_warning_line(storage) {
+            doctor_lines.push(format!("  {warning}"));
+        }
+        if !storage.unclassified_tables().is_empty() {
+            doctor_lines.push(format!(
+                "  unclassified tables: {}",
+                storage.unclassified_tables().join(", ")
+            ));
+        }
+    }
     if let Some(core_index) = &snapshot.core_index {
         doctor_lines.push(status_core_index_line(core_index));
         // Surface a non-silent config override prominently even in the concise
@@ -718,15 +739,18 @@ pub(crate) fn render_db_doctor(
     output: &CliOutput,
     report: &DoctorReport,
     core_index: &CoreIndexReport,
+    storage: Option<&StorageReport>,
 ) -> Result<()> {
     if output.is_json() {
         // Additive: the DoctorReport shape is unchanged; core-index readiness
-        // rides in a sibling object so downlevel JSON consumers are unaffected.
+        // and the issue #603 storage report ride in sibling objects so
+        // downlevel JSON consumers are unaffected.
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
                 "doctor": report,
                 "core_index": core_index,
+                "storage": storage,
             }))?
         );
         return Ok(());
@@ -790,7 +814,328 @@ pub(crate) fn render_db_doctor(
         lines.push(format!("errors: {}", report.errors.join(" | ")));
     }
     lines.extend(core_index_report_lines(core_index));
+    match storage {
+        Some(storage) => lines.extend(storage_report_lines(storage)),
+        None => lines.push(
+            "storage: unavailable (ClickHouse unreachable); storage state is transient and does              not affect the doctor exit code"
+                .to_string(),
+        ),
+    }
     output.section("DB Doctor", &lines);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Issue #603 — storage / reclaim rendering
+// ---------------------------------------------------------------------------
+
+/// Format a byte count for operator display. Deliberately plain: no "frees",
+/// no "recovers", no "partition" — see [`reclaim::FORBIDDEN_DENOMINATION_WORDS`].
+pub(crate) fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} {}", UNITS[0])
+    } else {
+        format!("{value:.2} {}", UNITS[unit])
+    }
+}
+
+fn format_horizon(seconds: f64) -> String {
+    if seconds >= 86_400.0 {
+        format!("{:.0}d", seconds / 86_400.0)
+    } else {
+        format!("{:.0}h", seconds / 3_600.0)
+    }
+}
+
+/// One concise line summarizing storage for the `moraine status` Database
+/// panel: bucket totals and disk headroom.
+pub(crate) fn status_storage_line(report: &StorageReport) -> String {
+    let disk = match report.disk {
+        Some(disk) => format!(
+            "disk free {} of {}",
+            format_bytes(disk.free_bytes),
+            format_bytes(disk.total_bytes)
+        ),
+        None => "disk free unknown".to_string(),
+    };
+    let buckets = report
+        .buckets
+        .iter()
+        .filter(|bucket| bucket.tables > 0)
+        .map(|bucket| {
+            format!(
+                "{} {}",
+                bucket.class.as_str(),
+                format_bytes(bucket.compressed_bytes)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "storage: {}  |  {disk}",
+        if buckets.is_empty() {
+            "no tables".to_string()
+        } else {
+            buckets
+        }
+    )
+}
+
+/// The prominent `moraine status` line shown when configuration authorizes
+/// deleting user history, plus the one-time retention notice.
+///
+/// A destructive policy is never invisible: this returns `Some` exactly when
+/// [`StorageReport::destructive_policies`] is non-empty.
+pub(crate) fn status_retention_warning_line(report: &StorageReport) -> Option<String> {
+    let destructive = report.destructive_policies();
+    if destructive.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "RETENTION CONFIGURED — user history will be deleted: {}",
+        destructive
+            .iter()
+            .map(|entry| {
+                format!(
+                    "{} after {}",
+                    entry.class.as_str(),
+                    entry
+                        .horizon_seconds
+                        .map(format_horizon)
+                        .unwrap_or_else(|| "?".to_string())
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
+}
+
+/// Full per-bucket storage block for `moraine db doctor`.
+pub(crate) fn storage_report_lines(report: &StorageReport) -> Vec<String> {
+    let mut lines = vec![status_storage_line(report)];
+    for bucket in &report.buckets {
+        lines.push(format!(
+            "  {} ({}): {} tables, {} rows, {}",
+            bucket.class.as_str(),
+            bucket.label,
+            bucket.tables,
+            bucket.rows,
+            format_bytes(bucket.compressed_bytes)
+        ));
+    }
+    for entry in &report.policy {
+        lines.push(format!(
+            "  policy {}: {} ({}{}){}",
+            entry.class.as_str(),
+            entry
+                .horizon_seconds
+                .map(format_horizon)
+                .unwrap_or_else(|| "no retention".to_string()),
+            entry.source,
+            match &entry.config_key {
+                Some(key) => format!(", {key}"),
+                None => String::new(),
+            },
+            // A `config_key` printed with no qualification is an invitation to
+            // set it. Bucket 4's key changes nothing an operator can observe,
+            // and this line is where they would otherwise never learn that.
+            match &entry.note {
+                Some(note) => format!(" — {note}"),
+                None => String::new(),
+            }
+        ));
+    }
+    if let Some(warning) = status_retention_warning_line(report) {
+        lines.push(warning);
+    }
+    let unclassified = report.unclassified_tables();
+    if !unclassified.is_empty() {
+        lines.push(format!(
+            "  UNCLASSIFIED TABLES (no reclaim scope may name them): {}",
+            unclassified.join(", ")
+        ));
+    }
+    for note in &report.notes {
+        lines.push(format!("  note: {note}"));
+    }
+    lines
+}
+
+/// Render `moraine db reclaim status`.
+pub(crate) fn render_reclaim_status(
+    output: &CliOutput,
+    report: &ReclaimStatusReport,
+    json: bool,
+) -> Result<()> {
+    if json || output.is_json() {
+        println!("{}", serde_json::to_string_pretty(report)?);
+        return Ok(());
+    }
+    let mut lines = Vec::new();
+    match &report.storage {
+        Some(storage) => lines.extend(storage_report_lines(storage)),
+        None => lines.push(format!(
+            "storage: unavailable{}",
+            match &report.error {
+                Some(error) => format!(" ({error})"),
+                None => String::new(),
+            }
+        )),
+    }
+    lines.push(format!(
+        "ledger: claimed={}, deleting={}, done={}, abandoned={}",
+        report.ledger.claimed, report.ledger.deleting, report.ledger.done, report.ledger.abandoned
+    ));
+    if let Some(blocked) = &report.ledger.blocked_reason {
+        lines.push(format!("ledger blocked: {blocked}"));
+    }
+    lines.push(format!(
+        "registered executors: {}",
+        if report.registered_executors.is_empty() {
+            "none (this build plans and reports only; nothing is deleted)".to_string()
+        } else {
+            report
+                .registered_executors
+                .iter()
+                .map(|scope| scope.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        }
+    ));
+    lines.extend(reclaimable_lines(&report.reclaimable));
+    lines.push(report.denomination.clone());
+    output.section("Storage Reclaim", &lines);
+    Ok(())
+}
+
+fn reclaimable_lines(estimates: &[reclaim::ReclaimableEstimate]) -> Vec<String> {
+    estimates
+        .iter()
+        .flat_map(|estimate| {
+            let mut lines = vec![format!(
+                "scope {}: {} units, {} rows, {} ({})",
+                estimate.scope.as_str(),
+                estimate.units,
+                estimate.estimated_rows,
+                format_bytes(estimate.estimated_bytes),
+                reclaim::ESTIMATE_QUALIFIER,
+            )];
+            if let Some(note) = &estimate.note {
+                lines.push(format!("  {note}"));
+            }
+            lines
+        })
+        .collect()
+}
+
+/// Render `moraine db reclaim plan`. Dry run: writes nothing.
+pub(crate) fn render_reclaim_plan(
+    output: &CliOutput,
+    plan: &ReclaimPlan,
+    json: bool,
+) -> Result<()> {
+    if json || output.is_json() {
+        println!("{}", serde_json::to_string_pretty(plan)?);
+        return Ok(());
+    }
+    let mut lines = vec!["dry run: nothing was written".to_string()];
+    lines.extend(reclaimable_lines(&plan.scopes));
+    if plan.pending_redrive > 0 {
+        lines.push(format!(
+            "ledger units awaiting re-drive: {}",
+            plan.pending_redrive
+        ));
+    }
+    lines.push(plan.denomination.clone());
+    output.section("Storage Reclaim Plan", &lines);
+    Ok(())
+}
+
+/// The unforced `moraine db reclaim run` refusal.
+///
+/// Names exactly what would be deleted and points at the export command as the
+/// pre-destructive safety valve, following the `--force` ceremony precedent.
+pub(crate) fn render_reclaim_refusal(
+    output: &CliOutput,
+    scope: ReclaimScope,
+    json: bool,
+) -> Result<()> {
+    let tables: Vec<&str> = scope.tables().iter().map(|table| table.name()).collect();
+    if json || output.is_json() {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "refused": true,
+                "reason": "confirmation required",
+                "scope": scope.as_str(),
+                "describes": scope.describe(),
+                "tables": tables,
+                "rerun_with": format!("moraine db reclaim run --scope {scope} --confirm"),
+                "export_first": "moraine export events --format jsonl",
+            }))?
+        );
+        return Ok(());
+    }
+    output.section(
+        "Storage Reclaim Refused",
+        &[
+            format!("scope: {} — {}", scope.as_str(), scope.describe()),
+            format!("would delete from: {}", tables.join(", ")),
+            "nothing was deleted: --confirm was not given".to_string(),
+            format!("re-run with: moraine db reclaim run --scope {scope} --confirm"),
+            "export first if unsure: moraine export events --format jsonl".to_string(),
+        ],
+    );
+    Ok(())
+}
+
+/// Render the outcome of a confirmed `moraine db reclaim run`.
+pub(crate) fn render_reclaim_outcome(
+    output: &CliOutput,
+    outcome: &ReclaimOutcome,
+    json: bool,
+) -> Result<()> {
+    if json || output.is_json() {
+        println!("{}", serde_json::to_string_pretty(outcome)?);
+        return Ok(());
+    }
+    let lines = match outcome {
+        ReclaimOutcome::NoExecutor { scope, message } => {
+            vec![format!("scope: {}", scope.as_str()), message.clone()]
+        }
+        ReclaimOutcome::Blocked {
+            scope,
+            pending_mutations,
+        } => vec![
+            format!("scope: {}", scope.as_str()),
+            format!(
+                "blocked: {pending_mutations} mutation(s) over this scope's tables are still \
+                 running; nothing was deleted"
+            ),
+        ],
+        ReclaimOutcome::Idle { scope } => {
+            vec![format!("scope: {}: nothing to reclaim", scope.as_str())]
+        }
+        ReclaimOutcome::Settled {
+            scope,
+            units,
+            reclaimed_rows,
+            denomination,
+        } => vec![
+            format!("scope: {}", scope.as_str()),
+            format!("units settled: {units}"),
+            format!("rows reclaimed: {reclaimed_rows}"),
+            denomination.clone(),
+        ],
+    };
+    output.section("Storage Reclaim", &lines);
     Ok(())
 }
 
@@ -1023,5 +1368,250 @@ mod tests {
         assert_eq!(format_age_seconds(125), "2m5s");
         assert_eq!(format_age_seconds(3725), "1h2m");
         assert_eq!(format_age_seconds(90_061), "1d1h");
+    }
+
+    // ---- issue #603 storage / reclaim rendering -------------------------
+
+    fn storage_fixture(retention: moraine_config::RetentionConfig) -> StorageReport {
+        let tables = vec![
+            moraine_clickhouse::StorageTableReport {
+                name: "events".to_string(),
+                class: Some(moraine_clickhouse::TableClass::CanonicalHistory),
+                rows: 1_990_776,
+                compressed_bytes: 4_787_723_965,
+                uncompressed_bytes: 11_420_351_515,
+                active_parts: 24,
+                oldest_retained: Some("2026-02-20T14:16:45Z".to_string()),
+            },
+            moraine_clickhouse::StorageTableReport {
+                name: "mcp_open_turns".to_string(),
+                class: Some(moraine_clickhouse::TableClass::Derived),
+                rows: 234_694,
+                compressed_bytes: 14_356_000_000,
+                uncompressed_bytes: 40_000_000_000,
+                active_parts: 303,
+                oldest_retained: None,
+            },
+        ];
+        StorageReport {
+            buckets: moraine_clickhouse::fold_buckets(&tables),
+            tables,
+            disk: Some(moraine_clickhouse::StorageDiskReport {
+                free_bytes: 11_780_276_224,
+                total_bytes: 994_662_584_320,
+            }),
+            policy: moraine_clickhouse::retention_policy_entries(&retention),
+            notes: Vec::new(),
+        }
+    }
+
+    /// **G-DENOM** (the rendered-string half). Fails for: an operator-facing
+    /// byte number without its qualifier, or any surface promising
+    /// partition-aligned deletion.
+    /// Denomination: rendered string.
+    ///
+    /// MUTATION (executed 2026-07-27): change
+    /// `reclaim::reclaimed_bytes_note()` to `"freed N bytes"` => the library
+    /// test `byte_denominations_carry_their_qualifiers_and_promise_nothing`
+    /// FAILS; this test additionally covers the strings the LIBRARY test
+    /// cannot see, because it renders them.
+    #[test]
+    fn no_rendered_storage_surface_promises_partition_aligned_deletion() {
+        let report = storage_fixture(moraine_config::RetentionConfig::default());
+        let mut rendered = storage_report_lines(&report);
+        rendered.push(status_storage_line(&report));
+        rendered.extend(reclaimable_lines(&[reclaim::ReclaimableEstimate {
+            scope: ReclaimScope::McpOpenOrphan,
+            units: 3,
+            estimated_rows: 10,
+            estimated_bytes: 5_368_709_120,
+            tables: vec!["mcp_open_events".to_string()],
+            note: Some("probe not registered".to_string()),
+        }]));
+        rendered.push(reclaim::estimated_bytes_note());
+        rendered.push(reclaim::reclaimed_bytes_note());
+        for scope in ReclaimScope::ALL {
+            rendered.push(scope.describe().to_string());
+        }
+
+        let joined = rendered.join("\n").to_lowercase();
+        for forbidden in reclaim::FORBIDDEN_DENOMINATION_WORDS {
+            assert!(
+                !joined.contains(forbidden),
+                "a reclaim surface must never say `{forbidden}`:\n{joined}"
+            );
+        }
+        // Any estimate line must carry the qualifier next to the number.
+        let estimate_line = rendered
+            .iter()
+            .find(|line| line.contains("scope mcp_open_orphan"))
+            .expect("estimate line");
+        assert!(
+            estimate_line.contains(reclaim::ESTIMATE_QUALIFIER),
+            "{estimate_line}"
+        );
+        assert!(reclaim::reclaimed_bytes_note().contains(reclaim::MERGE_DEFERRED_QUALIFIER));
+    }
+
+    /// A configured bucket-1/2 horizon must be impossible to miss.
+    ///
+    /// MUTATION (executed 2026-07-27): make
+    /// `RetentionPolicyEntry::is_destructive` drop its `is_protected` guard =>
+    /// the library test `default_retention_surfaces_no_destructive_policy`
+    /// FAILS. Here the direction bounded is the other one: a CONFIGURED
+    /// canonical horizon must produce a warning line, so a "fix" that always
+    /// returns false fails this test.
+    #[test]
+    fn a_configured_canonical_horizon_is_prominent_and_a_default_one_is_absent() {
+        let stock = storage_fixture(moraine_config::RetentionConfig::default());
+        assert_eq!(status_retention_warning_line(&stock), None);
+        assert!(!storage_report_lines(&stock)
+            .join("\n")
+            .contains("RETENTION CONFIGURED"));
+
+        let configured = storage_fixture(moraine_config::RetentionConfig {
+            canonical_history_horizon_days: Some(365.0),
+            ..moraine_config::RetentionConfig::default()
+        });
+        let warning = status_retention_warning_line(&configured).expect("warning line");
+        assert!(warning.contains("RETENTION CONFIGURED"), "{warning}");
+        assert!(
+            warning.contains("user history will be deleted"),
+            "{warning}"
+        );
+        assert!(warning.contains("canonical_history"), "{warning}");
+        assert!(warning.contains("365d"), "{warning}");
+        assert!(storage_report_lines(&configured)
+            .join("\n")
+            .contains("RETENTION CONFIGURED"));
+    }
+
+    /// The rendered half of G-TELEMETRY-HONESTY. A caveat that lives only in
+    /// a struct field reaches nobody.
+    ///
+    /// MUTATION (executed 2026-07-27): drop the `entry.note` arm from
+    /// `storage_report_lines` => FAILS here. The library test
+    /// `the_telemetry_horizon_never_reports_itself_as_configured` stays green,
+    /// because it can only see the struct.
+    #[test]
+    fn status_lines_render_the_telemetry_horizon_caveat() {
+        let rendered =
+            storage_report_lines(&storage_fixture(moraine_config::RetentionConfig::default()))
+                .join("\n");
+        let telemetry = rendered
+            .lines()
+            .find(|line| line.contains("policy telemetry"))
+            .expect("a telemetry policy line");
+        assert!(telemetry.contains("30d"), "{telemetry}");
+        assert!(telemetry.contains("(default"), "{telemetry}");
+        assert!(
+            telemetry.contains("retention.telemetry_horizon_days"),
+            "{telemetry}"
+        );
+        assert!(
+            telemetry.contains(moraine_clickhouse::TELEMETRY_HORIZON_NOT_CONFIGURABLE_NOTE),
+            "the line names a config key, so it must also say the key does nothing: {telemetry}"
+        );
+
+        // Upper bound: the other policy lines stay clean, so the caveat is a
+        // statement about this key rather than boilerplate on every row.
+        for class in ["canonical_history", "raw_audit", "derived", "never_delete"] {
+            let line = rendered
+                .lines()
+                .find(|line| line.starts_with(&format!("  policy {class}:")))
+                .unwrap_or_else(|| panic!("a `{class}` policy line"));
+            assert!(!line.contains(" — "), "{line}");
+        }
+    }
+
+    #[test]
+    fn the_status_storage_line_reports_buckets_and_disk_headroom() {
+        let line =
+            status_storage_line(&storage_fixture(moraine_config::RetentionConfig::default()));
+        assert!(line.contains("canonical_history 4.46 GiB"), "{line}");
+        assert!(line.contains("derived 13.37 GiB"), "{line}");
+        assert!(line.contains("disk free 10.97 GiB of 926.35 GiB"), "{line}");
+        // Empty buckets are omitted from the concise line but never invented.
+        assert!(!line.contains("telemetry"), "{line}");
+    }
+
+    /// The `--confirm` refusal **text**. Fails for: a refusal that does not
+    /// say what would be deleted, or that omits the pre-destructive safety
+    /// valve.
+    ///
+    /// This test renders `render_reclaim_refusal` directly, so it bounds
+    /// exactly one direction: the refusal stays actionable, because a refusal
+    /// naming no table is a refusal an operator cannot act on.
+    ///
+    /// It does **not** cover whether anything calls it. An earlier revision of
+    /// this docstring claimed the mutation "drop `args.confirm` from the guard
+    /// in `cmd_db_reclaim_run`" was compensated by
+    /// `clap_parses_reclaim_subcommands`; a reviewer ran that mutation and the
+    /// CLI suite stayed at 229/0. `clap_parses_reclaim_subcommands` proves the
+    /// flag parses and defaults to false, and nothing more. The gate itself is
+    /// now bounded by
+    /// `commands::tests::the_unconfirmed_run_ceremony_is_enforced_end_to_end`,
+    /// and its exit code by `commands::tests::a_refusal_exits_non_zero`.
+    #[test]
+    fn the_unconfirmed_refusal_names_every_table_and_the_export_valve() {
+        let output = CliOutput {
+            mode: OutputMode::Plain,
+            verbose: false,
+            unicode: false,
+            width: 100,
+        };
+        for scope in ReclaimScope::ALL {
+            // Rendering must not panic for any scope, and the JSON form must
+            // carry the same table list as the human form.
+            render_reclaim_refusal(&output, scope, false).expect("refusal renders");
+        }
+
+        // The canonical scope is the one whose refusal matters most.
+        let scope = ReclaimScope::CanonicalGeneration;
+        let tables: Vec<&str> = scope.tables().iter().map(|table| table.name()).collect();
+        assert!(tables.contains(&"events"));
+        assert!(tables.contains(&"raw_events"));
+        assert!(scope.describe().contains("USER HISTORY"));
+    }
+
+    #[test]
+    fn a_run_with_no_registered_executor_renders_as_deleting_nothing() {
+        let output = CliOutput {
+            mode: OutputMode::Plain,
+            verbose: false,
+            unicode: false,
+            width: 100,
+        };
+        let outcome = ReclaimOutcome::NoExecutor {
+            scope: ReclaimScope::McpOpenOrphan,
+            message: "no executor is registered for scope `mcp_open_orphan`; WI-05 adds it. \
+                      Nothing was deleted."
+                .to_string(),
+        };
+        render_reclaim_outcome(&output, &outcome, false).expect("outcome renders");
+        assert!(!outcome.deleted_anything());
+
+        // A blocked run is a distinct, counted outcome — not an indistinguishable
+        // "nothing to do".
+        let blocked = ReclaimOutcome::Blocked {
+            scope: ReclaimScope::McpOpenOrphan,
+            pending_mutations: 3,
+        };
+        assert!(!blocked.deleted_anything());
+        assert_ne!(
+            blocked,
+            ReclaimOutcome::Idle {
+                scope: ReclaimScope::McpOpenOrphan
+            }
+        );
+        render_reclaim_outcome(&output, &blocked, false).expect("blocked renders");
+    }
+
+    #[test]
+    fn byte_formatting_is_stable_across_unit_boundaries() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(1023), "1023 B");
+        assert_eq!(format_bytes(1024), "1.00 KiB");
+        assert_eq!(format_bytes(4_787_723_965), "4.46 GiB");
     }
 }

--- a/config/clickhouse.xml
+++ b/config/clickhouse.xml
@@ -36,8 +36,9 @@
 
   <!-- System-log retention (issue #603 WI-08).
 
-       This file is rendered as the WHOLE server config and launched with
-       `--config-file`, so ClickHouse's packaged `config.xml` — which ships
+       This file is rendered as the WHOLE server config and launched with an
+       explicit config-file flag, so ClickHouse's packaged `config.xml` — which
+       ships
        `<ttl>event_date + INTERVAL 30 DAY DELETE</ttl>` on each of these
        sections — is never loaded, and these tables had no retention of any
        kind. Verified empirically on the reference host (ClickHouse 25.12.5.44,

--- a/config/clickhouse.xml
+++ b/config/clickhouse.xml
@@ -34,10 +34,35 @@
   <uncompressed_cache_size>536870912</uncompressed_cache_size>
   <mark_cache_size>536870912</mark_cache_size>
 
+  <!-- System-log retention (issue #603 WI-08).
+
+       This file is rendered as the WHOLE server config and launched with
+       `--config-file`, so ClickHouse's packaged `config.xml` — which ships
+       `<ttl>event_date + INTERVAL 30 DAY DELETE</ttl>` on each of these
+       sections — is never loaded, and these tables had no retention of any
+       kind. Verified empirically on the reference host (ClickHouse 25.12.5.44,
+       2026-07-27): `system.query_log`, `system.metric_log`, and
+       `system.asynchronous_metric_log` all reported an empty TTL clause in
+       `create_table_query`, and no other MergeTree system log existed
+       (`part_log`, `trace_log`, `text_log` are not declared and are off).
+       That closes plan OQ-3 — there is no built-in fallback, so the horizon
+       below is a real bound rather than a restatement of one.
+
+       Measured effect of restoring the packaged 30-day horizon on the
+       reference host: query_log 1.15 GiB, metric_log 647 MiB, and
+       asynchronous_metric_log 202 MiB of rows are older than 30 days —
+       ~2.0 GiB of the 5.1 GiB these three occupy. (The plan's "~5 GiB" is
+       their TOTAL size, not what a 30-day horizon removes.)
+
+       These are ClickHouse's own diagnostics. No `moraine.*` table is named
+       here, so this section cannot delete user history by construction. TTLs
+       for the four Moraine telemetry tables live in `sql/039`, and those are
+       anchored so that their first application deletes nothing. -->
   <query_log>
     <database>system</database>
     <table>query_log</table>
     <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
   </query_log>
 
   <metric_log>
@@ -45,11 +70,13 @@
     <table>metric_log</table>
     <collect_interval_milliseconds>1000</collect_interval_milliseconds>
     <flush_interval_milliseconds>7000</flush_interval_milliseconds>
+    <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
   </metric_log>
 
   <asynchronous_metric_log>
     <database>system</database>
     <table>asynchronous_metric_log</table>
     <flush_interval_milliseconds>7000</flush_interval_milliseconds>
+    <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
   </asynchronous_metric_log>
 </clickhouse>

--- a/crates/moraine-clickhouse/src/canonical_indexes.rs
+++ b/crates/moraine-clickhouse/src/canonical_indexes.rs
@@ -1360,6 +1360,52 @@ fn now_unix_millis() -> i64 {
 #[cfg(test)]
 mod tests {
 
+    /// **G-BYPASS.** Fails for: a table reachable by a delete path that does
+    /// not go through `reclaim::emit_delete_statement` ceasing to be
+    /// `Derived`.
+    /// Denomination: exact class, per table, plus the roster length.
+    ///
+    /// §4 S3 says every `DELETE` is constructed by one function that re-derives
+    /// the table's class. That is not yet true of the tree: this module's
+    /// `reset_canonical_read_indexes` (via `truncate_index_table`) and
+    /// `mcp_open_projection::reclaim_orphan_delete_statements` both emit
+    /// row-removing SQL directly, and both predate #603. Their safety rests
+    /// entirely on the tables they name being bucket 3 — a property nothing
+    /// asserted, so reclassifying one of these three to `RawAudit` (an
+    /// argument someone could make for a read index that is expensive to
+    /// rebuild) would leave an unguarded `TRUNCATE` pointed at protected data
+    /// with the suite green.
+    ///
+    /// MUTATION (executed 2026-07-27), each run separately: reclassify
+    /// `mcp_session_directory` to `RawAudit`; reclassify `mcp_event_locator`
+    /// to `NeverDelete` => FAILS here in both cases. **Lower bound.**
+    ///
+    /// MUTATION (executed 2026-07-27): add a fourth, unclassified name to
+    /// `CANONICAL_INDEX_TABLES` => FAILS on the `classify` unwrap. **Width:
+    /// the roster is the loop's own source, so it cannot grow past its
+    /// coverage.**
+    #[test]
+    fn every_table_the_rebuild_truncates_directly_is_bucket_three() {
+        use crate::storage_class::{classify, TableClass};
+
+        assert_eq!(super::CANONICAL_INDEX_TABLES.len(), 3);
+        for table in super::CANONICAL_INDEX_TABLES {
+            let class = classify(table).unwrap_or_else(|| {
+                panic!("`{table}` is truncated by rebuild and must be classified")
+            });
+            assert_eq!(
+                class,
+                TableClass::Derived,
+                "`{table}` is emptied by `reset_canonical_read_indexes`, which bypasses \
+                 `reclaim::emit_delete_statement`; only bucket 3 may be reached that way"
+            );
+            assert!(
+                !class.is_protected(),
+                "`{table}` must not be protected while an unguarded TRUNCATE names it"
+            );
+        }
+    }
+
     /// The overlap audit must compare DISTINCT uids, never row counts.
     ///
     /// MUTATION: change either `uniqExact(event_uid)` back to `count()`; this

--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -29,6 +29,23 @@ pub use mcp_open_projection::{
     McpOpenGenerationReadiness, McpOpenHostRevision, McpOpenPublicationRequest, McpOpenSourceHead,
 };
 pub mod mcp_tool_names;
+/// Issue #603 WI-04. Ledger, planner, and authority types. No executor is
+/// registered in this build, so every `run` refuses.
+pub mod reclaim;
+/// Issue #603 WI-01. The ownership model as code: what may ever be deleted.
+pub mod storage_class;
+/// Issue #603 WI-02. Bytes, parts, disk headroom, and the effective policy.
+pub mod storage_report;
+pub use reclaim::{
+    ReclaimAuthority, ReclaimLedgerSummary, ReclaimOutcome, ReclaimPhase, ReclaimPlan,
+    ReclaimPredicate, ReclaimScope, ReclaimStatusReport, ReclaimTable, ReclaimUnit,
+    ReclaimableEstimate,
+};
+pub use storage_class::{classify, ClassifiedTable, TableClass, CLASSIFIED_TABLES};
+pub use storage_report::{
+    fold_buckets, retention_policy_entries, RetentionPolicyEntry, StorageBucketReport,
+    StorageDiskReport, StorageReport, StorageTableReport, TELEMETRY_HORIZON_NOT_CONFIGURABLE_NOTE,
+};
 
 use envelope::{StatementDropGuard, MIN_SERVER_EXECUTION_SECONDS};
 use std::sync::Arc;
@@ -1500,6 +1517,8 @@ pub const REQUIRED_SCHEMA_OBJECTS: &[&str] = &[
     "v_mcp_open_publication_headers",
     "v_current_mcp_open_generation_readiness",
     "v_publication_diagnostics",
+    // issue-603 WI-04 storage reclaim ledger (migration 038).
+    "storage_reclaim_ledger",
     "schema_migrations",
 ];
 
@@ -1689,6 +1708,16 @@ pub fn bundled_migrations() -> Vec<Migration> {
             version: "037",
             name: "037_search_ranking_metadata.sql",
             sql: include_str!("../../../sql/037_search_ranking_metadata.sql"),
+        },
+        Migration {
+            version: "038",
+            name: "038_storage_reclaim_ledger.sql",
+            sql: include_str!("../../../sql/038_storage_reclaim_ledger.sql"),
+        },
+        Migration {
+            version: "039",
+            name: "039_telemetry_retention.sql",
+            sql: include_str!("../../../sql/039_telemetry_retention.sql"),
         },
     ]
 }
@@ -3270,6 +3299,234 @@ mod tests {
         );
     }
 
+    fn migration_sql(version: &str) -> &'static str {
+        bundled_migrations()
+            .into_iter()
+            .find(|migration| migration.version == version)
+            .unwrap_or_else(|| panic!("migration {version} must be registered"))
+            .sql
+    }
+
+    /// The four relations migrations 034 and 035 must leave alone.
+    ///
+    /// This restores — shape-aware rather than as a substring match on one
+    /// statement form with a required trailing semicolon — the exact coverage
+    /// the two deleted per-migration loops carried. It is NOT subsumed by the
+    /// repo-wide S4 invariant: `search_documents` and `search_postings` are
+    /// `Derived`, and `migration_delete_findings` reports only protected
+    /// tables, so for those two S4 says nothing at all. The repo-wide
+    /// counterpart that does cover them is
+    /// `storage_class::tests::no_bundled_migration_empties_the_search_corpus`;
+    /// `events`/`raw_events` are covered by
+    /// `storage_class::tests::no_bundled_migration_removes_protected_rows`.
+    ///
+    /// MUTATION (executed 2026-07-27): append
+    /// `TRUNCATE TABLE moraine.search_documents;` to
+    /// `sql/034_batched_mcp_open_backfill.sql` => this helper FAILS from
+    /// `migration_034_resets_only_the_incomplete_derived_mcp_model`. Same for
+    /// `ALTER TABLE moraine.search_postings DELETE WHERE 1;`, which the
+    /// deleted substring loop would have missed even before it was deleted.
+    fn assert_migration_preserves_the_four_relations(version: &str, sql: &str) {
+        let removals = crate::storage_class::migration_row_removals(version, sql);
+        assert!(
+            !removals.is_empty(),
+            "{version} does truncate the mcp_open_* family, so a scanner reporting nothing here \
+             is broken rather than reassuring"
+        );
+        for preserved in [
+            "events",
+            "raw_events",
+            "search_documents",
+            "search_postings",
+        ] {
+            assert!(
+                !removals.iter().any(|finding| finding.table == preserved),
+                "{version} must preserve `{preserved}`: {removals:#?}"
+            );
+        }
+    }
+
+    /// Migration 038 installs the ledger and nothing else. The whole safety
+    /// argument for WI-04 is "no user data is touched", so the migration that
+    /// arrives with it must be provably additive.
+    #[test]
+    fn migration_038_installs_only_the_reclaim_ledger() {
+        let sql = migration_sql("038");
+        let statements = split_sql_statements(sql);
+        assert_eq!(
+            statements.len(),
+            1,
+            "038 must be exactly one statement: {statements:#?}"
+        );
+        assert!(statements[0].contains("CREATE TABLE IF NOT EXISTS moraine.storage_reclaim_ledger"));
+        assert!(statements[0].contains("ENGINE = ReplacingMergeTree(ledger_revision)"));
+        assert!(statements[0].contains("ORDER BY (scope, reclaim_id)"));
+        for column in [
+            "reclaim_id",
+            "scope",
+            "source_generation",
+            "candidate_generation",
+            "phase",
+            "estimated_rows",
+            "estimated_bytes",
+            "claimed_at",
+            "ledger_revision",
+        ] {
+            assert!(statements[0].contains(column), "038 must carry `{column}`");
+        }
+        // The ledger is durable state the reclaimer depends on for restart
+        // safety; a partition key would only add merge work.
+        assert!(!statements[0].contains("PARTITION BY"));
+        assert!(REQUIRED_SCHEMA_OBJECTS.contains(&"storage_reclaim_ledger"));
+        assert_eq!(
+            crate::storage_class::classify("storage_reclaim_ledger"),
+            Some(crate::storage_class::TableClass::NeverDelete)
+        );
+    }
+
+    /// **The WI-08 S5 gate.** Fails for: a telemetry TTL whose first
+    /// application deletes rows, **and** for one that deletes nothing ever.
+    /// Denomination: exact statement text, per table, in order.
+    ///
+    /// The three statements are matched by **equality**, not by prefix. That
+    /// is the whole difference between bounding the first application and
+    /// bounding the steady state: with `starts_with`, changing the anchor to
+    /// `DEFAULT now() + INTERVAL 50 YEAR` still matched the expected prefix,
+    /// so every row got an anchor fifty years out, the TTL never fired for any
+    /// row ever, and the suite stayed at 177/0 — with WI-08's entire purpose
+    /// (bounding unbounded telemetry growth on a host at 7.8 GiB free)
+    /// silently defeated. The counterpart live gate for that direction,
+    /// `reclaim-idle`/G-IDLE in plan §7.2, is not implemented, so this is the
+    /// only coverage the steady state has.
+    ///
+    /// MUTATION (executed 2026-07-27): change the four `MODIFY TTL` clauses in
+    /// `sql/039_telemetry_retention.sql` from `retention_anchor + INTERVAL 30
+    /// DAY` to `ts + INTERVAL 30 DAY` => FAILS: `ts` is the row's own
+    /// timestamp and a 30-day TTL on it removes five months of telemetry the
+    /// moment the ALTER materializes. **Lower bound: first application.**
+    ///
+    /// MUTATION (executed 2026-07-27): change the four `ADD COLUMN` defaults
+    /// to `DEFAULT now() + INTERVAL 50 YEAR` => FAILS on the exact-statement
+    /// assertion. **Upper bound: the TTL must still be reachable.**
+    ///
+    /// MUTATION (executed 2026-07-27): change one `INTERVAL 30 DAY` to
+    /// `INTERVAL 3000 DAY` => FAILS here and in
+    /// `migration_039_ttl_horizon_matches_the_configured_default`. **Width:
+    /// the horizon is one token and both tokens are pinned.**
+    ///
+    /// MUTATION (executed 2026-07-27): move the `MATERIALIZE COLUMN`
+    /// statement AFTER its `MODIFY TTL` => FAILS on the ordering assertion,
+    /// because a TTL that lands before the anchor is on disk evaluates an
+    /// unmaterialized `DEFAULT now()`.
+    #[test]
+    fn migration_039_ttls_are_anchored_so_first_application_deletes_nothing() {
+        let sql = migration_sql("039");
+        let statements = split_sql_statements(sql);
+        let telemetry = [
+            "ingest_heartbeats",
+            "search_query_log",
+            "search_hit_log",
+            "search_interaction_log",
+        ];
+        assert_eq!(
+            statements.len(),
+            telemetry.len() * 3,
+            "039 must be exactly add/materialize/modify per table: {statements:#?}"
+        );
+        let normalized: Vec<String> = statements
+            .iter()
+            .map(|statement| statement.split_whitespace().collect::<Vec<_>>().join(" "))
+            .collect();
+
+        for table in telemetry {
+            // `DEFAULT now()` and nothing else. An anchor that is not the wall
+            // clock at insert time makes the TTL unreachable for every FUTURE
+            // row, which no ordering or column-name assertion can see.
+            let add = format!(
+                "ALTER TABLE moraine.{table} ADD COLUMN IF NOT EXISTS retention_anchor DateTime \
+                 DEFAULT now()"
+            );
+            let materialize = format!(
+                "ALTER TABLE moraine.{table} MATERIALIZE COLUMN retention_anchor SETTINGS \
+                 mutations_sync = 1"
+            );
+            let modify = format!(
+                "ALTER TABLE moraine.{table} MODIFY TTL retention_anchor + INTERVAL 30 DAY DELETE"
+            );
+
+            let add_at = normalized
+                .iter()
+                .position(|statement| *statement == add)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "039 must add {table}'s anchor as exactly `{add}`. An anchor whose default \
+                         is anything other than `now()` — `now() + INTERVAL 50 YEAR`, say — leaves \
+                         the TTL unreachable forever: {normalized:#?}"
+                    )
+                });
+            let materialize_at = normalized
+                .iter()
+                .position(|statement| *statement == materialize)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "039 must stamp {table}'s anchor synchronously as exactly \
+                         `{materialize}`: {normalized:#?}"
+                    )
+                });
+            let modify_at = normalized
+                .iter()
+                .position(|statement| *statement == modify)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "039's TTL for {table} must be exactly `{modify}` — anchored on \
+                         `retention_anchor`, never on the row's own timestamp, and at the \
+                         configured horizon: {normalized:#?}"
+                    )
+                });
+
+            assert!(
+                add_at < materialize_at && materialize_at < modify_at,
+                "{table}: the anchor must be added, then stamped, then consumed by the TTL — a \
+                 TTL applied before the stamp evaluates an unmaterialized DEFAULT now()"
+            );
+        }
+
+        // Bounded in the other direction: 039 must not name a bucket-1/2 or
+        // never-delete table at all, and must remove nothing.
+        for protected in ["events", "raw_events", "ingest_errors", "search_documents"] {
+            assert!(
+                !sql.contains(&format!("moraine.{protected}")),
+                "039 must not name `{protected}`"
+            );
+        }
+        assert!(crate::storage_class::migration_delete_findings("039", sql).is_empty());
+        for statement in &statements {
+            assert!(!statement.contains("DROP"));
+            assert!(!statement.contains("TRUNCATE"));
+            assert!(!statement.to_uppercase().contains(" DELETE WHERE"));
+        }
+    }
+
+    /// The shipped TTL literal and the `[retention]` default must not drift.
+    /// Migration SQL is static text, so the horizon is baked in; this is what
+    /// keeps `moraine status`'s reported policy honest about what was applied.
+    #[test]
+    fn migration_039_ttl_horizon_matches_the_configured_default() {
+        let sql = migration_sql("039");
+        let expected = format!(
+            "INTERVAL {} DAY DELETE",
+            moraine_config::DEFAULT_RETENTION_TELEMETRY_HORIZON_DAYS
+        );
+        // Executable body only: the header comment quotes the clause too.
+        let body = split_sql_statements(sql).join(";\n");
+        assert_eq!(
+            body.matches(expected.as_str()).count(),
+            4,
+            "all four telemetry TTLs must use the `retention.telemetry_horizon_days` default \
+             ({expected})"
+        );
+    }
+
     #[test]
     fn migration_033_keeps_candidate_headers_and_children_independent() {
         let migration = bundled_migrations()
@@ -3348,17 +3605,7 @@ mod tests {
                 "034 must reset derived relation {derived}"
             );
         }
-        for canonical in [
-            "events",
-            "raw_events",
-            "search_documents",
-            "search_postings",
-        ] {
-            assert!(
-                !sql.contains(&format!("TRUNCATE TABLE moraine.{canonical};")),
-                "034 must preserve canonical relation {canonical}"
-            );
-        }
+        assert_migration_preserves_the_four_relations("034", sql);
         assert!(sql.contains("VALUES ('global', 0, generateSnowflakeID(), '')"));
         assert!(
             sql.find("VALUES ('global', 0, generateSnowflakeID(), '')")
@@ -3390,17 +3637,7 @@ mod tests {
                 "035 must reset derived relation {derived}"
             );
         }
-        for canonical in [
-            "events",
-            "raw_events",
-            "search_documents",
-            "search_postings",
-        ] {
-            assert!(
-                !sql.contains(&format!("TRUNCATE TABLE moraine.{canonical};")),
-                "035 must preserve canonical relation {canonical}"
-            );
-        }
+        assert_migration_preserves_the_four_relations("035", sql);
         assert!(
             sql.find("VALUES ('global', 0, generateSnowflakeID(), '')")
                 < sql.find("TRUNCATE TABLE moraine.mcp_open_events;"),

--- a/crates/moraine-clickhouse/src/mcp_open_projection.rs
+++ b/crates/moraine-clickhouse/src/mcp_open_projection.rs
@@ -124,7 +124,12 @@ struct SupersededGenerationRow {
 
 /// Bounds a reclaim DELETE's literal (session, generation) list far below the
 /// 8 MiB request payload cap.
-const RECLAIM_DELETE_CHUNK: usize = 1000;
+///
+/// `pub(crate)` because [`crate::reclaim::RECLAIM_DELETE_CHUNK`] is *defined
+/// as* this value rather than restating `1000`: the #603 driver's claim that
+/// the two reclaim paths "have one shape" has to be a compile-time fact, not a
+/// comment that survives one of the two being tuned.
+pub(crate) const RECLAIM_DELETE_CHUNK: usize = 1000;
 
 /// Superseded (session, generation) snapshot heads reclaimed because a newer
 /// generation exists in the same source-head lineage and the published

--- a/crates/moraine-clickhouse/src/reclaim.rs
+++ b/crates/moraine-clickhouse/src/reclaim.rs
@@ -1,0 +1,2242 @@
+//! Issue #603 WI-04 — the storage reclaim ledger, the dry-run planner, and the
+//! statement surface of the claim/execute/settle protocol.
+//!
+//! **Nothing in this module deletes any user data, and that is the point.**
+//! No executor is registered for any scope yet ([`executor_for`] returns
+//! `None` for every variant), so [`ClickHouseClient::reclaim_run`] refuses
+//! every scope. The ledger, the planner, the authority types, and the
+//! statement emitter must all exist and be trustworthy *before* the first
+//! executor lands, because the first executor is the point at which a bug
+//! costs an operator their history.
+//!
+//! ## What is NOT in this build: the §3.2 driver (descoped to WI-05)
+//!
+//! Plan §3.2 specifies a four-step protocol — plan, claim, execute, settle —
+//! and states that "any unit in `claimed` or `deleting` is re-driven to
+//! completion before new units are planned". **That driver is not implemented
+//! here.** [`emit_delete_statement`], [`ledger_claim_statement`],
+//! [`ledger_advance_statement`] and [`ledger_redrive_sql`] have zero
+//! production callers: they are the protocol's *statement surface*, built and
+//! unit-tested first so that the SQL a WI-05 executor will run is reviewable
+//! before it runs. [`ClickHouseClient::reclaim_run`] never reads the ledger,
+//! never claims, never advances, and never settles.
+//!
+//! Do not read [`tests::the_phase_machine_redrives_exactly_the_unsettled_phases`]
+//! as evidence to the contrary: it asserts enum predicates and SQL substrings.
+//! There is no claim for it to interrupt in this build, and the live half —
+//! SIGKILL between the child and parent deletes — is the `reclaim-restart`
+//! gate, which arrives with WI-05.
+//!
+//! **No executor may be registered before the driver is real.** Shipping an
+//! executor onto an unimplemented ledger protocol is how a partial delete
+//! becomes unrecoverable: the rows would go, nothing durable would record that
+//! they were going, and the crash the ledger exists to survive would strand
+//! exactly the children it exists to keep reachable. That ordering is not left
+//! to a comment — [`LEDGER_DRIVER_WIRED`] and
+//! `no_executor_may_be_registered_before_the_ledger_driver_is_wired` enforce
+//! it.
+//!
+//! ## INV-1 / INV-2 (plan §3.1)
+//!
+//! > **INV-1.** The reclaimer never evaluates whether a generation *should* be
+//! > live. It reads a liveness decision already durably recorded by the atomic
+//! > publication path and acts only on generations that decision has retired.
+//!
+//! > **INV-2.** The reclaimer issues **zero writes** to
+//! > `published_source_generations`, `ingest_checkpoint_transitions`,
+//! > `source_generation_publication_readiness`, `ingest_append_control`, or
+//! > `mcp_read_index_state`.
+//!
+//! INV-2 is what makes "a failed cleanup does not change which generation is
+//! live" a structural property rather than a hope. It is proved by
+//! [`tests::no_emitted_statement_writes_a_control_relation`] capturing every
+//! statement this module can emit across every scope, not by inspection.
+//!
+//! ## The ledger, and why the delete order is the inverse of the old reclaimer
+//!
+//! The existing `mcp_open` reclaimer derives its target set *from headers* and
+//! deletes the headers first. A crash between statements strands the children
+//! **forever**, because the set can never be re-derived; the reference host's
+//! 10.9M orphan `mcp_open_events` rows are that bug's output.
+//!
+//! The ledger makes the set durable independently of the rows, so this driver
+//! can delete **children first, parent last**. A crash then leaves an intact,
+//! still-authorizable snapshot rather than an unreachable orphan. Reader
+//! safety is preserved by the safety horizon and the anti-join — the unit is
+//! already non-live before it is claimed — not by delete ordering.
+//!
+//! ## Bounding
+//!
+//! Every statement runs under a `Background` envelope. Never `Migration`:
+//! `arms_cancel_guards()` is false for that class, so a runaway cleanup would
+//! be uncancellable by Moraine on a host that has already filled its disk
+//! twice. Never `ALTER … DELETE`, never `mutations_sync = 1`: cleanup uses
+//! lightweight `DELETE FROM` through the insert-profile transport.
+
+use std::fmt;
+
+use anyhow::{Context, Result};
+use moraine_config::{ProtectedRetentionBucket, RetentionConfig, RetentionHorizon};
+use serde::{Deserialize, Serialize};
+
+use crate::envelope::{QueryClass, QueryEnvelope};
+use crate::storage_class::{classify, TableClass};
+use crate::storage_report::StorageReport;
+use crate::{escape_identifier, escape_literal, ClickHouseClient};
+
+/// The ledger relation installed by migration 038.
+pub const RECLAIM_LEDGER_TABLE: &str = "storage_reclaim_ledger";
+
+/// Control relations the reclaimer must never write. INV-2, as data.
+///
+/// `published_source_generations` is publication truth; the next three are
+/// monotone revision allocators or the cache fence; `mcp_read_index_state` is
+/// the canonical-read-index readiness fence.
+pub const CONTROL_RELATIONS: &[&str] = &[
+    "published_source_generations",
+    "ingest_checkpoint_transitions",
+    "source_generation_publication_readiness",
+    "ingest_append_control",
+    "mcp_read_index_state",
+];
+
+/// Maximum `(key)` tuples inlined into one `DELETE … WHERE … IN (…)`.
+///
+/// Defined *as* the existing `mcp_open` reclaimer's chunk rather than
+/// restating the literal, so the two paths cannot claim "one shape" while
+/// drifting to two numbers. The definition is the coupling;
+/// `the_two_reclaim_paths_share_one_chunk_size` names it so a future edit that
+/// re-copies the literal fails a test rather than a code review.
+pub const RECLAIM_DELETE_CHUNK: usize = crate::mcp_open_projection::RECLAIM_DELETE_CHUNK;
+
+/// Whether `statement` writes a control relation, and which one (INV-2).
+///
+/// Matches the **bare** relation name, not just the backtick-escaped form. An
+/// earlier revision tested only ``statement.contains("`moraine`.{control}")``,
+/// so a plain `INSERT INTO moraine.published_source_generations …` — the exact
+/// text a hand-written repair statement or an un-escaped code path would
+/// produce — passed the invariant untouched. The escaped form is a subset of
+/// the bare one, so this is strictly wider and the bare match is what the
+/// invariant is actually about: the reclaimer must not write publication truth
+/// however it spells the qualifier.
+///
+/// `OPTIMIZE … FINAL` counts as a write. It returns no rows and reads as
+/// maintenance, but `published_source_generations` is a `ReplacingMergeTree`
+/// keyed on `publication_revision`: collapsing it discards every superseded
+/// revision, which breaks the as-of read §1 gives as the reason that table is
+/// never-delete. Nothing in the tree emits an `OPTIMIZE` today; the detector
+/// covers the shape so the first one to appear is a test failure rather than a
+/// statement the invariant waves through.
+pub fn writes_control_relation(statement: &str) -> Option<&'static str> {
+    let writes = statement.starts_with("INSERT INTO")
+        || statement.starts_with("DELETE FROM")
+        || statement.starts_with("ALTER")
+        || statement.starts_with("TRUNCATE")
+        || statement.starts_with("DROP")
+        || statement.starts_with("OPTIMIZE");
+    if !writes {
+        return None;
+    }
+    CONTROL_RELATIONS
+        .iter()
+        .find(|control| statement.contains(**control))
+        .copied()
+}
+
+/// Per-unit statement budget: at most one claim write, one phase advance, the
+/// deletes for the unit's tables, one settle write, and margin. Derived from
+/// named parts rather than a global constant, so no legitimate unit can exceed
+/// its own cap.
+const UNIT_STMT_CLAIM: u32 = 1;
+const UNIT_STMT_ADVANCE: u32 = 1;
+const UNIT_STMT_SETTLE: u32 = 1;
+/// Largest table count any single scope deletes from (see
+/// [`ReclaimScope::tables`]); asserted in the unit tests.
+const UNIT_STMT_MAX_TABLES: u32 = 7;
+const UNIT_STMT_MARGIN: u32 = 2;
+/// Per-unit statement cap fed to [`QueryEnvelope::new_batch`].
+pub const UNIT_STATEMENT_CAP: u32 = UNIT_STMT_CLAIM
+    + UNIT_STMT_ADVANCE
+    + UNIT_STMT_SETTLE
+    + UNIT_STMT_MAX_TABLES
+    + UNIT_STMT_MARGIN;
+
+/// Statement cap for the planner: the ledger re-drive probe, the candidate
+/// probe, and the `system.parts` estimate, with margin. The planner writes
+/// nothing.
+pub const PLAN_STATEMENT_CAP: u32 = 8;
+
+// ---------------------------------------------------------------------------
+// Denomination (plan §3.7) — what may be reported, and in what words
+// ---------------------------------------------------------------------------
+
+/// Qualifier every "bytes we could reclaim" number must carry. Nothing is
+/// partitioned by `source_generation`, so a reclaim is a lightweight `DELETE`
+/// masking rows via `_row_exists`; bytes come back only when a background
+/// merge gets to the part.
+pub const ESTIMATE_QUALIFIER: &str = "estimate";
+
+/// Qualifier every "bytes we did reclaim" number must carry.
+pub const MERGE_DEFERRED_QUALIFIER: &str = "merge-deferred";
+
+/// Words a reclaim surface may never use. "frees"/"recovers" promise an
+/// immediate on-disk effect that a lightweight `DELETE` does not deliver, and
+/// "partition" promises partition-aligned deletion that no table's layout
+/// supports.
+pub const FORBIDDEN_DENOMINATION_WORDS: &[&str] = &["frees", "recovers", "partition"];
+
+/// The one sentence every surface uses for an estimate.
+pub fn estimated_bytes_note() -> String {
+    format!(
+        "reclaimable bytes are an {ESTIMATE_QUALIFIER}; a lightweight DELETE masks rows and \
+         returns bytes only when a background merge rewrites the part"
+    )
+}
+
+/// The one sentence every surface uses after a run.
+pub fn reclaimed_bytes_note() -> String {
+    format!(
+        "reclaimed row counts are exact; the on-disk delta is {MERGE_DEFERRED_QUALIFIER} and is \
+         not a guarantee"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Scopes and predicates
+// ---------------------------------------------------------------------------
+
+/// A reclaimable unit kind. One variant per work item that will register an
+/// executor; each names a target table set and, per table, a predicate shape.
+///
+/// This is an enum rather than a string so that adding a scope without
+/// deciding its tables, its predicate shapes, its authority, and whether it is
+/// on by default is a compile error in five places.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReclaimScope {
+    /// WS-3a (WI-05): `(session_id, candidate_generation)` pairs present in
+    /// the `mcp_open_*` child tables with no corresponding publication header.
+    /// Provably dead: an exact `(slot, generation)` match against the
+    /// header-authorized session is required to pin one, on either engine.
+    McpOpenOrphan,
+    /// WS-3b (WI-07): canonical read-index rows whose
+    /// `(source_host, source_name, source_file, source_generation)` is not in
+    /// the published heads. All three targets are content-free and rebuildable
+    /// via `moraine db core-index rebuild`.
+    ReadIndexGeneration,
+    /// WS-3c (WI-09): superseded canonical/raw/search rows. Buckets 1 and 2,
+    /// so it is unreachable without an explicit `[retention]` key.
+    CanonicalGeneration,
+}
+
+impl ReclaimScope {
+    pub const ALL: [ReclaimScope; 3] = [
+        Self::McpOpenOrphan,
+        Self::ReadIndexGeneration,
+        Self::CanonicalGeneration,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::McpOpenOrphan => "mcp_open_orphan",
+            Self::ReadIndexGeneration => "read_index_generation",
+            Self::CanonicalGeneration => "canonical_generation",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|scope| scope.as_str() == value)
+    }
+
+    /// Tables this scope deletes from, **children first, parent last**
+    /// (plan §3.2 and §3.5). A crash mid-unit must leave derived data missing
+    /// over intact canonical data, never the inverse.
+    pub fn tables(self) -> &'static [ReclaimTable] {
+        match self {
+            Self::McpOpenOrphan => &[
+                ReclaimTable::McpOpenEvents,
+                ReclaimTable::McpOpenTurns,
+                ReclaimTable::McpOpenPublicationHeaders,
+            ],
+            Self::ReadIndexGeneration => &[
+                ReclaimTable::McpEventNavigation,
+                ReclaimTable::McpEventLocator,
+                ReclaimTable::McpSessionDirectory,
+            ],
+            Self::CanonicalGeneration => &[
+                ReclaimTable::SearchPostings,
+                ReclaimTable::SearchDocuments,
+                ReclaimTable::ToolIo,
+                ReclaimTable::EventLinks,
+                ReclaimTable::IngestErrors,
+                ReclaimTable::RawEvents,
+                ReclaimTable::Events,
+            ],
+        }
+    }
+
+    /// Whether stock configuration may reach this scope at all.
+    ///
+    /// `CanonicalGeneration` is not merely "off by default": it is
+    /// unconstructible as an authorized claim without a `[retention]` key,
+    /// because [`ReclaimAuthority::for_scope`] cannot produce a token for it
+    /// from a default config.
+    pub fn is_default_on(self) -> bool {
+        match self {
+            Self::McpOpenOrphan | Self::ReadIndexGeneration => true,
+            Self::CanonicalGeneration => false,
+        }
+    }
+
+    /// Human-readable description used by the CLI refusal.
+    pub fn describe(self) -> &'static str {
+        match self {
+            Self::McpOpenOrphan => {
+                "orphan legacy open-projection rows (no publication header; unreadable by design)"
+            }
+            Self::ReadIndexGeneration => {
+                "canonical read-index rows for superseded source generations (content-free, \
+                 rebuildable with `moraine db core-index rebuild`)"
+            }
+            Self::CanonicalGeneration => {
+                "canonical, raw, and search rows for superseded source generations (USER HISTORY)"
+            }
+        }
+    }
+}
+
+impl fmt::Display for ReclaimScope {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// A table a reclaim scope may name. Closed enum, because the whole safety
+/// argument rests on the per-table predicate shape being decided once, in
+/// [`ReclaimTable::predicate`], as an exhaustive match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReclaimTable {
+    McpOpenEvents,
+    McpOpenTurns,
+    McpOpenPublicationHeaders,
+    McpSessionDirectory,
+    McpEventLocator,
+    McpEventNavigation,
+    SearchPostings,
+    SearchDocuments,
+    ToolIo,
+    EventLinks,
+    IngestErrors,
+    RawEvents,
+    Events,
+}
+
+/// The shape of the predicate a table's delete may carry.
+///
+/// **Hazard H3, as a type.** `tool_io` and `event_links` have no
+/// `source_file`/`source_generation` column at all, so a generation-shaped
+/// predicate against them is a compile-time-valid, runtime-wrong statement.
+/// Making the shape part of an exhaustive `match` turns "someone writes a
+/// generation predicate for `tool_io`" from a code-review catch into a
+/// changed match arm that the tests below assert directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReclaimPredicate {
+    /// `(source_host, source_name, source_file, source_generation)` is on the
+    /// row itself and is exact.
+    Generation,
+    /// `(session_id, candidate_generation)` is on the row itself.
+    SessionGeneration,
+    /// The row carries no generation. Its liveness is a **uid set** captured
+    /// into the ledger before the parent delete runs, or the rows become
+    /// unreachable the moment their parent goes.
+    UidSet,
+    /// The row's own `source_file`/`source_generation` are back-filled type
+    /// defaults on the overwhelming majority of rows and must never be
+    /// predicated on. The only safe predicate joins through the **document**.
+    DocumentJoin,
+}
+
+impl ReclaimPredicate {
+    /// Columns a delete of this shape must reference, all of them.
+    ///
+    /// **This is the check that catches the failure that actually empties a
+    /// table.** Re-deriving the class and checking the token proves the
+    /// emitter may name `events`; it says nothing about *which* rows the
+    /// statement removes. An executor that produced `WHERE session_id IN ()`,
+    /// or fell back to `WHERE 1` on an empty chunk, previously passed the last
+    /// independent check before a `DELETE` reached ClickHouse — and the INV-2
+    /// corpus itself built every statement with `"1"`, a full-table delete.
+    ///
+    /// Every name here is verified present on every table of the shape:
+    /// `source_host` reaches `events`/`raw_events`/`ingest_errors`/
+    /// `search_documents` via sql/032:25-70 and the read indexes via sql/036;
+    /// `candidate_generation` reaches `mcp_open_events`/`mcp_open_turns` via
+    /// sql/033:8,13 and `mcp_open_publication_headers` at creation.
+    /// `search_postings` has **no** `event_uid` column at all — its link to
+    /// the document is `doc_id` — which is why `DocumentJoin` is a separate
+    /// shape rather than `UidSet`.
+    pub fn required_columns(self) -> &'static [&'static str] {
+        match self {
+            Self::Generation => &[
+                "source_host",
+                "source_name",
+                "source_file",
+                "source_generation",
+            ],
+            Self::SessionGeneration => &["session_id", "candidate_generation"],
+            Self::UidSet => &["event_uid"],
+            Self::DocumentJoin => &["doc_id"],
+        }
+    }
+}
+
+impl ReclaimTable {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::McpOpenEvents => "mcp_open_events",
+            Self::McpOpenTurns => "mcp_open_turns",
+            Self::McpOpenPublicationHeaders => "mcp_open_publication_headers",
+            Self::McpSessionDirectory => "mcp_session_directory",
+            Self::McpEventLocator => "mcp_event_locator",
+            Self::McpEventNavigation => "mcp_event_navigation",
+            Self::SearchPostings => "search_postings",
+            Self::SearchDocuments => "search_documents",
+            Self::ToolIo => "tool_io",
+            Self::EventLinks => "event_links",
+            Self::IngestErrors => "ingest_errors",
+            Self::RawEvents => "raw_events",
+            Self::Events => "events",
+        }
+    }
+
+    /// The predicate shape this table's delete must use. Exhaustive by
+    /// construction: a new variant without an arm is a compile error.
+    pub fn predicate(self) -> ReclaimPredicate {
+        match self {
+            Self::McpOpenEvents | Self::McpOpenTurns | Self::McpOpenPublicationHeaders => {
+                ReclaimPredicate::SessionGeneration
+            }
+            Self::McpSessionDirectory | Self::McpEventNavigation => ReclaimPredicate::Generation,
+            // `mcp_event_locator` is ORDER BY (event_uid, source_host) and
+            // `event_uid` embeds `source_generation`, so a generation
+            // predicate is exact — but `session_id` on a locator row is NOT
+            // key-determined, so a locator delete must never carry one.
+            Self::McpEventLocator => ReclaimPredicate::Generation,
+            Self::SearchPostings => ReclaimPredicate::DocumentJoin,
+            // `search_documents` is ORDER BY (event_uid, source_host) alone,
+            // so one physical row serves BOTH attributions of a
+            // double-attributed uid. Generation-keyed, never session-keyed.
+            Self::SearchDocuments => ReclaimPredicate::Generation,
+            // H3: no generation column exists on either of these.
+            Self::ToolIo | Self::EventLinks => ReclaimPredicate::UidSet,
+            Self::IngestErrors | Self::RawEvents | Self::Events => ReclaimPredicate::Generation,
+        }
+    }
+
+    /// The storage class of this table, re-derived from the classification.
+    /// Panics only if the classification and this enum disagree, which
+    /// `every_reclaim_table_is_classified` makes impossible to ship.
+    pub fn class(self) -> Option<TableClass> {
+        classify(self.name())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// §4 S2/S3 — authority
+// ---------------------------------------------------------------------------
+
+/// Permission to emit a delete naming a table of a given class.
+///
+/// Two of the variants are constructible from a default config; two are not
+/// constructible **at all** without a [`RetentionHorizon`], which has no
+/// `Default`, no `From<()>`, and only one source: an explicit config key.
+/// A missing setting therefore cannot type-check into deletion authority.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ReclaimAuthority {
+    /// Bucket 3. Constructible from `Default`.
+    DerivedOnly,
+    /// Bucket 4. Constructible from `Default`.
+    Telemetry,
+    /// Bucket 2. **Not** constructible without config.
+    RawAudit(RetentionHorizon),
+    /// Bucket 1. **Not** constructible without config.
+    CanonicalHistory(RetentionHorizon),
+}
+
+impl ReclaimAuthority {
+    /// Whether this token authorizes a delete naming a table of `class`.
+    ///
+    /// **Exactly one class per variant.** §4 S3 requires the *corresponding*
+    /// token and S2 makes permission per-bucket: `retention.raw_audit_horizon_days`
+    /// is what authorizes `raw_events`/`ingest_errors`, and nothing else is.
+    /// An earlier revision let `CanonicalHistory(_)` cover `RawAudit` and
+    /// `Derived` on the reasoning that the canonical horizon is the strictest
+    /// one — but that makes the emitter's check depend on
+    /// [`Self::for_scope`] demanding both keys, which is precisely the
+    /// planner-side check S3 says the emitter must not lean on. A scope
+    /// spanning two buckets carries two tokens; see
+    /// [`Self::for_scope`]'s `CanonicalGeneration` arm.
+    ///
+    /// `NeverDelete` is authorized by nothing: there is deliberately no
+    /// variant that could return `true` for it.
+    pub fn authorizes(self, class: TableClass) -> bool {
+        match (self, class) {
+            (_, TableClass::NeverDelete) => false,
+            (Self::DerivedOnly, TableClass::Derived) => true,
+            (Self::Telemetry, TableClass::Telemetry) => true,
+            (Self::RawAudit(_), TableClass::RawAudit) => true,
+            (Self::CanonicalHistory(_), TableClass::CanonicalHistory) => true,
+            _ => false,
+        }
+    }
+
+    /// The authority tokens `retention` produces for `scope`, or the missing
+    /// config key when it produces none.
+    ///
+    /// `CanonicalGeneration` needs both protected horizons because its table
+    /// list spans buckets 1 and 2; a config that names only one of them is
+    /// refused naming the other, rather than silently reclaiming half a unit.
+    pub fn for_scope(
+        scope: ReclaimScope,
+        retention: &RetentionConfig,
+    ) -> Result<Vec<ReclaimAuthority>, MissingAuthority> {
+        match scope {
+            ReclaimScope::McpOpenOrphan | ReclaimScope::ReadIndexGeneration => {
+                Ok(vec![Self::DerivedOnly])
+            }
+            ReclaimScope::CanonicalGeneration => {
+                let canonical = RetentionHorizon::from_config(
+                    retention,
+                    ProtectedRetentionBucket::CanonicalHistory,
+                )
+                .ok_or(MissingAuthority {
+                    scope,
+                    config_key: ProtectedRetentionBucket::CanonicalHistory.config_key(),
+                })?;
+                let raw =
+                    RetentionHorizon::from_config(retention, ProtectedRetentionBucket::RawAudit)
+                        .ok_or(MissingAuthority {
+                            scope,
+                            config_key: ProtectedRetentionBucket::RawAudit.config_key(),
+                        })?;
+                Ok(vec![
+                    Self::DerivedOnly,
+                    Self::RawAudit(raw),
+                    Self::CanonicalHistory(canonical),
+                ])
+            }
+        }
+    }
+}
+
+/// A scope asked for without the config key that would authorize it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MissingAuthority {
+    pub scope: ReclaimScope,
+    pub config_key: &'static str,
+}
+
+impl fmt::Display for MissingAuthority {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "scope `{}` deletes user history and is not configured: set `{}` to a horizon of at \
+             least 7 days first. Export before pruning with `moraine export events --format jsonl`.",
+            self.scope, self.config_key
+        )
+    }
+}
+
+impl std::error::Error for MissingAuthority {}
+
+/// Refusal from the statement emitter (§4 S3, the second independent check).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmitRefusal {
+    /// [`classify`] returned `None`. S1: unknown is not deletable.
+    UnclassifiedTable { table: String },
+    /// The table's class is not authorized by any supplied token.
+    Unauthorized { table: String, class: TableClass },
+    /// The predicate does not bind the claimed unit: it fails to name one or
+    /// more of the shape's key columns, so the statement's extent is not the
+    /// unit's extent. `WHERE 1` is the limiting case.
+    UnboundPredicate {
+        table: String,
+        predicate: ReclaimPredicate,
+        missing: Vec<&'static str>,
+    },
+}
+
+impl fmt::Display for EmitRefusal {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnclassifiedTable { table } => write!(
+                formatter,
+                "refusing to emit a delete naming unclassified table `{table}`: an unknown table \
+                 is not deletable"
+            ),
+            Self::Unauthorized { table, class } => write!(
+                formatter,
+                "refusing to emit a delete naming `{table}` ({}): no authority token for this \
+                 class was supplied",
+                class.as_str()
+            ),
+            Self::UnboundPredicate {
+                table,
+                predicate,
+                missing,
+            } => write!(
+                formatter,
+                "refusing to emit a delete naming `{table}`: its predicate does not name {} — a \
+                 {predicate:?} delete must bind every key column of the claimed unit, or its \
+                 extent is not the unit's extent",
+                missing.join(", ")
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EmitRefusal {}
+
+// ---------------------------------------------------------------------------
+// Ledger
+// ---------------------------------------------------------------------------
+
+/// Ledger phase. Advances only forward; `settle` writes `Done`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReclaimPhase {
+    /// Written **before any delete**, from relations the deletes do not touch.
+    Claimed,
+    /// Deletes in flight. A crash here leaves a unit whose parent still
+    /// exists; the next run re-drives it from the ledger.
+    Deleting,
+    Done,
+    /// Abandoned by an operator or by a bound. Never re-driven.
+    Abandoned,
+}
+
+impl ReclaimPhase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Claimed => "claimed",
+            Self::Deleting => "deleting",
+            Self::Done => "done",
+            Self::Abandoned => "abandoned",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        [Self::Claimed, Self::Deleting, Self::Done, Self::Abandoned]
+            .into_iter()
+            .find(|phase| phase.as_str() == value)
+    }
+
+    /// Phases a run must re-drive to completion before planning new units.
+    pub fn needs_redrive(self) -> bool {
+        matches!(self, Self::Claimed | Self::Deleting)
+    }
+}
+
+/// One claimed unit of reclamation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReclaimUnit {
+    pub reclaim_id: String,
+    pub scope: ReclaimScope,
+    pub source_host: String,
+    pub source_name: String,
+    pub source_file: String,
+    pub source_generation: u32,
+    /// Empty for generation-scoped units.
+    pub session_id: String,
+    /// Zero for generation-scoped units.
+    pub candidate_generation: u64,
+    pub phase: ReclaimPhase,
+    pub estimated_rows: u64,
+    pub estimated_bytes: u64,
+}
+
+/// Ledger totals by phase.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReclaimLedgerSummary {
+    pub claimed: u64,
+    pub deleting: u64,
+    pub done: u64,
+    pub abandoned: u64,
+    /// Present when a run could not proceed. Never `None` merely because
+    /// nothing needed doing — hazard H9's failure mode is precisely that
+    /// "blocked" and "nothing to do" were indistinguishable.
+    pub blocked_reason: Option<String>,
+}
+
+impl ReclaimLedgerSummary {
+    pub fn needs_redrive(&self) -> u64 {
+        self.claimed + self.deleting
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plan / run outcomes
+// ---------------------------------------------------------------------------
+
+/// A dry-run estimate for one scope. Writes nothing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReclaimableEstimate {
+    pub scope: ReclaimScope,
+    pub units: u64,
+    pub estimated_rows: u64,
+    pub estimated_bytes: u64,
+    /// Tables the scope would delete from, in emission order.
+    pub tables: Vec<String>,
+    /// Why the scope reported zero units, when it did.
+    pub note: Option<String>,
+}
+
+/// The full `moraine db reclaim plan` result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReclaimPlan {
+    pub scopes: Vec<ReclaimableEstimate>,
+    /// [`estimated_bytes_note`]. Carried in the payload so a JSON consumer
+    /// cannot render a byte count without the qualifier.
+    pub denomination: String,
+    /// Units already in the ledger awaiting re-drive.
+    pub pending_redrive: u64,
+}
+
+/// The full `moraine db reclaim status` result: WI-02's storage report plus
+/// the ledger and the dry-run estimates.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReclaimStatusReport {
+    /// `false` when ClickHouse could not be reached; every other field is then
+    /// its empty value. Mirrors the never-fails shape of the core-index
+    /// report: storage state is transient and must not fail a doctor exit.
+    pub available: bool,
+    pub storage: Option<StorageReport>,
+    pub ledger: ReclaimLedgerSummary,
+    pub reclaimable: Vec<ReclaimableEstimate>,
+    /// Scopes an executor exists for. Empty in this build.
+    pub registered_executors: Vec<ReclaimScope>,
+    pub denomination: String,
+    pub error: Option<String>,
+}
+
+/// Outcome of `moraine db reclaim run`.
+///
+/// **Hazard H9, as a type.** The existing projection reclaim gate returns
+/// `Ok(default)` with no log and no counter when a mutation is pending, so a
+/// permanently stuck mutation disables reclamation forever with zero operator
+/// signal. `Blocked` is a distinct variant carrying the pending count, and it
+/// is surfaced by `reclaim status`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ReclaimOutcome {
+    /// No executor is registered for the scope. The only outcome this build
+    /// can produce for a `run`.
+    NoExecutor {
+        scope: ReclaimScope,
+        message: String,
+    },
+    /// A prior mutation over the scope's tables is still running.
+    Blocked {
+        scope: ReclaimScope,
+        pending_mutations: u64,
+    },
+    /// Nothing to reclaim.
+    Idle { scope: ReclaimScope },
+    /// Units were settled.
+    Settled {
+        scope: ReclaimScope,
+        units: u64,
+        reclaimed_rows: u64,
+        /// [`reclaimed_bytes_note`].
+        denomination: String,
+    },
+}
+
+impl ReclaimOutcome {
+    pub fn scope(&self) -> ReclaimScope {
+        match self {
+            Self::NoExecutor { scope, .. }
+            | Self::Blocked { scope, .. }
+            | Self::Idle { scope }
+            | Self::Settled { scope, .. } => *scope,
+        }
+    }
+
+    /// Whether the outcome represents work actually performed.
+    pub fn deleted_anything(&self) -> bool {
+        matches!(self, Self::Settled { units, .. } if *units > 0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Executor registry
+// ---------------------------------------------------------------------------
+
+/// Whether [`ClickHouseClient::reclaim_run`] genuinely claims units into the
+/// ledger, re-drives unsettled ones, and settles them (plan §3.2).
+///
+/// `false` in WI-04: the four statement builders exist and are unit-tested,
+/// but nothing calls them outside `#[cfg(test)]`. WI-05 wires the driver and
+/// flips this in the same PR that registers the first executor — which is the
+/// only order that is safe, and which
+/// `no_executor_may_be_registered_before_the_ledger_driver_is_wired` enforces.
+///
+/// Flipping this constant without wiring the driver is not a shortcut past
+/// that test; it is a false statement in a safety guard, and it is one line in
+/// a diff.
+pub const LEDGER_DRIVER_WIRED: bool = false;
+
+/// A registered scope executor.
+///
+/// Deliberately empty in WI-04. WI-05 registers `McpOpenOrphan`, WI-07
+/// registers `ReadIndexGeneration`, WI-09 registers `CanonicalGeneration`.
+/// Until then every `run` refuses, and the refusal names the work item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegisteredExecutor {
+    pub scope: ReclaimScope,
+}
+
+/// The executor for `scope`, if one has been registered in this build.
+pub fn executor_for(scope: ReclaimScope) -> Option<RegisteredExecutor> {
+    match scope {
+        // WI-05 registers this.
+        ReclaimScope::McpOpenOrphan => None,
+        // WI-07 registers this.
+        ReclaimScope::ReadIndexGeneration => None,
+        // WI-09 registers this.
+        ReclaimScope::CanonicalGeneration => None,
+    }
+}
+
+/// Every scope with a registered executor. Empty in this build.
+pub fn registered_executors() -> Vec<ReclaimScope> {
+    ReclaimScope::ALL
+        .into_iter()
+        .filter(|scope| executor_for(*scope).is_some())
+        .collect()
+}
+
+/// The work item that will register `scope`'s executor, for the refusal text.
+fn pending_work_item(scope: ReclaimScope) -> &'static str {
+    match scope {
+        ReclaimScope::McpOpenOrphan => "WI-05",
+        ReclaimScope::ReadIndexGeneration => "WI-07",
+        ReclaimScope::CanonicalGeneration => "WI-09",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Statement construction
+// ---------------------------------------------------------------------------
+
+/// The single function that constructs a `DELETE` naming a reclaim table
+/// (§4 S3, the emitter-side check).
+///
+/// It performs three checks, and the third is the one that bounds *extent*:
+///
+/// 1. It re-derives the table's class from [`classify`] — an *independent*
+///    source from whatever the planner used to build the unit.
+/// 2. It refuses unless handed a token that authorizes that class. The
+///    regression: a planner bug that mis-scopes a unit still cannot produce a
+///    canonical delete, because the emitter checks again.
+/// 3. It refuses a predicate whose text does not **mention** every key column
+///    of the table's [`ReclaimPredicate`] shape. Checks 1 and 2 prove the
+///    emitter may name `events`; only check 3 constrains *which rows* leave.
+///    Without it, an executor falling back to `WHERE 1` on an empty chunk
+///    passed the last independent gate before a `DELETE` reached ClickHouse.
+///
+///    It is `predicate_sql.contains(column)` — **name presence, not binding**.
+///    It cannot tell a bound key tuple from a mention: `WHERE (session_id,
+///    candidate_generation) IN ()` passes (correctly — it deletes nothing) and
+///    so would a predicate that merely spelled the column names. Turning that
+///    into a real binding check needs a predicate the emitter *builds* rather
+///    than one it inspects, which is WI-09's shape. Until then the honest
+///    statement of what check 3 buys is: an executor cannot emit a predicate
+///    that names no key column at all.
+///
+/// Lightweight `DELETE FROM`, never `ALTER … DELETE`, never
+/// `mutations_sync = 1`.
+pub fn emit_delete_statement(
+    database: &str,
+    table: ReclaimTable,
+    predicate_sql: &str,
+    authorities: &[ReclaimAuthority],
+) -> Result<String, EmitRefusal> {
+    let name = table.name();
+    let Some(class) = classify(name) else {
+        return Err(EmitRefusal::UnclassifiedTable {
+            table: name.to_string(),
+        });
+    };
+    if !authorities
+        .iter()
+        .any(|authority| authority.authorizes(class))
+    {
+        return Err(EmitRefusal::Unauthorized {
+            table: name.to_string(),
+            class,
+        });
+    }
+    let predicate = table.predicate();
+    let missing: Vec<&'static str> = predicate
+        .required_columns()
+        .iter()
+        .copied()
+        .filter(|column| !predicate_sql.contains(column))
+        .collect();
+    if !missing.is_empty() {
+        return Err(EmitRefusal::UnboundPredicate {
+            table: name.to_string(),
+            predicate,
+            missing,
+        });
+    }
+    Ok(format!(
+        "DELETE FROM {}.{name}\nWHERE {predicate_sql}",
+        escape_identifier(database)
+    ))
+}
+
+/// Ledger claim write. Happens **before any delete** and is derived from
+/// relations the deletes do not touch, which is what makes a crash recoverable.
+pub fn ledger_claim_statement(database: &str, unit: &ReclaimUnit) -> String {
+    format!(
+        "INSERT INTO {}.{RECLAIM_LEDGER_TABLE}\n\
+         (reclaim_id, scope, source_host, source_name, source_file, source_generation,\n \
+          session_id, candidate_generation, phase, estimated_rows, estimated_bytes,\n \
+          claimed_at, ledger_revision)\n\
+         VALUES ({}, {}, {}, {}, {}, toUInt32({}), {}, toUInt64({}), {}, toUInt64({}), \
+         toUInt64({}), now64(3), generateSnowflakeID())",
+        escape_identifier(database),
+        escape_literal(&unit.reclaim_id),
+        escape_literal(unit.scope.as_str()),
+        escape_literal(&unit.source_host),
+        escape_literal(&unit.source_name),
+        escape_literal(&unit.source_file),
+        unit.source_generation,
+        escape_literal(&unit.session_id),
+        unit.candidate_generation,
+        escape_literal(unit.phase.as_str()),
+        unit.estimated_rows,
+        unit.estimated_bytes,
+    )
+}
+
+/// Advance a claimed unit to a later phase. A `ReplacingMergeTree` keyed on
+/// `(scope, reclaim_id)` collapses to the newest `ledger_revision`, so this is
+/// an insert, never an update and never a delete.
+pub fn ledger_advance_statement(database: &str, unit: &ReclaimUnit, phase: ReclaimPhase) -> String {
+    let advanced = ReclaimUnit {
+        phase,
+        ..unit.clone()
+    };
+    ledger_claim_statement(database, &advanced)
+}
+
+/// Units awaiting re-drive, oldest first. Read at the head of every run and on
+/// startup: a `claimed` or `deleting` unit is completed **before** new units
+/// are planned.
+pub fn ledger_redrive_sql(database: &str, limit: usize) -> String {
+    format!(
+        "SELECT reclaim_id, scope, source_host, source_name, source_file,\n \
+          toUInt32(source_generation) AS source_generation, session_id,\n \
+          toUInt64(candidate_generation) AS candidate_generation, phase,\n \
+          toUInt64(estimated_rows) AS estimated_rows, toUInt64(estimated_bytes) AS estimated_bytes\n\
+         FROM {}.{RECLAIM_LEDGER_TABLE} FINAL\n\
+         WHERE phase IN ('claimed', 'deleting')\n\
+         ORDER BY claimed_at ASC, reclaim_id ASC\n\
+         LIMIT {limit}\n\
+         FORMAT JSONEachRow",
+        escape_identifier(database)
+    )
+}
+
+/// Ledger totals by phase.
+pub fn ledger_summary_sql(database: &str) -> String {
+    format!(
+        "SELECT phase, toUInt64(count()) AS units\n\
+         FROM {}.{RECLAIM_LEDGER_TABLE} FINAL\n\
+         GROUP BY phase\n\
+         FORMAT JSONEachRow",
+        escape_identifier(database)
+    )
+}
+
+/// Pending mutations over a scope's tables (hazard H9). A run that finds any
+/// returns [`ReclaimOutcome::Blocked`] carrying the count, never `Ok(default)`.
+pub fn pending_mutations_sql(database: &str, scope: ReclaimScope) -> String {
+    let tables = scope
+        .tables()
+        .iter()
+        .map(|table| escape_literal(table.name()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "SELECT toUInt64(count()) AS pending\n\
+         FROM system.mutations\n\
+         WHERE database = {}\n   \
+           AND table IN ({tables})\n   \
+           AND is_done = 0\n\
+         FORMAT JSONEachRow",
+        escape_literal(database)
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct LedgerPhaseRow {
+    phase: String,
+    units: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct PendingMutationsRow {
+    pending: u64,
+}
+
+impl ClickHouseClient {
+    /// Ledger totals by phase. Never writes.
+    pub async fn reclaim_ledger_summary(&self) -> Result<ReclaimLedgerSummary> {
+        let rows: Vec<LedgerPhaseRow> = self
+            .query_json_each_row(
+                &ledger_summary_sql(&self.cfg.database),
+                Some(&self.cfg.database),
+            )
+            .await
+            .context("failed to read the storage reclaim ledger")?;
+        let mut summary = ReclaimLedgerSummary::default();
+        for row in rows {
+            match ReclaimPhase::parse(&row.phase) {
+                Some(ReclaimPhase::Claimed) => summary.claimed = row.units,
+                Some(ReclaimPhase::Deleting) => summary.deleting = row.units,
+                Some(ReclaimPhase::Done) => summary.done = row.units,
+                Some(ReclaimPhase::Abandoned) => summary.abandoned = row.units,
+                None => {}
+            }
+        }
+        Ok(summary)
+    }
+
+    /// Pending mutations over `scope`'s tables.
+    pub async fn reclaim_pending_mutations(&self, scope: ReclaimScope) -> Result<u64> {
+        let rows: Vec<PendingMutationsRow> = self
+            .query_json_each_row(
+                &pending_mutations_sql(&self.cfg.database, scope),
+                Some(&self.cfg.database),
+            )
+            .await
+            .context("failed to inspect pending reclaim mutations")?;
+        Ok(rows.first().map(|row| row.pending).unwrap_or(0))
+    }
+
+    /// The dry-run planner. **Writes nothing.**
+    ///
+    /// In this build every scope reports zero units with a note naming the
+    /// work item that will register its probe: the candidate-set probe is
+    /// executor-specific (an anti-join against headers for `McpOpenOrphan`, an
+    /// anti-join against published heads for the other two) and lives with the
+    /// executor it belongs to, so that the probe and the delete it authorizes
+    /// are reviewed together rather than one release apart.
+    pub async fn reclaim_plan(
+        &self,
+        retention: &RetentionConfig,
+        scopes: &[ReclaimScope],
+    ) -> Result<ReclaimPlan> {
+        let ledger = self.reclaim_ledger_summary().await.unwrap_or_default();
+        let scopes = scopes
+            .iter()
+            .map(|scope| self.plan_scope(*scope, retention))
+            .collect();
+        Ok(ReclaimPlan {
+            scopes,
+            denomination: estimated_bytes_note(),
+            pending_redrive: ledger.needs_redrive(),
+        })
+    }
+
+    fn plan_scope(&self, scope: ReclaimScope, retention: &RetentionConfig) -> ReclaimableEstimate {
+        let note = match ReclaimAuthority::for_scope(scope, retention) {
+            Err(missing) => Some(missing.to_string()),
+            Ok(_) => Some(format!(
+                "no candidate probe is registered for `{scope}` in this build; {} adds it",
+                pending_work_item(scope)
+            )),
+        };
+        ReclaimableEstimate {
+            scope,
+            units: 0,
+            estimated_rows: 0,
+            estimated_bytes: 0,
+            tables: scope
+                .tables()
+                .iter()
+                .map(|table| table.name().to_string())
+                .collect(),
+            note,
+        }
+    }
+
+    /// `moraine db reclaim run`.
+    ///
+    /// Refuses every scope in this build: no executor is registered. The
+    /// authority check still runs first, so a bucket-1/2 scope is refused for
+    /// the *missing config key* rather than for the missing executor — the
+    /// refusal an operator will still get once WI-09 lands.
+    ///
+    /// The `ReclaimAuthority::for_scope` call below is **the S2 enforcement
+    /// point at the command boundary**, not a nicety for a better error
+    /// message. Once an executor is registered, deleting that one line lets a
+    /// run with no `[retention]` key proceed. It is guarded by
+    /// `reclaim_run_refuses_an_unconfigured_canonical_scope_before_anything_else`,
+    /// and the executor check below it by
+    /// `reclaim_run_refuses_a_registered_scope_without_reaching_clickhouse` —
+    /// both of which call this function, which
+    /// `this_build_registers_no_executor` deliberately does not.
+    ///
+    /// This build reads no ledger and writes no claim; see the module docs on
+    /// the descoped §3.2 driver.
+    pub async fn reclaim_run(
+        &self,
+        retention: &RetentionConfig,
+        scope: ReclaimScope,
+    ) -> Result<ReclaimOutcome> {
+        ReclaimAuthority::for_scope(scope, retention)?;
+        if executor_for(scope).is_none() {
+            return Ok(ReclaimOutcome::NoExecutor {
+                scope,
+                message: format!(
+                    "no executor is registered for scope `{scope}`; {} adds it. Nothing was \
+                     deleted.",
+                    pending_work_item(scope)
+                ),
+            });
+        }
+        // Unreachable in this build; kept so the H9 signal path is not written
+        // for the first time in the same PR as the first executor.
+        let pending = self.reclaim_pending_mutations(scope).await?;
+        if pending > 0 {
+            return Ok(ReclaimOutcome::Blocked {
+                scope,
+                pending_mutations: pending,
+            });
+        }
+        Ok(ReclaimOutcome::Idle { scope })
+    }
+
+    /// `moraine db reclaim status`: WI-02's storage report, the ledger, and
+    /// the dry-run estimates, under one `Background` envelope.
+    ///
+    /// Never fails: an unreachable ClickHouse yields `available: false` with
+    /// the error attached, so the surrounding command still renders.
+    pub async fn reclaim_status(
+        &self,
+        retention: &RetentionConfig,
+        budget: &moraine_config::ValidatedQueryBudget,
+        admin_budget: &moraine_config::ValidatedQueryBudget,
+    ) -> ReclaimStatusReport {
+        let gathered = QueryEnvelope::new_batch(
+            "reclaim-status",
+            QueryClass::Background,
+            budget,
+            admin_budget,
+            PLAN_STATEMENT_CAP,
+        )
+        .scope(async {
+            let storage = self.storage_report(retention).await?;
+            let ledger = self.reclaim_ledger_summary().await.unwrap_or_default();
+            let plan = self.reclaim_plan(retention, &ReclaimScope::ALL).await?;
+            anyhow::Ok((storage, ledger, plan))
+        })
+        .await;
+
+        match gathered {
+            Ok((storage, ledger, plan)) => ReclaimStatusReport {
+                available: true,
+                storage: Some(storage),
+                ledger,
+                reclaimable: plan.scopes,
+                registered_executors: registered_executors(),
+                denomination: estimated_bytes_note(),
+                error: None,
+            },
+            Err(error) => ReclaimStatusReport {
+                available: false,
+                storage: None,
+                ledger: ReclaimLedgerSummary::default(),
+                reclaimable: Vec::new(),
+                registered_executors: registered_executors(),
+                denomination: estimated_bytes_note(),
+                error: Some(error.to_string()),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unit(scope: ReclaimScope) -> ReclaimUnit {
+        ReclaimUnit {
+            reclaim_id: "7'2".to_string(),
+            scope,
+            source_host: "host-a".to_string(),
+            source_name: "codex".to_string(),
+            source_file: "/tmp/a'b.jsonl".to_string(),
+            source_generation: 3,
+            session_id: "s-1".to_string(),
+            candidate_generation: 99,
+            phase: ReclaimPhase::Claimed,
+            estimated_rows: 10,
+            estimated_bytes: 20,
+        }
+    }
+
+    fn derived_only() -> Vec<ReclaimAuthority> {
+        vec![ReclaimAuthority::DerivedOnly]
+    }
+
+    fn full_authority() -> Vec<ReclaimAuthority> {
+        let retention = RetentionConfig {
+            canonical_history_horizon_days: Some(365.0),
+            raw_audit_horizon_days: Some(90.0),
+            ..RetentionConfig::default()
+        };
+        ReclaimAuthority::for_scope(ReclaimScope::CanonicalGeneration, &retention)
+            .expect("configured retention grants authority")
+    }
+
+    /// A predicate of the shape `table` requires, naming every key column of
+    /// the claimed unit.
+    ///
+    /// The corpus used to build every statement with `"1"` — a full-table
+    /// delete — which is why it could not have caught an executor that emitted
+    /// one. The emitter now refuses that, so the corpus has to bind its units
+    /// like a real executor would.
+    fn sample_predicate(table: ReclaimTable) -> String {
+        match table.predicate() {
+            ReclaimPredicate::Generation => "(source_host, source_name, source_file, \
+                 source_generation) IN (('host-a', 'codex', '/tmp/a.jsonl', 3))"
+                .to_string(),
+            ReclaimPredicate::SessionGeneration => {
+                "(session_id, candidate_generation) IN (('s-1', 99))".to_string()
+            }
+            ReclaimPredicate::UidSet => "event_uid IN ('u-1', 'u-2')".to_string(),
+            ReclaimPredicate::DocumentJoin => {
+                "doc_id IN (SELECT event_uid FROM moraine.search_documents)".to_string()
+            }
+        }
+    }
+
+    /// Every statement this module can emit, across every scope and every
+    /// table, with maximal authority. The corpus **G-INV2** asserts over.
+    fn every_emittable_statement() -> Vec<String> {
+        let mut statements = Vec::new();
+        let authorities = full_authority();
+        for scope in ReclaimScope::ALL {
+            statements.push(ledger_claim_statement("moraine", &unit(scope)));
+            for phase in [
+                ReclaimPhase::Deleting,
+                ReclaimPhase::Done,
+                ReclaimPhase::Abandoned,
+            ] {
+                statements.push(ledger_advance_statement("moraine", &unit(scope), phase));
+            }
+            statements.push(pending_mutations_sql("moraine", scope));
+            for table in scope.tables() {
+                statements.push(
+                    emit_delete_statement(
+                        "moraine",
+                        *table,
+                        &sample_predicate(*table),
+                        &authorities,
+                    )
+                    .expect("full authority emits every table"),
+                );
+            }
+        }
+        statements.push(ledger_summary_sql("moraine"));
+        statements.push(ledger_redrive_sql("moraine", 64));
+        statements
+    }
+
+    /// **G-INV2.** Fails for: the reclaimer writing a control relation.
+    /// Denomination: statement text, all scopes.
+    ///
+    /// MUTATION (executed 2026-07-27): add
+    /// `statements.push(format!("INSERT INTO {}.published_source_generations VALUES (1)", escape_identifier("moraine")))`
+    /// to `every_emittable_statement` => FAILS naming
+    /// `published_source_generations`. **Lower bound.**
+    ///
+    /// MUTATION (executed 2026-07-27): add the same statement written
+    /// **unescaped** — `INSERT INTO moraine.published_source_generations
+    /// VALUES (1)` — which the previous
+    /// ``statement.contains("`moraine`.{control}")`` form let through
+    /// untouched. => FAILS now. **Width: the invariant is about the relation,
+    /// not about one spelling of the qualifier.**
+    ///
+    /// MUTATION (executed 2026-07-27): make `writes_control_relation` return
+    /// `None` unconditionally => the negative-corpus assertion below FAILS, so
+    /// a detector that detects nothing is not a passing "fix". **Upper
+    /// bound.**
+    #[test]
+    fn no_emitted_statement_writes_a_control_relation() {
+        let statements = every_emittable_statement();
+        assert!(
+            statements.len() >= 20,
+            "the INV-2 corpus must actually contain the statements it claims to check: {}",
+            statements.len()
+        );
+        assert!(
+            statements
+                .iter()
+                .any(|statement| statement.contains("DELETE FROM `moraine`.events")),
+            "the corpus must include the most dangerous statement the emitter can produce"
+        );
+
+        for statement in &statements {
+            assert_eq!(
+                writes_control_relation(statement),
+                None,
+                "INV-2 violated by `{statement}`"
+            );
+        }
+
+        // The detector must actually detect, in both spellings, or the loop
+        // above passes because nothing is ever a violation.
+        for (statement, expected) in [
+            (
+                "INSERT INTO moraine.published_source_generations VALUES (1)",
+                Some("published_source_generations"),
+            ),
+            (
+                "INSERT INTO `moraine`.published_source_generations VALUES (1)",
+                Some("published_source_generations"),
+            ),
+            (
+                "ALTER TABLE moraine.ingest_checkpoint_transitions DELETE WHERE 1",
+                Some("ingest_checkpoint_transitions"),
+            ),
+            (
+                "TRUNCATE TABLE moraine.mcp_read_index_state",
+                Some("mcp_read_index_state"),
+            ),
+            (
+                "DROP TABLE moraine.ingest_append_control",
+                Some("ingest_append_control"),
+            ),
+            // `OPTIMIZE … FINAL` returns no rows and reads as maintenance, but
+            // `published_source_generations` is a ReplacingMergeTree keyed on
+            // `publication_revision`: collapsing it destroys every superseded
+            // revision and breaks as-of reads exactly as §1's rationale warns.
+            //
+            // MUTATION (executed 2026-07-27): drop
+            // `|| statement.starts_with("OPTIMIZE")` from
+            // `writes_control_relation` => FAILS on both rows below.
+            (
+                "OPTIMIZE TABLE moraine.published_source_generations FINAL",
+                Some("published_source_generations"),
+            ),
+            (
+                "OPTIMIZE TABLE `moraine`.ingest_checkpoint_transitions FINAL DEDUPLICATE",
+                Some("ingest_checkpoint_transitions"),
+            ),
+            // Width: `OPTIMIZE` on a derived relation is legal — the shape is
+            // not the violation, the relation is. Widening the detector to
+            // "any OPTIMIZE" turns this red.
+            ("OPTIMIZE TABLE moraine.mcp_open_turns FINAL", None),
+            // Reads are not writes: the pending-mutation probe names every
+            // scope table and must stay legal.
+            (
+                "SELECT count() FROM moraine.published_source_generations",
+                None,
+            ),
+            // A generation predicate mentions `source_generation`, which is a
+            // prefix of a control relation's name but not the relation.
+            (
+                "DELETE FROM `moraine`.events\nWHERE source_generation = 3",
+                None,
+            ),
+        ] {
+            assert_eq!(
+                writes_control_relation(statement),
+                expected,
+                "detector disagreed on `{statement}`"
+            );
+        }
+    }
+
+    #[test]
+    fn control_relations_are_exactly_the_five_inv2_names() {
+        assert_eq!(CONTROL_RELATIONS.len(), 5);
+        for control in CONTROL_RELATIONS {
+            assert_eq!(
+                classify(control),
+                Some(TableClass::NeverDelete),
+                "`{control}` must also be never-delete in the classification"
+            );
+        }
+        // No reclaim table may be a control relation. Belt and braces: this
+        // catches a future scope adding `mcp_read_index_state` to its list.
+        for scope in ReclaimScope::ALL {
+            for table in scope.tables() {
+                assert!(
+                    !CONTROL_RELATIONS.contains(&table.name()),
+                    "scope `{scope}` names control relation `{}`",
+                    table.name()
+                );
+            }
+        }
+    }
+
+    /// **G-NOAUTH.** Fails for: the emitter producing a canonical delete
+    /// without a token.
+    /// Denomination: statement text.
+    ///
+    /// MUTATION (executed 2026-07-27): delete the `authorizes` check from
+    /// `emit_delete_statement` (S3's re-derivation) => `events`, `raw_events`,
+    /// and `ingest_errors` all emit under `DerivedOnly` and this test FAILS.
+    /// That is the point of having two checks: the planner-side check in
+    /// `ReclaimAuthority::for_scope` is a different function, so removing
+    /// either one alone must still fail a named test.
+    #[test]
+    fn the_emitter_refuses_protected_tables_without_a_token() {
+        for reclaim_table in [
+            ReclaimTable::Events,
+            ReclaimTable::RawEvents,
+            ReclaimTable::IngestErrors,
+        ] {
+            let refusal = emit_delete_statement(
+                "moraine",
+                reclaim_table,
+                &sample_predicate(reclaim_table),
+                &derived_only(),
+            )
+            .expect_err("a derived-only token must not emit a protected delete");
+            // The binding used to be named `table`, which shadowed the loop
+            // variable and made the guard compare a `&String` to itself. A
+            // tautology inside a safety check is worse than no check: it reads
+            // as coverage.
+            assert!(
+                matches!(
+                    refusal,
+                    EmitRefusal::Unauthorized { ref table, .. } if table == reclaim_table.name()
+                ),
+                "{refusal:?}"
+            );
+            assert!(refusal.to_string().contains(reclaim_table.name()));
+        }
+
+        // Bounded in the other direction: a derived table still emits under a
+        // derived-only token, or the emitter would refuse everything and the
+        // test above would pass vacuously.
+        let statement = emit_delete_statement(
+            "moraine",
+            ReclaimTable::McpOpenEvents,
+            &sample_predicate(ReclaimTable::McpOpenEvents),
+            &derived_only(),
+        )
+        .expect("derived tables emit under a derived-only token");
+        assert!(statement.starts_with("DELETE FROM `moraine`.mcp_open_events"));
+
+        // And with full authority the protected tables do emit, so the refusal
+        // above is about the token and not about the table.
+        for reclaim_table in [ReclaimTable::Events, ReclaimTable::RawEvents] {
+            emit_delete_statement(
+                "moraine",
+                reclaim_table,
+                &sample_predicate(reclaim_table),
+                &full_authority(),
+            )
+            .expect("configured retention authorizes the protected tables");
+        }
+    }
+
+    /// **G-AUTHMATRIX.** Fails for: any authority variant authorizing any
+    /// class other than its own.
+    /// Denomination: the full (variant x class) truth table.
+    ///
+    /// §4 S3 requires the *corresponding* token; S2 makes permission
+    /// per-bucket. `CanonicalHistory(_)` used to also return `true` for
+    /// `RawAudit` and `Derived`, which was unreachable only because
+    /// `for_scope` demands both keys — i.e. only because of the planner-side
+    /// check S3 says the emitter must not depend on.
+    /// `no_authority_variant_can_unlock_a_never_delete_table` bounded only the
+    /// never-delete row of this table.
+    ///
+    /// MUTATION (executed 2026-07-27): restore
+    /// `(Self::CanonicalHistory(_), TableClass::CanonicalHistory |
+    /// TableClass::RawAudit | TableClass::Derived) => true` => FAILS on two
+    /// cells. **Width: widening any arm by one class breaks a named cell.**
+    ///
+    /// MUTATION (executed 2026-07-27): narrow
+    /// `(Self::DerivedOnly, TableClass::Derived)` to `=> false` => FAILS on
+    /// the `DerivedOnly`/`Derived` cell, so emptying the matrix is not a
+    /// passing "fix". **Both directions.**
+    #[test]
+    fn each_authority_variant_authorizes_exactly_its_own_bucket() {
+        let horizon = |bucket| {
+            RetentionHorizon::from_config(
+                &RetentionConfig {
+                    canonical_history_horizon_days: Some(365.0),
+                    raw_audit_horizon_days: Some(90.0),
+                    ..RetentionConfig::default()
+                },
+                bucket,
+            )
+            .expect("configured")
+        };
+        let matrix = [
+            (
+                ReclaimAuthority::DerivedOnly,
+                TableClass::Derived,
+                "bucket 3",
+            ),
+            (
+                ReclaimAuthority::Telemetry,
+                TableClass::Telemetry,
+                "bucket 4",
+            ),
+            (
+                ReclaimAuthority::RawAudit(horizon(ProtectedRetentionBucket::RawAudit)),
+                TableClass::RawAudit,
+                "bucket 2",
+            ),
+            (
+                ReclaimAuthority::CanonicalHistory(horizon(
+                    ProtectedRetentionBucket::CanonicalHistory,
+                )),
+                TableClass::CanonicalHistory,
+                "bucket 1",
+            ),
+        ];
+        for (authority, own, label) in matrix {
+            for class in TableClass::ALL {
+                let expected = class == own;
+                assert_eq!(
+                    authority.authorizes(class),
+                    expected,
+                    "{authority:?} ({label}) vs {class:?}: a token authorizes its own bucket and \
+                     nothing else"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_authority_variant_can_unlock_a_never_delete_table() {
+        let mut authorities = full_authority();
+        authorities.push(ReclaimAuthority::Telemetry);
+        for authority in authorities {
+            assert!(
+                !authority.authorizes(TableClass::NeverDelete),
+                "{authority:?} must not authorize never-delete"
+            );
+        }
+    }
+
+    /// **G-BOUNDPRED.** Fails for: a delete whose predicate does not bind the
+    /// claimed unit.
+    /// Denomination: per-table, per-required-column.
+    ///
+    /// This is the last independent check before a `DELETE` reaches
+    /// ClickHouse. Class and token prove the emitter may *name* `events`;
+    /// nothing before this constrained *which rows leave*, and the INV-2
+    /// corpus itself built every statement with `"1"` — a full-table delete
+    /// that `no_emitted_statement_writes_a_control_relation` accepted.
+    ///
+    /// MUTATION (executed 2026-07-27): delete the `missing` check from
+    /// `emit_delete_statement` => FAILS on the `"1"` case for all 13 tables.
+    /// **Lower bound.**
+    ///
+    /// MUTATION (executed 2026-07-27): make `required_columns` return `&[]`
+    /// for every shape => FAILS the same way. **Same direction, other end of
+    /// the mechanism.**
+    ///
+    /// MUTATION (executed 2026-07-27): make the check `any` rather than
+    /// `all` (accept a predicate naming *one* key column) => FAILS on the
+    /// partial-tuple case below, where a generation delete names
+    /// `source_generation` but not the file it belongs to and would sweep
+    /// every host's generation 3. **Width: dropping one column from the
+    /// requirement breaks a named case.**
+    ///
+    /// The upper bound is `every_emittable_statement`, which builds a
+    /// shape-correct predicate for all 13 tables and must keep emitting.
+    #[test]
+    fn the_emitter_refuses_a_predicate_that_does_not_bind_the_unit() {
+        let authorities = full_authority();
+        for scope in ReclaimScope::ALL {
+            for reclaim_table in scope.tables() {
+                let refusal = emit_delete_statement("moraine", *reclaim_table, "1", &authorities)
+                    .expect_err("a constant-true predicate must never emit");
+                let EmitRefusal::UnboundPredicate {
+                    ref table,
+                    ref missing,
+                    ..
+                } = refusal
+                else {
+                    panic!("{refusal:?}");
+                };
+                assert_eq!(table, reclaim_table.name());
+                assert_eq!(
+                    *missing,
+                    reclaim_table.predicate().required_columns().to_vec(),
+                    "`WHERE 1` names none of `{}`'s key columns",
+                    reclaim_table.name()
+                );
+                assert!(refusal.to_string().contains(reclaim_table.name()));
+            }
+        }
+
+        // An empty `IN ()` list — the shape a WI-05 executor produces on an
+        // empty chunk — still names its columns and is therefore emittable;
+        // it deletes nothing, which is correct. The refusal is about a
+        // predicate that names no column at all.
+        emit_delete_statement(
+            "moraine",
+            ReclaimTable::McpOpenEvents,
+            "(session_id, candidate_generation) IN ()",
+            &authorities,
+        )
+        .expect("an empty key list is bound, just empty");
+
+        // A partial tuple is NOT enough: `source_generation = 3` alone spans
+        // every host, name, and file that ever had a generation 3.
+        let refusal = emit_delete_statement(
+            "moraine",
+            ReclaimTable::Events,
+            "source_generation = 3",
+            &authorities,
+        )
+        .expect_err("a partial key tuple must not emit");
+        assert!(
+            matches!(
+                refusal,
+                EmitRefusal::UnboundPredicate { ref missing, .. }
+                    if missing == &vec!["source_host", "source_name", "source_file"]
+            ),
+            "{refusal:?}"
+        );
+
+        // The shapes' column sets are the documented ones. `search_postings`
+        // has no `event_uid` column at all, so `DocumentJoin` is keyed on
+        // `doc_id`; asserting that here keeps the hazard visible next to the
+        // guard that enforces it.
+        assert_eq!(
+            ReclaimPredicate::DocumentJoin.required_columns(),
+            &["doc_id"]
+        );
+        assert_eq!(ReclaimPredicate::UidSet.required_columns(), &["event_uid"]);
+        assert_eq!(
+            ReclaimPredicate::SessionGeneration.required_columns(),
+            &["session_id", "candidate_generation"]
+        );
+        assert_eq!(
+            ReclaimPredicate::Generation.required_columns(),
+            &[
+                "source_host",
+                "source_name",
+                "source_file",
+                "source_generation"
+            ]
+        );
+    }
+
+    #[test]
+    fn emitted_deletes_are_lightweight_and_unsynchronized() {
+        for statement in every_emittable_statement() {
+            assert!(
+                !statement.contains("ALTER TABLE"),
+                "cleanup must never use ALTER … DELETE: {statement}"
+            );
+            assert!(
+                !statement.contains("mutations_sync"),
+                "cleanup must never set mutations_sync: {statement}"
+            );
+            assert!(
+                !statement.contains("OPTIMIZE"),
+                "production never OPTIMIZEs: {statement}"
+            );
+        }
+    }
+
+    /// **G-NOGEN.** Fails for: `tool_io` / `event_links` given a generation
+    /// predicate.
+    /// Denomination: match arms.
+    ///
+    /// The mapping is an exhaustive `match` over a closed enum, so adding a
+    /// table without deciding its predicate shape is a compile error. This
+    /// test pins the two arms the hazard is about, plus the two that are
+    /// dangerous for a different reason.
+    ///
+    /// MUTATION (executed 2026-07-27): change the `ToolIo | EventLinks` arm to
+    /// `ReclaimPredicate::Generation` => this test FAILS on both. Bounds the
+    /// direction *a table with no generation column gains a generation
+    /// predicate*; the `Generation` assertions below bound the opposite
+    /// direction, so flipping everything to `UidSet` does not pass either.
+    #[test]
+    fn tables_without_a_generation_column_carry_a_uid_set_predicate() {
+        assert_eq!(
+            ReclaimTable::ToolIo.predicate(),
+            ReclaimPredicate::UidSet,
+            "tool_io has no source_file/source_generation column"
+        );
+        assert_eq!(
+            ReclaimTable::EventLinks.predicate(),
+            ReclaimPredicate::UidSet,
+            "event_links has no source_file/source_generation column"
+        );
+        assert_eq!(
+            ReclaimTable::SearchPostings.predicate(),
+            ReclaimPredicate::DocumentJoin,
+            "83.6% of postings carry back-filled type defaults for source_generation; the only \
+             safe predicate joins through the document"
+        );
+        for table in [
+            ReclaimTable::Events,
+            ReclaimTable::RawEvents,
+            ReclaimTable::IngestErrors,
+            ReclaimTable::SearchDocuments,
+            ReclaimTable::McpEventLocator,
+            ReclaimTable::McpEventNavigation,
+            ReclaimTable::McpSessionDirectory,
+        ] {
+            assert_eq!(
+                table.predicate(),
+                ReclaimPredicate::Generation,
+                "{} is directly generation-keyed",
+                table.name()
+            );
+        }
+        for table in [
+            ReclaimTable::McpOpenEvents,
+            ReclaimTable::McpOpenTurns,
+            ReclaimTable::McpOpenPublicationHeaders,
+        ] {
+            assert_eq!(table.predicate(), ReclaimPredicate::SessionGeneration);
+        }
+    }
+
+    #[test]
+    fn every_reclaim_table_is_classified_and_never_never_delete() {
+        for scope in ReclaimScope::ALL {
+            for table in scope.tables() {
+                let class = table
+                    .class()
+                    .unwrap_or_else(|| panic!("`{}` must be classified", table.name()));
+                assert_ne!(
+                    class,
+                    TableClass::NeverDelete,
+                    "`{}` must never appear in a reclaim scope",
+                    table.name()
+                );
+            }
+        }
+    }
+
+    /// **G-DEFAULT** (the planner half). Fails for: default config
+    /// authorizing canonical deletion.
+    /// Denomination: exact table-name set.
+    ///
+    /// MUTATION (executed 2026-07-27): make `ReclaimAuthority::for_scope`
+    /// return `Ok(vec![Self::DerivedOnly])` for `CanonicalGeneration` — the
+    /// planner-side check S3 relies on — => the reachable set gains `events`,
+    /// `raw_events`, `ingest_errors`, `search_documents`, `search_postings`,
+    /// `tool_io`, `event_links` and this test FAILS on the exact-set
+    /// assertion. Bounds the direction *the default reachable set grows*; the
+    /// non-empty assertion bounds the opposite direction, so emptying the set
+    /// is not a passing "fix".
+    ///
+    /// A companion mutation keeps the two answers from drifting apart:
+    /// flipping only `is_default_on` to `true` for `CanonicalGeneration`
+    /// (executed 2026-07-27) leaves THIS test green but FAILS
+    /// `default_on_scopes_agree_with_the_authority_check`, so the advertised
+    /// default and the enforced default cannot disagree silently.
+    #[test]
+    fn the_default_reachable_table_set_excludes_all_user_history() {
+        let retention = RetentionConfig::default();
+        let mut reachable: Vec<&str> = ReclaimScope::ALL
+            .into_iter()
+            .filter(|scope| ReclaimAuthority::for_scope(*scope, &retention).is_ok())
+            .flat_map(|scope| scope.tables().iter().map(|table| table.name()))
+            .collect();
+        reachable.sort_unstable();
+        reachable.dedup();
+
+        assert_eq!(
+            reachable,
+            vec![
+                "mcp_event_locator",
+                "mcp_event_navigation",
+                "mcp_open_events",
+                "mcp_open_publication_headers",
+                "mcp_open_turns",
+                "mcp_session_directory",
+            ],
+            "the stock-config reachable table set"
+        );
+        assert!(!reachable.is_empty());
+        for forbidden in ["events", "raw_events", "ingest_errors", "search_documents"] {
+            assert!(
+                !reachable.contains(&forbidden),
+                "`{forbidden}` must be unreachable under stock configuration"
+            );
+        }
+        for name in &reachable {
+            assert_eq!(
+                classify(name),
+                Some(TableClass::Derived),
+                "every default-reachable table must be bucket 3: `{name}`"
+            );
+        }
+        // And the scope that would reach user history refuses, naming the key.
+        let missing = ReclaimAuthority::for_scope(ReclaimScope::CanonicalGeneration, &retention)
+            .expect_err("canonical scope must refuse under stock configuration");
+        assert_eq!(
+            missing.config_key,
+            "retention.canonical_history_horizon_days"
+        );
+        assert!(missing.to_string().contains("moraine export events"));
+    }
+
+    /// **G-TOKENS.** Fails for: a scope handed an authority token it does not
+    /// need.
+    /// Denomination: the exact token vector, per scope, both directions.
+    ///
+    /// `the_default_reachable_table_set_excludes_all_user_history` pins the
+    /// reachable **tables**; nothing pinned the reachable **tokens**. Adding
+    /// `Self::Telemetry` to the `McpOpenOrphan | ReadIndexGeneration` arm was
+    /// GREEN across the whole suite (executed 2026-07-27), because no scope's
+    /// `tables()` currently names a bucket-4 relation — i.e. the emitter was
+    /// safe only by virtue of the planner's table list, which is exactly the
+    /// planner-side reasoning §4 S3 says the emitter must not lean on. This is
+    /// set equality on the vector itself, in the same denomination as the
+    /// `NeverDelete` roster.
+    ///
+    /// MUTATION (executed 2026-07-27): add `Self::Telemetry` to the default
+    /// arm => FAILS here, and nowhere else.
+    ///
+    /// MUTATION (executed 2026-07-27): drop `Self::DerivedOnly` from
+    /// `CanonicalGeneration`'s vector => FAILS here **and** in
+    /// `emit_delete_statement`'s refusal tests, because that scope's table
+    /// list opens with five derived relations. **Lower bound.**
+    #[test]
+    fn for_scope_hands_out_exactly_the_tokens_each_scope_needs() {
+        use std::collections::BTreeSet;
+
+        let stock = RetentionConfig::default();
+        for scope in [
+            ReclaimScope::McpOpenOrphan,
+            ReclaimScope::ReadIndexGeneration,
+        ] {
+            assert_eq!(
+                ReclaimAuthority::for_scope(scope, &stock).expect("default-on scope"),
+                vec![ReclaimAuthority::DerivedOnly],
+                "`{scope}` must carry the derived token and nothing else"
+            );
+        }
+
+        let configured = RetentionConfig {
+            canonical_history_horizon_days: Some(365.0),
+            raw_audit_horizon_days: Some(90.0),
+            ..RetentionConfig::default()
+        };
+        let raw = RetentionHorizon::from_config(&configured, ProtectedRetentionBucket::RawAudit)
+            .expect("raw horizon");
+        let canonical =
+            RetentionHorizon::from_config(&configured, ProtectedRetentionBucket::CanonicalHistory)
+                .expect("canonical horizon");
+        assert_eq!(
+            ReclaimAuthority::for_scope(ReclaimScope::CanonicalGeneration, &configured)
+                .expect("fully configured canonical scope"),
+            vec![
+                ReclaimAuthority::DerivedOnly,
+                ReclaimAuthority::RawAudit(raw),
+                ReclaimAuthority::CanonicalHistory(canonical),
+            ],
+            "the canonical scope spans buckets 1, 2 and 3 and must carry exactly those three"
+        );
+
+        // Width, stated as the invariant rather than as a list: no scope may
+        // hold a token no table of its own needs.
+        for scope in ReclaimScope::ALL {
+            let Ok(tokens) = ReclaimAuthority::for_scope(scope, &configured) else {
+                continue;
+            };
+            let needed: BTreeSet<TableClass> = scope
+                .tables()
+                .iter()
+                .filter_map(|table| table.class())
+                .collect();
+            for token in tokens {
+                assert!(
+                    needed.iter().any(|class| token.authorizes(*class)),
+                    "`{scope}` carries `{token:?}`, which authorizes no class in its own table \
+                     list {needed:?} — a token nobody needs is a token nobody notices widening"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn default_on_scopes_agree_with_the_authority_check() {
+        let retention = RetentionConfig::default();
+        for scope in ReclaimScope::ALL {
+            assert_eq!(
+                scope.is_default_on(),
+                ReclaimAuthority::for_scope(scope, &retention).is_ok(),
+                "`{scope}` disagrees between is_default_on and for_scope"
+            );
+        }
+    }
+
+    #[test]
+    fn a_partially_configured_canonical_scope_is_refused_naming_the_missing_key() {
+        // Canonical horizon set, raw/audit absent: the scope spans both
+        // buckets, so half-authority must refuse rather than reclaim half.
+        let retention = RetentionConfig {
+            canonical_history_horizon_days: Some(365.0),
+            ..RetentionConfig::default()
+        };
+        let missing = ReclaimAuthority::for_scope(ReclaimScope::CanonicalGeneration, &retention)
+            .expect_err("half-configured retention must refuse");
+        assert_eq!(missing.config_key, "retention.raw_audit_horizon_days");
+    }
+
+    // ---- ledger ---------------------------------------------------------
+
+    /// **G-LEDGER** (the pure half, and *only* the pure half).
+    ///
+    /// This asserts enum predicates and SQL substrings. It does **not** prove
+    /// a re-drive: [`ClickHouseClient::reclaim_run`] never claims, so there is
+    /// no claim for this test to interrupt, and `ledger_redrive_sql` has no
+    /// production caller. Read it as "the phase machine and the re-drive query
+    /// say the right thing", not as coverage of §3.2's driver, which is
+    /// descoped to WI-05 (see the module docs and [`LEDGER_DRIVER_WIRED`]).
+    /// The live half — SIGKILL between the child and parent deletes — is the
+    /// `reclaim-restart` gate, and it arrives with the first executor.
+    #[test]
+    fn the_phase_machine_redrives_exactly_the_unsettled_phases() {
+        assert!(ReclaimPhase::Claimed.needs_redrive());
+        assert!(ReclaimPhase::Deleting.needs_redrive());
+        assert!(!ReclaimPhase::Done.needs_redrive());
+        assert!(
+            !ReclaimPhase::Abandoned.needs_redrive(),
+            "an abandoned unit must never be silently resumed"
+        );
+        for phase in [
+            ReclaimPhase::Claimed,
+            ReclaimPhase::Deleting,
+            ReclaimPhase::Done,
+            ReclaimPhase::Abandoned,
+        ] {
+            assert_eq!(ReclaimPhase::parse(phase.as_str()), Some(phase));
+        }
+        assert_eq!(ReclaimPhase::parse("deleted"), None);
+
+        let redrive = ledger_redrive_sql("moraine", 64);
+        assert!(redrive.contains("phase IN ('claimed', 'deleting')"));
+        assert!(
+            !redrive.contains("'done'") && !redrive.contains("'abandoned'"),
+            "a settled unit must never be re-driven"
+        );
+        assert!(redrive.contains("ORDER BY claimed_at ASC"));
+    }
+
+    #[test]
+    fn ledger_writes_are_inserts_that_collapse_by_revision() {
+        let claimed = ledger_claim_statement("moraine", &unit(ReclaimScope::McpOpenOrphan));
+        assert!(claimed.starts_with("INSERT INTO `moraine`.storage_reclaim_ledger"));
+        assert!(claimed.contains("generateSnowflakeID()"));
+        assert!(claimed.contains("'claimed'"));
+        // Literals are escaped: a source file or reclaim id containing a quote
+        // must not terminate the statement.
+        assert!(claimed.contains("'/tmp/a\\'b.jsonl'"));
+        assert!(claimed.contains("'7\\'2'"));
+
+        let deleting = ledger_advance_statement(
+            "moraine",
+            &unit(ReclaimScope::McpOpenOrphan),
+            ReclaimPhase::Deleting,
+        );
+        assert!(deleting.starts_with("INSERT INTO `moraine`.storage_reclaim_ledger"));
+        assert!(deleting.contains("'deleting'"));
+        assert!(
+            !deleting.contains("ALTER") && !deleting.contains("DELETE FROM"),
+            "advancing a phase must never mutate the ledger in place"
+        );
+    }
+
+    #[test]
+    fn the_pending_mutation_probe_names_only_the_scopes_own_tables() {
+        for scope in ReclaimScope::ALL {
+            let sql = pending_mutations_sql("moraine", scope);
+            assert!(sql.contains("FROM system.mutations"));
+            assert!(sql.contains("is_done = 0"));
+            for table in scope.tables() {
+                assert!(
+                    sql.contains(&format!("'{}'", table.name())),
+                    "`{scope}` probe must name `{}`",
+                    table.name()
+                );
+            }
+        }
+    }
+
+    // ---- ordering -------------------------------------------------------
+
+    #[test]
+    fn canonical_is_deleted_last_and_children_precede_their_parents() {
+        let canonical: Vec<&str> = ReclaimScope::CanonicalGeneration
+            .tables()
+            .iter()
+            .map(|table| table.name())
+            .collect();
+        assert_eq!(
+            canonical,
+            vec![
+                "search_postings",
+                "search_documents",
+                "tool_io",
+                "event_links",
+                "ingest_errors",
+                "raw_events",
+                "events",
+            ],
+            "a crash must leave derived data missing over intact canonical data, never the inverse"
+        );
+
+        // The orphan scope deletes children before the header, the inverse of
+        // the existing reclaimer. That inversion is the stranded-child fix.
+        let orphan: Vec<&str> = ReclaimScope::McpOpenOrphan
+            .tables()
+            .iter()
+            .map(|table| table.name())
+            .collect();
+        assert_eq!(
+            orphan,
+            vec![
+                "mcp_open_events",
+                "mcp_open_turns",
+                "mcp_open_publication_headers",
+            ]
+        );
+        assert!(
+            orphan.iter().position(|name| *name == "mcp_open_events")
+                < orphan
+                    .iter()
+                    .position(|name| *name == "mcp_open_publication_headers"),
+            "children first, parent last"
+        );
+    }
+
+    #[test]
+    fn the_unit_statement_cap_covers_the_widest_scope() {
+        let widest = ReclaimScope::ALL
+            .into_iter()
+            .map(|scope| scope.tables().len() as u32)
+            .max()
+            .expect("scopes exist");
+        assert_eq!(
+            widest, UNIT_STMT_MAX_TABLES,
+            "UNIT_STMT_MAX_TABLES must track the widest scope, or a legitimate unit could exceed \
+             its own statement cap"
+        );
+        assert_eq!(UNIT_STATEMENT_CAP, 1 + 1 + 1 + 7 + 2);
+    }
+
+    #[test]
+    fn the_two_reclaim_paths_share_one_chunk_size() {
+        // The doc claims "the two paths have one shape". It is a definition,
+        // not a copy: `RECLAIM_DELETE_CHUNK` here IS the projection
+        // reclaimer's constant, so tuning one tunes both.
+        assert_eq!(
+            RECLAIM_DELETE_CHUNK,
+            crate::mcp_open_projection::RECLAIM_DELETE_CHUNK,
+            "the #603 driver and the existing mcp_open reclaimer must not drift to two chunk sizes"
+        );
+        assert_eq!(RECLAIM_DELETE_CHUNK, 1_000);
+    }
+
+    // ---- executors ------------------------------------------------------
+
+    /// Names only what it checks: the registry is empty. It deliberately does
+    /// **not** call `reclaim_run`, so it is not the guard for anything inside
+    /// that function — see the two `reclaim_run_*` tests below, which do.
+    #[test]
+    fn this_build_registers_no_executor() {
+        assert!(registered_executors().is_empty());
+        for scope in ReclaimScope::ALL {
+            assert!(executor_for(scope).is_none(), "`{scope}` must not execute");
+        }
+    }
+
+    /// **D1's ordering, as a gate rather than a promise.** An executor
+    /// registered onto an unimplemented §3.2 driver deletes rows that nothing
+    /// durable records: the crash the ledger exists to survive would strand
+    /// exactly the children it exists to keep reachable.
+    ///
+    /// MUTATION (executed 2026-07-27): make `executor_for` return
+    /// `Some(RegisteredExecutor { scope })` for `McpOpenOrphan` while
+    /// `LEDGER_DRIVER_WIRED` stays `false` => FAILS here. That is the whole
+    /// point: WI-05 must flip the constant in the same PR, which is the PR
+    /// that has to make it true.
+    #[test]
+    fn no_executor_may_be_registered_before_the_ledger_driver_is_wired() {
+        assert!(
+            LEDGER_DRIVER_WIRED || registered_executors().is_empty(),
+            "an executor is registered but `reclaim_run` still never claims, advances, or settles \
+             a ledger unit. Wire the §3.2 driver and set LEDGER_DRIVER_WIRED, or unregister the \
+             executor: {:?}",
+            registered_executors()
+        );
+        // WI-04 ships neither. Stated as an equality so that flipping the
+        // constant alone, without registering anything, is also a failing
+        // test rather than a quiet lie.
+        assert_eq!(
+            (LEDGER_DRIVER_WIRED, registered_executors().len()),
+            (false, 0),
+            "WI-04 wires no §3.2 driver and registers no executor; WI-05 changes both, in one PR"
+        );
+    }
+
+    /// A client pointed at a port nothing listens on. Any test that reaches
+    /// the network fails loudly instead of passing on a stale assumption.
+    fn offline_client() -> ClickHouseClient {
+        ClickHouseClient::new(moraine_config::ClickHouseConfig {
+            url: "http://127.0.0.1:1".to_string(),
+            database: "moraine".to_string(),
+            timeout_seconds: 1.0,
+            ..Default::default()
+        })
+        .expect("client construction performs no I/O")
+    }
+
+    /// **G-RUNAUTH.** Fails for: `reclaim_run` proceeding past a scope whose
+    /// `[retention]` key is absent.
+    /// Denomination: the returned error, and its named config key.
+    ///
+    /// `ReclaimAuthority::for_scope` inside `reclaim_run` is the S2
+    /// enforcement point at the command boundary. Deleting it left the suite
+    /// at 177/0, because `this_build_registers_no_executor` never called
+    /// `reclaim_run` at all — it asserted over the registry.
+    ///
+    /// MUTATION (executed 2026-07-27): delete the
+    /// `ReclaimAuthority::for_scope(scope, retention)?;` line from
+    /// `reclaim_run` => FAILS here: the call returns `Ok(NoExecutor)` instead
+    /// of the missing-key error. **Lower bound.**
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reclaim_run_refuses_an_unconfigured_canonical_scope_before_anything_else() {
+        let client = offline_client();
+        let error = client
+            .reclaim_run(
+                &RetentionConfig::default(),
+                ReclaimScope::CanonicalGeneration,
+            )
+            .await
+            .expect_err("an unconfigured bucket-1 scope must not run");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("retention.canonical_history_horizon_days"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("moraine export events"), "{rendered}");
+    }
+
+    /// **G-RUNEXEC.** Fails for: `reclaim_run` proceeding past the executor
+    /// registry.
+    /// Denomination: the returned outcome, and the absence of any I/O.
+    ///
+    /// MUTATION (executed 2026-07-27): delete the
+    /// `if executor_for(scope).is_none() { … }` block from `reclaim_run` =>
+    /// FAILS here: control reaches `reclaim_pending_mutations`, the offline
+    /// client cannot connect, and the call returns `Err` instead of
+    /// `NoExecutor`. **Lower bound, and it is the bound that matters: with an
+    /// authorized scope, that block is all that stands between a run and the
+    /// server.**
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reclaim_run_refuses_a_registered_scope_without_reaching_clickhouse() {
+        let client = offline_client();
+        // Fully authorized, so the authority check cannot be what refuses.
+        let retention = RetentionConfig {
+            canonical_history_horizon_days: Some(365.0),
+            raw_audit_horizon_days: Some(90.0),
+            ..RetentionConfig::default()
+        };
+        for scope in ReclaimScope::ALL {
+            let outcome = client
+                .reclaim_run(&retention, scope)
+                .await
+                .unwrap_or_else(|error| {
+                    panic!("`{scope}` must refuse locally, not by failing to connect: {error:#}")
+                });
+            match outcome {
+                ReclaimOutcome::NoExecutor {
+                    scope: refused,
+                    ref message,
+                } => {
+                    assert_eq!(refused, scope);
+                    assert!(message.contains("Nothing was deleted"), "{message}");
+                    assert!(message.contains(pending_work_item(scope)), "{message}");
+                }
+                other => panic!("`{scope}` produced {other:?}"),
+            }
+            assert!(!outcome.deleted_anything());
+        }
+    }
+
+    // ---- denomination ---------------------------------------------------
+
+    /// **G-DENOM** (the library half; the rendered-string half lives in
+    /// `apps/moraine/src/render.rs`). Fails for: a byte number reported
+    /// without its qualifier, or a surface promising partition-aligned
+    /// deletion.
+    /// Denomination: rendered string.
+    ///
+    /// MUTATION (executed 2026-07-27): change `reclaimed_bytes_note` to
+    /// `"freed N bytes"` => this test FAILS on both the `merge-deferred`
+    /// assertion and the forbidden-word scan.
+    #[test]
+    fn byte_denominations_carry_their_qualifiers_and_promise_nothing() {
+        let estimate = estimated_bytes_note();
+        let reclaimed = reclaimed_bytes_note();
+        assert!(estimate.contains(ESTIMATE_QUALIFIER));
+        assert!(reclaimed.contains(MERGE_DEFERRED_QUALIFIER));
+        assert!(reclaimed.contains("exact"), "row counts ARE deterministic");
+
+        for text in [&estimate, &reclaimed] {
+            let lowered = text.to_lowercase();
+            for forbidden in FORBIDDEN_DENOMINATION_WORDS {
+                assert!(
+                    !lowered.contains(forbidden),
+                    "`{forbidden}` promises something no table's layout supports: {text}"
+                );
+            }
+        }
+
+        // The scope descriptions are operator-facing too.
+        for scope in ReclaimScope::ALL {
+            let lowered = scope.describe().to_lowercase();
+            for forbidden in FORBIDDEN_DENOMINATION_WORDS {
+                assert!(
+                    !lowered.contains(forbidden),
+                    "`{scope}` description uses `{forbidden}`"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn scope_names_round_trip() {
+        for scope in ReclaimScope::ALL {
+            assert_eq!(ReclaimScope::parse(scope.as_str()), Some(scope));
+        }
+        assert_eq!(ReclaimScope::parse("everything"), None);
+        assert_eq!(ReclaimScope::parse(""), None);
+    }
+}

--- a/crates/moraine-clickhouse/src/storage_class.rs
+++ b/crates/moraine-clickhouse/src/storage_class.rs
@@ -1,0 +1,5031 @@
+//! Issue #603 WI-01 — the ownership model of [`plans/603-reclamation.md` §1]
+//! encoded as code rather than documented in a table.
+//!
+//! This module is the **safety foundation** of #603: it decides what may ever
+//! be deleted automatically. Nothing here deletes anything; everything that
+//! does must route its table names through [`classify`] first.
+//!
+//! ## Why a total function with no default arm (§4 S1)
+//!
+//! The failure mode this exists to prevent is: a future migration adds a
+//! table, nobody classifies it, a scope glob sweeps it up, and the operator
+//! discovers it when the rows are gone. So:
+//!
+//! * [`classify`] returns `Option<TableClass>`. `None` means *unknown*, and
+//!   unknown is a hard error in the planner — never a fallthrough to
+//!   "probably derived".
+//! * [`CLASSIFIED_TABLES`] and [`REQUIRED_SCHEMA_OBJECTS`] are asserted
+//!   **mutually exhaustive** by [`classification_gaps`], which the unit test
+//!   `classification_and_required_schema_objects_are_mutually_exhaustive`
+//!   drives. Adding a table to the schema without classifying it fails that
+//!   test; classifying a table that the schema handshake does not require
+//!   fails it too.
+//!
+//! ## Why the classes are not the four spec buckets verbatim
+//!
+//! The spec names four buckets; this enum has five variants. The extra one is
+//! [`TableClass::NeverDelete`], which carries the *Auto = never* rows of
+//! buckets 2 and 3 — publication truth, revision allocators, the cache fence,
+//! the readiness fence. Those are not "raw audit data an operator may
+//! configure a retention for"; they are control state whose deletion breaks
+//! ingest or silently changes query results, so they get a class no authority
+//! token can unlock rather than a bucket with a configurable horizon.
+
+use std::collections::BTreeSet;
+
+use crate::REQUIRED_SCHEMA_OBJECTS;
+
+/// Storage ownership class of one physical table (issue #603 §1).
+///
+/// The class is the *authority* axis, not the *scope* axis: it says what kind
+/// of permission a delete naming this table needs, not whether any scope
+/// currently targets it. A table can be [`TableClass::Derived`] and still be
+/// unreachable by default because no default scope names it.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TableClass {
+    /// Bucket 1. Retained by default; deletion requires explicit user config.
+    CanonicalHistory,
+    /// Bucket 2 with a configurable retention. Never silently shortened.
+    RawAudit,
+    /// Bucket 3. Rebuildable derived data, eligible for automatic reclamation
+    /// once the replacement/cutover it derives from is verified.
+    Derived,
+    /// Bucket 4. Operational telemetry, bounded by safe default TTLs.
+    Telemetry,
+    /// No code path may ever delete it. Publication truth, revision
+    /// allocators, control fences, and the migration ledger.
+    NeverDelete,
+}
+
+impl TableClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CanonicalHistory => "canonical_history",
+            Self::RawAudit => "raw_audit",
+            Self::Derived => "derived",
+            Self::Telemetry => "telemetry",
+            Self::NeverDelete => "never_delete",
+        }
+    }
+
+    /// Human-facing bucket label used by the storage report and CLI.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::CanonicalHistory => "canonical user history",
+            Self::RawAudit => "raw / audit source data",
+            Self::Derived => "rebuildable derived data",
+            Self::Telemetry => "operational telemetry",
+            Self::NeverDelete => "control state (never deleted)",
+        }
+    }
+
+    /// Whether a `DELETE`/`TRUNCATE` naming a table of this class requires an
+    /// explicit [`crate::reclaim::ReclaimAuthority`] token (§4 S3), and
+    /// whether a bundled migration may contain one at all (§4 S4).
+    ///
+    /// `Derived` and `Telemetry` are the two classes stock configuration may
+    /// reclaim; the other three are protected.
+    pub fn is_protected(self) -> bool {
+        matches!(
+            self,
+            Self::CanonicalHistory | Self::RawAudit | Self::NeverDelete
+        )
+    }
+
+    /// Every class, for exhaustive folds. Adding a variant without adding it
+    /// here fails `every_class_is_enumerated`.
+    pub const ALL: [TableClass; 5] = [
+        Self::CanonicalHistory,
+        Self::RawAudit,
+        Self::Derived,
+        Self::Telemetry,
+        Self::NeverDelete,
+    ];
+}
+
+/// One row of the §1 ownership table.
+#[derive(Debug, Clone, Copy)]
+pub struct ClassifiedTable {
+    /// Unqualified table name inside the Moraine database, or the
+    /// `system.`-qualified name of a ClickHouse system log.
+    pub name: &'static str,
+    pub class: TableClass,
+    /// Why this class and not a looser one. Read this before reclassifying:
+    /// several of these entries encode a failure that has already happened.
+    pub rationale: &'static str,
+}
+
+/// ClickHouse's own system logs. Not Moraine tables, not part of the schema
+/// handshake, bounded by the `<ttl>` entries in `config/clickhouse.xml`
+/// (issue #603 WI-08).
+///
+/// Verified empirically on the reference host (ClickHouse 25.12.5.44,
+/// 2026-07-27): all three carry **no** TTL, because `config/clickhouse.xml` is
+/// rendered as the whole server config and launched with `--config-file`, so
+/// the packaged `config.xml` that ships `event_date + INTERVAL 30 DAY DELETE`
+/// is never loaded. `system.tables.create_table_query` contains no `TTL`
+/// clause for any of the three — `metric_log`'s only match on the substring is
+/// a *column* named `…OrTTLMicroseconds`.
+///
+/// This closes plan OQ-3, which required the answer before WI-08 could be
+/// sized. §8 of the plan records it as RESOLVED with this evidence; the two
+/// must not drift, because OQ-3 open would mean WI-08 — which ships here — was
+/// sized against an unverified premise.
+pub const CLICKHOUSE_SYSTEM_LOGS: &[&str] = &[
+    "system.query_log",
+    "system.metric_log",
+    "system.asynchronous_metric_log",
+];
+
+/// Physical tables that exist in the Moraine database but are deliberately
+/// **not** in [`REQUIRED_SCHEMA_OBJECTS`].
+///
+/// `file_attention_project_roots` is read at `file_attention.rs` yet was never
+/// registered in the schema handshake. That is a pre-existing gap (#603 §1
+/// bucket 3 note) and #603 deliberately does not fix it — a schema-handshake
+/// change is a separate, separately revertible edit. It is classified here
+/// anyway, because an unclassified table is exactly what this module exists to
+/// make impossible.
+///
+/// This constant suppresses a *finding*, so it needs a width bound of its own.
+/// For a round it did not have one: the doc claimed "the exhaustiveness test
+/// names it explicitly so the exemption cannot silently grow", and the only
+/// naming was a failure-message string. MUTATION (executed 2026-07-28): adding
+/// `"events"` here left the whole crate GREEN, and so did adding
+/// `"search_documents"` — an operator could have un-registered canonical
+/// history from the schema handshake and no test would have said so. Its two
+/// sibling constants were both already bounded ([`CLICKHOUSE_SYSTEM_LOGS`] by a
+/// length assertion, [`SCHEMA_VIEW_OBJECTS`] by `stale_view_declarations`);
+/// this was the one that was not.
+/// `the_unregistered_table_exemption_is_exactly_one_table` is the bound.
+pub const UNREGISTERED_PHYSICAL_TABLES: &[&str] = &["file_attention_project_roots"];
+
+/// [`REQUIRED_SCHEMA_OBJECTS`] entries that are views or materialized views
+/// rather than physical tables, and therefore hold no bytes and need no class.
+///
+/// Named explicitly rather than sniffed from a `v_`/`mv_` prefix: migration
+/// 032 installs `search_term_stats` and `search_corpus_stats` as plain
+/// `CREATE VIEW`s under names that carry no prefix, so a prefix heuristic
+/// would classify two views as unclassified tables and a future *table* named
+/// `v_something` as a view.
+pub const SCHEMA_VIEW_OBJECTS: &[&str] = &[
+    "search_term_stats",
+    "search_corpus_stats",
+    "mv_mcp_session_directory_from_events",
+    "mv_mcp_event_locator_from_events",
+    "mv_mcp_event_navigation_from_events",
+    "v_published_source_generation_history",
+    "v_current_published_source_generations",
+    "v_current_ingest_checkpoint_transitions",
+    "v_current_source_generation_publication_readiness",
+    "v_current_ingest_append_control",
+    "v_live_events",
+    "v_live_event_links",
+    "v_live_tool_io",
+    "v_live_search_documents",
+    "v_live_search_postings",
+    "v_mcp_open_publication_headers",
+    "v_current_mcp_open_generation_readiness",
+    "v_publication_diagnostics",
+];
+
+/// The §1 ownership model. Every physical table in the Moraine database plus
+/// the three ClickHouse system logs.
+///
+/// Verified against the reference host on 2026-07-27: `system.tables` reports
+/// exactly 32 non-view relations in `moraine`, and this list carries those 32
+/// plus `storage_reclaim_ledger` (added by migration 038) and the 3 system
+/// logs.
+pub const CLASSIFIED_TABLES: &[ClassifiedTable] = &[
+    // ---- Bucket 1 — canonical user history -------------------------------
+    ClassifiedTable {
+        name: "events",
+        class: TableClass::CanonicalHistory,
+        rationale: "The canonical record. `ingested_at` is deliberately excluded from the sort \
+                    key so FINAL dedups across monthly partitions (sql/019), which means a \
+                    replayed generation lands in the current month while its predecessor stays \
+                    in an old month interleaved with unrelated live sources: no partition-level \
+                    operation is ever safe here.",
+    },
+    // ---- Bucket 2 — raw / audit source data ------------------------------
+    ClassifiedTable {
+        name: "raw_events",
+        class: TableClass::RawAudit,
+        rationale: "`raw_json` is the complete untruncated source record and has zero runtime \
+                    readers, which makes it the largest pure-audit candidate — and is exactly \
+                    why it stays opt-in: bucket 2 is never silently shortened.",
+    },
+    ClassifiedTable {
+        name: "ingest_errors",
+        class: TableClass::RawAudit,
+        rationale: "Untruncated 20 000-char `raw_fragment` of what failed to parse. No readers, \
+                    but it is the only evidence an operator has after a bad ingest.",
+    },
+    // ---- Bucket 2/3 — control state that may never be deleted ------------
+    ClassifiedTable {
+        name: "published_source_generations",
+        class: TableClass::NeverDelete,
+        rationale: "Publication truth. As-of reads reconstruct heads under \
+                    `publication_revision <= R`; a request pinned at r_old <= R < r_new loses \
+                    the source entirely from an ALL INNER JOIN, so deleting a superseded row is \
+                    a silent mid-request disappearance, not a stale answer.",
+    },
+    ClassifiedTable {
+        name: "ingest_checkpoint_transitions",
+        class: TableClass::NeverDelete,
+        rationale: "Resume cursor AND a monotone allocator source: the next checkpoint revision \
+                    is `max(checkpoint_revision) + 1` over the whole history for the host. The \
+                    reference host's maximum is 1 784 588 514 188 (a wall-clock-ms seed), so \
+                    deleting the row that holds the maximum restarts allocation near 1 and \
+                    collides with thousands of live rows. `transition_revision` additionally \
+                    looks rows up by `operation_id` across all history for retry idempotency, \
+                    so even a time-based TTL breaks retry safety.",
+    },
+    ClassifiedTable {
+        name: "source_generation_publication_readiness",
+        class: TableClass::NeverDelete,
+        rationale: "Same monotone-allocator hazard as `ingest_checkpoint_transitions`: the next \
+                    readiness revision is derived from the maximum over all history.",
+    },
+    ClassifiedTable {
+        name: "ingest_append_control",
+        class: TableClass::NeverDelete,
+        rationale: "One row per host; the cache fence. Startup hard-refuses to run without it, \
+                    so deleting it does not degrade ingest, it stops it.",
+    },
+    ClassifiedTable {
+        name: "publication_diagnostic_events",
+        class: TableClass::NeverDelete,
+        rationale: "Bounded by distinct (host, name, file, kind) and self-collapsing, so there \
+                    is nothing to gain by deleting it and a diagnostic history to lose.",
+    },
+    ClassifiedTable {
+        name: "ingest_checkpoints",
+        class: TableClass::NeverDelete,
+        rationale: "Looks like retired telemetry; is not. Still written by the sink and still \
+                    read as legacy resume state.",
+    },
+    ClassifiedTable {
+        name: "schema_migrations",
+        class: TableClass::NeverDelete,
+        rationale: "The migration ledger, created by the runner rather than by `sql/`. Deleting \
+                    a row re-applies a migration.",
+    },
+    ClassifiedTable {
+        name: "mcp_read_index_state",
+        class: TableClass::NeverDelete,
+        rationale: "Three control rows; the canonical-read-index readiness fence. Reset only \
+                    via the explicit `core-index rebuild` path, never by reclamation.",
+    },
+    ClassifiedTable {
+        name: "storage_reclaim_ledger",
+        class: TableClass::NeverDelete,
+        rationale: "The #603 reclaim ledger itself (migration 038). Restart safety is exactly \
+                    the property that a claimed unit outlives the crash that interrupted it, so \
+                    a reclaimer that could delete its own ledger would reintroduce the stranded- \
+                    child bug it exists to fix. Settling advances `phase`, never deletes.",
+    },
+    ClassifiedTable {
+        name: "search_conversation_terms",
+        class: TableClass::NeverDelete,
+        rationale: "Hazard H5. A SummingMergeTree accumulator with NO tombstone path: a delete \
+                    never decrements, so any reclaim naming it leaves the corpus permanently \
+                    overstated, and §1 marks it `never (pending OQ-1)` because OQ-1 records that \
+                    removal `is not reversible without a corpus-wide re-tokenize`. Whether it is \
+                    dropped or rebuilt is OQ-1 and blocks WI-09; until that is answered the safe \
+                    class is the one no authority token can unlock, not the one the stock \
+                    `DerivedOnly` token authorizes. Migration 010 truncates it on install and is \
+                    allowlisted for exactly that.",
+    },
+    // ---- Bucket 3 — rebuildable derived data -----------------------------
+    ClassifiedTable {
+        name: "mcp_open_events",
+        class: TableClass::Derived,
+        rationale: "Legacy open projection. `candidate_generation` is in the sort key so \
+                    ReplacingMergeTree can never collapse two candidate generations — the \
+                    uncollapsible-generation mechanism behind the PR-604 disk-fill incident.",
+    },
+    ClassifiedTable {
+        name: "mcp_open_turns",
+        class: TableClass::Derived,
+        rationale: "Same uncollapsible-generation property; the single largest table on the \
+                    reference host, almost entirely `event_summaries_json`.",
+    },
+    ClassifiedTable {
+        name: "mcp_open_publication_headers",
+        class: TableClass::Derived,
+        rationale: "One durable row per candidate publication per session; the authorization \
+                    barrier a reader pins. Never collapses.",
+    },
+    ClassifiedTable {
+        name: "mcp_open_sessions",
+        class: TableClass::Derived,
+        rationale: "Published per-session pointer for the v1 open engine. Collapses cleanly.",
+    },
+    ClassifiedTable {
+        name: "mcp_open_generation_readiness",
+        class: TableClass::Derived,
+        rationale: "Grows as candidate-publications x sources.",
+    },
+    ClassifiedTable {
+        name: "mcp_open_dirty_sessions",
+        class: TableClass::Derived,
+        rationale: "Projection debt queue; post-merge bounded by session count.",
+    },
+    ClassifiedTable {
+        name: "mcp_open_backfill_plans",
+        class: TableClass::Derived,
+        rationale: "One row per session mid-backfill. A live plan row is also the exclusion \
+                    that keeps orphan reclaim off a session currently being prepared.",
+    },
+    ClassifiedTable {
+        name: "mcp_open_projection_state",
+        class: TableClass::Derived,
+        rationale: "Single 'global' row; the v1 projection readiness flag.",
+    },
+    ClassifiedTable {
+        name: "mcp_session_directory",
+        class: TableClass::Derived,
+        rationale: "Canonical read index. `source_generation` is in the key, so one aggregate \
+                    row set survives per generation forever. Content-free by design and fully \
+                    rebuildable via `moraine db core-index rebuild`.",
+    },
+    ClassifiedTable {
+        name: "mcp_event_locator",
+        class: TableClass::Derived,
+        rationale: "Canonical read index. `event_uid` embeds `source_generation`, so a \
+                    superseded generation's uids are disjoint from the live one's and a \
+                    generation predicate is exact. `session_id` on a locator row is NOT \
+                    key-determined, so a locator delete must never be predicated on it.",
+    },
+    ClassifiedTable {
+        name: "mcp_event_navigation",
+        class: TableClass::Derived,
+        rationale: "Canonical read index, explicitly content-free. `source_generation` is in \
+                    the key.",
+    },
+    ClassifiedTable {
+        name: "search_documents",
+        class: TableClass::Derived,
+        rationale: "Rebuildable from `events`, but ORDER BY (event_uid, source_host) alone \
+                    means ONE physical row serves BOTH attributions of a double-attributed uid \
+                    (19 846 of them on the reference host). Deleting 'the document for session \
+                    X' deletes it for live session Y and silently changes BM25 df and scores, \
+                    so no delete naming this table may be predicated on `session_id`.",
+    },
+    ClassifiedTable {
+        name: "search_postings",
+        class: TableClass::Derived,
+        rationale: "83.6% of rows on the reference host carry `source_file=''` and \
+                    `source_generation=0` — back-filled type defaults from migration 032, not \
+                    real provenance. Predicating a posting delete on the posting's own \
+                    generation deletes the entire live corpus; the only safe predicate joins \
+                    through the document, mirroring `v_live_search_postings`.",
+    },
+    ClassifiedTable {
+        name: "tool_io",
+        class: TableClass::Derived,
+        rationale: "Denormalized duplicate of tool payloads already in `events`. Has NO \
+                    `source_file`/`source_generation` column at all, so any generation-shaped \
+                    predicate is a compile-time-valid, runtime-wrong statement — its liveness \
+                    is a uid set joined through `events`.",
+    },
+    ClassifiedTable {
+        name: "event_links",
+        class: TableClass::Derived,
+        rationale: "Derived edge set with no readers, and the same missing-generation-column \
+                    hazard as `tool_io`.",
+    },
+    ClassifiedTable {
+        name: "file_attention_project_roots",
+        class: TableClass::Derived,
+        rationale: "Bounded by distinct (project_id, worktree_root) and rebuilt by its \
+                    materialized views. Not registered in REQUIRED_SCHEMA_OBJECTS — see \
+                    UNREGISTERED_PHYSICAL_TABLES.",
+    },
+    // ---- Bucket 4 — operational telemetry --------------------------------
+    ClassifiedTable {
+        name: "ingest_heartbeats",
+        class: TableClass::Telemetry,
+        rationale: "Only the latest row is ever read, but one row is written every 5 s per \
+                    host. Time-partitioned, so a TTL genuinely drops whole parts.",
+    },
+    ClassifiedTable {
+        name: "search_query_log",
+        class: TableClass::Telemetry,
+        rationale: "Single reader is a rolling 7-day hot-query window, so the default 30-day \
+                    horizon carries 4x headroom over the only horizon any code depends on.",
+    },
+    ClassifiedTable {
+        name: "search_hit_log",
+        class: TableClass::Telemetry,
+        rationale: "No readers. Up to `result_limit` rows per query, so the highest-volume \
+                    telemetry table by construction.",
+    },
+    ClassifiedTable {
+        name: "search_interaction_log",
+        class: TableClass::Telemetry,
+        rationale: "No writer and no reader; migration 020 already says so, and the reference \
+                    host carries zero active parts. Dropping the table is plan OQ-2; a TTL is \
+                    free in the meantime.",
+    },
+    // ---- ClickHouse system logs ------------------------------------------
+    ClassifiedTable {
+        name: "system.query_log",
+        class: TableClass::Telemetry,
+        rationale: "3.51 GiB / 14.0M rows on the reference host spanning five months, with no \
+                    TTL because the packaged `config.xml` is never loaded.",
+    },
+    ClassifiedTable {
+        name: "system.metric_log",
+        class: TableClass::Telemetry,
+        rationale: "One row per second forever at the configured 1000 ms collect interval.",
+    },
+    ClassifiedTable {
+        name: "system.asynchronous_metric_log",
+        class: TableClass::Telemetry,
+        rationale: "542M rows on the reference host; cheap per row, unbounded in aggregate.",
+    },
+];
+
+/// The ownership class of `table`, or `None` when the table is unknown to the
+/// classification (§4 S1).
+///
+/// `None` is a hard error for every caller that is about to delete something.
+/// It is deliberately not "probably derived": the whole point of this function
+/// is that a table nobody thought about is a table nobody may delete.
+///
+/// Accepts either an unqualified Moraine table name (`events`) or a
+/// `system.`-qualified system log.
+pub fn classify(table: &str) -> Option<TableClass> {
+    CLASSIFIED_TABLES
+        .iter()
+        .find(|entry| entry.name == table)
+        .map(|entry| entry.class)
+}
+
+/// The full classification entry, including the rationale, for `table`.
+pub fn classification(table: &str) -> Option<&'static ClassifiedTable> {
+    CLASSIFIED_TABLES.iter().find(|entry| entry.name == table)
+}
+
+/// Every Moraine (non-`system.`) table of `class`, sorted.
+pub fn tables_of_class(class: TableClass) -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = CLASSIFIED_TABLES
+        .iter()
+        .filter(|entry| entry.class == class && !entry.name.starts_with("system."))
+        .map(|entry| entry.name)
+        .collect();
+    names.sort_unstable();
+    names
+}
+
+/// Both directions of the §4 S1 exhaustiveness invariant, as name sets.
+///
+/// Returned rather than asserted so the unit test can name each side in its
+/// failure message, and so a future caller (a doctor probe, say) can surface a
+/// drift without panicking.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ClassificationGaps {
+    /// Schema objects the handshake requires that are neither classified nor
+    /// declared a view. **A new table that nobody classified lands here.**
+    pub unclassified_schema_objects: Vec<String>,
+    /// Classified Moraine tables that the schema handshake does not require
+    /// and that are not on the documented unregistered allowlist.
+    pub classified_but_unregistered: Vec<String>,
+    /// Names declared to be views that the schema handshake does not require.
+    pub stale_view_declarations: Vec<String>,
+    /// **The third side.** `CREATE TABLE`s in [`crate::bundled_migrations`]
+    /// naming something neither classified nor declared a view.
+    ///
+    /// The other two fields compare two hand-maintained Rust lists to each
+    /// other, so a migration that installs a table nobody ever registered
+    /// leaves both of them empty — which is precisely how
+    /// `file_attention_project_roots` (migration 026) came to need
+    /// [`UNREGISTERED_PHYSICAL_TABLES`]. This field reads `sql/`.
+    pub unclassified_migration_tables: Vec<String>,
+}
+
+impl ClassificationGaps {
+    /// Whether all four vectors are empty.
+    ///
+    /// Every caller today is a test, and a summary that omitted a field would
+    /// be green in all of them, because each also asserts its fields
+    /// individually. `each_classification_gap_vector_names_a_planted_gap`
+    /// therefore asserts this method **per field**: a gap planted in any one of
+    /// the four has to make it `false`. Without that, hard-wiring it to `true`
+    /// is green, and the first non-test adopter inherits a summary that always
+    /// says "no gaps".
+    pub fn is_empty(&self) -> bool {
+        self.unclassified_schema_objects.is_empty()
+            && self.classified_but_unregistered.is_empty()
+            && self.stale_view_declarations.is_empty()
+            && self.unclassified_migration_tables.is_empty()
+    }
+}
+
+/// Compute [`ClassificationGaps`] between [`CLASSIFIED_TABLES`],
+/// [`SCHEMA_VIEW_OBJECTS`], [`REQUIRED_SCHEMA_OBJECTS`], and the `CREATE TABLE`
+/// statements of every bundled migration.
+pub fn classification_gaps() -> ClassificationGaps {
+    let created: Vec<String> = crate::bundled_migrations()
+        .iter()
+        .flat_map(|migration| migration_created_tables(migration.sql))
+        .collect();
+    classification_gaps_between(
+        &REQUIRED_SCHEMA_OBJECTS.iter().copied().collect(),
+        &SCHEMA_VIEW_OBJECTS.iter().copied().collect(),
+        &UNREGISTERED_PHYSICAL_TABLES.iter().copied().collect(),
+        &CLASSIFIED_TABLES
+            .iter()
+            .map(|entry| entry.name)
+            .filter(|name| !name.starts_with("system."))
+            .collect(),
+        &created,
+    )
+}
+
+/// [`classification_gaps`] over supplied sets rather than over the shipped
+/// constants.
+///
+/// Split out **only** so the non-vacuity companions can plant a gap in each
+/// input and watch the corresponding field name it. Three of the four fields
+/// are pure functions of `&'static` constants, so a test built from those
+/// constants alone can assert nothing beyond "the shipped tree is clean" — and
+/// a field narrowed to `Vec::new()` satisfies that assertion just as well as a
+/// working one. `each_classification_gap_vector_names_a_planted_gap` is the
+/// bound; `the_migration_side_of_exhaustiveness_actually_parses_create_table`
+/// is the same claim for the fourth, which reads `sql/`.
+fn classification_gaps_between(
+    required: &BTreeSet<&str>,
+    views: &BTreeSet<&str>,
+    unregistered: &BTreeSet<&str>,
+    classified: &BTreeSet<&str>,
+    created: &[String],
+) -> ClassificationGaps {
+    ClassificationGaps {
+        unclassified_schema_objects: required
+            .iter()
+            .filter(|name| !classified.contains(*name) && !views.contains(*name))
+            .map(|name| (*name).to_string())
+            .collect(),
+        classified_but_unregistered: classified
+            .iter()
+            .filter(|name| !required.contains(*name) && !unregistered.contains(*name))
+            .map(|name| (*name).to_string())
+            .collect(),
+        stale_view_declarations: views
+            .iter()
+            .filter(|name| !required.contains(*name))
+            .map(|name| (*name).to_string())
+            .collect(),
+        unclassified_migration_tables: {
+            // No `!views.contains(…)` companion here, deliberately. There used
+            // to be one and it was unreachable: `created_table` returns `None`
+            // for `CREATE VIEW`/`CREATE MATERIALIZED VIEW`, and no bundled
+            // migration creates a physical table under a name in
+            // `SCHEMA_VIEW_OBJECTS`, so no view name could reach the filter.
+            //
+            // MUTATION (executed 2026-07-27): add the filter back => the whole
+            // crate stays GREEN, which is the measurement that it was dead
+            // code rather than a guard.
+            //
+            // Removing it is also the safer reading: a migration that installs
+            // a real table named `search_term_stats` *is* a classification gap
+            // and should be reported as one.
+            let mut created: Vec<String> = created
+                .iter()
+                .filter(|name| !classified.contains(name.as_str()))
+                .cloned()
+                .collect();
+            created.sort();
+            created.dedup();
+            created
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// §4 S4 — the repo-wide migration invariant
+// ---------------------------------------------------------------------------
+
+/// One migration's licence to perform named *shapes* of removal against a
+/// named set of tables.
+///
+/// Keyed on **(version, table, shape)**. Each looser key was fail-open one
+/// dimension at a time, and each was found by appending one statement to a
+/// migration that already had an entry:
+///
+/// * Keyed on `version` alone, appending
+///   `TRUNCATE TABLE moraine.search_documents;` to `sql/020` was invisible —
+///   exempting a version exempted every table it did not yet name.
+/// * Keyed on `(version, table)`, appending `TRUNCATE TABLE moraine.events;` to
+///   `sql/012` was invisible, and `DROP TABLE moraine.events;` appended to
+///   `sql/020` passed the gate. 012's own reason says its statements are
+///   "guarded by a WHERE that skips already-correct rows … none removes a row";
+///   that entry was nonetheless authorizing a truncate of bucket 1.
+///
+/// **A finding whose shape is `None` is never exempt.** An exemption is a
+/// licence for a statement somebody read and described; a form nobody has named
+/// is the case the gate exists for, and it stays a finding inside an exempted
+/// migration exactly as it would anywhere else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MigrationRemovalExemption {
+    pub version: &'static str,
+    /// Unqualified table names this entry covers.
+    pub tables: &'static [&'static str],
+    /// Statement shapes this entry covers.
+    ///
+    /// The licence is the **cross product** of `tables` and `shapes`, and
+    /// `every_allowlist_entry_is_load_bearing_and_still_exempts_a_live_migration`
+    /// requires every pair in it to be witnessed by a real statement of the
+    /// migration. An entry whose cross product would over-grant has to be split
+    /// into two entries, which is why `032` appears twice.
+    pub shapes: &'static [DeleteShape],
+    pub reason: &'static str,
+}
+
+/// Migrations allowed to contain a statement of a named shape against a named
+/// table, each with the reason.
+///
+/// Growing this list is a deliberate act that shows up in review as an edit to
+/// this constant — which is the whole point of paying the one-line cost here
+/// rather than loosening a table's class, or widening
+/// [`BENIGN_ALTER_OPERATIONS`], to make a migration compile clean.
+///
+/// Entries are in version order, and a version may hold more than one when a
+/// single entry's cross product would over-grant.
+///
+/// Every entry is historical and one-shot except the standing
+/// [`DeleteShape::MaterializedViewInto`] writers, which are standing by
+/// construction.
+///
+/// `012` and `013` are here because [`benign_shape`] is an allowlist: they were
+/// invisible for as long as the gate enumerated destructive shapes, since no
+/// round of that enumeration ever listed `ALTER … UPDATE`. Between them they
+/// rewrite five columns across twenty-one statements on `moraine.events` and
+/// `moraine.raw_events`. `009`, `014`, `031`, `032` and `036` are here for the
+/// same reason one round later: `MATERIALIZE COLUMN` and `INSERT` were on the
+/// benign list, so a migration that rewrites a column of canonical history —
+/// 014 materializes three on `moraine.events` — or appends to a never-delete
+/// control table said nothing.
+///
+/// `004`, `011`, `012`, `014` and `032` gained a second kind of entry in round
+/// 6, when the write-head check moved from `is_protected()` to
+/// [`relation_is_guarded`] and started consulting
+/// [`MIGRATION_PRESERVED_DERIVED_TABLES`]. That surfaced eleven statements —
+/// nine `CREATE MATERIALIZED VIEW … TO` and two `INSERT INTO` — admitted until
+/// then because `search_documents`/`search_postings` are `Derived`. They are
+/// the views that *populate* the corpus and the backfills that reseed it, so
+/// every one is legitimate; the reason they now have to be named is that the
+/// same head aimed at the same table with a `SELECT * REPLACE (…)` **empties**
+/// it (executed in `clickhouse local`: 23 bytes of `text_content` to 0 through
+/// `FINAL`, still 0 after `OPTIMIZE … FINAL`), and nothing distinguished the
+/// two.
+///
+/// Every one of these is legitimate, and "a bundled migration rewrites a column
+/// on canonical history" — or "writes into the BM25 corpus" — is exactly the
+/// sentence this gate exists to make somebody type.
+pub const MIGRATION_DELETE_ALLOWLIST: &[MigrationRemovalExemption] = &[
+    MigrationRemovalExemption {
+        version: "004",
+        tables: &["search_documents", "search_postings"],
+        shapes: &[DeleteShape::MaterializedViewInto],
+        reason: "installs the two standing writers that build the search corpus in the first \
+                 place: `mv_search_documents_from_events` from `moraine.events`, and \
+                 `mv_search_postings` tokenizing the documents. Both are the corpus's source, \
+                 not a supersede of it",
+    },
+    MigrationRemovalExemption {
+        version: "009",
+        tables: &["search_documents"],
+        shapes: &[DeleteShape::AlterRewriteColumn],
+        reason: "adds the MATERIALIZED column `has_codex_mcp` and materializes it across every \
+                 existing part. The rewrite is the point of the migration — without it the flag \
+                 is false for all history — and it touches only the column it just added",
+    },
+    MigrationRemovalExemption {
+        version: "010",
+        tables: &["search_conversation_terms"],
+        shapes: &[
+            DeleteShape::Truncate,
+            DeleteShape::InsertInto,
+            DeleteShape::MaterializedViewInto,
+        ],
+        reason: "installs `search_conversation_terms`, TRUNCATEs it once so the accumulator \
+                 starts from a known-empty state, backfills it from `search_documents`, then \
+                 installs the materialized view that keeps it current. The table is never-delete \
+                 (H5: no tombstone path) and these are the only bundled statements that may \
+                 empty or supersede it",
+    },
+    MigrationRemovalExemption {
+        version: "011",
+        tables: &["search_documents", "search_postings"],
+        shapes: &[DeleteShape::MaterializedViewInto],
+        reason: "the #300 provider-to-harness rename redefines both 004 writers so their \
+                 projections carry the renamed column. Same two standing views, recreated, \
+                 selecting the same rows",
+    },
+    MigrationRemovalExemption {
+        version: "012",
+        tables: &["search_documents", "search_postings"],
+        shapes: &[DeleteShape::MaterializedViewInto],
+        reason: "adds `inference_provider` to both standing writers alongside 012's `ALTER … \
+                 UPDATE` backfills. Split from 012's other entry so the licence is not the cross \
+                 product: 012 may rewrite eight tables' columns and may recreate these two \
+                 views, and neither permission implies the other",
+    },
+    MigrationRemovalExemption {
+        version: "012",
+        tables: &[
+            "raw_events",
+            "events",
+            "event_links",
+            "tool_io",
+            "ingest_errors",
+            "search_documents",
+            "search_postings",
+            "search_hit_log",
+        ],
+        shapes: &[DeleteShape::AlterUpdate],
+        reason: "issue #300 harness rename: eight `ALTER … UPDATE` backfills that set \
+                 `inference_provider` from `harness`, then eight that rewrite the legacy \
+                 `claude` harness label to `claude-code`. Every one is guarded by a WHERE that \
+                 skips already-correct rows, so re-running is a no-op; none removes a row",
+    },
+    MigrationRemovalExemption {
+        version: "013",
+        tables: &[
+            "events",
+            "search_documents",
+            "search_postings",
+            "search_hit_log",
+        ],
+        shapes: &[DeleteShape::AlterUpdate],
+        reason: "canonicalizes the legacy `thinking` payload label to `reasoning` across the \
+                 canonical table and the projections that copy `payload_type` out of it. \
+                 Idempotent by the same already-correct WHERE guard as 012; it overwrites two \
+                 metadata columns and a flag, never `payload_json`",
+    },
+    MigrationRemovalExemption {
+        version: "014",
+        tables: &["search_documents"],
+        shapes: &[DeleteShape::MaterializedViewInto],
+        reason: "harmonized token accounting redefines `mv_search_documents_from_events` to \
+                 project the three new token columns. `search_postings` is not touched, and \
+                 listing it here would grant a permission 014 does not use",
+    },
+    MigrationRemovalExemption {
+        version: "014",
+        tables: &["events", "search_documents"],
+        shapes: &[DeleteShape::AlterRewriteColumn],
+        reason: "harmonized token accounting materializes `endpoint_kind`, \
+                 `token_usage_buckets` and `token_usage_native_units` across every part of \
+                 canonical history, then across the search projection. Each is a MATERIALIZED \
+                 column 014 itself adds, so the rewrite fills columns that were empty rather \
+                 than replacing recorded values — but it is a rewrite of `moraine.events`, and \
+                 it must be read as one",
+    },
+    MigrationRemovalExemption {
+        version: "020",
+        tables: &[
+            "events",
+            "raw_events",
+            "event_links",
+            "tool_io",
+            "search_documents",
+            "search_postings",
+            "search_conversation_terms",
+            "search_hit_log",
+        ],
+        shapes: &[DeleteShape::AlterDelete],
+        reason: "issue #386 one-shot purge of empty-session_id claude-code rows; the only \
+                 bundled migration that has ever legitimately removed canonical or raw rows",
+    },
+    MigrationRemovalExemption {
+        version: "031",
+        tables: &[
+            "ingest_append_control",
+            "ingest_checkpoint_transitions",
+            "published_source_generations",
+            "source_generation_publication_readiness",
+        ],
+        shapes: &[DeleteShape::InsertInto],
+        reason: "seeds the four never-delete control relations of atomic source publication. \
+                 Each is a ReplacingMergeTree keyed by a monotone revision, so the seed row is \
+                 an append that supersedes nothing: the migration runs once, before any \
+                 revision has been allocated",
+    },
+    MigrationRemovalExemption {
+        version: "032",
+        tables: &["search_documents", "search_postings"],
+        shapes: &[DeleteShape::AlterRewriteColumn],
+        reason: "re-declares `source_name` as `LowCardinality(String)` on both search \
+                 projections, which rewrites every part. The corpus is rebuildable by a full \
+                 re-tokenize and the column's values are preserved by the conversion, but the \
+                 statement does rewrite the whole table",
+    },
+    MigrationRemovalExemption {
+        version: "032",
+        tables: &["search_conversation_terms"],
+        shapes: &[DeleteShape::MaterializedViewInto],
+        reason: "recreates `mv_search_conversation_terms` after the source-host read-model \
+                 change; the standing writer into the never-delete accumulator is 010's, \
+                 redefined, not a new one. Split from 032's other entry so the licence is not \
+                 the cross product: 032 may rewrite a column of the search projections and may \
+                 install this view, and neither permission implies the other",
+    },
+    MigrationRemovalExemption {
+        version: "032",
+        tables: &["search_documents", "search_postings"],
+        shapes: &[DeleteShape::MaterializedViewInto, DeleteShape::InsertInto],
+        reason: "the source-host live read model recreates both standing writers and backfills \
+                 the rows that predate `source_host`. The two `INSERT INTO`s are the only \
+                 bundled statements that append to the corpus directly; both are additive \
+                 reseeds, neither carries a `REPLACE` that would supersede a live document",
+    },
+    MigrationRemovalExemption {
+        version: "036",
+        tables: &["mcp_read_index_state"],
+        shapes: &[DeleteShape::InsertInto],
+        reason: "stamps the three canonical read indexes as built. `mcp_read_index_state` is \
+                 never-delete because it is the fence a reader consults before trusting an \
+                 index, and these three appends are what set the fence in the first place",
+    },
+];
+
+/// Derived tables that no bundled migration may remove rows from, with the
+/// reason each one is more expensive to lose than its `Derived` class suggests.
+///
+/// This is the coverage the per-migration 034/035 loops used to provide for
+/// `search_documents`/`search_postings`. Those loops were substring matches on
+/// one statement form pinned to two versions; this is the same claim made
+/// shape-aware and repo-wide, so it also covers migration 040.
+pub const MIGRATION_PRESERVED_DERIVED_TABLES: &[(&str, &str)] = &[
+    (
+        "search_documents",
+        "§2: `text_content` is the only remaining copy that could prove the ranking path wrong \
+         while #597's C1 is open, and the corpus is rebuildable only by a full re-tokenize",
+    ),
+    (
+        "search_postings",
+        "the BM25 posting list; a migration that empties it silently changes every score until a \
+         corpus-wide rebuild runs",
+    ),
+];
+
+/// A statement in a bundled migration that is not on the benign allowlist and
+/// names a table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationDeleteFinding {
+    pub version: String,
+    pub table: String,
+    pub class: TableClass,
+    /// What the statement appears to do, when [`delete_shape`] recognizes it.
+    /// `None` means "not benign, and not a shape anyone has named" — the case
+    /// the gate exists for, and never a reason to suppress the finding.
+    pub shape: Option<DeleteShape>,
+    /// The offending statement, trimmed and collapsed to one line.
+    pub statement: String,
+}
+
+/// Statement shapes that destroy rows.
+///
+/// **This enum classifies findings; it does not decide them.** The gate is
+/// [`benign_shape`], and a statement it does not recognize is a finding whether
+/// or not anything here matches — see [`migration_row_removals`].
+///
+/// It was the gate for four rounds, and each round's adversarial sweep found
+/// shapes the previous round's list could not see: the `DROP` family, then
+/// `MODIFY TTL` / `CLEAR COLUMN` / `MOVE … TO TABLE` / `REPLACE TABLE` /
+/// `RENAME`, then `ALTER … UPDATE` / `REPLACE PARTITION` / `OPTIMIZE … FINAL` /
+/// `DETACH PARTITION`. Enumerating destructive forms is an unbounded
+/// adversarial search against a SQL dialect that keeps growing. Enumerating
+/// benign ones is bounded by what migrations in this repository actually do —
+/// 294 statements, [`BENIGN_STATEMENT_HEADS`] plus
+/// [`BENIGN_ALTER_OPERATIONS`] — so that is what the gate enumerates now.
+///
+/// The fifth round added [`DeleteShape::AlterRewriteColumn`],
+/// [`DeleteShape::InsertInto`] and [`DeleteShape::MaterializedViewInto`]. Those
+/// are **not** a fifth attempt at completing the destructive enumeration: each
+/// names a form that was on the *benign* list and had to come off it, and the
+/// label exists so the exemption key — which is
+/// `(version, table, shape)` — can license the bundled migrations that
+/// legitimately use them.
+///
+/// What survives here is the reporting: "`ALTER … UPDATE` on `events`" is a
+/// far better failure message than "unrecognized statement on `events`", and
+/// the arms are still pinned in both directions by
+/// `every_row_removing_shape_is_recognized_including_the_ones_the_old_guard_missed`,
+/// which asserts the shape and not only the finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeleteShape {
+    /// `TRUNCATE [TABLE|DATABASE] [IF EXISTS] <name>`.
+    Truncate,
+    /// `DELETE FROM <name> …` (lightweight delete).
+    DeleteFrom,
+    /// `ALTER TABLE <name> … DELETE …` (mutation).
+    AlterDelete,
+    /// `ALTER TABLE <name> UPDATE <col> = <expr> WHERE …` (mutation).
+    ///
+    /// The standard ClickHouse overwrite. `UPDATE payload_json = '' WHERE 1`
+    /// keeps every row and destroys 3.52 GiB of compressed column content on
+    /// the reference host — [`DeleteShape::AlterClear`] with an arbitrary
+    /// expression instead of the column default. Twenty-one of these ship in
+    /// `sql/012` and `sql/013`; both are on [`MIGRATION_DELETE_ALLOWLIST`].
+    AlterUpdate,
+    /// `INSERT INTO <name> …` where `<name>` is protected.
+    ///
+    /// See [`PROTECTED_WRITE_HEADS`]: on a `ReplacingMergeTree` an insert that
+    /// repeats the sort key with a higher version supersedes the row that was
+    /// there, and `moraine.events` is one.
+    InsertInto,
+    /// `CREATE MATERIALIZED VIEW <v> TO <name> …` where `<name>` is protected.
+    ///
+    /// [`DeleteShape::InsertInto`] installed as standing state: every future
+    /// insert into the MV's source writes into `<name>` too.
+    MaterializedViewInto,
+    /// `ALTER TABLE <name> … MATERIALIZE COLUMN <col>` / `… MODIFY COLUMN <col>
+    /// <type> …`.
+    ///
+    /// Both rewrite the stored bytes of a column that already has values.
+    ///
+    /// `MATERIALIZE COLUMN` recomputes the column from its current
+    /// `DEFAULT`/`MATERIALIZED` expression across all parts. **This repository
+    /// documents the hazard itself**: `sql/037_search_ranking_metadata.sql`
+    /// records that #603 must materialize `text_digest` and `payload_phase`
+    /// *before* dropping either source column, "or every historical digest
+    /// silently becomes the digest of an empty string". `events` ships
+    /// `inference_provider … DEFAULT ''` and `author … DEFAULT ''` today, so
+    /// the default a materialize would recompute against exists.
+    ///
+    /// A `MODIFY COLUMN` that re-declares the type rewrites every part:
+    /// `MODIFY COLUMN ingested_at DateTime` on the `DateTime64(3)` column that
+    /// feeds `PARTITION BY toYYYYMM(ingested_at)` drops the millisecond
+    /// component from all canonical history. The gate cannot tell a widening
+    /// from a narrowing without the schema, so it reports both — see
+    /// [`MODIFY_COLUMN_METADATA_KEYWORDS`] for the metadata forms that stay
+    /// benign.
+    AlterRewriteColumn,
+    /// `ALTER TABLE <name> … MODIFY TTL <expr> …`, or a `MODIFY COLUMN <col>
+    /// TTL <expr>` that puts a TTL on one column.
+    ///
+    /// **A TTL expression with no action clause defaults to `DELETE`**, and
+    /// `materialize_ttl_after_modify` defaults to 1, so the ALTER mutates
+    /// existing parts immediately: every row past the horizon is gone when the
+    /// statement returns. `MODIFY TTL … GROUP BY … SET …` collapses rows
+    /// instead of removing them, which is destructive in the same way.
+    ///
+    /// The `TO DISK` / `TO VOLUME` / `RECOMPRESS` forms move or re-encode
+    /// bytes without removing a row and are nonetheless reported. That is a
+    /// deliberate over-approximation, not an oversight: there is no storage
+    /// policy and no tiering TTL anywhere in this tree, so a carve-out would
+    /// be untested surface guarding a statement nobody writes, while *any*
+    /// TTL policy landing on canonical history is a review event.
+    /// `REMOVE TTL` is not a shape — it deletes the policy, not the rows.
+    AlterModifyTtl,
+    /// `ALTER TABLE <name> … DROP PARTITION|PART|COLUMN|DETACHED …`.
+    AlterDrop,
+    /// `ALTER TABLE <name> … DETACH PARTITION|PART …`.
+    ///
+    /// Step **one** of the two-step `DETACH` + `DROP DETACHED` delete. The
+    /// parts move to `detached/` and the rows stop being readable under a
+    /// protected name, which is the same claim
+    /// [`DeleteShape::RenameRelation`] is here for. The `DROP` list has
+    /// covered step two (`" DROP DETACHED"`) since the round that added it.
+    AlterDetach,
+    /// `ALTER TABLE <name> … REPLACE PARTITION <p> FROM <other>`.
+    ///
+    /// There is no `REPLACE PART`: `EXPLAIN AST` on ClickHouse 25.12.5.44
+    /// rejects it, so the `PARTITION` spelling is the whole shape.
+    ///
+    /// Atomically discards the **destination's** partition and replaces it with
+    /// the source's. `events` spans six active partitions on the reference
+    /// host, so one statement discards a month. Invisible to
+    /// [`DeleteShape::ReplaceRelation`], whose test is a `starts_with` prefix
+    /// and cannot see an infix `REPLACE PARTITION`.
+    AlterReplacePartition,
+    /// `ALTER TABLE <name> … CLEAR COLUMN <col> [IN PARTITION …]`.
+    ///
+    /// Rewrites every part with the column's default in place of its values.
+    /// On `events` that is the 3.48 GiB `payload_json` column: the rows
+    /// survive and their content does not, which no `DROP`-shaped predicate
+    /// sees. `CLEAR INDEX` / `CLEAR PROJECTION` discard derived structures and
+    /// are not shapes.
+    AlterClear,
+    /// `ALTER TABLE <name> … MOVE PARTITION … TO TABLE <other>` /
+    /// `… MOVE PART … TO SHARD <path>`.
+    ///
+    /// Detaches the parts from the source and attaches them elsewhere, so the
+    /// source loses the rows. The `TO DISK` / `TO VOLUME` forms move bytes
+    /// between storage tiers and remove nothing, so the **destination** — not
+    /// the `MOVE` keyword — is the extent, and the test is written as the
+    /// negation of the tiering destinations rather than as a list of the
+    /// removing ones. `EXPLAIN AST` on ClickHouse 25.12.5.44 rejects
+    /// `MOVE PART … TO TABLE` and `MOVE PARTITION … TO SHARD`, so the two
+    /// valid removing spellings are the two above; enumerating them positively
+    /// would have to be revisited the next time ClickHouse adds a destination.
+    AlterMove,
+    /// `DROP TABLE [IF EXISTS] <name>` / `DROP DATABASE [IF EXISTS] <name>`.
+    DropRelation,
+    /// `[CREATE OR] REPLACE TABLE <name> …`.
+    ///
+    /// Atomically swaps a populated table for a freshly created empty one.
+    /// Reported by no `DROP`- or `TRUNCATE`-shaped predicate, and
+    /// [`created_table`] recognizes it too so a table installed this way still
+    /// has to be classified.
+    ReplaceRelation,
+    /// `RENAME TABLE|DATABASE <a> TO <b>` / `EXCHANGE TABLES <a> AND <b>`.
+    ///
+    /// Neither removes a row by itself, but both make the rows that were
+    /// reachable under a protected name unreachable under it — `EXCHANGE
+    /// TABLES moraine.events AND moraine.events_empty` is `TRUNCATE` with
+    /// extra steps and a rollback. **Every** name the statement mentions is
+    /// reported, because the displaced relation may be either operand.
+    RenameRelation,
+    /// `OPTIMIZE TABLE <name> FINAL [DEDUPLICATE [BY …]]`.
+    ///
+    /// `events` is a `ReplacingMergeTree`, so `FINAL` applies the collapse
+    /// immediately instead of whenever a merge happens to run, and
+    /// `DEDUPLICATE BY` collapses on an arbitrary column subset — a hand-picked
+    /// subset can fold together rows that are not duplicates at all.
+    /// `reclaim.rs`'s emitter has treated `OPTIMIZE … FINAL` as a write since
+    /// the round that added it; this is the same argument applied to the
+    /// migration path, where a hand-written upgrade statement is likelier to
+    /// appear.
+    OptimizeFinal,
+}
+
+/// Statement heads that cannot remove or overwrite a row of any table they
+/// name, and the migration or corpus statement that witnesses each one.
+///
+/// **This is the gate.** A statement whose head is not here and whose ALTER
+/// clauses are not in [`BENIGN_ALTER_OPERATIONS`] is a finding for every
+/// protected table it names, whether or not [`delete_shape`] recognizes it.
+///
+/// Two of these heads are conditional on the class of the relation they write
+/// into rather than on their form alone — see [`PROTECTED_WRITE_HEADS`]. They
+/// are listed here anyway, because the head is what
+/// `every_benign_entry_is_witnessed_by_a_real_statement` iterates and the
+/// condition is what [`benign_shape`] applies.
+///
+/// Entries are matched against the uppercased, whitespace-collapsed statement
+/// with `starts_with`, so `CREATE TABLE` does **not** admit
+/// `CREATE OR REPLACE TABLE` — a different head, and a destructive one.
+///
+/// Every entry is exercised by a bundled migration or by a named row of the
+/// negative corpus; `every_benign_entry_is_witnessed_by_a_real_statement`
+/// fails for one that is not, which is what stops this list from becoming the
+/// same unbounded enumeration in the other direction. That test also separates
+/// **tree-witnessed** from **corpus-witnessed** entries, because a row the same
+/// author added alongside an entry is not evidence that this repository writes
+/// the form.
+///
+/// **Adding a head here means adding a rule to [`BENIGN_HEAD_TARGET_RULES`]**,
+/// which is where the question "can a statement with this head displace a
+/// relation that already exists?" has to be answered — in code, with the gated
+/// answer executed against a probe. `CREATE OR REPLACE VIEW ` shipped for three
+/// rounds answering it in a comment, and the comment was wrong.
+const BENIGN_STATEMENT_HEADS: &[&str] = &[
+    // Reads nothing away. sql/ has no bare SELECT; the corpus does.
+    "SELECT ",
+    // Appends. 25 statements across sql/, both the VALUES and the `… SELECT`
+    // forms. Conditional on the target's class — see [`PROTECTED_WRITE_HEADS`].
+    "INSERT INTO ",
+    "CREATE DATABASE ",
+    "CREATE TABLE ",
+    // Views hold no rows. `CREATE MATERIALIZED VIEW` must precede nothing here;
+    // it is listed separately because `CREATE VIEW` is not its prefix, and it
+    // is conditional on its `TO` target's class for the same reason `INSERT`
+    // is: an MV with a `TO` clause is a standing writer.
+    "CREATE VIEW ",
+    "CREATE MATERIALIZED VIEW ",
+    // The atomic spelling of the drop-and-recreate that nine bundled
+    // migrations already perform on views (002, 004, 006, 011, 012, 014, 019,
+    // 032, 033). **Conditional on the class of the name it replaces** — see
+    // [`PROTECTED_REPLACE_HEADS`], and do not restore the sentence this
+    // comment used to carry ("a view holds no rows, so this one can destroy
+    // nothing"), which was measurably false.
+    "CREATE OR REPLACE VIEW ",
+    // Safe unconditionally, and unlike the head above that is a property of
+    // the server rather than of this list: `DROP VIEW` on a table throws
+    // `Code: 80 … is not a View` (executed, 25.12.5.44).
+    "DROP VIEW ",
+];
+
+/// `ALTER TABLE` operation clauses that cannot remove or overwrite a row.
+///
+/// An operation is the clause's first token plus the token after it, so
+/// `MODIFY ORDER BY` appears as `MODIFY ORDER` and
+/// `ADD COLUMN IF NOT EXISTS x` still reduces to `ADD COLUMN`. `ALTER` accepts
+/// comma-separated operations; [`alter_clauses`] splits them and **every**
+/// clause must reduce to an entry here, because one destructive operation is
+/// enough to make the statement a finding no matter what it is bundled with.
+///
+/// Three operations are **conditional** and therefore deliberately absent —
+/// listing them would admit their destructive spellings. See
+/// [`clause_is_benign`]:
+///
+/// * `MOVE PARTITION` / `MOVE PART` — benign only with a `TO DISK` /
+///   `TO VOLUME` destination.
+/// * `MODIFY COLUMN` — benign only as a metadata change; see
+///   [`modify_column_is_metadata_only`].
+/// * `MODIFY QUERY` — benign only on a declared [`SCHEMA_VIEW_OBJECTS`] name.
+///
+/// The three derived-structure families are here in full — `INDEX`,
+/// `PROJECTION` and `STATISTICS` each get `ADD`/`DROP`/`CLEAR`/`MATERIALIZE`.
+/// A half-family is its own defect: for a round this list carried
+/// `DROP PROJECTION` and `CLEAR PROJECTION` without `ADD PROJECTION`, so a
+/// migration could delete a projection but not create one.
+const BENIGN_ALTER_OPERATIONS: &[&str] = &[
+    "ADD COLUMN",
+    "ADD CONSTRAINT",
+    "ADD INDEX",
+    "ADD PROJECTION",
+    "ADD STATISTICS",
+    "CLEAR INDEX",
+    "CLEAR PROJECTION",
+    "CLEAR STATISTICS",
+    "COMMENT COLUMN",
+    "DROP CONSTRAINT",
+    "DROP INDEX",
+    "DROP PROJECTION",
+    "DROP STATISTICS",
+    "MATERIALIZE INDEX",
+    "MATERIALIZE PROJECTION",
+    "MATERIALIZE STATISTICS",
+    "MATERIALIZE TTL",
+    // The table's own comment. `COMMENT COLUMN` was already here; this is the
+    // relation-level spelling of the same metadata edit.
+    "MODIFY COMMENT",
+    // `MODIFY ORDER BY` — the sort key, not the rows.
+    "MODIFY ORDER",
+    "MODIFY SETTING",
+    // Deletes the TTL policy, not the rows it would have removed.
+    "REMOVE TTL",
+    "RENAME COLUMN",
+    // Reverts a table setting to its default. Changes no row.
+    "RESET SETTING",
+];
+
+/// Tokens that may follow the column name in a benign `MODIFY COLUMN` clause.
+///
+/// A `MODIFY COLUMN` clause is
+/// `MODIFY COLUMN [IF EXISTS] <name> [<type>] [<property> …]`. When the token
+/// after the name is one of these the clause edits metadata; when it is
+/// anything else it is a **type declaration**, and re-declaring a type rewrites
+/// every part.
+///
+/// The full set ClickHouse 25.12.5.44 accepts in that position is
+/// `COLLATE, DEFAULT, MATERIALIZED, ALIAS, EPHEMERAL, AUTO_INCREMENT, COMMENT,
+/// CODEC, STATISTICS, TTL, PRIMARY KEY, SETTINGS, REMOVE, MODIFY` — read off
+/// the parser's own error message, then each candidate re-checked with
+/// `EXPLAIN AST` (2026-07-27). This list is a deliberate **subset**:
+///
+/// * `TTL` is absent, but the absence guards nothing on its own and the doc
+///   must not pretend otherwise: `EXPLAIN AST` rejects `MODIFY COLUMN <c> TTL
+///   …` without a preceding type, so in valid ClickHouse the type is always the
+///   first tail token and this list is never consulted for a column TTL. **The
+///   type check is what catches it.** (MUTATION: adding `"TTL"` here left the
+///   whole crate GREEN when measured on 2026-07-27, because nothing bounded
+///   this list at all; re-measured 2026-07-28 it is **RED** in
+///   `a_modify_column_property_the_parser_accepts_is_reported_not_admitted`,
+///   which is the bound that constant was missing.) The entry stays off the
+///   list as defence in depth against a dialect that later relaxes the
+///   requirement, and [`modify_column_sets_ttl`] — which *is*
+///   load-bearing, for the label — is what reports it as
+///   [`DeleteShape::AlterModifyTtl`] rather than
+///   [`DeleteShape::AlterRewriteColumn`].
+///
+///   Why a column TTL is a removal at all: it replaces expired values with the
+///   column default and, once every value in a part has expired, removes the
+///   column from that part on disk — [`DeleteShape::AlterClear`] on a rolling
+///   horizon. The reference host reports `materialize_ttl_after_modify = 1` and
+///   `merge_with_ttl_timeout = 14400`, so it lands within four hours unaided,
+///   and `MATERIALIZE TTL` forces it immediately.
+/// * `ALIAS` and `EPHEMERAL` are absent because they convert a **stored**
+///   column into one that is not stored. That is `DROP COLUMN` under another
+///   name: `MODIFY COLUMN payload_json ALIAS ''` discards 3.48 GiB of canonical
+///   payload.
+/// * `PRIMARY KEY` is absent because changing the primary key rewrites the
+///   parts.
+/// * `COLLATE`, `SETTINGS` and `AFTER` are absent because `EXPLAIN AST`
+///   rejects each of them in this position without a preceding type — at which
+///   point the type is the first token and this list is never consulted.
+///   Listing them would be dead surface. (Re-measured 2026-07-28:
+///   `MODIFY COLUMN c COLLATE 'en'`, `… SETTINGS max_compress_block_size = 1`
+///   and `… AFTER other` are all syntax errors.) `FIRST` is present because it
+///   is the one position modifier the parser accepts without a type, and column
+///   order is schema metadata rather than column content.
+/// * `STATISTICS(<type>)` and `AUTO_INCREMENT` are absent, and this doc used to
+///   claim they were rejected in this position too. **They are not.**
+///   Re-measured 2026-07-28: `ALTER TABLE t MODIFY COLUMN c
+///   STATISTICS(tdigest)` and `ALTER TABLE t MODIFY COLUMN c AUTO_INCREMENT`
+///   are both VALID without a preceding type. (Bare `STATISTICS tdigest`, with
+///   no parentheses, is not.) So for these two the surface is live and their
+///   absence is a deliberate **over-approximation**: a statistics declaration
+///   and an auto-increment flag rewrite no column bytes, and the gate reports
+///   them anyway, which costs one allowlist line if a migration ever writes
+///   one. That is the fail-closed direction, and it is recorded here rather
+///   than mislabelled as dead surface. `a_modify_column_property_the_parser_accepts_is_reported_not_admitted`
+///   pins both as findings, so adding either to this list turns a green test
+///   red — the non-vacuity bound this constant did not have.
+const MODIFY_COLUMN_METADATA_KEYWORDS: &[&str] = &[
+    "CODEC",
+    "COMMENT",
+    "DEFAULT",
+    // Column order in the schema, not column content.
+    "FIRST",
+    "MATERIALIZED",
+    // `MODIFY SETTING` / `RESET SETTING`, the per-column spellings.
+    "MODIFY",
+    "REMOVE",
+    "RESET",
+];
+
+/// Split an `ALTER TABLE` body into its comma-separated operation clauses.
+///
+/// This is the fix for the round-4 root cause. The previous implementation was
+/// not a clause parser at all: it scanned the whole body for any token in a
+/// verb list, which failed in **both** directions.
+///
+/// * Fail-closed. `MODIFY COLUMN author String DEFAULT '' COMMENT 'who'`
+///   reduced to two operations — the real `MODIFY COLUMN` and a phantom
+///   `COMMENT 'WHO'` manufactured from the inline column comment — and every
+///   operation had to be benign, so ordinary DDL was rejected.
+/// * Fail-open. The `MOVE` tiering test searched the whole statement, so
+///   `ADD COLUMN c String DEFAULT 'x TO DISK y', MOVE PARTITION '202601' TO
+///   TABLE moraine.mcp_open_turns` was admitted on a substring inside an
+///   unrelated literal.
+///
+/// Splitting on top-level commas and judging each clause on its own text
+/// closes both. The input is [`mask_quoted`], so a comma inside a literal
+/// cannot split a clause and a keyword inside one cannot be read.
+///
+/// **A mis-split fails closed.** `UPDATE a = 1, b = 2 WHERE 1` is one
+/// ClickHouse operation whose arguments contain a top-level comma, so it splits
+/// into `UPDATE a = 1` and `b = 2 WHERE 1`; the first is not benign and the
+/// second reduces to `B =`, which is not benign either.
+/// `a_mis_split_alter_clause_fails_closed` pins that direction.
+///
+/// **An unbalanced body yields no clause at all**, which [`alter_is_benign`]
+/// treats as a finding. A well-formed statement's parentheses balance outside
+/// its literals, so this costs nothing and closes the round-6 vector where an
+/// unrecognized `(` — a heredoc's, before [`scan_statement`] learned the
+/// syntax — held the depth above zero and stopped the top-level comma from
+/// splitting off a `DROP COLUMN`. The lexer fix and this one are independent:
+/// either alone kills that statement.
+fn alter_clauses(masked_upper: &str) -> Vec<String> {
+    let tokens: Vec<&str> = masked_upper.split_whitespace().collect();
+    // `ALTER TABLE <name> [ON CLUSTER <cluster>]`. Skipping the name is what
+    // stops a relation whose name is an operation keyword from being read as
+    // one; skipping `ON CLUSTER <cluster>` is what stops the distributed
+    // spelling from presenting `ON` as its first clause head.
+    let mut start = 3;
+    if tokens.get(3) == Some(&"ON") && tokens.get(4) == Some(&"CLUSTER") {
+        start = 6;
+    }
+    if tokens.len() <= start {
+        return Vec::new();
+    }
+
+    let body = tokens[start..].join(" ");
+    let mut fragments = Vec::new();
+    let mut depth = 0usize;
+    let mut unbalanced = false;
+    let mut current = String::new();
+    for ch in body.chars() {
+        match ch {
+            '(' => {
+                depth += 1;
+                current.push(ch);
+            }
+            ')' => {
+                if depth == 0 {
+                    unbalanced = true;
+                }
+                depth = depth.saturating_sub(1);
+                current.push(ch);
+            }
+            ',' if depth == 0 => {
+                if !current.trim().is_empty() {
+                    fragments.push(current.trim().to_string());
+                }
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.trim().is_empty() {
+        fragments.push(current.trim().to_string());
+    }
+    if unbalanced || depth != 0 {
+        return Vec::new();
+    }
+    merge_clause_continuations(fragments)
+}
+
+/// Re-join the fragments of the operations whose *own arguments* are a
+/// comma-separated list.
+///
+/// Three ClickHouse operations take a comma-separated tail, and splitting on
+/// every top-level comma made all three unrepresentable — round 6's false
+/// findings, each `EXPLAIN AST`-valid on 25.12.5.44:
+///
+/// * `MODIFY SETTING index_granularity = 8192, min_bytes_for_wide_part = 0` —
+///   **the ordinary spelling**; `MODIFY SETTING` takes a list.
+/// * `RESET SETTING a, b`, and the query-level `… SETTINGS alter_sync = 2,
+///   mutations_sync = 1` tail any clause may carry.
+/// * `MODIFY QUERY SELECT 1 AS a, 2 AS b` — so `MODIFY QUERY` support was
+///   single-column-only.
+///
+/// Each reported shape `None`, and a `None` shape is categorically unexemptable
+/// (see [`MIGRATION_DELETE_ALLOWLIST`]), so a migration that legitimately
+/// needed a two-setting `MODIFY SETTING` could not be allowlisted at all. The
+/// parser was the only thing that could fix it.
+///
+/// **Merging cannot launder a command**, for two independent reasons.
+/// Syntactically: ClickHouse does not accept an alter command after a settings
+/// list or a `MODIFY QUERY` — `MODIFY SETTING a = 8192, DROP COLUMN c`,
+/// `RESET SETTING a, DROP COLUMN c`, `MODIFY QUERY SELECT 1, DROP COLUMN c`
+/// and the comma-free `MODIFY SETTING a = 2 DROP COLUMN c` are all syntax
+/// errors (executed, 25.12.5.44). And structurally: a settings continuation
+/// must be exactly `<ident> = <value>` or a bare `<ident>`, so `DROP COLUMN c`
+/// is not one and stays its own clause, where it is a finding.
+fn merge_clause_continuations(fragments: Vec<String>) -> Vec<String> {
+    let mut clauses: Vec<String> = Vec::new();
+    for fragment in fragments {
+        let continues = clauses
+            .last()
+            .is_some_and(|open| clause_takes_comma_tail(open, &fragment));
+        match clauses.last_mut() {
+            Some(open) if continues => {
+                open.push_str(", ");
+                open.push_str(&fragment);
+            }
+            _ => clauses.push(fragment),
+        }
+    }
+    clauses
+}
+
+/// Whether `fragment` continues the argument list of the clause `open`.
+fn clause_takes_comma_tail(open: &str, fragment: &str) -> bool {
+    match clause_operation(open).as_str() {
+        // The tail is a whole `SELECT`, whose projection list, `GROUP BY` and
+        // window definitions are full of top-level commas, so nothing short of
+        // a SQL parser could find its end. Swallowing to the end of the
+        // statement is sound *because* `MODIFY QUERY` is benign only on a
+        // declared [`SCHEMA_VIEW_OBJECTS`] name: every clause of an `ALTER`
+        // applies to the one relation the `ALTER` names, and on any other name
+        // the whole statement is already a finding.
+        "MODIFY QUERY" => true,
+        "MODIFY SETTING" => is_setting_assignment(fragment),
+        "RESET SETTING" => is_setting_name(fragment),
+        // The query-level `SETTINGS` tail, which any clause may carry.
+        _ => {
+            open.split_whitespace().any(|token| token == "SETTINGS")
+                && is_setting_assignment(fragment)
+        }
+    }
+}
+
+/// `<ident> = <value>`, and nothing longer.
+///
+/// Three tokens exactly. A settings value is a scalar — a number, or a literal
+/// that [`mask_quoted`] has already collapsed to one token — so this covers
+/// every settings list in the tree while refusing to absorb `DROP COLUMN
+/// payload_json` (whose second token is `COLUMN`, not `=`) or the compound
+/// `y = 2 DROP COLUMN payload_json` (six tokens). A settings value written as
+/// an arithmetic expression would be a finding rather than a bypass; §7.4
+/// records it.
+fn is_setting_assignment(fragment: &str) -> bool {
+    let tokens: Vec<&str> = fragment.split_whitespace().collect();
+    tokens.len() == 3 && tokens[1] == "=" && is_bare_identifier(tokens[0])
+}
+
+/// A single bare identifier, which is all `RESET SETTING`'s list holds.
+fn is_setting_name(fragment: &str) -> bool {
+    let mut tokens = fragment.split_whitespace();
+    tokens.next().is_some_and(is_bare_identifier) && tokens.next().is_none()
+}
+
+fn is_bare_identifier(token: &str) -> bool {
+    !token.is_empty()
+        && token
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
+/// Reduce one clause to `"<FIRST> <SECOND>"`, or `"<FIRST>"` at end of clause.
+///
+/// There is no verb allowlist any more. Under the old whole-body token scan an
+/// unlisted verb was a **silent pass**, so the list had to be exhaustive
+/// against a dialect that keeps growing; now the clause head is reduced
+/// unconditionally and an unrecognized head simply fails
+/// [`BENIGN_ALTER_OPERATIONS`] lookup, which is a finding. Completing the
+/// enumeration stopped being load-bearing, so the enumeration is gone.
+fn clause_operation(clause: &str) -> String {
+    let mut tokens = clause.split_whitespace();
+    let first = tokens.next().unwrap_or_default();
+    match tokens.next() {
+        Some(second) => format!("{first} {second}"),
+        None => first.to_string(),
+    }
+}
+
+/// Everything after the column name in a `MODIFY COLUMN <name> …` clause: the
+/// optional type followed by the optional properties.
+///
+/// `MODIFY COLUMN [IF EXISTS] <name>` is the prefix; the caller judges the
+/// tail. Reading the type positionally rather than by pattern is what lets
+/// `MODIFY COLUMN ttl_seconds UInt32` and `MODIFY COLUMN c UInt32 TTL x`
+/// disagree: only the second has a bare `TTL` token *after* the name.
+fn column_clause_tail(clause: &str) -> Vec<&str> {
+    let mut tokens = clause.split_whitespace().skip(2).peekable();
+    if tokens.peek() == Some(&"IF") {
+        tokens.next();
+        if tokens.peek() == Some(&"EXISTS") {
+            tokens.next();
+        }
+    }
+    if tokens.next().is_none() {
+        // No column name: the clause did not parse.
+        return Vec::new();
+    }
+    tokens.collect()
+}
+
+/// Whether a `MODIFY COLUMN` clause edits metadata rather than stored bytes.
+///
+/// A bare `MODIFY COLUMN <name>` with no tail is not valid ClickHouse; it
+/// reports `false`, because a clause the parser could not finish reading is the
+/// case that must fail loudly.
+fn modify_column_is_metadata_only(clause: &str) -> bool {
+    match column_clause_tail(clause).first() {
+        None => false,
+        Some(first) => MODIFY_COLUMN_METADATA_KEYWORDS
+            .iter()
+            .any(|keyword| *first == *keyword || first.starts_with(&format!("{keyword}("))),
+    }
+}
+
+/// Whether a `MODIFY COLUMN` clause attaches a TTL to the column.
+///
+/// A bare `TTL` token in the tail, so a column *named* `ttl` cannot trip it and
+/// a literal cannot smuggle one in — the clause is masked.
+fn modify_column_sets_ttl(clause: &str) -> bool {
+    column_clause_tail(clause).contains(&"TTL")
+}
+
+/// Whether one masked `ALTER` clause cannot remove or overwrite a row.
+///
+/// `relation` is the table the `ALTER` names, needed only by `MODIFY QUERY`.
+fn clause_is_benign(clause: &str, relation: Option<&str>) -> bool {
+    match clause_operation(clause).as_str() {
+        // Tiering moves bytes between storage tiers and keeps every row in the
+        // table it names. `MOVE … TO TABLE` and `MOVE … TO SHARD` do not. The
+        // destination is read from **this clause**, not from the statement.
+        "MOVE PARTITION" | "MOVE PART" => {
+            clause.contains(" TO DISK") || clause.contains(" TO VOLUME")
+        }
+        "MODIFY COLUMN" => modify_column_is_metadata_only(clause),
+        // Redefining a materialized view's SELECT changes what it writes from
+        // now on and rewrites nothing that exists. Scoped to declared views: on
+        // a `MergeTree` name it is a statement ClickHouse rejects, and an
+        // undeclared name is unknown, which S1 treats as protected.
+        "MODIFY QUERY" => relation.is_some_and(|name| SCHEMA_VIEW_OBJECTS.contains(&name)),
+        operation => BENIGN_ALTER_OPERATIONS.contains(&operation),
+    }
+}
+
+/// Whether every clause of one `ALTER TABLE` statement is benign.
+///
+/// An `ALTER` that yields no clause at all is **not** benign: the parser
+/// failing to reach an operation is exactly the case that must fail loudly.
+fn alter_is_benign(masked_upper: &str, relation: Option<&str>) -> bool {
+    let clauses = alter_clauses(masked_upper);
+    if clauses.is_empty() {
+        return false;
+    }
+    clauses
+        .iter()
+        .all(|clause| clause_is_benign(clause, relation))
+}
+
+/// Statement heads that write rows into a relation they do not otherwise
+/// touch, paired with the shape a write into a **protected** relation reports.
+///
+/// Appending is benign for the rows already in a table — except on a
+/// `ReplacingMergeTree`, where repeating the sort key with a higher version
+/// supersedes them. `moraine.events` is
+/// `ReplacingMergeTree(event_version)` with `payload_json` outside the sort
+/// key, so
+/// `INSERT INTO moraine.events SELECT * REPLACE ('' AS payload_json,
+/// event_version + 1 AS event_version) FROM moraine.events FINAL` blanks every
+/// payload in canonical history: unreachable immediately through `FINAL` and
+/// `v_live_events`, physically gone at the next merge. A
+/// `CREATE MATERIALIZED VIEW … TO moraine.events` installs the same overwrite
+/// as standing state.
+///
+/// The class is what separates the hazard from the ordinary case, and the gate
+/// already knows it: superseding a `Derived` row costs a rebuild, superseding a
+/// canonical or never-delete one costs the record. So these two heads are
+/// benign for an unprotected target and a finding for a protected one — see
+/// [`benign_shape`].
+const PROTECTED_WRITE_HEADS: &[(&str, DeleteShape)] = &[
+    ("INSERT INTO ", DeleteShape::InsertInto),
+    (
+        "CREATE MATERIALIZED VIEW ",
+        DeleteShape::MaterializedViewInto,
+    ),
+];
+
+/// Why a statement with a given benign head, aimed at a relation that already
+/// exists, cannot destroy it.
+///
+/// Round 6's `CREATE OR REPLACE VIEW` hole was not a missing check so much as a
+/// question nobody had been made to answer. `INSERT INTO ` and
+/// `CREATE MATERIALIZED VIEW ` carried a target-class condition;
+/// `CREATE OR REPLACE VIEW ` carried a *sentence* asserting it needed none, and
+/// the sentence was wrong. Making the answer a value means the next head cannot
+/// ship without one, and the `ClassGated` arm is executed rather than asserted:
+/// see `every_benign_head_answers_the_target_class_question`.
+///
+/// It is `#[cfg(test)]` — a review obligation, not a runtime one — but it lives
+/// here rather than in the test module on purpose, so that the author adding a
+/// head to [`BENIGN_STATEMENT_HEADS`] reads it in the same screen.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HeadTargetRule {
+    /// [`benign_shape`] resolves the relation and consults
+    /// [`relation_is_guarded`]. The probe is a statement with this head aimed
+    /// at `moraine.events`, which the gate must reject.
+    ClassGated(&'static str),
+    /// The head cannot name an existing relation as something it overwrites,
+    /// with the reason. A reason is not a proof, so each one names a mechanism
+    /// that was checked against the server rather than assumed.
+    CannotDisplace(&'static str),
+}
+
+/// One rule per [`BENIGN_STATEMENT_HEADS`] entry, and the test requires the two
+/// lists to correspond exactly — same entries, same order.
+#[cfg(test)]
+const BENIGN_HEAD_TARGET_RULES: &[(&str, HeadTargetRule)] = &[
+    (
+        "SELECT ",
+        HeadTargetRule::CannotDisplace(
+            "a read. It writes nowhere, which is the one case in this \
+                                       table that needs no server behaviour to be true.",
+        ),
+    ),
+    (
+        "INSERT INTO ",
+        HeadTargetRule::ClassGated("INSERT INTO moraine.events SELECT * FROM moraine.raw_events"),
+    ),
+    (
+        "CREATE DATABASE ",
+        HeadTargetRule::CannotDisplace(
+            "names a database and has no `OR REPLACE` spelling, so on an existing name it is \
+             either `IF NOT EXISTS` (a no-op) or an error. It cannot swap out a populated one.",
+        ),
+    ),
+    (
+        "CREATE TABLE ",
+        HeadTargetRule::CannotDisplace(
+            "errors on an existing name unless it carries `IF NOT EXISTS`, in which case it does \
+             nothing. `CREATE OR REPLACE TABLE` is a different head and is not on the benign \
+             list — the `starts_with` match is what keeps them apart.",
+        ),
+    ),
+    (
+        "CREATE VIEW ",
+        HeadTargetRule::CannotDisplace(
+            "same as `CREATE TABLE`: no `OR REPLACE`, so an existing name is an error or a \
+             no-op. The replacing spelling is the entry below, and it is gated.",
+        ),
+    ),
+    (
+        "CREATE MATERIALIZED VIEW ",
+        HeadTargetRule::ClassGated(
+            "CREATE MATERIALIZED VIEW moraine.mv_x TO moraine.events AS SELECT * FROM \
+             moraine.raw_events",
+        ),
+    ),
+    (
+        "CREATE OR REPLACE VIEW ",
+        HeadTargetRule::ClassGated("CREATE OR REPLACE VIEW moraine.events AS SELECT 1"),
+    ),
+    (
+        "DROP VIEW ",
+        HeadTargetRule::CannotDisplace(
+            "the server refuses it: `DROP VIEW` on a `MergeTree` throws `Code: 80 … is not a \
+             View` (executed on 25.12.5.44). This is the one entry whose safety is a property \
+             of ClickHouse rather than of the statement, which is exactly the claim \
+             `CREATE OR REPLACE VIEW` was wrongly assumed to share.",
+        ),
+    ),
+];
+
+/// Statement heads that **replace** the relation they name, paired with the
+/// shape a replacement of a guarded relation reports.
+///
+/// `CREATE OR REPLACE VIEW` shipped on [`BENIGN_STATEMENT_HEADS`] with no
+/// target-class check for three rounds, under the claim that "a view holds no
+/// rows, so unlike `CREATE OR REPLACE TABLE` … this one can destroy nothing".
+/// **Executed on ClickHouse 25.12.5.44:** a `MergeTree` table with three rows,
+/// then `CREATE OR REPLACE VIEW probe.t AS SELECT 99 AS a;` — no error,
+/// `count()` goes 3 → 1 and `system.tables.engine` goes `MergeTree` → `View`.
+/// Repeated against a `ReplacingMergeTree(event_version)` shaped like
+/// `moraine.events`: 2 rows → 1, engine → `View`. ClickHouse's
+/// `CREATE OR REPLACE` builds a replacement and `EXCHANGE`s it in; it does not
+/// check that what stood there was a view. So
+/// `CREATE OR REPLACE VIEW moraine.events AS SELECT 1` is `TRUNCATE` plus
+/// `DROP` in one statement, and it was admitted.
+///
+/// Gated exactly as [`PROTECTED_WRITE_HEADS`] is, on
+/// [`relation_is_guarded`] — and `every_benign_head_answers_the_target_class_question`
+/// is what makes shipping a fourth head in this family without an answer
+/// impossible rather than merely discouraged.
+const PROTECTED_REPLACE_HEADS: &[(&str, DeleteShape)] =
+    &[("CREATE OR REPLACE VIEW ", DeleteShape::ReplaceRelation)];
+
+/// Whether a bundled migration may not write into or replace `table`.
+///
+/// Three sources, because the class alone is not the whole answer:
+///
+/// * an unknown name is guarded (S1: unknown is not deletable);
+/// * a [`TableClass::is_protected`] class is guarded;
+/// * a [`MIGRATION_PRESERVED_DERIVED_TABLES`] name is guarded **even though it
+///   is `Derived`**, which is the entire reason that constant exists. Round 6
+///   found the gap by aiming the `ReplacingMergeTree` supersede at the search
+///   corpus instead of at `events`: executed in `clickhouse local`,
+///   `INSERT INTO moraine.search_documents SELECT * REPLACE ('' AS
+///   text_content, doc_version + 1 AS doc_version) FROM
+///   moraine.search_documents FINAL` takes `sum(length(text_content))` from 23
+///   to **0** through `FINAL`, and it is still 0 after `OPTIMIZE … FINAL`. The
+///   `CREATE MATERIALIZED VIEW … TO` twin installs it as standing state.
+///   `no_bundled_migration_empties_the_search_corpus` could not see either,
+///   because it filters [`migration_row_removals`] and the write heads had
+///   already admitted them.
+///
+/// A declared [`SCHEMA_VIEW_OBJECTS`] name is **not** guarded: replacing a
+/// declared view is the drop-and-recreate nine bundled migrations perform, and
+/// an *undeclared* view name is unknown, so it is. That is the condition that
+/// makes `CREATE OR REPLACE VIEW` safe — the name has to be one somebody
+/// registered as a view — rather than the shape of the head.
+fn relation_is_guarded(table: &str) -> bool {
+    if SCHEMA_VIEW_OBJECTS.contains(&table) {
+        return false;
+    }
+    classify(table).is_none_or(|class| class.is_protected())
+        || MIGRATION_PRESERVED_DERIVED_TABLES
+            .iter()
+            .any(|(name, _)| *name == table)
+}
+
+/// The relation a [`PROTECTED_REPLACE_HEADS`] statement replaces, or the one a
+/// `CREATE OR REPLACE TABLE` / `REPLACE TABLE` installs over.
+///
+/// Unlike [`named_relations`]' generic parse this one steps *over*
+/// [`NEVER_A_RELATION`] rather than bailing on it, because in
+/// `CREATE OR REPLACE VIEW moraine.events AS …` the object keyword stands
+/// between the head and the name that is actually at risk.
+fn replace_target(normalized: &str) -> Option<String> {
+    let mut words = normalized.split_whitespace();
+    words.next()?; // CREATE | REPLACE
+    let mut candidate = words.next()?;
+    while is_relation_noise(candidate)
+        || NEVER_A_RELATION.contains(&candidate.to_ascii_uppercase().as_str())
+    {
+        candidate = words.next()?;
+    }
+    unqualified_name(candidate)
+}
+
+/// The relation a [`PROTECTED_WRITE_HEADS`] statement writes into.
+///
+/// `INSERT INTO <t>` names it directly. `CREATE MATERIALIZED VIEW <v> TO <t>
+/// AS …` names it after `TO`; an MV with no `TO` owns its storage and writes
+/// into nothing that existed, so it reports `None`.
+fn write_target(normalized: &str, head: &str) -> Option<String> {
+    if head == "INSERT INTO " {
+        return named_relations(normalized, None).into_iter().next();
+    }
+    let tokens: Vec<&str> = normalized.split_whitespace().collect();
+    let mut idx = 0;
+    while idx < tokens.len() {
+        let upper = tokens[idx].to_ascii_uppercase();
+        if upper == "AS" {
+            return None;
+        }
+        if upper == "TO" {
+            return tokens.get(idx + 1).and_then(|name| unqualified_name(name));
+        }
+        idx += 1;
+    }
+    None
+}
+
+/// Whether one already-normalized statement is on the benign allowlist.
+///
+/// Returns the matched head — `"ALTER TABLE"` for the clause-parsed case — so a
+/// test can assert *which* entry admitted a statement rather than only that
+/// something did.
+fn benign_shape(statement: &str) -> Option<&'static str> {
+    let masked = mask_quoted(&statement.to_ascii_uppercase());
+    if masked.starts_with("ALTER TABLE ") {
+        let relation = named_relations(statement, None).into_iter().next();
+        return alter_is_benign(&masked, relation.as_deref()).then_some("ALTER TABLE");
+    }
+    let head = BENIGN_STATEMENT_HEADS
+        .iter()
+        .find(|head| masked.starts_with(**head))
+        .copied()?;
+    if PROTECTED_WRITE_HEADS
+        .iter()
+        .any(|(write_head, _)| *write_head == head)
+    {
+        // An MV with no `TO` owns its storage and writes into nothing that
+        // existed, so an absent target is an append nobody needs to authorize.
+        //
+        // An `INSERT` is the opposite: it always writes somewhere, so a target
+        // this parser could not resolve is a target it could not check. The
+        // spellings that reach here are `INSERT INTO FUNCTION remote(...)` and
+        // `INSERT INTO TABLE FUNCTION ...`, where the name-skip lands on the
+        // `NEVER_A_RELATION` keyword `FUNCTION` and `named_relations` comes
+        // back empty. `remote('127.0.0.1', 'moraine', 'events')` reaches the
+        // same rows the class check exists to protect: executed on 25.12.5.44,
+        // an `INSERT INTO FUNCTION remote(...) SELECT * REPLACE ('' AS
+        // payload_json, event_version + 1 AS event_version) FROM moraine.events
+        // FINAL` took `sum(length(payload_json))` from 87 to 0 through `FINAL`,
+        // and it stayed 0 after `OPTIMIZE ... FINAL`.
+        //
+        // MUTATION: restore the bare `return Some(head)` and
+        // `an_insert_whose_target_this_parser_cannot_resolve_is_a_finding` fails.
+        if let Some(target) = write_target(statement, head) {
+            return (!relation_is_guarded(&target)).then_some(head);
+        }
+        return (head != "INSERT INTO ").then_some(head);
+    }
+    if PROTECTED_REPLACE_HEADS
+        .iter()
+        .any(|(replace_head, _)| *replace_head == head)
+    {
+        // A head that replaces the relation it names has to resolve that name:
+        // unlike the write heads there is no benign "no target" reading, so an
+        // unparseable one is a finding.
+        let target = replace_target(statement)?;
+        return (!relation_is_guarded(&target)).then_some(head);
+    }
+    Some(head)
+}
+
+/// `ALTER … DROP <what>` clauses that destroy data, as opposed to the ones
+/// that only change metadata.
+///
+/// `DROP CONSTRAINT` (sql/025:2), `DROP INDEX`, and `DROP PROJECTION` remove no
+/// rows and must not be findings, or the guard would forbid an ordinary schema
+/// edit and be turned off.
+///
+/// **The width bound is `the_destructive_drop_clause_list_is_exactly_the_four_that_remove_storage`,
+/// not the negative corpus.** This doc used to claim that each of those three
+/// clauses "is a named negative-corpus row on `moraine.events`, so widening
+/// this list by one clause turns a green test red". That mechanism cannot
+/// work — all three are [`BENIGN_ALTER_OPERATIONS`] entries, so
+/// [`benign_shape`] admits the statement and [`delete_shape`] is never
+/// consulted, and adding any of them was measured **GREEN** while the corpus
+/// was the only bound. Since the inversion this list only *labels*, so the
+/// bound had to move to a test that calls [`alter_clause_shape`] directly.
+///
+/// MUTATION (executed 2026-07-28, against the tree that ships this doc):
+/// adding `"DROP INDEX"`, `"DROP CONSTRAINT"` or `"DROP PROJECTION"` here is
+/// **RED** in every case, and the single failure is
+/// `the_destructive_drop_clause_list_is_exactly_the_four_that_remove_storage`.
+const DESTRUCTIVE_ALTER_DROP_CLAUSES: &[&str] = &[
+    "DROP PARTITION",
+    "DROP PART ",
+    "DROP COLUMN",
+    "DROP DETACHED",
+];
+
+/// Name what one already-comment-stripped, whitespace-normalized statement
+/// appears to do, or `None` when no named shape fits.
+///
+/// **`None` is not a pass.** [`migration_row_removals`] has already decided the
+/// statement is not benign by the time it calls this; the answer only picks the
+/// label in the finding. That is the whole point of the inversion: a
+/// destructive form nobody has named yet reports `None` and is still reported.
+///
+/// `DROP VIEW` is deliberately not a shape: a view holds no rows, and the tree
+/// drops and recreates views constantly (sql/002, 004, 006, 011, 012, 014,
+/// 019, 032, 033 — nine of the thirty-nine). A materialized view dropped with
+/// `DROP TABLE`
+/// rather than `DROP VIEW` *is* reported — [`SCHEMA_VIEW_OBJECTS`] is the
+/// declared exemption, and an undeclared name resolves to `None` from
+/// [`classify`], which S1 treats as protected.
+fn delete_shape(statement: &str) -> Option<DeleteShape> {
+    let masked = mask_quoted(&statement.to_ascii_uppercase());
+    if masked.starts_with("TRUNCATE ") {
+        return Some(DeleteShape::Truncate);
+    }
+    if masked.starts_with("DELETE FROM") {
+        return Some(DeleteShape::DeleteFrom);
+    }
+    if masked.starts_with("DROP TABLE") || masked.starts_with("DROP DATABASE") {
+        return Some(DeleteShape::DropRelation);
+    }
+    if masked.starts_with("CREATE OR REPLACE TABLE") || masked.starts_with("REPLACE TABLE") {
+        return Some(DeleteShape::ReplaceRelation);
+    }
+    if masked.starts_with("RENAME TABLE")
+        || masked.starts_with("RENAME DATABASE")
+        || masked.starts_with("EXCHANGE TABLES")
+    {
+        return Some(DeleteShape::RenameRelation);
+    }
+    if masked.starts_with("OPTIMIZE ")
+        && (masked.contains(" FINAL") || masked.contains(" DEDUPLICATE"))
+    {
+        return Some(DeleteShape::OptimizeFinal);
+    }
+    for (head, shape) in PROTECTED_WRITE_HEADS {
+        if masked.starts_with(head) && write_target(statement, head).is_some() {
+            return Some(*shape);
+        }
+    }
+    for (head, shape) in PROTECTED_REPLACE_HEADS {
+        if masked.starts_with(head) && replace_target(statement).is_some() {
+            return Some(*shape);
+        }
+    }
+    if masked.starts_with("ALTER TABLE") {
+        // Clause by clause, in the same priority order the whole-statement
+        // `contains` scan used — but a keyword inside a literal can no longer
+        // pick the label, and a keyword in one clause can no longer be read as
+        // if it belonged to another.
+        // The label of the most destructive clause wins, so the priority is
+        // the order of this list rather than the order the clauses appear in:
+        // `ADD COLUMN x String, DROP COLUMN payload_json` reports `AlterDrop`.
+        let shapes: Vec<DeleteShape> = alter_clauses(&masked)
+            .iter()
+            .filter_map(|clause| alter_clause_shape(clause))
+            .collect();
+        return ALTER_SHAPE_PRIORITY
+            .iter()
+            .find(|shape| shapes.contains(shape))
+            .copied();
+    }
+    None
+}
+
+/// Most destructive first. A clause list is reduced to the first of these it
+/// contains, which keeps the label stable regardless of clause order.
+const ALTER_SHAPE_PRIORITY: &[DeleteShape] = &[
+    DeleteShape::AlterDelete,
+    DeleteShape::AlterUpdate,
+    DeleteShape::AlterModifyTtl,
+    DeleteShape::AlterDrop,
+    DeleteShape::AlterDetach,
+    DeleteShape::AlterClear,
+    DeleteShape::AlterReplacePartition,
+    DeleteShape::AlterMove,
+    DeleteShape::AlterRewriteColumn,
+];
+
+/// What one masked `ALTER` clause appears to do, or `None` for a clause that
+/// removes nothing — including the benign ones, which never reach here.
+fn alter_clause_shape(clause: &str) -> Option<DeleteShape> {
+    if clause.starts_with("DELETE") {
+        return Some(DeleteShape::AlterDelete);
+    }
+    if clause.starts_with("UPDATE") {
+        return Some(DeleteShape::AlterUpdate);
+    }
+    if clause.starts_with("MODIFY TTL")
+        || (clause.starts_with("MODIFY COLUMN") && modify_column_sets_ttl(clause))
+    {
+        return Some(DeleteShape::AlterModifyTtl);
+    }
+    if DESTRUCTIVE_ALTER_DROP_CLAUSES
+        .iter()
+        .any(|prefix| clause.starts_with(prefix))
+    {
+        return Some(DeleteShape::AlterDrop);
+    }
+    if clause.starts_with("DETACH PARTITION") || clause.starts_with("DETACH PART ") {
+        return Some(DeleteShape::AlterDetach);
+    }
+    if clause.starts_with("CLEAR COLUMN") {
+        return Some(DeleteShape::AlterClear);
+    }
+    if clause.starts_with("REPLACE PARTITION") {
+        return Some(DeleteShape::AlterReplacePartition);
+    }
+    if (clause.starts_with("MOVE PARTITION") || clause.starts_with("MOVE PART "))
+        && !(clause.contains(" TO DISK") || clause.contains(" TO VOLUME"))
+    {
+        return Some(DeleteShape::AlterMove);
+    }
+    if clause.starts_with("MATERIALIZE COLUMN")
+        || (clause.starts_with("MODIFY COLUMN") && !modify_column_is_metadata_only(clause))
+    {
+        return Some(DeleteShape::AlterRewriteColumn);
+    }
+    None
+}
+
+/// What one character of a statement is, to this module's lexer.
+///
+/// The distinction exists because the two consumers want opposite things from
+/// a comment: [`normalize_statement`] deletes it, [`mask_quoted`] must not read
+/// it as code. Both get the answer from the same walk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CharKind {
+    /// Ordinary SQL, and the opening delimiter of a literal or a heredoc.
+    Code,
+    /// Inside a string literal, a quoted identifier or a heredoc body, up to
+    /// and including the closing delimiter.
+    Quoted,
+    /// Inside a `--`, `/* … */` or `#` comment, delimiters included.
+    Comment,
+}
+
+/// Walk one statement, reporting what each character is.
+///
+/// One state machine serves [`normalize_statement`] and [`mask_quoted`], which
+/// is the point: a comment stripper and a literal masker that disagree about
+/// where a literal or a comment ends are two parsers, and the gap between them
+/// is a laundering channel. Round 6 found that gap twice, in the two syntaxes
+/// this function did not know:
+///
+/// * **`#` line comments.** `SELECT 1 # trailing` is valid ClickHouse
+///   (executed, 25.12.5.44). The stripper knew `--` and `/* … */` only, so a
+///   `'`, `"` or backtick parked in a `#` comment opened a literal ClickHouse
+///   never sees; [`mask_quoted`] then masked the rest of the statement,
+///   clause-separating comma included, and
+///   `ADD COLUMN c String # a " b⏎, DROP COLUMN payload_json` reduced to one
+///   benign `ADD COLUMN`. Executed in `clickhouse local`, that statement takes
+///   the column list from `['uid','payload_json']` to `['uid','c']`.
+/// * **`$$…$$` / `$tag$…$tag$` heredocs.** `SELECT $tag$a'b$tag$` returns
+///   `a'b` (executed). An unrecognized heredoc body is read as code, which is
+///   fail-closed for a comma but fail-**open** for a parenthesis:
+///   `COMMENT $$($$, DROP COLUMN payload_json` drove [`alter_clauses`]' paren
+///   depth to 1 so the top-level comma never split. (The depth guard now also
+///   fails closed on an unbalanced body, so that vector is dead twice over.)
+///
+/// `'…'` is a string literal, `"…"` and `` `…` `` are quoted identifiers.
+/// `\'` and `''` escape a quote inside a single-quoted literal, matching
+/// [`crate::split_sql_statements`].
+///
+/// A `#` starts a comment wherever it appears outside a literal. ClickHouse is
+/// narrower — it wants `# ` or `#!`, and rejects `SELECT 1#2` as an
+/// unrecognized token (executed) — so treating every bare `#` as a comment
+/// discards a tail of a statement the server would refuse to run anyway.
+fn scan_statement(statement: &str, mut visit: impl FnMut(char, CharKind)) {
+    let chars: Vec<char> = statement.chars().collect();
+    let mut idx = 0;
+    while idx < chars.len() {
+        let ch = chars[idx];
+        // ---- comments ----
+        if ch == '-' && chars.get(idx + 1) == Some(&'-') {
+            while idx < chars.len() && chars[idx] != '\n' {
+                visit(chars[idx], CharKind::Comment);
+                idx += 1;
+            }
+            continue;
+        }
+        if ch == '#' {
+            while idx < chars.len() && chars[idx] != '\n' {
+                visit(chars[idx], CharKind::Comment);
+                idx += 1;
+            }
+            continue;
+        }
+        if ch == '/' && chars.get(idx + 1) == Some(&'*') {
+            visit('/', CharKind::Comment);
+            visit('*', CharKind::Comment);
+            idx += 2;
+            while idx < chars.len() && !(chars[idx] == '*' && chars.get(idx + 1) == Some(&'/')) {
+                visit(chars[idx], CharKind::Comment);
+                idx += 1;
+            }
+            if idx < chars.len() {
+                visit('*', CharKind::Comment);
+                visit('/', CharKind::Comment);
+                idx += 2;
+            }
+            continue;
+        }
+        // ---- heredocs ----
+        if ch == '$' {
+            if let Some(tag_len) = heredoc_tag_len(&chars, idx) {
+                // `$tag$` opens; everything through the matching `$tag$`
+                // closes. The opening delimiter reports Code so the masked
+                // text still shows a heredoc where one stood.
+                for offset in 0..tag_len {
+                    visit(chars[idx + offset], CharKind::Code);
+                }
+                let open = &chars[idx..idx + tag_len];
+                let mut cursor = idx + tag_len;
+                while cursor < chars.len() {
+                    if chars[cursor] == '$' && chars[cursor..].starts_with(open) {
+                        for offset in 0..tag_len {
+                            visit(chars[cursor + offset], CharKind::Quoted);
+                        }
+                        cursor += tag_len;
+                        break;
+                    }
+                    visit(chars[cursor], CharKind::Quoted);
+                    cursor += 1;
+                }
+                idx = cursor;
+                continue;
+            }
+        }
+        // ---- literals and quoted identifiers ----
+        if ch == '\'' || ch == '"' || ch == '`' {
+            visit(ch, CharKind::Code);
+            idx += 1;
+            while idx < chars.len() {
+                let inner = chars[idx];
+                visit(inner, CharKind::Quoted);
+                if inner == '\\' && idx + 1 < chars.len() {
+                    visit(chars[idx + 1], CharKind::Quoted);
+                    idx += 2;
+                    continue;
+                }
+                if inner == ch {
+                    if ch == '\'' && chars.get(idx + 1) == Some(&'\'') {
+                        visit('\'', CharKind::Quoted);
+                        idx += 2;
+                        continue;
+                    }
+                    idx += 1;
+                    break;
+                }
+                idx += 1;
+            }
+            continue;
+        }
+        visit(ch, CharKind::Code);
+        idx += 1;
+    }
+}
+
+/// Length of the `$tag$` delimiter opening at `start`, or `None` when the `$`
+/// is not a heredoc open.
+///
+/// The tag charset is the one ClickHouse 25.12.5.44 accepts, read off by
+/// probing each candidate character with `EXPLAIN AST` (2026-07-27):
+/// `$a$`, `$A9$`, `$_$`, `$a-b$`, `$a.b$`, `$a+b$` and the empty `$$` are
+/// valid; `$a#b$`, `$a"b$`, `$a(b$` and `$a b$` are not. A `$` whose tag would
+/// contain anything else is not an open — which is why `SELECT 5 $ 5` is a
+/// syntax error rather than an unterminated heredoc.
+///
+/// The delimiter must also *close*: a lone `$$` at the end of a statement
+/// opens nothing, because masking to end-of-statement on an unmatched
+/// delimiter would let one stray character blank a clause.
+fn heredoc_tag_len(chars: &[char], start: usize) -> Option<usize> {
+    let is_tag_char =
+        |ch: char| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '.' || ch == '+';
+    let mut cursor = start + 1;
+    while cursor < chars.len() && is_tag_char(chars[cursor]) {
+        cursor += 1;
+    }
+    if chars.get(cursor) != Some(&'$') {
+        return None;
+    }
+    let tag_len = cursor - start + 1;
+    let open = &chars[start..start + tag_len];
+    let closes = chars
+        .get(start + tag_len..)?
+        .windows(tag_len)
+        .any(|window| window == open);
+    closes.then_some(tag_len)
+}
+
+/// Strip `--`, `#` and `/* … */` comments, then collapse all whitespace runs
+/// to single spaces.
+///
+/// **Comments are stripped only outside a string literal, and a literal is
+/// only a literal outside a comment.** Both halves have been a live defect:
+///
+/// * The implementation before round 5 cut every line at its first `--`
+///   unconditionally, which made `ALTER TABLE moraine.events MODIFY COLUMN c
+///   COMMENT 'a -- b', DROP COLUMN payload_json` normalize to a statement
+///   ending mid-literal — the `DROP COLUMN` vanished.
+/// * The implementation before round 6 did not know `#` at all, so a quote
+///   parked inside a `#` comment opened a literal that ClickHouse never sees.
+///   See [`scan_statement`].
+///
+/// `comments_are_stripped_only_outside_a_string_literal` and
+/// `the_lexer_knows_every_clickhouse_comment_and_quote_syntax` are the guards.
+fn normalize_statement(statement: &str) -> String {
+    let mut out = String::with_capacity(statement.len());
+    scan_statement(statement, |ch, kind| {
+        // A comment contributes whitespace, exactly as it does to the server.
+        out.push(if kind == CharKind::Comment { ' ' } else { ch });
+    });
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Replace the *contents* of every string literal, quoted identifier and
+/// heredoc with `_`, keeping the delimiters, the token count and the
+/// whitespace.
+///
+/// Every substring and comma test the `ALTER` parser makes runs against the
+/// masked text, so a literal cannot smuggle a keyword or a clause separator
+/// past it. `ALTER TABLE moraine.events ADD COLUMN c String DEFAULT
+/// 'x TO DISK y', MOVE PARTITION '202601' TO TABLE moraine.mcp_open_turns` was
+/// **admitted** before this existed: the `MOVE` clause's tiering test searched
+/// the whole statement, and the laundering substring sat in an unrelated
+/// literal.
+///
+/// Comments become spaces rather than `_`, which is what the server does with
+/// them. That choice is about the false-positive rate and **not** about safety,
+/// and the doc must not claim otherwise: MUTATION (executed 2026-07-28)
+/// emitting `_` for comment characters leaves the crate GREEN, because a
+/// comment ends at its newline and the `_` run it leaves behind becomes a
+/// clause head that is on no benign list. The failure direction is
+/// over-reporting. In the pipeline the question does not arise at all —
+/// [`normalize_statement`] has already deleted every comment before
+/// [`benign_shape`] and [`delete_shape`] mask anything.
+fn mask_quoted(statement: &str) -> String {
+    let mut out = String::with_capacity(statement.len());
+    scan_statement(statement, |ch, kind| {
+        // The opening delimiter reports `Code` and is kept, so a masked
+        // literal is still visibly a literal; everything up to and including
+        // the closing delimiter becomes `_`.
+        out.push(match kind {
+            CharKind::Code => ch,
+            CharKind::Quoted => '_',
+            CharKind::Comment => ' ',
+        });
+    });
+    out
+}
+
+/// Strip the database qualifier, backticks/quotes, and any trailing
+/// punctuation from one identifier token.
+fn unqualified_name(candidate: &str) -> Option<String> {
+    // `CREATE TABLE moraine.tight(a String)` puts the column list flush
+    // against the name, so cut at the paren before splitting the qualifier.
+    let head = candidate.split('(').next().unwrap_or(candidate);
+    let unqualified = head.rsplit('.').next().unwrap_or(head);
+    let cleaned = unqualified.trim_matches(|c| c == '`' || c == '"' || c == ';' || c == ',');
+    (!cleaned.is_empty()).then(|| cleaned.to_string())
+}
+
+/// Tokens that stand between a statement keyword and the relation name.
+///
+/// `FROM` and `INTO` are here so that one leading-keyword skip serves every
+/// statement head — `DELETE FROM t`, `INSERT INTO t`, `ALTER TABLE t`,
+/// `OPTIMIZE TABLE t` and `TRUNCATE DATABASE d` all reduce the same way. That
+/// is what lets [`named_relations`] work for a statement whose shape nobody has
+/// named, which is the case the gate is now built around.
+fn is_relation_noise(word: &str) -> bool {
+    matches!(
+        word.to_ascii_uppercase().as_str(),
+        "TABLE"
+            | "TABLES"
+            | "DATABASE"
+            | "IF"
+            | "NOT"
+            | "EXISTS"
+            | "OR"
+            | "REPLACE"
+            | "FROM"
+            | "INTO"
+    )
+}
+
+/// Object keywords that the leading-keyword skip can land on, and that no
+/// relation in this database is named.
+///
+/// A finding filed against one of these is a **phantom**: it reads like a real
+/// table and is not one. `CREATE OR REPLACE VIEW moraine.v_live_events AS …`
+/// used to be reported against a relation literally named `VIEW`, because
+/// `is_relation_noise` eats `OR` and `REPLACE` and then takes `VIEW` as the
+/// name — which classifies as unknown, and unknown is protected.
+///
+/// Landing here yields an empty parse, which
+/// [`migration_row_removals`] reports as [`UNPARSED_RELATION`]: still a
+/// finding, still `NeverDelete`, but the message no longer names a table that
+/// does not exist. Fail-closed is preserved; only the label changes.
+const NEVER_A_RELATION: &[&str] = &[
+    "VIEW",
+    "MATERIALIZED",
+    "DICTIONARY",
+    "FUNCTION",
+    "TEMPORARY",
+    "LIVE",
+    "WINDOW",
+];
+
+/// Every table a non-benign statement names, unqualified.
+///
+/// Handles `moraine.t`, `` `moraine`.t ``, `` `moraine`.`t` ``, a bare `t`,
+/// and the `IF EXISTS` variants of `TRUNCATE`/`DROP`.
+///
+/// `shape` is `Option` because the caller reaches here for **any** statement
+/// the benign allowlist rejected, named shape or not. Only
+/// [`DeleteShape::RenameRelation`] changes the parse: it names two relations
+/// and the displaced one may be either operand — `RENAME TABLE moraine.events
+/// TO moraine.attic` empties the name `events`, and `RENAME TABLE
+/// moraine.scratch TO moraine.events` displaces whatever `events` was. Every
+/// other statement, including the unnamed ones, yields exactly one name, which
+/// `every_shape_but_rename_names_exactly_one_relation` pins.
+///
+/// An empty result is a **parse failure**, not an absence, and
+/// [`migration_row_removals`] reports it as [`UNPARSED_RELATION`] rather than
+/// dropping the statement.
+fn named_relations(statement: &str, shape: Option<DeleteShape>) -> Vec<String> {
+    let normalized = normalize_statement(statement);
+    let mut words = normalized.split_whitespace();
+    // Skip the statement keyword; `is_relation_noise` eats the rest of the
+    // prefix, so one is enough for every spelling.
+    if words.next().is_none() {
+        return Vec::new();
+    }
+
+    // A materialized view's extent is its `TO` target, not the token after the
+    // statement keyword — which is `MATERIALIZED`, a phantom.
+    if shape == Some(DeleteShape::MaterializedViewInto) {
+        return write_target(statement, "CREATE MATERIALIZED VIEW ")
+            .into_iter()
+            .collect();
+    }
+
+    // `CREATE OR REPLACE VIEW moraine.events` puts `VIEW` — a
+    // [`NEVER_A_RELATION`] keyword — where the generic parse looks, so the
+    // generic parse would report `<unparsed>` for the one statement whose
+    // whole hazard is the name it displaces. The same walk serves
+    // `CREATE OR REPLACE TABLE` and `REPLACE TABLE`.
+    if shape == Some(DeleteShape::ReplaceRelation) {
+        return replace_target(&normalized).into_iter().collect();
+    }
+
+    if shape == Some(DeleteShape::RenameRelation) {
+        let mut names = Vec::new();
+        for word in words {
+            let upper = word.to_ascii_uppercase();
+            // `ON CLUSTER '<name>'` names a cluster, not a relation.
+            if upper == "ON" {
+                break;
+            }
+            if upper == "TO" || upper == "AND" || is_relation_noise(word) {
+                continue;
+            }
+            if let Some(name) = unqualified_name(word) {
+                if !names.contains(&name) {
+                    names.push(name);
+                }
+            }
+        }
+        return names;
+    }
+
+    let mut candidate = match words.next() {
+        Some(word) => word,
+        None => return Vec::new(),
+    };
+    while is_relation_noise(candidate) {
+        candidate = match words.next() {
+            Some(word) => word,
+            None => return Vec::new(),
+        };
+    }
+    if NEVER_A_RELATION.contains(&candidate.to_ascii_uppercase().as_str()) {
+        return Vec::new();
+    }
+    unqualified_name(candidate).into_iter().collect()
+}
+
+/// The table a `CREATE TABLE` statement installs, unqualified, or `None` for
+/// every other statement — including `CREATE MATERIALIZED VIEW` and
+/// `CREATE VIEW`, which install no physical relation and hold no bytes.
+///
+/// `CREATE OR REPLACE TABLE` and the bare `REPLACE TABLE` install a physical
+/// relation too. Before they were recognized here, installing a table that way
+/// was a **double** miss: `classification_gaps`' migration side did not see the
+/// new unclassified table, and [`delete_shape`] did not see that the statement
+/// had emptied whatever stood in its place.
+fn created_table(statement: &str) -> Option<String> {
+    let normalized = normalize_statement(statement);
+    let upper = normalized.to_ascii_uppercase();
+    if !(upper.starts_with("CREATE TABLE")
+        || upper.starts_with("CREATE OR REPLACE TABLE")
+        || upper.starts_with("REPLACE TABLE"))
+    {
+        return None;
+    }
+    let mut words = normalized.split_whitespace();
+    words.next()?; // CREATE | REPLACE
+    let mut candidate = words.next()?;
+    while is_relation_noise(candidate) {
+        candidate = words.next()?;
+    }
+    unqualified_name(candidate)
+}
+
+/// Every physical table one migration's SQL creates, in statement order.
+pub fn migration_created_tables(sql: &str) -> Vec<String> {
+    crate::split_sql_statements(sql)
+        .iter()
+        .filter_map(|statement| created_table(statement))
+        .collect()
+}
+
+/// Scan one migration's SQL for statements that are not on the benign
+/// allowlist and name a protected ([`TableClass::is_protected`]) table.
+///
+/// The pre-#603 guards this replaces were substring matches over exactly one
+/// statement form, pinned by a hard-coded `.find(|m| m.version == "034")`
+/// lookup, so `ALTER TABLE moraine.events DELETE WHERE …`,
+/// `DELETE FROM moraine.events`, and `TRUNCATE TABLE IF EXISTS moraine.events`
+/// all passed them untouched — and a newly added migration was covered by no
+/// guard of the family at all. This function is per-statement, fail-closed,
+/// and runs over **every** bundled migration.
+///
+/// An unclassified table is reported as a finding too: `classify` returning
+/// `None` is the S1 hard error, and a migration that deletes from a table
+/// nobody classified is precisely the regression S1 exists to catch.
+pub fn migration_delete_findings(version: &str, sql: &str) -> Vec<MigrationDeleteFinding> {
+    migration_row_removals(version, sql)
+        .into_iter()
+        .filter(|finding| finding.class.is_protected())
+        .collect()
+}
+
+/// Stand-in table name for a non-benign statement whose relation could not be
+/// parsed at all.
+///
+/// It classifies as `NeverDelete` like any other unknown name, so an
+/// unparseable statement fails the gate instead of falling out of it. Nothing
+/// in the tree produces one; the alternative is a `Vec::new()` that reads
+/// exactly like "this statement is fine".
+pub const UNPARSED_RELATION: &str = "<unparsed>";
+
+/// Every statement in one migration that is not on the benign allowlist,
+/// **regardless of the class of the table it names**, with the allowlist
+/// applied.
+///
+/// The gate is [`benign_shape`] and it is fail-closed: a statement is a finding
+/// unless its head, or every one of its `ALTER` operations, is a named benign
+/// form. [`delete_shape`] then labels the finding and is free to answer `None`.
+///
+/// [`migration_delete_findings`] is this filtered to the protected classes. A
+/// caller that must guard one specific derived relation — the search corpus,
+/// say — uses this, because "`Derived` is deletable" is a statement about the
+/// reclaimer's authority model, not a licence for a bundled migration to empty
+/// the BM25 corpus on upgrade.
+pub fn migration_row_removals(version: &str, sql: &str) -> Vec<MigrationDeleteFinding> {
+    let views: BTreeSet<&str> = SCHEMA_VIEW_OBJECTS.iter().copied().collect();
+    // (version, table, shape). A `None` shape matches no entry, so a statement
+    // nobody has named is a finding even inside an exempted migration.
+    let is_exempt = |table: &str, shape: Option<DeleteShape>| {
+        let Some(shape) = shape else {
+            return false;
+        };
+        MIGRATION_DELETE_ALLOWLIST.iter().any(|exemption| {
+            exemption.version == version
+                && exemption.tables.contains(&table)
+                && exemption.shapes.contains(&shape)
+        })
+    };
+    crate::split_sql_statements(sql)
+        .into_iter()
+        .flat_map(|statement| {
+            let normalized = normalize_statement(&statement);
+            // A statement that is only a comment survives `split_sql_statements`
+            // and normalizes to nothing. It names no relation and destroys none.
+            if normalized.is_empty() {
+                return Vec::new();
+            }
+            if benign_shape(&normalized).is_some() {
+                return Vec::new();
+            }
+            let shape = delete_shape(&normalized);
+            let mut relations = named_relations(&normalized, shape);
+            if relations.is_empty() {
+                relations.push(UNPARSED_RELATION.to_string());
+            }
+            relations
+                .into_iter()
+                .filter(|table| !is_exempt(table.as_str(), shape))
+                // A view holds no rows. `DROP TABLE moraine.search_term_stats`
+                // (sql/004:213, sql/006:4) names an object migration 032
+                // replaced with a `CREATE VIEW`, so the drop destroys nothing.
+                // Scoped to `DropRelation`: `TRUNCATE TABLE
+                // moraine.search_term_stats` would be a statement ClickHouse
+                // rejects against a view and accepts against a table someone
+                // reinstated under that name, so it stays a finding —
+                // `truncating_a_declared_view_name_is_still_a_finding` is what
+                // stops this exemption from being widened to every shape.
+                .filter(|table| {
+                    !(shape == Some(DeleteShape::DropRelation) && views.contains(table.as_str()))
+                })
+                .map(|table| {
+                    // Unknown => treated as protected (S1: unknown is not
+                    // deletable).
+                    let class = classify(&table).unwrap_or(TableClass::NeverDelete);
+                    MigrationDeleteFinding {
+                        version: version.to_string(),
+                        table,
+                        class,
+                        shape,
+                        statement: normalized.clone(),
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bundled_migrations;
+
+    #[test]
+    fn every_class_is_enumerated() {
+        // Adding a TableClass variant without adding it to ALL breaks every
+        // per-bucket fold silently; this is the one place that notices.
+        assert_eq!(TableClass::ALL.len(), 5);
+        let mut seen: BTreeSet<&str> = BTreeSet::new();
+        for class in TableClass::ALL {
+            assert!(seen.insert(class.as_str()), "duplicate class {class:?}");
+            assert!(!class.label().is_empty());
+        }
+    }
+
+    /// **G-CLASSIFY.** Fails for: a schema table exists with no bucket.
+    /// Denomination: set equality, both directions.
+    ///
+    /// MUTATION (executed 2026-07-27): add `"reclaim_scratch"` to
+    /// `REQUIRED_SCHEMA_OBJECTS` and nothing else =>
+    /// `unclassified_schema_objects` is `["reclaim_scratch"]` and this test
+    /// fails. The guard bounds the direction *schema grows without
+    /// classification*; `classified_but_unregistered` bounds the opposite
+    /// direction (classification names a table the schema does not require),
+    /// which the second mutation below exercises.
+    ///
+    /// MUTATION (executed 2026-07-27): remove `"tool_io"` from
+    /// `REQUIRED_SCHEMA_OBJECTS` => `classified_but_unregistered` is
+    /// `["tool_io"]` and this test fails.
+    ///
+    /// MUTATION (executed 2026-07-27): append
+    /// `CREATE TABLE moraine.reclaim_scratch (a String) ENGINE = MergeTree
+    /// ORDER BY a;` to `sql/003_ingest_heartbeats.sql`, classifying and
+    /// registering it nowhere => `unclassified_migration_tables` is
+    /// `["reclaim_scratch"]` and this test fails. Before the third side
+    /// existed that mutation left the suite at 177/0, because the other two
+    /// fields compare two Rust lists that both still agreed with each other.
+    #[test]
+    fn classification_and_required_schema_objects_are_mutually_exhaustive() {
+        let gaps = classification_gaps();
+        assert!(
+            gaps.unclassified_schema_objects.is_empty(),
+            "schema objects with no storage class (add them to CLASSIFIED_TABLES, or to \
+             SCHEMA_VIEW_OBJECTS if they are views): {:?}",
+            gaps.unclassified_schema_objects
+        );
+        assert!(
+            gaps.classified_but_unregistered.is_empty(),
+            "classified tables missing from REQUIRED_SCHEMA_OBJECTS (register them, or add them \
+             to UNREGISTERED_PHYSICAL_TABLES with a reason): {:?}",
+            gaps.classified_but_unregistered
+        );
+        assert!(
+            gaps.stale_view_declarations.is_empty(),
+            "SCHEMA_VIEW_OBJECTS names objects the schema handshake no longer requires: {:?}",
+            gaps.stale_view_declarations
+        );
+        assert!(
+            gaps.unclassified_migration_tables.is_empty(),
+            "a bundled migration CREATEs a table with no storage class (classify it in \
+             CLASSIFIED_TABLES): {:?}",
+            gaps.unclassified_migration_tables
+        );
+        assert!(gaps.is_empty());
+    }
+
+    /// The third side, bounded in the direction that proves it reads `sql/` at
+    /// all rather than vacuously returning an empty vector.
+    #[test]
+    fn the_migration_side_of_exhaustiveness_actually_parses_create_table() {
+        // Every physical table the schema installs is created by some bundled
+        // migration, except `schema_migrations`, which the runner creates.
+        let created: BTreeSet<String> = crate::bundled_migrations()
+            .iter()
+            .flat_map(|migration| migration_created_tables(migration.sql))
+            .collect();
+        assert!(created.contains("events"), "{created:?}");
+        assert!(created.contains("storage_reclaim_ledger"));
+        assert!(created.contains("file_attention_project_roots"));
+        assert!(
+            !created.contains("schema_migrations"),
+            "the migration ledger is created by the runner, not by sql/"
+        );
+        let classified: BTreeSet<&str> = CLASSIFIED_TABLES
+            .iter()
+            .map(|entry| entry.name)
+            .filter(|name| !name.starts_with("system."))
+            .collect();
+        assert_eq!(
+            created.len(),
+            classified.len() - 1,
+            "every classified Moraine table except `schema_migrations` is created by a bundled \
+             migration: created={created:?}"
+        );
+
+        // A materialized view is not a physical table and must not be counted:
+        // the tree creates dozens, and counting them would force every MV into
+        // CLASSIFIED_TABLES.
+        assert_eq!(
+            created_table("CREATE MATERIALIZED VIEW moraine.mv_x TO moraine.events AS SELECT 1"),
+            None
+        );
+        assert_eq!(created_table("CREATE VIEW moraine.v_x AS SELECT 1"), None);
+        assert_eq!(
+            created_table("CREATE TABLE IF NOT EXISTS `moraine`.`brand_new` (a String)"),
+            Some("brand_new".to_string())
+        );
+        assert_eq!(
+            created_table("CREATE TABLE moraine.tight(a String)"),
+            Some("tight".to_string())
+        );
+        // `CREATE OR REPLACE TABLE` installs a physical relation too. Missing
+        // it was a double miss: the new table escaped classification here AND
+        // the statement's emptying of whatever it replaced escaped
+        // `delete_shape`.
+        //
+        // MUTATION (executed 2026-07-27): remove the `CREATE OR REPLACE
+        // TABLE`/`REPLACE TABLE` prefixes from `created_table` => FAILS on
+        // these two rows.
+        assert_eq!(
+            created_table("CREATE OR REPLACE TABLE moraine.brand_new (a String)"),
+            Some("brand_new".to_string())
+        );
+        assert_eq!(
+            created_table("REPLACE TABLE `moraine`.`brand_new` (a String)"),
+            Some("brand_new".to_string())
+        );
+    }
+
+    #[test]
+    fn classification_covers_the_hosts_thirty_two_physical_tables() {
+        // Verified against the reference host 2026-07-27: `system.tables`
+        // reports 32 non-view relations in `moraine`. This build adds
+        // `storage_reclaim_ledger` (migration 038), so the classified Moraine
+        // table count is 33 and the total including system logs is 36.
+        let moraine_tables = CLASSIFIED_TABLES
+            .iter()
+            .filter(|entry| !entry.name.starts_with("system."))
+            .count();
+        assert_eq!(moraine_tables, 33, "classified Moraine tables");
+        assert_eq!(CLICKHOUSE_SYSTEM_LOGS.len(), 3);
+        assert_eq!(CLASSIFIED_TABLES.len(), moraine_tables + 3);
+    }
+
+    #[test]
+    fn every_classification_carries_a_rationale_and_no_duplicates() {
+        let mut seen: BTreeSet<&str> = BTreeSet::new();
+        for entry in CLASSIFIED_TABLES {
+            assert!(
+                seen.insert(entry.name),
+                "duplicate classification for `{}`",
+                entry.name
+            );
+            assert!(
+                entry.rationale.len() > 40,
+                "`{}` needs a rationale explaining why this class and not a looser one",
+                entry.name
+            );
+        }
+        for log in CLICKHOUSE_SYSTEM_LOGS {
+            assert_eq!(
+                classify(log),
+                Some(TableClass::Telemetry),
+                "system log `{log}` must be classified telemetry"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_tables_are_unclassified_rather_than_derived() {
+        assert_eq!(classify("not_a_moraine_table"), None);
+        assert_eq!(classify(""), None);
+        // Near-misses must not classify: a prefix/suffix match would make a
+        // future `events_v2` inherit `events`' class by accident.
+        assert_eq!(classify("events_v2"), None);
+        assert_eq!(classify("moraine.events"), None);
+    }
+
+    #[test]
+    fn protected_classes_are_exactly_the_three_the_emitter_gates_on() {
+        assert!(TableClass::CanonicalHistory.is_protected());
+        assert!(TableClass::RawAudit.is_protected());
+        assert!(TableClass::NeverDelete.is_protected());
+        assert!(!TableClass::Derived.is_protected());
+        assert!(!TableClass::Telemetry.is_protected());
+    }
+
+    /// **G-NEVERDELETE.** Fails for: a never-delete table losing its class,
+    /// and for a new never-delete table arriving with no coverage.
+    /// Denomination: exact name set, both directions.
+    ///
+    /// This is set equality rather than a `for` loop over a chosen few.
+    /// `is_protected()` is the sole gate in BOTH `emit_delete_statement` and
+    /// `migration_delete_findings`, so a never-delete table quietly reclassed
+    /// `Telemetry` becomes reachable by a telemetry token and eligible for a
+    /// future TTL — and the previous loop covered 7 of the 9 entries, leaving
+    /// `ingest_checkpoints` (whose own rationale says "Looks like retired
+    /// telemetry; is not") and `publication_diagnostic_events` uncovered.
+    ///
+    /// MUTATION (executed 2026-07-27), each run separately: flip
+    /// `ingest_checkpoints` to `Telemetry`; flip `publication_diagnostic_events`
+    /// to `Derived`; flip `search_conversation_terms` to `Derived` => this test
+    /// FAILS on the set equality in each case. All three left the suite at
+    /// 177/0 before this guard existed.
+    ///
+    /// MUTATION (executed 2026-07-27): promote a table INTO the class without
+    /// listing it — flip `ingest_heartbeats` from `Telemetry` to
+    /// `NeverDelete` => this test FAILS, forcing the roster to be updated
+    /// deliberately. That is the *width* bound: the guard is a set, so it
+    /// cannot be satisfied by a subset in either direction, and a new
+    /// never-delete table cannot arrive uncovered.
+    #[test]
+    fn the_never_delete_roster_is_exactly_these_tables() {
+        assert_eq!(
+            tables_of_class(TableClass::NeverDelete),
+            vec![
+                "ingest_append_control",
+                "ingest_checkpoint_transitions",
+                "ingest_checkpoints",
+                "mcp_read_index_state",
+                "publication_diagnostic_events",
+                "published_source_generations",
+                "schema_migrations",
+                "search_conversation_terms",
+                "source_generation_publication_readiness",
+                "storage_reclaim_ledger",
+            ],
+            "every never-delete table must be listed here, and every table listed here must still \
+             be never-delete: `is_protected()` is the only gate the emitter and the migration \
+             invariant consult"
+        );
+        for control in tables_of_class(TableClass::NeverDelete) {
+            assert_eq!(classify(control), Some(TableClass::NeverDelete));
+            assert!(
+                TableClass::NeverDelete.is_protected(),
+                "`{control}` is only unreachable because never-delete is protected"
+            );
+        }
+
+        // The allocator rationale must stay attached to the table it explains:
+        // a TTL on checkpoint history regresses max(checkpoint_revision) from
+        // a wall-clock-ms seed to a colliding small value.
+        let checkpoint = classification("ingest_checkpoint_transitions").expect("classified");
+        assert!(checkpoint.rationale.contains("1 784 588 514 188"));
+        assert!(checkpoint.rationale.contains("monotone allocator"));
+        // H5, as the reason `search_conversation_terms` is not merely derived.
+        let terms = classification("search_conversation_terms").expect("classified");
+        assert!(
+            terms.rationale.to_lowercase().contains("no tombstone path"),
+            "{terms:?}"
+        );
+        assert!(terms.rationale.contains("OQ-1"));
+    }
+
+    // ---- §4 S4 migration invariant ------------------------------------
+
+    /// **G-MIGRATION.** Fails for: a bundled migration removing rows from a
+    /// canonical, raw-audit, or never-delete table.
+    /// Denomination: per-statement parse over every bundled migration.
+    ///
+    /// Every mutation below is appended to `sql/003_ingest_heartbeats.sql`,
+    /// which carries no statement-count or content assertion of its own, so
+    /// the only test that reacts is the invariant under examination.
+    ///
+    /// MUTATION (executed 2026-07-27), all three run separately against an
+    /// isolated copy of the tree, all three pass the *old* substring guards:
+    ///   1. append `ALTER TABLE moraine.events DELETE WHERE 1;` => FAILS
+    ///      here, finding `{table: "events", class: CanonicalHistory}`.
+    ///   2. append `DELETE FROM moraine.events;` => FAILS here.
+    ///   3. append `TRUNCATE TABLE IF EXISTS moraine.events;` => FAILS here.
+    ///
+    /// Four further mutations, all appended to
+    /// `sql/003_ingest_heartbeats.sql` and all run separately, cover the
+    /// `DROP` family. Every one of them left the suite at 177/0 before the
+    /// `DropRelation`/`AlterDrop` shapes existed, and
+    /// `DROP TABLE moraine.events` removes strictly more canonical history
+    /// than the `TRUNCATE` the shape list did catch:
+    ///   4. `DROP TABLE IF EXISTS moraine.events;` => FAILS here.
+    ///   5. `ALTER TABLE moraine.events DROP PARTITION '202601';` => FAILS.
+    ///   6. `ALTER TABLE moraine.events DROP COLUMN payload_json;` => FAILS.
+    ///   7. `DROP TABLE moraine.published_source_generations;` => FAILS with
+    ///      class `NeverDelete`.
+    ///
+    /// MUTATION (executed 2026-07-27): remove the `DROP TABLE`/`DROP DATABASE`
+    /// arm from `delete_shape` and append mutation 4 => the shape test
+    /// `every_row_removing_shape_is_recognized_including_the_ones_the_old_guard_missed`
+    /// FAILS, so the new arm is load-bearing rather than decorative. Since the
+    /// inversion, that mutation no longer changes *this* test's answer: the
+    /// finding survives with a `None` shape, because the gate is
+    /// [`benign_shape`] and `DROP TABLE` is not on it.
+    ///
+    /// The four mutations the inversion added, each appended to
+    /// `sql/003_ingest_heartbeats.sql`, each run separately (executed
+    /// 2026-07-27), each GREEN here before the inversion and RED after:
+    ///   8.  `ALTER TABLE moraine.events UPDATE payload_json = '' WHERE 1;`
+    ///   9.  `ALTER TABLE moraine.events REPLACE PARTITION '202601' FROM
+    ///       moraine.scratch;`
+    ///   10. `OPTIMIZE TABLE moraine.events FINAL DEDUPLICATE BY event_uid;`
+    ///   11. `ALTER TABLE moraine.events DETACH PARTITION '202601';`
+    ///
+    /// Two controls bound the opposite direction — the gate is not simply
+    /// "any statement fails". Appending `TRUNCATE TABLE moraine.mcp_open_turns;`
+    /// (Derived) leaves this test GREEN, and so does appending
+    /// `DROP VIEW IF EXISTS moraine.v_live_events;` +
+    /// `DROP TABLE IF EXISTS moraine.search_term_stats;` +
+    /// `ALTER TABLE moraine.event_links DROP CONSTRAINT IF EXISTS c_x;`
+    /// (both executed 2026-07-27). The standing upper bound is the tree itself:
+    /// the gate runs over all 294 statements of the 39 bundled migrations and
+    /// is green, including the 64 `ADD COLUMN`s, the 41 `DROP VIEW`s, the 32
+    /// `CREATE TABLE`s and the 25 `INSERT`s.
+    ///
+    /// Round 5 added five more end-to-end mutations of the same kind, each a
+    /// statement the *inverted* gate admitted and each `EXPLAIN AST`-valid on
+    /// ClickHouse 25.12.5.44 (executed 2026-07-27, each RED here now):
+    ///   12. `ALTER TABLE moraine.events MODIFY COLUMN payload_json String TTL
+    ///       ingested_at + INTERVAL 1 DAY;`
+    ///   13. `ALTER TABLE moraine.events MATERIALIZE COLUMN payload_json;`
+    ///   14. `INSERT INTO moraine.events SELECT * REPLACE ('' AS payload_json,
+    ///       event_version + 1 AS event_version) FROM moraine.events FINAL;`
+    ///   15. `CREATE MATERIALIZED VIEW moraine.mv_z TO moraine.events AS SELECT
+    ///       * FROM moraine.raw_events;`
+    ///   16. `ALTER TABLE moraine.events MODIFY COLUMN c COMMENT 'a -- b',
+    ///       DROP COLUMN payload_json;` — the comment-laundered drop, which the
+    ///       old normalizer truncated to a benign `MODIFY COLUMN`.
+    ///
+    /// And three more controls, each of which the *round-4* gate rejected and
+    /// this one admits: `ALTER TABLE moraine.events ADD PROJECTION p_x (SELECT
+    /// a, b ORDER BY ts);`, `CREATE OR REPLACE VIEW moraine.v_z AS SELECT 1;`,
+    /// and `ALTER TABLE moraine.events ADD COLUMN note String DEFAULT 'x'
+    /// COMMENT 'drop this';`.
+    #[test]
+    fn no_bundled_migration_removes_protected_rows() {
+        let mut findings = Vec::new();
+        for migration in bundled_migrations() {
+            findings.extend(migration_delete_findings(migration.version, migration.sql));
+        }
+        assert!(
+            findings.is_empty(),
+            "bundled migrations must not contain a statement outside the benign allowlist that \
+             names a canonical, raw-audit, or never-delete table. Findings: {findings:#?}. If the \
+             statement is genuinely benign, add its shape to BENIGN_STATEMENT_HEADS or \
+             BENIGN_ALTER_OPERATIONS *and* a corpus row that witnesses it. If the migration \
+             legitimately must destroy those rows, add the (version, table) pair to \
+             MIGRATION_DELETE_ALLOWLIST with a reason."
+        );
+    }
+
+    /// Every `(relation, shape)` an unexempted migration would be reported
+    /// for, in statement order. The allowlist's own denominator.
+    ///
+    /// It mirrors [`migration_row_removals`] with only the allowlist removed —
+    /// including the `DropRelation`-on-a-declared-view filter. Dropping that
+    /// filter here made the denominator wider than the numerator it is compared
+    /// against, which stayed invisible for as long as no migration that drops a
+    /// declared view name (`004`, `006`) also had an allowlist entry.
+    fn unexempted_relations(sql: &str) -> Vec<(String, Option<DeleteShape>)> {
+        let views: BTreeSet<&str> = SCHEMA_VIEW_OBJECTS.iter().copied().collect();
+        crate::split_sql_statements(sql)
+            .into_iter()
+            .flat_map(|statement| {
+                let normalized = normalize_statement(&statement);
+                if normalized.is_empty() || benign_shape(&normalized).is_some() {
+                    return Vec::new();
+                }
+                let shape = delete_shape(&normalized);
+                let mut relations = named_relations(&normalized, shape);
+                if relations.is_empty() {
+                    relations.push(UNPARSED_RELATION.to_string());
+                }
+                relations
+                    .into_iter()
+                    .filter(|relation| {
+                        !(shape == Some(DeleteShape::DropRelation)
+                            && views.contains(relation.as_str()))
+                    })
+                    .map(|relation| (relation, shape))
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// **G-ALLOWLIST.** Every exemption names a migration that still exists,
+    /// and every `(version, table, shape)` triple in its cross product really
+    /// would be a finding without it. An entry that exempts nothing is an entry
+    /// nobody would notice going stale, and a cross product wider than the
+    /// migration is a licence nobody asked for.
+    ///
+    /// MUTATION (executed 2026-07-27): drop `"012"` and `"013"` from the
+    /// allowlist => FAILS in `no_bundled_migration_removes_protected_rows`
+    /// with twelve findings on `events`/`raw_events`, all `AlterUpdate`. That
+    /// is the inversion earning its keep: those twenty-one statements were
+    /// invisible to four consecutive rounds of destructive-shape enumeration.
+    ///
+    /// MUTATION (executed 2026-07-27): merge 032's two entries into one whose
+    /// cross product is `{search_documents, search_postings,
+    /// search_conversation_terms} × {AlterRewriteColumn,
+    /// MaterializedViewInto}` => FAILS here on the four unwitnessed pairs. That
+    /// is what stops an entry from being widened by adding a table to the list
+    /// that already carries the shape somebody wanted.
+    ///
+    /// The key's own width lives in `the_allowlist_key_is_version_table_and_shape`.
+    #[test]
+    fn every_allowlist_entry_is_load_bearing_and_still_exempts_a_live_migration() {
+        let versions: Vec<&str> = MIGRATION_DELETE_ALLOWLIST
+            .iter()
+            .map(|exemption| exemption.version)
+            .collect();
+        assert_eq!(
+            versions,
+            vec![
+                "004", "009", "010", "011", "012", "012", "013", "014", "014", "020", "031", "032",
+                "032", "032", "036"
+            ]
+        );
+
+        for exemption in MIGRATION_DELETE_ALLOWLIST {
+            let version = exemption.version;
+            assert!(exemption.reason.len() > 40, "`{version}` needs a reason");
+            assert!(!exemption.tables.is_empty(), "`{version}` exempts no table");
+            assert!(!exemption.shapes.is_empty(), "`{version}` exempts no shape");
+            let migration = bundled_migrations()
+                .into_iter()
+                .find(|migration| migration.version == version)
+                .unwrap_or_else(|| {
+                    panic!("the allowlist must not outlive the migration `{version}` it exempts")
+                });
+            // Unexempted, every pair in the cross product really is reported:
+            // this is what proves the allowlist is load-bearing rather than
+            // decorative, and that the entry is not wider than its migration.
+            let unexempted = unexempted_relations(migration.sql);
+            for table in exemption.tables {
+                for shape in exemption.shapes {
+                    assert!(
+                        unexempted
+                            .iter()
+                            .any(|(name, seen)| name == table && *seen == Some(*shape)),
+                        "allowlist entry `{version}`/`{table}`/{shape:?} exempts nothing; delete \
+                         it, or split the entry so its cross product stops over-granting. \
+                         {version} names: {unexempted:?}"
+                    );
+                }
+            }
+        }
+
+        // And nothing is exempted that no entry for that version names. The
+        // check aggregates across entries because a version may hold more than
+        // one, each carrying a different shape.
+        for migration in bundled_migrations() {
+            let entries: Vec<&MigrationRemovalExemption> = MIGRATION_DELETE_ALLOWLIST
+                .iter()
+                .filter(|exemption| exemption.version == migration.version)
+                .collect();
+            if entries.is_empty() {
+                continue;
+            }
+            let leaked: Vec<(String, Option<DeleteShape>)> = unexempted_relations(migration.sql)
+                .into_iter()
+                .filter(|(table, shape)| {
+                    !entries.iter().any(|exemption| {
+                        exemption.tables.contains(&table.as_str())
+                            && shape.is_some_and(|shape| exemption.shapes.contains(&shape))
+                    })
+                })
+                .collect();
+            assert!(
+                leaked.is_empty(),
+                "`{}` destroys rows in {leaked:?}, which its exemptions do not name — add them \
+                 with a reason or fix the migration",
+                migration.version
+            );
+        }
+
+        // The historical purges are still the ones being exempted.
+        let entry = |version: &str, shape: DeleteShape| {
+            MIGRATION_DELETE_ALLOWLIST
+                .iter()
+                .find(|exemption| exemption.version == version && exemption.shapes.contains(&shape))
+                .unwrap_or_else(|| panic!("no `{version}` entry carries {shape:?}"))
+        };
+        assert!(entry("010", DeleteShape::Truncate)
+            .tables
+            .contains(&"search_conversation_terms"));
+        assert!(entry("020", DeleteShape::AlterDelete)
+            .tables
+            .contains(&"events"));
+        assert!(entry("020", DeleteShape::AlterDelete)
+            .tables
+            .contains(&"raw_events"));
+        // …the two the inversion surfaced overwrite canonical history…
+        assert!(entry("012", DeleteShape::AlterUpdate)
+            .tables
+            .contains(&"events"));
+        assert!(entry("013", DeleteShape::AlterUpdate)
+            .tables
+            .contains(&"events"));
+        // …and the one this round surfaced rewrites three of its columns.
+        assert!(entry("014", DeleteShape::AlterRewriteColumn)
+            .tables
+            .contains(&"events"));
+    }
+
+    /// **G-ALLOWLIST, key width.** All three dimensions of the exemption key
+    /// are load-bearing, each pinned by a pair of statements that differ in
+    /// exactly that dimension.
+    ///
+    /// Every looser key passed the whole suite while being fail-open, which is
+    /// how the same defect shipped three rounds running:
+    ///
+    /// MUTATION (executed 2026-07-27), each run separately against an isolated
+    /// copy:
+    ///   * drop the `exemption.version == version` conjunct => FAILS on the
+    ///     version pair.
+    ///   * drop the `exemption.tables.contains(&table)` conjunct => FAILS on
+    ///     the table pair. Before this test existed, replacing the per-table
+    ///     filter with a version-only equivalent left the suite GREEN at 195/0.
+    ///   * drop the `exemption.shapes.contains(&shape)` conjunct => FAILS on
+    ///     the shape pair.
+    ///   * make a `None` shape exempt (`let Some(shape) = shape else { return
+    ///     true }`) => FAILS on the unnamed-shape row.
+    #[test]
+    fn the_allowlist_key_is_version_table_and_shape() {
+        let reported = |version: &str, sql: &str| migration_row_removals(version, sql).len();
+
+        // Version: `012` may rewrite `events` with `ALTER … UPDATE`; `011` may
+        // not, and nothing else about the statement changes.
+        let update = "ALTER TABLE moraine.events UPDATE payload_json = '' WHERE 1";
+        assert_eq!(reported("012", update), 0, "012 exempts this exactly");
+        assert_eq!(reported("011", update), 1, "the version is part of the key");
+
+        // Table: `020` may `ALTER … DELETE` from `events`, and from seven
+        // others — but not from `ingest_errors`, which it does not name.
+        let delete = |table: &str| format!("ALTER TABLE moraine.{table} DELETE WHERE 1");
+        assert_eq!(reported("020", &delete("events")), 0);
+        assert_eq!(
+            reported("020", &delete("ingest_errors")),
+            1,
+            "the table is part of the key"
+        );
+
+        // Shape: 012's licence is `AlterUpdate` on `events`. Its own reason
+        // says "none removes a row"; a TRUNCATE of the same table under the
+        // same version must not ride on it.
+        assert_eq!(
+            reported("012", "TRUNCATE TABLE moraine.events"),
+            1,
+            "the shape is part of the key"
+        );
+        assert_eq!(
+            reported("020", "DROP TABLE moraine.events"),
+            1,
+            "020's licence is AlterDelete, not DropRelation"
+        );
+
+        // Unnamed shape: an exempted migration is not a place where a
+        // statement nobody has named becomes acceptable.
+        assert_eq!(
+            delete_shape("ALTER TABLE moraine.events APPLY DELETED MASK"),
+            None
+        );
+        assert_eq!(
+            reported("012", "ALTER TABLE moraine.events APPLY DELETED MASK"),
+            1,
+            "a `None` shape matches no entry"
+        );
+    }
+
+    /// **G-BENIGN, non-vacuity.** Every entry of the benign allowlist is
+    /// reached by a real statement — a bundled migration's, or a named row of
+    /// the negative corpus in
+    /// `every_row_removing_shape_is_recognized_including_the_ones_the_old_guard_missed`.
+    ///
+    /// The inversion's whole claim is that the *benign* list is bounded by what
+    /// this repository actually does, unlike the destructive list. That claim
+    /// is only true if nobody may add a speculative entry: an unwitnessed
+    /// benign form is an unbounded enumeration wearing the other hat, and it is
+    /// a hole in the gate rather than a false positive.
+    ///
+    /// MUTATION (executed 2026-07-28): add `"ATTACH PARTITION"` to
+    /// `BENIGN_ALTER_OPERATIONS` => FAILS here, unwitnessed. MUTATION: add
+    /// `"OPTIMIZE "` to `BENIGN_STATEMENT_HEADS` => FAILS here **and** in the
+    /// `OPTIMIZE … FINAL` positive rows.
+    ///
+    /// **Tree-witnessed and corpus-witnessed are not the same claim**, and for
+    /// a round this test conflated them. It reads `BENIGN_CORPUS`, so an entry
+    /// whose only witness is a row the same author added alongside it satisfies
+    /// it — the list is then bounded by what somebody wrote in one commit
+    /// rather than by "what this repository actually does". That is how
+    /// `CREATE OR REPLACE VIEW` shipped: grepping `sql/` finds it in **zero**
+    /// bundled migrations. [`CORPUS_WITNESSED_BENIGN_ENTRIES`] is the declared
+    /// set, and this test pins it in both directions, so an entry moving from
+    /// tree-witnessed to corpus-witnessed — or a new speculative one — is an
+    /// edit somebody has to make on purpose.
+    #[test]
+    fn every_benign_entry_is_witnessed_by_a_real_statement() {
+        let tree: Vec<String> = bundled_migrations()
+            .iter()
+            .flat_map(|migration| crate::split_sql_statements(migration.sql))
+            .map(|statement| normalize_statement(&statement))
+            .filter(|statement| !statement.is_empty())
+            .collect();
+        let corpus: Vec<String> = BENIGN_CORPUS
+            .iter()
+            .map(|sql| normalize_statement(sql))
+            .collect();
+        let statements: Vec<String> = tree.iter().chain(corpus.iter()).cloned().collect();
+
+        // Every operation of every `ALTER TABLE` statement, in clause order.
+        let alter_operations = |source: &[String]| -> BTreeSet<String> {
+            source
+                .iter()
+                .filter(|statement| statement.to_ascii_uppercase().starts_with("ALTER TABLE "))
+                .flat_map(|statement| {
+                    alter_clauses(&mask_quoted(&statement.to_ascii_uppercase()))
+                        .iter()
+                        .map(|clause| clause_operation(clause))
+                        .collect::<Vec<_>>()
+                })
+                .collect()
+        };
+        let reached_in_tree = alter_operations(&tree);
+        let reached = alter_operations(&statements);
+
+        let declared: BTreeSet<&str> = CORPUS_WITNESSED_BENIGN_ENTRIES
+            .iter()
+            .map(|(entry, _)| *entry)
+            .collect();
+        let mut corpus_only: BTreeSet<&str> = BTreeSet::new();
+
+        for head in BENIGN_STATEMENT_HEADS {
+            assert!(
+                statements
+                    .iter()
+                    .any(|statement| benign_shape(statement) == Some(*head)),
+                "benign head `{head}` is not reached by any bundled migration or corpus row; a \
+                 benign form nobody writes is a hole in the gate, not a convenience"
+            );
+            if !tree
+                .iter()
+                .any(|statement| benign_shape(statement) == Some(*head))
+            {
+                corpus_only.insert(head);
+            }
+        }
+
+        for operation in BENIGN_ALTER_OPERATIONS {
+            assert!(
+                reached.contains(*operation),
+                "benign ALTER operation `{operation}` is not reached by any bundled migration or \
+                 corpus row: {reached:?}"
+            );
+            if !reached_in_tree.contains(*operation) {
+                corpus_only.insert(operation);
+            }
+        }
+        // The four conditional operations, which are not in the constant
+        // because listing them would admit their destructive spellings.
+        for operation in [
+            "MOVE PARTITION",
+            "MOVE PART",
+            "MODIFY COLUMN",
+            "MODIFY QUERY",
+        ] {
+            assert!(
+                reached.contains(operation),
+                "conditional ALTER operation `{operation}` is not reached: {reached:?}"
+            );
+        }
+
+        assert_eq!(
+            corpus_only, declared,
+            "the set of benign entries whose only witness is a `BENIGN_CORPUS` row has changed. \
+             An entry that no bundled migration reaches is bounded by what one author wrote in \
+             one commit, not by what this repository does; declare it in \
+             CORPUS_WITNESSED_BENIGN_ENTRIES with the reason it is worth carrying, or delete it."
+        );
+        for (entry, reason) in CORPUS_WITNESSED_BENIGN_ENTRIES {
+            assert!(reason.len() > 40, "`{entry}` needs a reason");
+        }
+    }
+
+    /// Benign entries that **no bundled migration reaches**, with the reason
+    /// each is worth carrying anyway.
+    ///
+    /// Every one of these is a form this repository has not written yet, so
+    /// each is a promise about a statement somebody might write rather than a
+    /// description of one that exists. That is a weaker footing than the rest
+    /// of the list stands on, and it is where the round-6 `CREATE OR REPLACE
+    /// VIEW` hole lived — grepping `sql/` finds that head in zero migrations,
+    /// and sixteen of the twenty-three `BENIGN_ALTER_OPERATIONS` entries are
+    /// in the same position.
+    ///
+    /// The rule that follows from it: **a corpus-witnessed head that can write
+    /// into or replace an existing relation must carry a target-class
+    /// condition** — `every_benign_head_answers_the_target_class_question`
+    /// enforces it for every head, witnessed or not.
+    const CORPUS_WITNESSED_BENIGN_ENTRIES: &[(&str, &str)] = &[
+        (
+            "SELECT ",
+            "no bundled migration is a bare SELECT; the entry exists so a future data-driven \
+             migration reads as benign rather than as an unnamed shape",
+        ),
+        (
+            "CREATE OR REPLACE VIEW ",
+            "zero bundled migrations use it — the nine that drop and recreate a view spell it as \
+             `DROP VIEW` then `CREATE VIEW`. Carried because it is the atomic spelling of that \
+             pair, and gated on the class of the name it replaces because ClickHouse does not \
+             check that the name was a view (executed: 3 rows to 1, engine MergeTree to View)",
+        ),
+        (
+            "COMMENT COLUMN",
+            "the tree documents its columns in the `CREATE TABLE` rather than with this clause. \
+             Column metadata, no row",
+        ),
+        (
+            "MODIFY COMMENT",
+            "the relation-level spelling of `COMMENT COLUMN`, and unwitnessed for the same \
+             reason. Table metadata, no row",
+        ),
+        (
+            "ADD PROJECTION",
+            "no bundled migration uses projections. The family is listed whole because a round \
+             shipped `DROP`/`CLEAR PROJECTION` without `ADD PROJECTION`, and a gate that permits \
+             deleting a derived structure but not creating one gets turned off",
+        ),
+        (
+            "CLEAR PROJECTION",
+            "the maintenance half of the PROJECTION family",
+        ),
+        (
+            "DROP PROJECTION",
+            "the removal half of the PROJECTION family, and one of the three clauses \
+             `the_destructive_drop_clause_list_is_exactly_the_four_that_remove_storage` bounds \
+             against",
+        ),
+        (
+            "MATERIALIZE PROJECTION",
+            "the backfill half of the PROJECTION family",
+        ),
+        (
+            "ADD STATISTICS",
+            "no bundled migration declares column statistics. Same whole-family argument as \
+             PROJECTION",
+        ),
+        (
+            "CLEAR STATISTICS",
+            "the maintenance half of the STATISTICS family",
+        ),
+        (
+            "DROP STATISTICS",
+            "the removal half of the STATISTICS family",
+        ),
+        (
+            "MATERIALIZE STATISTICS",
+            "the backfill half of the STATISTICS family",
+        ),
+        (
+            "CLEAR INDEX",
+            "the tree adds and materializes a secondary index but never clears one; the INDEX \
+             family is listed whole for the same reason as the other two",
+        ),
+        (
+            "DROP INDEX",
+            "the removal half of the INDEX family, and one of the three clauses \
+             `the_destructive_drop_clause_list_is_exactly_the_four_that_remove_storage` bounds \
+             against",
+        ),
+        (
+            "MATERIALIZE TTL",
+            "no bundled TTL exists to materialize before sql/039, and 039 anchors its TTLs on a \
+             column it materializes instead. Carried because forcing an already-declared TTL to \
+             apply removes nothing the declaration had not already licensed — §7.4 records the \
+             residual",
+        ),
+        (
+            "MODIFY SETTING",
+            "no bundled migration changes a table setting after creation. A setting, not a row; \
+             its comma-separated argument list is what `merge_clause_continuations` exists for",
+        ),
+        (
+            "RESET SETTING",
+            "reverts a table setting to its default; the inverse of `MODIFY SETTING`, listed so \
+             the pair is whole",
+        ),
+        (
+            "REMOVE TTL",
+            "deletes a TTL policy rather than the rows it would have removed — the inverse of \
+             the shape this gate reports most often, and unwritten for the same reason \
+             `MATERIALIZE TTL` is",
+        ),
+    ];
+
+    /// **G-HEADCLASS.** Every benign head answers, in code, whether a statement
+    /// with that head aimed at an existing relation can displace it.
+    ///
+    /// This is the rule that would have stopped round 6's blocking finding
+    /// before it shipped. `CREATE OR REPLACE VIEW ` went onto
+    /// [`BENIGN_STATEMENT_HEADS`] with a comment asserting it needed no
+    /// target-class check — "a view holds no rows, so unlike `CREATE OR REPLACE
+    /// TABLE` … this one can destroy nothing" — while `INSERT INTO ` and
+    /// `CREATE MATERIALIZED VIEW ` two lines above it both carried one. The
+    /// asymmetry was invisible because nothing required the question to be
+    /// answered at all.
+    ///
+    /// [`HeadTargetRule::ClassGated`] is **executed**: the probe is run through
+    /// [`benign_shape`] and must be rejected. A rule that claims a gate the
+    /// code does not have fails here.
+    ///
+    /// MUTATION (executed 2026-07-28): change `CREATE OR REPLACE VIEW `'s rule
+    /// to `CannotDisplace` => FAILS here (the head is in
+    /// [`PROTECTED_REPLACE_HEADS`], so the arms disagree). Delete the
+    /// [`PROTECTED_REPLACE_HEADS`] branch from [`benign_shape`] but keep the
+    /// rule => FAILS here on the probe, which is admitted.
+    /// An `INSERT` whose target this parser cannot resolve is a finding, because
+    /// a target it could not name is a target it could not class-check.
+    ///
+    /// `INSERT INTO FUNCTION remote(...)` and `INSERT INTO TABLE FUNCTION ...`
+    /// land the name-skip on the [`NEVER_A_RELATION`] keyword `FUNCTION`, so
+    /// [`named_relations`] returns empty and [`write_target`] returns `None`.
+    /// The `None` arm exists for a materialized view with no `TO`, which owns
+    /// its storage and displaces nothing — but an `INSERT` always writes
+    /// somewhere, and `remote('127.0.0.1', 'moraine', 'events')` reaches the
+    /// rows [`PROTECTED_WRITE_HEADS`] exists to protect. Executed on
+    /// 25.12.5.44: `INSERT INTO FUNCTION remote(...) SELECT * REPLACE ('' AS
+    /// payload_json, event_version + 1 AS event_version) FROM moraine.events
+    /// FINAL` took `sum(length(payload_json))` from 87 to 0 through `FINAL`,
+    /// and it was still 0 after `OPTIMIZE ... FINAL`.
+    ///
+    /// MUTATION (executed 2026-07-28): restore the bare `return Some(head)` in
+    /// [`benign_shape`]'s [`PROTECTED_WRITE_HEADS`] arm => FAILS here. The MV
+    /// half of the same assertion keeps that arm from being narrowed instead.
+    #[test]
+    fn an_insert_whose_target_this_parser_cannot_resolve_is_a_finding() {
+        for statement in [
+            "INSERT INTO FUNCTION remote('127.0.0.1:9000', 'moraine', 'events') SELECT 1",
+            "INSERT INTO TABLE FUNCTION remote('127.0.0.1:9000', 'moraine', 'events') SELECT 1",
+            "INSERT INTO FUNCTION clusterAllReplicas('c', 'moraine', 'events') SELECT 1",
+        ] {
+            assert!(
+                benign_shape(&normalize_statement(statement)).is_none(),
+                "an INSERT whose target this parser cannot resolve must not be admitted: \
+                 {statement}"
+            );
+        }
+
+        // The narrowing direction: a materialized view with no `TO` genuinely
+        // has no target, owns its own storage, and must stay benign.
+        let mv = "CREATE MATERIALIZED VIEW moraine.mv_own ENGINE = MergeTree ORDER BY a \
+                  AS SELECT a FROM moraine.events";
+        assert!(
+            benign_shape(&normalize_statement(mv)).is_some(),
+            "a materialized view with no TO displaces nothing and must stay benign"
+        );
+    }
+
+    #[test]
+    fn every_benign_head_answers_the_target_class_question() {
+        let ruled: Vec<&str> = BENIGN_HEAD_TARGET_RULES
+            .iter()
+            .map(|(head, _)| *head)
+            .collect();
+        assert_eq!(
+            ruled,
+            BENIGN_STATEMENT_HEADS.to_vec(),
+            "every benign head needs exactly one target-class rule, in the same order, so adding \
+             a head forces the question to be answered"
+        );
+
+        for (head, rule) in BENIGN_HEAD_TARGET_RULES {
+            let gated = PROTECTED_WRITE_HEADS
+                .iter()
+                .any(|(write_head, _)| write_head == head)
+                || PROTECTED_REPLACE_HEADS
+                    .iter()
+                    .any(|(replace_head, _)| replace_head == head);
+            match rule {
+                HeadTargetRule::ClassGated(probe) => {
+                    assert!(
+                        gated,
+                        "`{head}` claims a target-class gate but is in neither \
+                         PROTECTED_WRITE_HEADS nor PROTECTED_REPLACE_HEADS"
+                    );
+                    let normalized = normalize_statement(probe);
+                    assert_eq!(
+                        benign_shape(&normalized),
+                        None,
+                        "`{head}`'s probe `{probe}` aims at bucket-1 `moraine.events` and must be \
+                         a finding"
+                    );
+                    let findings = migration_delete_findings("999", probe);
+                    assert_eq!(findings.len(), 1, "`{probe}`");
+                    assert_eq!(findings[0].table, "events");
+                }
+                HeadTargetRule::CannotDisplace(reason) => {
+                    assert!(
+                        !gated,
+                        "`{head}` is target-class gated but its rule says it cannot displace \
+                         anything; the two must not disagree"
+                    );
+                    assert!(reason.len() > 40, "`{head}` needs a reason");
+                }
+            }
+        }
+    }
+
+    /// **G-SEARCHCORPUS.** Fails for: a bundled migration emptying
+    /// `search_documents` or `search_postings`.
+    /// Denomination: per-statement parse over every bundled migration.
+    ///
+    /// This is the coverage the deleted 034/035 loops used to carry. Those
+    /// loops asserted over `["events", "raw_events", "search_documents",
+    /// "search_postings"]`; the repo-wide S4 invariant that replaced them
+    /// reports only `is_protected()` tables, and both search tables are
+    /// `Derived`, so for one round they were covered by no test in any
+    /// migration.
+    ///
+    /// MUTATION (executed 2026-07-27): append
+    /// `TRUNCATE TABLE moraine.search_documents;` to
+    /// `sql/003_ingest_heartbeats.sql` => FAILS here (and leaves
+    /// `no_bundled_migration_removes_protected_rows` green, which is exactly
+    /// the gap). Same for `search_postings`, and for
+    /// `ALTER TABLE moraine.search_documents DELETE WHERE 1;`.
+    ///
+    /// Bounded in the other direction by the tree itself: migrations 034 and
+    /// 035 truncate six `mcp_open_*` relations on every run and this test is
+    /// green, so it is not "no migration may truncate anything derived".
+    #[test]
+    fn no_bundled_migration_empties_the_search_corpus() {
+        let guarded: BTreeSet<&str> = MIGRATION_PRESERVED_DERIVED_TABLES
+            .iter()
+            .map(|(name, _)| *name)
+            .collect();
+        for (name, reason) in MIGRATION_PRESERVED_DERIVED_TABLES {
+            assert_eq!(
+                classify(name),
+                Some(TableClass::Derived),
+                "`{name}` is guarded here precisely because its class does not guard it"
+            );
+            assert!(reason.len() > 40, "`{name}` needs a reason");
+        }
+
+        let findings: Vec<MigrationDeleteFinding> = bundled_migrations()
+            .iter()
+            .flat_map(|migration| migration_row_removals(migration.version, migration.sql))
+            .filter(|finding| guarded.contains(finding.table.as_str()))
+            .collect();
+        assert!(
+            findings.is_empty(),
+            "a bundled migration removes rows from the search corpus. Findings: {findings:#?}"
+        );
+
+        // And the scanner really does see derived removals, or the assertion
+        // above would pass because `migration_row_removals` reports nothing.
+        let derived_removals: Vec<MigrationDeleteFinding> = bundled_migrations()
+            .iter()
+            .flat_map(|migration| migration_row_removals(migration.version, migration.sql))
+            .filter(|finding| finding.class == TableClass::Derived)
+            .collect();
+        assert!(
+            derived_removals
+                .iter()
+                .any(|finding| finding.table == "mcp_open_events"),
+            "034/035 truncate the mcp_open_* family; a scanner that cannot see that cannot see a \
+             search-corpus truncate either: {derived_removals:#?}"
+        );
+    }
+
+    /// **G-SEARCHCORPUS, supersede side.** The corpus is guarded against a
+    /// statement that *writes into* it, not only one that removes from it.
+    ///
+    /// Round 6's finding, and the reason it survived round 5: `benign_shape`
+    /// admitted an `INSERT INTO` / `CREATE MATERIALIZED VIEW … TO` whose target
+    /// was not `is_protected()`, and both search tables are `Derived`. But
+    /// [`MIGRATION_PRESERVED_DERIVED_TABLES`] exists *precisely because*
+    /// `Derived` does not guard the corpus, and
+    /// `no_bundled_migration_empties_the_search_corpus` filters
+    /// [`migration_row_removals`], which never saw these statements at all.
+    ///
+    /// Both tables are `ReplacingMergeTree` on the reference host — the
+    /// identical hazard [`PROTECTED_WRITE_HEADS`] spells out for `events`.
+    /// **Executed in `clickhouse local` 25.12.5.44** against a
+    /// `ReplacingMergeTree(doc_version) ORDER BY (event_uid, source_host)`
+    /// shaped like `sql/004`'s: `INSERT INTO moraine.search_documents SELECT *
+    /// REPLACE ('' AS text_content, doc_version + 1 AS doc_version) FROM
+    /// moraine.search_documents FINAL` takes `sum(length(text_content))` from
+    /// **23 to 0** through `FINAL`, and it is still 0 after `OPTIMIZE …
+    /// FINAL` — the rows survive and their content does not.
+    ///
+    /// MUTATION (executed 2026-07-28): narrow [`relation_is_guarded`] back to
+    /// `classify(table).is_none_or(|class| class.is_protected())` => FAILS here
+    /// on all four rows.
+    #[test]
+    fn a_write_into_the_search_corpus_is_a_finding_even_though_it_is_derived() {
+        for (sql, table, shape) in [
+            (
+                "INSERT INTO moraine.search_documents SELECT * REPLACE ('' AS text_content, \
+                 doc_version + 1 AS doc_version) FROM moraine.search_documents FINAL",
+                "search_documents",
+                DeleteShape::InsertInto,
+            ),
+            (
+                "INSERT INTO moraine.search_postings SELECT * REPLACE (0 AS tf, post_version + 1 \
+                 AS post_version) FROM moraine.search_postings FINAL",
+                "search_postings",
+                DeleteShape::InsertInto,
+            ),
+            (
+                "CREATE MATERIALIZED VIEW moraine.mv_blank TO moraine.search_documents AS SELECT \
+                 * REPLACE ('' AS text_content) FROM moraine.events",
+                "search_documents",
+                DeleteShape::MaterializedViewInto,
+            ),
+            (
+                "CREATE MATERIALIZED VIEW moraine.mv_blank TO moraine.search_postings AS SELECT * \
+                 FROM moraine.search_documents",
+                "search_postings",
+                DeleteShape::MaterializedViewInto,
+            ),
+        ] {
+            assert!(
+                benign_shape(&normalize_statement(sql)).is_none(),
+                "`{sql}` must not be admitted by the benign allowlist"
+            );
+            // `Derived`, so `migration_delete_findings` filters it out on
+            // purpose; the corpus floor reads `migration_row_removals`.
+            assert!(migration_delete_findings("999", sql).is_empty());
+            let findings = migration_row_removals("999", sql);
+            assert_eq!(findings.len(), 1, "`{sql}`");
+            assert_eq!(findings[0].table, table);
+            assert_eq!(findings[0].shape, Some(shape));
+            assert_eq!(findings[0].class, TableClass::Derived);
+        }
+
+        // Width: a `Derived` target that is *not* on the preserved list stays
+        // benign, so this is not "no migration may write into anything
+        // derived". `mcp_open_turns` is the corpus's control.
+        assert!(benign_shape(&normalize_statement(
+            "INSERT INTO moraine.mcp_open_turns SELECT * FROM moraine.events"
+        ))
+        .is_some());
+    }
+
+    /// **G-REPLACE.** `CREATE OR REPLACE VIEW` replaces whatever stands under
+    /// the name, and ClickHouse does not check that it was a view.
+    ///
+    /// The head shipped on [`BENIGN_STATEMENT_HEADS`] with no target-class
+    /// check under the claim that "a view holds no rows, so … this one can
+    /// destroy nothing". **Executed, ClickHouse 25.12.5.44:** a `MergeTree`
+    /// with three rows, then `CREATE OR REPLACE VIEW probe.t AS SELECT 99 AS
+    /// a;` — no error, `count()` 3 → 1, `system.tables.engine` `MergeTree` →
+    /// `View`. Repeated on a `ReplacingMergeTree(event_version)` shaped like
+    /// `moraine.events`: 2 rows → 1, engine → `View`.
+    ///
+    /// The contrast is `DROP VIEW`, which really is safe on a table and is safe
+    /// because of the *server*: `DROP VIEW probe.t2` on a `MergeTree` throws
+    /// `Code: 80 … is not a View` (executed). That is why one of the two heads
+    /// needs a condition and the other does not.
+    ///
+    /// MUTATION (executed 2026-07-28): delete the [`PROTECTED_REPLACE_HEADS`]
+    /// branch from [`benign_shape`] => FAILS here on all four protected rows.
+    #[test]
+    fn replacing_a_relation_with_a_view_is_gated_on_the_targets_class() {
+        for (sql, table) in [
+            (
+                "CREATE OR REPLACE VIEW moraine.events AS SELECT 1",
+                "events",
+            ),
+            (
+                "CREATE OR REPLACE VIEW moraine.raw_events AS SELECT 1",
+                "raw_events",
+            ),
+            (
+                "CREATE OR REPLACE VIEW `moraine`.`ingest_append_control` AS SELECT 1",
+                "ingest_append_control",
+            ),
+            // Unknown is protected (S1), so an undeclared view name is a
+            // finding too — which is what makes the declared-view carve-out
+            // below a decision somebody registered rather than a prefix guess.
+            (
+                "CREATE OR REPLACE VIEW moraine.v_not_declared AS SELECT 1",
+                "v_not_declared",
+            ),
+        ] {
+            assert!(
+                benign_shape(&normalize_statement(sql)).is_none(),
+                "`{sql}` must not be admitted by the benign allowlist"
+            );
+            let findings = migration_delete_findings("999", sql);
+            assert_eq!(findings.len(), 1, "`{sql}`");
+            assert_eq!(
+                findings[0].table, table,
+                "the finding names the relation the statement displaces, not the `VIEW` keyword"
+            );
+            assert_eq!(findings[0].shape, Some(DeleteShape::ReplaceRelation));
+        }
+
+        // `Derived`-but-preserved is a finding as well: W3 and W1 share the
+        // gate, so the corpus is protected from the replace head too.
+        let findings = migration_row_removals(
+            "999",
+            "CREATE OR REPLACE VIEW moraine.search_documents AS SELECT 1",
+        );
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].table, "search_documents");
+
+        // Width, both directions: a declared view name is the drop-and-recreate
+        // nine bundled migrations already perform, and an ordinary `Derived`
+        // table is not preserved.
+        for sql in [
+            "CREATE OR REPLACE VIEW moraine.v_live_events AS SELECT * FROM moraine.events",
+            "CREATE OR REPLACE VIEW moraine.mcp_open_turns AS SELECT 1",
+        ] {
+            assert!(
+                benign_shape(&normalize_statement(sql)).is_some(),
+                "`{sql}` must stay admitted"
+            );
+        }
+    }
+
+    /// The negative corpus: statements that name `moraine.events` — bucket 1,
+    /// the most protected class there is — and must be admitted by
+    /// [`benign_shape`] anyway.
+    ///
+    /// **Every row names `moraine.events` on purpose.** A row naming a
+    /// `Derived` table would be vacuous: `migration_delete_findings` filters on
+    /// `is_protected()` before anything else, so such a row is empty under
+    /// *every* possible benign list, including an empty one.
+    ///
+    /// It is a constant rather than a literal inside the test because
+    /// `every_benign_entry_is_witnessed_by_a_real_statement` reads it too: the
+    /// benign list may contain nothing this corpus and the bundled migrations
+    /// do not between them reach.
+    const BENIGN_CORPUS: &[&str] = &[
+        "ALTER TABLE moraine.events ADD COLUMN IF NOT EXISTS x String",
+        "ALTER TABLE moraine.events ADD CONSTRAINT c_x CHECK ts > 0",
+        "ALTER TABLE moraine.events ADD INDEX IF NOT EXISTS idx_x ts TYPE minmax GRANULARITY 4",
+        "ALTER TABLE moraine.events COMMENT COLUMN payload_json 'the payload'",
+        "ALTER TABLE moraine.events MATERIALIZE INDEX idx_x",
+        "ALTER TABLE moraine.events MATERIALIZE TTL",
+        "ALTER TABLE moraine.events RENAME COLUMN IF EXISTS a TO b",
+        // The three derived-structure families, in full. A migration that may
+        // drop a projection but not create one is a gate nobody can work with;
+        // `every_benign_entry_is_witnessed_by_a_real_statement` requires each
+        // of these rows before the operation may be listed.
+        "ALTER TABLE moraine.events ADD PROJECTION p_x (SELECT * ORDER BY ts)",
+        "ALTER TABLE moraine.events MATERIALIZE PROJECTION p_x",
+        "ALTER TABLE moraine.events ADD STATISTICS ts TYPE tdigest",
+        "ALTER TABLE moraine.events DROP STATISTICS ts",
+        "ALTER TABLE moraine.events CLEAR STATISTICS ts",
+        "ALTER TABLE moraine.events MATERIALIZE STATISTICS ts",
+        // The relation-level spelling of `COMMENT COLUMN`, and the inverse of
+        // `MODIFY SETTING`.
+        "ALTER TABLE moraine.events MODIFY COMMENT 'the canonical record'",
+        "ALTER TABLE moraine.events RESET SETTING index_granularity",
+        "SELECT deleteme FROM moraine.events",
+        "CREATE DATABASE IF NOT EXISTS moraine",
+        "CREATE TABLE IF NOT EXISTS moraine.events (a String) ENGINE = MergeTree ORDER BY a",
+        "CREATE VIEW IF NOT EXISTS moraine.v_events AS SELECT * FROM moraine.events",
+        // Non-vacuous through the *head*, not the name: without the
+        // `CREATE OR REPLACE VIEW ` entry the leading-keyword skip lands on
+        // `VIEW`, [`NEVER_A_RELATION`] empties the parse, and the row is a
+        // finding on `<unparsed>`.
+        "CREATE OR REPLACE VIEW moraine.v_live_events AS SELECT * FROM moraine.events",
+        // An MV writing into a `Derived` target. The class is the whole
+        // difference: the same statement aimed at `moraine.events` is a
+        // finding, two rows down in the positive corpus.
+        "CREATE MATERIALIZED VIEW IF NOT EXISTS moraine.mv_events TO moraine.mcp_open_turns AS \
+         SELECT * FROM moraine.raw_events",
+        // An MV with no `TO` owns its storage and supersedes nothing.
+        "CREATE MATERIALIZED VIEW moraine.mv_own ENGINE = MergeTree ORDER BY a AS SELECT a FROM \
+         moraine.events",
+        // Redefining a declared materialized view's SELECT. Scoped to
+        // SCHEMA_VIEW_OBJECTS: the same clause on `moraine.events` is a
+        // finding, and non-vacuous here because an undeclared MV name is
+        // unknown, which S1 treats as protected.
+        "ALTER TABLE moraine.mv_mcp_session_directory_from_events MODIFY QUERY SELECT 1",
+        // TTL width: `MODIFY TTL` and nothing broader. Widening the benign
+        // `MODIFY ORDER` entry to a bare `MODIFY` admits `MODIFY TTL`, and the
+        // TTL rows of the positive corpus go green-to-red.
+        "ALTER TABLE moraine.events REMOVE TTL",
+        "ALTER TABLE moraine.events MODIFY ORDER BY (event_uid, ts)",
+        "ALTER TABLE moraine.events MODIFY SETTING index_granularity = 8192",
+        // The comma-tailed operations. Every one is `EXPLAIN AST`-valid on
+        // 25.12.5.44 and every one was a **false finding** until round 6:
+        // `alter_clauses` split on their argument lists' own commas, they
+        // reported shape `None`, and a `None` shape is categorically
+        // unexemptable — so a migration needing a two-setting `MODIFY SETTING`,
+        // the ordinary spelling, could not be allowlisted at all. See
+        // [`merge_clause_continuations`].
+        "ALTER TABLE moraine.events MODIFY SETTING index_granularity = 8192, \
+         min_bytes_for_wide_part = 0",
+        "ALTER TABLE moraine.events RESET SETTING index_granularity, min_bytes_for_wide_part",
+        "ALTER TABLE moraine.events ADD COLUMN a2 String SETTINGS alter_sync = 2, \
+         mutations_sync = 1",
+        "ALTER TABLE moraine.events MODIFY COLUMN payload_json COMMENT 'x' SETTINGS \
+         max_compress_block_size = 1, min_compress_block_size = 2",
+        "ALTER TABLE moraine.mv_mcp_session_directory_from_events MODIFY QUERY SELECT 1 AS a, 2 \
+         AS b",
+        // MODIFY COLUMN width: the metadata forms, and only those. Each names
+        // a different [`MODIFY_COLUMN_METADATA_KEYWORDS`] entry; removing one
+        // turns its row red, and removing the positional check turns the
+        // type-declaring rows of the positive corpus green.
+        "ALTER TABLE moraine.events MODIFY COLUMN payload_json COMMENT 'the payload'",
+        "ALTER TABLE moraine.events MODIFY COLUMN payload_json CODEC(ZSTD(3))",
+        "ALTER TABLE moraine.events MODIFY COLUMN payload_json REMOVE TTL",
+        "ALTER TABLE moraine.events MODIFY COLUMN payload_json DEFAULT ''",
+        "ALTER TABLE moraine.events MODIFY COLUMN payload_json MATERIALIZED toString(1)",
+        "ALTER TABLE moraine.events MODIFY COLUMN payload_json FIRST",
+        "ALTER TABLE moraine.events MODIFY COLUMN payload_json MODIFY SETTING \
+         max_compress_block_size = 1",
+        "ALTER TABLE moraine.events MODIFY COLUMN payload_json RESET SETTING \
+         max_compress_block_size",
+        "ALTER TABLE moraine.events MODIFY COLUMN IF EXISTS payload_json COMMENT 'x'",
+        // The phantom-operation case. Under the whole-body verb scan this
+        // reduced to `ADD COLUMN` **and** a manufactured `COMMENT 'DROP`, and
+        // was rejected. One clause, one operation.
+        "ALTER TABLE moraine.events ADD COLUMN note String DEFAULT 'x' COMMENT 'drop this'",
+        // A comma inside a literal is content, not a clause separator. Without
+        // [`mask_quoted`] this splits into `ADD COLUMN x String COMMENT 'a` and
+        // `DROP COLUMN payload_json'`, and the second half is a false finding
+        // on bucket 1.
+        "ALTER TABLE moraine.events ADD COLUMN x String COMMENT 'a, DROP COLUMN payload_json'",
+        // CLEAR width: only columns hold row content. Adding `"CLEAR COLUMN"`
+        // to BENIGN_ALTER_OPERATIONS turns the positive corpus's two
+        // `CLEAR COLUMN` rows red; these two must stay benign regardless.
+        "ALTER TABLE moraine.events CLEAR INDEX idx_x IN PARTITION '202601'",
+        "ALTER TABLE moraine.events CLEAR PROJECTION p_x",
+        // MOVE width: the destination is the extent. Tiering keeps every row
+        // in the table it names; `TO TABLE` does not.
+        "ALTER TABLE moraine.events MOVE PARTITION '202601' TO DISK 'cold'",
+        "ALTER TABLE moraine.events MOVE PART '202601_1_1_0' TO VOLUME 'slow'",
+        // DROP width: sql/025:2's constraint drop, plus the two other
+        // metadata-only DROP clauses. Removing any of `DROP CONSTRAINT`,
+        // `DROP INDEX` or `DROP PROJECTION` from BENIGN_ALTER_OPERATIONS turns
+        // one of these red. The constraint row named `moraine.event_links` for
+        // a round, which bounded nothing: running the SAME narrowing with that
+        // row restored to `event_links` is GREEN across the whole suite
+        // (executed 2026-07-27), because `event_links` is `Derived` and the
+        // class filter discards it before the statement is inspected.
+        "ALTER TABLE moraine.events DROP CONSTRAINT IF EXISTS events_ts_domain",
+        "ALTER TABLE moraine.events DROP INDEX idx_x",
+        "ALTER TABLE moraine.events DROP PROJECTION p_x",
+        // Views hold no rows; the tree drops them on nearly every run.
+        "DROP VIEW IF EXISTS moraine.v_live_events",
+        "DROP VIEW IF EXISTS moraine.mv_search_postings",
+    ];
+
+    /// **G-SHAPE, positive side.** Every statement the benign allowlist must
+    /// reject, checked for the finding *and* for the label it is reported
+    /// under.
+    ///
+    /// The shape assertion is not decoration. Since the inversion,
+    /// [`delete_shape`] no longer decides anything: deleting one of its arms
+    /// leaves the finding intact and only degrades the message, so a corpus
+    /// that asserted findings alone would pin nothing about it. Asserting the
+    /// shape restores a lower, an upper and a width bound on every arm.
+    ///
+    /// The `DROP` rows are the S4 hole one reviewer found by bundling each of
+    /// them into a migration and watching the suite stay at 177/0. The
+    /// `MODIFY TTL`, `CLEAR COLUMN`, `MOVE … TO TABLE`, `REPLACE TABLE`,
+    /// `RENAME`/`EXCHANGE` and `TRUNCATE DATABASE` rows are the next reviewer
+    /// doing the same thing to the extended list. The `ALTER … UPDATE`,
+    /// `REPLACE PARTITION`, `OPTIMIZE … FINAL` and `DETACH PARTITION` rows are
+    /// the reviewer after that — the fourth consecutive round to find shapes
+    /// the enumeration could not see, which is why the gate is an allowlist
+    /// now and this corpus only labels what the allowlist already caught.
+    ///
+    /// MUTATION (executed 2026-07-27), each run separately against an isolated
+    /// copy of the tree, each by deleting the named arm from `delete_shape`:
+    ///   * `" MODIFY TTL"` => FAILS on the four TTL rows below.
+    ///   * `" CLEAR COLUMN"` => FAILS on the two `CLEAR COLUMN` rows.
+    ///   * the `MOVE … TO TABLE` arm => FAILS on the two `MOVE` rows.
+    ///   * the `REPLACE TABLE` arm => FAILS on the two `REPLACE TABLE` rows.
+    ///   * the `RENAME`/`EXCHANGE` arm => FAILS on the rename rows.
+    ///   * narrowing `TRUNCATE ` to `TRUNCATE TABLE` => FAILS on
+    ///     `TRUNCATE DATABASE moraine`, which every other `TRUNCATE` row in
+    ///     this corpus carries the `TABLE` keyword for and so could not bound.
+    ///   * `" DROP PART "` => FAILS on the `DROP PART '202601_1_1_0'` row.
+    ///     `" DROP PARTITION"` does not cover it: `DROP PART 'p'` does not
+    ///     contain that substring.
+    ///   * `" UPDATE "` => FAILS on the two `ALTER … UPDATE` rows.
+    ///   * `" DETACH PARTITION"` / `" DETACH PART "` => FAILS on the two
+    ///     `DETACH` rows, each of which bounds one of the pair.
+    ///   * `" REPLACE PARTITION"` / `" REPLACE PART "` => same, on the two
+    ///     `REPLACE PARTITION`/`REPLACE PART` rows.
+    ///   * the `OPTIMIZE` arm => FAILS on the three `OPTIMIZE` rows.
+    ///
+    /// Width, in the narrowing direction:
+    ///   * `" DELETE "` -> `" DELETE WHERE "` => FAILS on
+    ///     `DELETE IN PARTITION '202601' WHERE 1`, real ClickHouse syntax that
+    ///     no other `ALTER … DELETE` row in this corpus spells.
+    ///   * dropping `|| upper.starts_with("RENAME DATABASE")` => FAILS on the
+    ///     `RENAME DATABASE moraine TO moraine_old` row, which reports one
+    ///     relation instead of two once the generic parse takes over.
+    ///   * dropping the `OPTIMIZE … DEDUPLICATE` disjunct => FAILS on the
+    ///     `DEDUPLICATE BY` row, the only one without `FINAL`.
+    ///
+    /// The `MODIFY TTL` arm additionally has an end-to-end demonstration,
+    /// because this corpus is *its own* guard and could be deleted alongside
+    /// it. Appending `sql/039`'s three TTL statements retargeted at
+    /// `moraine.events` / `moraine.raw_events` /
+    /// `moraine.ingest_checkpoint_transitions` to
+    /// `sql/003_ingest_heartbeats.sql` and running
+    /// `no_bundled_migration_removes_protected_rows` **alone**:
+    ///   * with the arm present => FAILS, three findings (executed 2026-07-27).
+    ///   * with the arm deleted, **before the inversion** => PASSES: the S4
+    ///     invariant reported zero findings for a migration that puts a
+    ///     `DELETE`-defaulting TTL on canonical history. That is the state this
+    ///     branch shipped in for a round.
+    ///   * with the arm deleted, **after the inversion** => still FAILS, three
+    ///     findings, now labelled `None` instead of `AlterModifyTtl`. That
+    ///     difference is the inversion.
+    #[test]
+    fn every_row_removing_shape_is_recognized_including_the_ones_the_old_guard_missed() {
+        for (sql, table, shape) in [
+            (
+                "ALTER TABLE moraine.events DELETE WHERE 1",
+                "events",
+                DeleteShape::AlterDelete,
+            ),
+            // Width for `" DELETE "`: narrowing it to `" DELETE WHERE "` — the
+            // only form every other row here spells — misses this one.
+            (
+                "ALTER TABLE moraine.events DELETE IN PARTITION '202601' WHERE 1",
+                "events",
+                DeleteShape::AlterDelete,
+            ),
+            (
+                "DELETE FROM moraine.events WHERE 1",
+                "events",
+                DeleteShape::DeleteFrom,
+            ),
+            (
+                "TRUNCATE TABLE IF EXISTS moraine.events",
+                "events",
+                DeleteShape::Truncate,
+            ),
+            (
+                "TRUNCATE TABLE moraine.events;",
+                "events",
+                DeleteShape::Truncate,
+            ),
+            (
+                "truncate table `moraine`.`events`",
+                "events",
+                DeleteShape::Truncate,
+            ),
+            (
+                "DELETE FROM `moraine`.raw_events WHERE 1",
+                "raw_events",
+                DeleteShape::DeleteFrom,
+            ),
+            (
+                "ALTER TABLE other_db.ingest_checkpoint_transitions DELETE WHERE 1",
+                "ingest_checkpoint_transitions",
+                DeleteShape::AlterDelete,
+            ),
+            // `TRUNCATE DATABASE` takes every table with it and names none of
+            // them. Only the bare `TRUNCATE ` arm sees it.
+            (
+                "TRUNCATE DATABASE moraine",
+                "moraine",
+                DeleteShape::Truncate,
+            ),
+            // The DROP family.
+            (
+                "DROP TABLE IF EXISTS moraine.events",
+                "events",
+                DeleteShape::DropRelation,
+            ),
+            (
+                "DROP TABLE moraine.events",
+                "events",
+                DeleteShape::DropRelation,
+            ),
+            (
+                "drop table `moraine`.`events`;",
+                "events",
+                DeleteShape::DropRelation,
+            ),
+            (
+                "DROP TABLE moraine.published_source_generations",
+                "published_source_generations",
+                DeleteShape::DropRelation,
+            ),
+            (
+                "ALTER TABLE moraine.events DROP PARTITION '202601'",
+                "events",
+                DeleteShape::AlterDrop,
+            ),
+            (
+                "ALTER TABLE moraine.events DROP PART '202601_1_1_0'",
+                "events",
+                DeleteShape::AlterDrop,
+            ),
+            (
+                "ALTER TABLE moraine.events DROP COLUMN payload_json",
+                "events",
+                DeleteShape::AlterDrop,
+            ),
+            (
+                "ALTER TABLE moraine.raw_events DROP DETACHED PARTITION '202601'",
+                "raw_events",
+                DeleteShape::AlterDrop,
+            ),
+            (
+                "DROP DATABASE IF EXISTS moraine",
+                "moraine",
+                DeleteShape::DropRelation,
+            ),
+            // DETACH is step ONE of the two-step delete whose step two
+            // (`DROP DETACHED`) the row above covers.
+            (
+                "ALTER TABLE moraine.events DETACH PARTITION '202601'",
+                "events",
+                DeleteShape::AlterDetach,
+            ),
+            (
+                "ALTER TABLE moraine.raw_events DETACH PART '202601_1_1_0'",
+                "raw_events",
+                DeleteShape::AlterDetach,
+            ),
+            // The TTL family. A TTL expression with no action clause defaults
+            // to DELETE, so the second row is a canonical-history deletion
+            // written without the word.
+            (
+                "ALTER TABLE moraine.events MODIFY TTL retention_anchor + INTERVAL 30 DAY DELETE",
+                "events",
+                DeleteShape::AlterModifyTtl,
+            ),
+            (
+                "ALTER TABLE moraine.events MODIFY TTL ts + INTERVAL 30 DAY",
+                "events",
+                DeleteShape::AlterModifyTtl,
+            ),
+            (
+                "ALTER TABLE moraine.raw_events MODIFY TTL ingested_at + INTERVAL 7 DAY DELETE",
+                "raw_events",
+                DeleteShape::AlterModifyTtl,
+            ),
+            (
+                "ALTER TABLE moraine.ingest_checkpoint_transitions MODIFY TTL created_at + \
+                 INTERVAL 30 DAY",
+                "ingest_checkpoint_transitions",
+                DeleteShape::AlterModifyTtl,
+            ),
+            // CLEAR COLUMN keeps the rows and destroys their content.
+            (
+                "ALTER TABLE moraine.events CLEAR COLUMN payload_json",
+                "events",
+                DeleteShape::AlterClear,
+            ),
+            (
+                "ALTER TABLE moraine.events CLEAR COLUMN payload_json IN PARTITION '202601'",
+                "events",
+                DeleteShape::AlterClear,
+            ),
+            // UPDATE does the same thing with an arbitrary expression, and is
+            // the form four consecutive rounds of shape enumeration missed.
+            (
+                "ALTER TABLE moraine.events UPDATE payload_json = '' WHERE 1",
+                "events",
+                DeleteShape::AlterUpdate,
+            ),
+            (
+                "ALTER TABLE moraine.raw_events UPDATE raw_json = '' WHERE ts < now()",
+                "raw_events",
+                DeleteShape::AlterUpdate,
+            ),
+            // MOVE … TO TABLE removes the parts from the source.
+            (
+                "ALTER TABLE moraine.events MOVE PARTITION '202601' TO TABLE moraine.trash",
+                "events",
+                DeleteShape::AlterMove,
+            ),
+            (
+                "ALTER TABLE moraine.events MOVE PART '202601_1_1_0' TO SHARD \
+                 '/clickhouse/tables/x'",
+                "events",
+                DeleteShape::AlterMove,
+            ),
+            // The laundering destination, in the *same* clause this time. This
+            // is the row that makes [`mask_quoted`] load-bearing: without it
+            // the tiering test finds ` TO DISK` inside the partition literal
+            // and admits a move off canonical history.
+            (
+                "ALTER TABLE moraine.events MOVE PARTITION 'x TO DISK y' TO TABLE \
+                 moraine.mcp_open_turns",
+                "events",
+                DeleteShape::AlterMove,
+            ),
+            // REPLACE PARTITION discards the DESTINATION's partition, and the
+            // destination is the table the statement names first.
+            (
+                "ALTER TABLE moraine.events REPLACE PARTITION '202601' FROM moraine.scratch",
+                "events",
+                DeleteShape::AlterReplacePartition,
+            ),
+            // CREATE OR REPLACE swaps a populated table for an empty one.
+            (
+                "CREATE OR REPLACE TABLE moraine.events (a String) ENGINE = MergeTree ORDER BY a",
+                "events",
+                DeleteShape::ReplaceRelation,
+            ),
+            (
+                "REPLACE TABLE moraine.events (a String) ENGINE = MergeTree ORDER BY a",
+                "events",
+                DeleteShape::ReplaceRelation,
+            ),
+            // `events` is a ReplacingMergeTree: FINAL applies the collapse now
+            // rather than at some future merge, and DEDUPLICATE BY collapses on
+            // an arbitrary column subset. `reclaim.rs` has treated
+            // `OPTIMIZE … FINAL` as a write since the round that added it.
+            (
+                "OPTIMIZE TABLE moraine.events FINAL",
+                "events",
+                DeleteShape::OptimizeFinal,
+            ),
+            (
+                "OPTIMIZE TABLE moraine.events FINAL DEDUPLICATE BY event_uid",
+                "events",
+                DeleteShape::OptimizeFinal,
+            ),
+            (
+                "OPTIMIZE TABLE moraine.events DEDUPLICATE",
+                "events",
+                DeleteShape::OptimizeFinal,
+            ),
+            // A1: the accumulator is never-delete, so a migration truncating
+            // it outside the 010 exemption is a finding.
+            (
+                "TRUNCATE TABLE moraine.search_conversation_terms",
+                "search_conversation_terms",
+                DeleteShape::Truncate,
+            ),
+            // A column TTL replaces expired values with the column default and
+            // removes the column from a part once every value in it has
+            // expired: `CLEAR COLUMN` on a rolling horizon, and
+            // `MATERIALIZE TTL` — itself benign — forces it immediately.
+            (
+                "ALTER TABLE moraine.events MODIFY COLUMN payload_json String TTL ingested_at + \
+                 INTERVAL 1 DAY",
+                "events",
+                DeleteShape::AlterModifyTtl,
+            ),
+            // …the zero horizon, which expires every value at once…
+            (
+                "ALTER TABLE moraine.events MODIFY COLUMN payload_json String TTL ingested_at + \
+                 INTERVAL 0 SECOND",
+                "events",
+                DeleteShape::AlterModifyTtl,
+            ),
+            // …and the `ON CLUSTER` spelling, which the clause parser has to
+            // skip past before it can see any clause at all. (The type is not
+            // optional here: `EXPLAIN AST` rejects `MODIFY COLUMN <c> TTL …`
+            // without one, which is why every row of this family carries it.)
+            (
+                "ALTER TABLE moraine.events ON CLUSTER 'c' MODIFY COLUMN payload_json String TTL \
+                 ingested_at + INTERVAL 1 DAY",
+                "events",
+                DeleteShape::AlterModifyTtl,
+            ),
+            // Converting a stored column to one that is not stored is
+            // `DROP COLUMN` under another name.
+            (
+                "ALTER TABLE moraine.events MODIFY COLUMN payload_json ALIAS other_col",
+                "events",
+                DeleteShape::AlterRewriteColumn,
+            ),
+            (
+                "ALTER TABLE moraine.events MODIFY COLUMN payload_json EPHEMERAL ''",
+                "events",
+                DeleteShape::AlterRewriteColumn,
+            ),
+            (
+                "ALTER TABLE moraine.events MODIFY COLUMN payload_json PRIMARY KEY",
+                "events",
+                DeleteShape::AlterRewriteColumn,
+            ),
+            (
+                "ALTER TABLE moraine.raw_events MODIFY COLUMN raw_json String TTL ingested_at + \
+                 INTERVAL 1 DAY",
+                "raw_events",
+                DeleteShape::AlterModifyTtl,
+            ),
+            // MATERIALIZE COLUMN recomputes a column from its DEFAULT across
+            // every part. sql/037 documents this exact hazard against
+            // `text_digest`; `events` ships two `DEFAULT ''` columns today.
+            (
+                "ALTER TABLE moraine.events MATERIALIZE COLUMN payload_type",
+                "events",
+                DeleteShape::AlterRewriteColumn,
+            ),
+            // A type re-declaration rewrites every part. This one narrows the
+            // column that `PARTITION BY toYYYYMM(ingested_at)` is built on.
+            (
+                "ALTER TABLE moraine.events MODIFY COLUMN ingested_at DateTime",
+                "events",
+                DeleteShape::AlterRewriteColumn,
+            ),
+            // The no-op re-declaration is reported too. The gate cannot see the
+            // current type, so it cannot tell this from the row above; the cost
+            // is one allowlist line for sql/032, which really does convert
+            // `source_name` to `LowCardinality(String)` across every part.
+            (
+                "ALTER TABLE moraine.events MODIFY COLUMN payload_json String",
+                "events",
+                DeleteShape::AlterRewriteColumn,
+            ),
+            // `events` is `ReplacingMergeTree(event_version)` with
+            // `payload_json` outside the sort key, so an insert that repeats
+            // the key with a higher version blanks canonical history:
+            // unreachable through FINAL immediately, gone at the next merge.
+            (
+                "INSERT INTO moraine.events SELECT * REPLACE ('' AS payload_json, event_version + \
+                 1 AS event_version) FROM moraine.events FINAL",
+                "events",
+                DeleteShape::InsertInto,
+            ),
+            (
+                "INSERT INTO moraine.events SELECT * FROM moraine.raw_events",
+                "events",
+                DeleteShape::InsertInto,
+            ),
+            // Clause priority, both halves. A benign clause must not mask a
+            // destructive one's label, and between two destructive clauses the
+            // more destructive wins regardless of the order they are written
+            // in — which is what [`ALTER_SHAPE_PRIORITY`] is for.
+            (
+                "ALTER TABLE moraine.events ADD COLUMN x String, DROP COLUMN payload_json",
+                "events",
+                DeleteShape::AlterDrop,
+            ),
+            (
+                "ALTER TABLE moraine.events UPDATE payload_json = '' WHERE 1, DELETE WHERE 1",
+                "events",
+                DeleteShape::AlterDelete,
+            ),
+            // The same overwrite installed as standing state, and the finding
+            // is filed against the `TO` target rather than the phantom
+            // `MATERIALIZED` the leading-keyword skip would have produced.
+            (
+                "CREATE MATERIALIZED VIEW IF NOT EXISTS moraine.mv_events TO moraine.events AS \
+                 SELECT * FROM moraine.raw_events",
+                "events",
+                DeleteShape::MaterializedViewInto,
+            ),
+        ] {
+            assert!(
+                benign_shape(&normalize_statement(sql)).is_none(),
+                "`{sql}` must not be admitted by the benign allowlist"
+            );
+            let findings = migration_delete_findings("999", sql);
+            assert_eq!(
+                findings.len(),
+                1,
+                "`{sql}` must be recognized as a protected removal"
+            );
+            assert_eq!(findings[0].table, table);
+            assert_eq!(
+                findings[0].shape,
+                Some(shape),
+                "`{sql}` must be reported as {shape:?}"
+            );
+        }
+
+        // RENAME/EXCHANGE name two relations and the displaced one may be
+        // either operand, so both are reported and the finding count is not 1.
+        for (sql, expected) in [
+            (
+                "RENAME TABLE moraine.events TO moraine.attic_events",
+                vec!["events", "attic_events"],
+            ),
+            (
+                "RENAME TABLE moraine.mcp_open_turns TO moraine.events",
+                vec!["events"],
+            ),
+            // Width for the `ON CLUSTER` break: without it, `'c'` is parsed as
+            // a third relation, unclassified, and reported.
+            (
+                "RENAME TABLE moraine.events TO moraine.attic_events ON CLUSTER 'c'",
+                vec!["events", "attic_events"],
+            ),
+            // Width for the `RENAME DATABASE` disjunct: dropping it leaves the
+            // statement a finding (the head is not benign) but the generic
+            // one-relation parse reports `moraine` alone.
+            (
+                "RENAME DATABASE moraine TO moraine_old",
+                vec!["moraine", "moraine_old"],
+            ),
+            (
+                "EXCHANGE TABLES moraine.events AND moraine.mcp_open_turns",
+                vec!["events"],
+            ),
+        ] {
+            let reported: Vec<String> = migration_delete_findings("999", sql)
+                .into_iter()
+                .map(|finding| finding.table)
+                .collect();
+            assert_eq!(
+                reported, expected,
+                "`{sql}` must report every protected relation it displaces"
+            );
+        }
+
+        // Bounded in the other direction: the benign corpus must be admitted,
+        // or the gate would forbid an ordinary schema edit and be turned off.
+        for sql in BENIGN_CORPUS {
+            let normalized = normalize_statement(sql);
+            assert!(
+                benign_shape(&normalized).is_some(),
+                "`{sql}` must be admitted by the benign allowlist"
+            );
+            assert!(
+                migration_delete_findings("999", sql).is_empty(),
+                "`{sql}` must not be reported as a protected removal"
+            );
+        }
+
+        // The declared-view `DROP TABLE`s are the one benign case the head list
+        // cannot express, because it is the *name* and not the shape that makes
+        // them safe. sql/004:213 and sql/006:4 — objects migration 032 replaced
+        // with plain `CREATE VIEW`s, declared in SCHEMA_VIEW_OBJECTS.
+        for sql in [
+            "DROP TABLE IF EXISTS moraine.search_term_stats",
+            "DROP TABLE IF EXISTS moraine.search_corpus_stats",
+        ] {
+            assert!(benign_shape(&normalize_statement(sql)).is_none());
+            assert!(
+                migration_delete_findings("999", sql).is_empty(),
+                "`{sql}` names a declared view and must not be a finding"
+            );
+        }
+
+        // A tiering move is not a removal shape *either*, and the label layer
+        // has to say so independently of the gate. Without this, widening
+        // `AlterMove` to every `MOVE` — dropping the destination test — is
+        // invisible: the two rows above are already benign, so nothing asks
+        // `delete_shape` about them.
+        for sql in [
+            "ALTER TABLE moraine.events MOVE PARTITION '202601' TO DISK 'cold'",
+            "ALTER TABLE moraine.events MOVE PART '202601_1_1_0' TO VOLUME 'slow'",
+        ] {
+            assert_eq!(
+                delete_shape(&normalize_statement(sql)),
+                None,
+                "`{sql}` moves bytes between tiers and removes nothing"
+            );
+        }
+
+        // Width: an undeclared name dropped with DROP TABLE is still a
+        // finding, because S1 says unknown is not deletable. Removing the
+        // SCHEMA_VIEW_OBJECTS exemption test above without removing this one
+        // would be a contradiction, which is the point.
+        let findings = migration_delete_findings("999", "DROP TABLE moraine.mv_not_declared");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].class, TableClass::NeverDelete);
+    }
+
+    /// **G-BENIGN, fail-closed.** The gate's whole promise: a statement nobody
+    /// anticipated is a finding, not a pass.
+    ///
+    /// None of these has a [`DeleteShape`]. Before the inversion every one of
+    /// them was silently benign; each was found by an adversarial sweep in the
+    /// round after the one that "completed" the destructive list.
+    ///
+    /// MUTATION (executed 2026-07-27): add `"ALTER TABLE"` unconditionally to
+    /// the benign heads (i.e. make `alter_is_benign` return `true`) => FAILS
+    /// here on the first four rows. MUTATION: make `alter_is_benign` return
+    /// `true` for an empty operation list => FAILS on the truncated-`ALTER`
+    /// row, which is the parse-failure case.
+    #[test]
+    fn a_statement_nobody_anticipated_is_a_finding_rather_than_a_pass() {
+        for sql in [
+            // Real ClickHouse, destructive, and named by no DeleteShape arm.
+            "ALTER TABLE moraine.events APPLY DELETED MASK",
+            "ALTER TABLE moraine.events FREEZE PARTITION '202601'",
+            "ALTER TABLE moraine.events ATTACH PARTITION '202601' FROM moraine.scratch",
+            // A benign operation bundled with a destructive one. `ALTER`
+            // accepts comma-separated operations; only checking the first would
+            // pass this.
+            "ALTER TABLE moraine.events ADD COLUMN x String, DROP COLUMN payload_json",
+            // The laundering case. The `MOVE` clause's tiering test used to
+            // search the whole statement, so the substring in the unrelated
+            // literal admitted a `MOVE … TO TABLE` off canonical history.
+            "ALTER TABLE moraine.events ADD COLUMN c String DEFAULT 'x TO DISK y', MOVE \
+             PARTITION '202601' TO TABLE moraine.mcp_open_turns",
+            // `MODIFY QUERY` is scoped to declared views; `moraine.events` is
+            // not one.
+            "ALTER TABLE moraine.events MODIFY QUERY SELECT 1",
+            // An `ALTER` whose operation clause did not parse. This is the row
+            // that pins `alter_is_benign`'s empty-clause guard: without it,
+            // "no operation found" reads as "no destructive operation found".
+            "ALTER TABLE moraine.events",
+            // A `MODIFY COLUMN` whose tail did not parse — `EXPLAIN AST`
+            // rejects this, which is exactly why the gate must not read it as
+            // "no property, therefore no dangerous property". It pins
+            // `modify_column_is_metadata_only`'s empty-tail arm.
+            "ALTER TABLE moraine.events MODIFY COLUMN payload_json",
+        ] {
+            let normalized = normalize_statement(sql);
+            assert!(
+                benign_shape(&normalized).is_none(),
+                "`{sql}` must not be admitted by the benign allowlist"
+            );
+            let findings = migration_delete_findings("999", sql);
+            assert!(
+                findings.iter().any(|finding| finding.table == "events"),
+                "`{sql}` must be a finding on `events`: {findings:#?}"
+            );
+        }
+
+        // Not ClickHouse at all — the case where the parser is what failed. The
+        // relation name is junk, so the finding is on an unclassified name;
+        // unknown is not deletable, so it is a finding all the same.
+        let findings = migration_delete_findings("999", "SOME NEW STATEMENT KIND moraine.events");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].class, TableClass::NeverDelete);
+
+        // A statement whose relation cannot be parsed at all is reported under
+        // UNPARSED_RELATION rather than dropped.
+        let findings = migration_delete_findings("999", "ALTER TABLE");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].table, UNPARSED_RELATION);
+        assert_eq!(findings[0].class, TableClass::NeverDelete);
+    }
+
+    /// **G-SHAPE, class-filter side.** The one row whose purpose is the class
+    /// filter rather than the shape, asserted in *both* halves so it is not
+    /// vacuous.
+    ///
+    /// `TRUNCATE TABLE moraine.mcp_open_turns` sat in the negative corpus
+    /// above for a round, where it bounded nothing: `mcp_open_turns` is
+    /// `Derived`, so `migration_delete_findings` discards it on class before
+    /// `delete_shape` is consulted, which makes
+    /// `migration_delete_findings(..).is_empty()` true for that row under
+    /// *every* possible shape list — including an empty one. Asserting that
+    /// the shape IS seen and that the class is what suppresses it makes the
+    /// same statement carry the claim it was always meant to.
+    ///
+    /// MUTATION (executed 2026-07-27): delete the `Truncate` arm from
+    /// `delete_shape` => FAILS here on the `row_removals` half.
+    /// **Non-vacuity.** (The arm has plenty of other coverage — that run also
+    /// took down seven further tests, including migrations 034/035 and the 010
+    /// allowlist entry — so this row is about the *negative* claim, not about
+    /// whether `TRUNCATE` is recognized at all.)
+    ///
+    /// MUTATION (executed 2026-07-27): make `TableClass::Derived` protected =>
+    /// FAILS here on the `delete_findings` half. **Upper bound: 034/035 reset
+    /// six `mcp_open_*` relations on every run and must stay legal.**
+    #[test]
+    fn a_derived_truncate_is_seen_as_a_removal_and_suppressed_only_by_its_class() {
+        let sql = "TRUNCATE TABLE moraine.mcp_open_turns";
+        let removals = migration_row_removals("999", sql);
+        assert_eq!(removals.len(), 1, "the shape must be recognized: {sql}");
+        assert_eq!(removals[0].table, "mcp_open_turns");
+        assert_eq!(removals[0].class, TableClass::Derived);
+        assert!(
+            migration_delete_findings("999", sql).is_empty(),
+            "and suppressed by `is_protected()`, not by the parser"
+        );
+    }
+
+    /// **G-SHAPE, exemption width.** The `SCHEMA_VIEW_OBJECTS` exemption is
+    /// scoped to `DropRelation` and must stay scoped to it.
+    ///
+    /// MUTATION (executed 2026-07-27): widen the exemption in
+    /// `migration_row_removals` from
+    /// `shape == DeleteShape::DropRelation && views.contains(…)` to
+    /// `views.contains(…)` => FAILS here. Nothing else in the suite noticed,
+    /// because the only declared-view rows in the corpus were `DROP TABLE`s.
+    #[test]
+    fn truncating_a_declared_view_name_is_still_a_finding() {
+        let findings = migration_delete_findings("999", "TRUNCATE TABLE moraine.search_term_stats");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].table, "search_term_stats");
+        // Unclassified: S1 says unknown is not deletable.
+        assert_eq!(findings[0].class, TableClass::NeverDelete);
+        // And the exemption really is live for the shape it is scoped to.
+        assert!(
+            migration_delete_findings("999", "DROP TABLE moraine.search_term_stats").is_empty()
+        );
+    }
+
+    /// **G-CLAUSE.** An `ALTER` clause is judged on its own text, in both
+    /// directions.
+    ///
+    /// This is the round-4 root cause. `alter_operations` was not a clause
+    /// parser: it matched any bare token from a verb list anywhere in the
+    /// body, which produced phantom operations out of column comments *and*
+    /// let a `MOVE` clause launder its destination through a substring in an
+    /// unrelated literal.
+    ///
+    /// MUTATION (executed 2026-07-27), each run separately against an isolated
+    /// copy:
+    ///   * make `clause_is_benign`'s `MOVE` arm search the whole statement
+    ///     instead of the clause => FAILS on the laundering row.
+    ///   * delete the `mask_quoted` call in `benign_shape` => FAILS on the
+    ///     laundering row.
+    ///   * replace `alter_clauses` with the old whole-body verb scan => FAILS
+    ///     on the phantom rows.
+    ///   * drop the `ON CLUSTER` skip in `alter_clauses` => FAILS on the
+    ///     `ON CLUSTER` row, whose first clause head becomes `ON`.
+    ///   * drop the paren-depth tracking => FAILS on the `ADD PROJECTION` row,
+    ///     whose `(SELECT a, b …)` splits into two clauses.
+    #[test]
+    fn an_alter_clause_is_judged_on_its_own_text() {
+        // Admitted: one clause, one operation. Each of these was a finding
+        // under the whole-body verb scan, filed against a phantom operation
+        // manufactured from an inline column property.
+        for sql in [
+            "ALTER TABLE moraine.events MODIFY COLUMN payload_json COMMENT 'the payload'",
+            "ALTER TABLE moraine.events ADD COLUMN note String DEFAULT 'x' COMMENT 'drop this'",
+            "ALTER TABLE moraine.events ADD PROJECTION p_x (SELECT a, b ORDER BY ts)",
+            "ALTER TABLE moraine.events ON CLUSTER 'c' ADD COLUMN x String",
+        ] {
+            assert!(
+                benign_shape(&normalize_statement(sql)).is_some(),
+                "`{sql}` is one benign clause"
+            );
+        }
+
+        // Rejected: the destination of a `MOVE` clause is read from that
+        // clause. The single-clause control is the width bound — it was
+        // already red, so only the *scope* of the test was defeated.
+        for sql in [
+            "ALTER TABLE moraine.events ADD COLUMN c String DEFAULT 'x TO DISK y', MOVE \
+             PARTITION '202601' TO TABLE moraine.mcp_open_turns",
+            "ALTER TABLE moraine.events MOVE PARTITION '202601' TO TABLE moraine.mcp_open_turns",
+        ] {
+            let findings = migration_delete_findings("999", sql);
+            assert_eq!(findings.len(), 1, "`{sql}` moves a partition off `events`");
+            assert_eq!(findings[0].table, "events");
+            assert_eq!(findings[0].shape, Some(DeleteShape::AlterMove));
+        }
+
+        // And the tiering forms stay benign, clause-locally.
+        assert!(benign_shape(&normalize_statement(
+            "ALTER TABLE moraine.events ADD COLUMN c String, MOVE PARTITION '202601' TO DISK \
+             'cold'"
+        ))
+        .is_some());
+    }
+
+    /// **G-CLAUSE, fail direction.** A clause split that does not match
+    /// ClickHouse's own grammar fails **closed**.
+    ///
+    /// `UPDATE a = 1, b = 2 WHERE 1` is one ClickHouse operation whose
+    /// arguments contain a top-level comma, so [`alter_clauses`] splits it in
+    /// two. Neither half is benign, which is the direction a parser
+    /// disagreement has to fail in. Same for `MODIFY TTL e1, e2`.
+    ///
+    /// MUTATION (executed 2026-07-28): make `clause_operation` return the
+    /// first token only, so `B =` reduces to `B` => still RED here, but
+    /// `alter_is_benign`'s `all()` is what carries it; make `alter_is_benign`
+    /// use `any()` instead of `all()` => FAILS here.
+    ///
+    /// Rows three and four are the **width bound on
+    /// [`merge_clause_continuations`]**: a settings continuation is
+    /// `<ident> = <value>` or a single bare `<ident>`, and nothing longer, so a
+    /// destructive clause parked after a settings list is not absorbed into it.
+    /// (ClickHouse rejects both statements outright — executed, 25.12.5.44 —
+    /// but the parser must not depend on the server to refuse them.)
+    ///
+    /// MUTATION (executed 2026-07-28): relax [`is_setting_assignment`] from
+    /// `tokens.len() == 3` to `tokens.len() >= 3` => FAILS on row three. Drop
+    /// [`is_setting_name`]'s `tokens.next().is_none()` conjunct => FAILS on row
+    /// four, where `DROP COLUMN payload_json` would otherwise be absorbed into
+    /// a benign `RESET SETTING` and **admitted**. That second one was GREEN
+    /// when the continuation merge first landed.
+    #[test]
+    fn a_mis_split_alter_clause_fails_closed() {
+        for sql in [
+            "ALTER TABLE moraine.events UPDATE a = 1, b = 2 WHERE 1",
+            "ALTER TABLE moraine.events MODIFY TTL ts + INTERVAL 1 DAY, x + INTERVAL 2 DAY",
+            "ALTER TABLE moraine.events MODIFY SETTING index_granularity = 8192, x = 1 DROP \
+             COLUMN payload_json",
+            "ALTER TABLE moraine.events RESET SETTING index_granularity, DROP COLUMN payload_json",
+        ] {
+            let normalized = normalize_statement(sql);
+            assert!(
+                benign_shape(&normalized).is_none(),
+                "`{sql}` must not be admitted"
+            );
+        }
+        // The first two still carry a usable label.
+        assert_eq!(
+            delete_shape(&normalize_statement(
+                "ALTER TABLE moraine.events UPDATE a = 1, b = 2 WHERE 1"
+            )),
+            Some(DeleteShape::AlterUpdate)
+        );
+        assert_eq!(
+            delete_shape(&normalize_statement(
+                "ALTER TABLE moraine.events MODIFY TTL ts + INTERVAL 1 DAY, x + INTERVAL 2 DAY"
+            )),
+            Some(DeleteShape::AlterModifyTtl)
+        );
+    }
+
+    /// **G-DROPWIDTH.** [`DESTRUCTIVE_ALTER_DROP_CLAUSES`] is exactly the four
+    /// `DROP` clauses that remove storage, bounded by calling
+    /// [`alter_clause_shape`] rather than by the corpus.
+    ///
+    /// The constant's doc claimed for a round that each of `DROP INDEX`,
+    /// `DROP CONSTRAINT` and `DROP PROJECTION` "is a named negative-corpus row
+    /// on `moraine.events`, so widening this list by one clause turns a green
+    /// test red". That mechanism cannot work — all three are
+    /// [`BENIGN_ALTER_OPERATIONS`] entries, so [`benign_shape`] admits the
+    /// statement and [`delete_shape`] is never reached, and adding any one of
+    /// them was measured **GREEN** while the corpus was the only bound. Since
+    /// the inversion this list only labels, which is why this test exists and
+    /// calls [`alter_clause_shape`] directly.
+    ///
+    /// MUTATION (executed 2026-07-28), against this test: add `"DROP INDEX"`,
+    /// `"DROP CONSTRAINT"` or `"DROP PROJECTION"` => FAILS on the matching
+    /// non-removal row. Remove `"DROP PART "` => FAILS on the `DROP PART` row,
+    /// which `"DROP PARTITION"` does not cover.
+    #[test]
+    fn the_destructive_drop_clause_list_is_exactly_the_four_that_remove_storage() {
+        for clause in [
+            "DROP PARTITION '202601'",
+            "DROP PART '202601_1_1_0'",
+            "DROP COLUMN PAYLOAD_JSON",
+            "DROP DETACHED PARTITION '202601'",
+        ] {
+            assert_eq!(
+                alter_clause_shape(clause),
+                Some(DeleteShape::AlterDrop),
+                "`{clause}` removes rows or a column's storage"
+            );
+        }
+        // The metadata-only DROPs remove nothing, and must not be labelled — a
+        // gate that calls an ordinary schema edit destructive gets turned off.
+        for clause in [
+            "DROP INDEX IDX_X",
+            "DROP CONSTRAINT IF EXISTS EVENTS_TS_DOMAIN",
+            "DROP PROJECTION P_X",
+            "DROP STATISTICS TS",
+        ] {
+            assert_eq!(
+                alter_clause_shape(clause),
+                None,
+                "`{clause}` changes metadata and must not be reported as a removal"
+            );
+        }
+    }
+
+    /// **G-UNREGISTERED.** The one exemption from the schema handshake stays
+    /// one, and stays that one.
+    ///
+    /// [`UNREGISTERED_PHYSICAL_TABLES`] suppresses a finding, and it was the
+    /// only constant of its family with no width bound: its doc claimed "the
+    /// exhaustiveness test names it explicitly so the exemption cannot silently
+    /// grow", and the only naming was a failure-message string. MUTATION
+    /// (executed 2026-07-28): adding `"events"` left the whole crate GREEN, and
+    /// so did adding `"search_documents"`. Its two siblings were both already
+    /// bounded — [`CLICKHOUSE_SYSTEM_LOGS`] by a length assertion in
+    /// `classification_covers_the_hosts_thirty_two_physical_tables`,
+    /// [`SCHEMA_VIEW_OBJECTS`] by `stale_view_declarations`.
+    #[test]
+    fn the_unregistered_table_exemption_is_exactly_one_table() {
+        assert_eq!(
+            UNREGISTERED_PHYSICAL_TABLES,
+            ["file_attention_project_roots"],
+            "this list excuses a physical table from the schema handshake. Growing it is a \
+             deliberate act; growing it by a table that holds user history is the regression S1 \
+             exists to prevent"
+        );
+        // And the exemption is load-bearing rather than stale: the table really
+        // is classified, and really is absent from the handshake.
+        assert_eq!(
+            classify("file_attention_project_roots"),
+            Some(TableClass::Derived)
+        );
+        assert!(!crate::REQUIRED_SCHEMA_OBJECTS.contains(&"file_attention_project_roots"));
+    }
+
+    /// **G-MODIFYCOLUMN, non-vacuity and width.**
+    /// [`MODIFY_COLUMN_METADATA_KEYWORDS`] had no bound in either direction:
+    /// MUTATION (executed 2026-07-28) adding `"ZAPNONSENSE"`, `"STATISTICS"` or
+    /// `"AUTO_INCREMENT"` was GREEN across the crate. Its two sibling lists are
+    /// bounded by `every_benign_entry_is_witnessed_by_a_real_statement`, which
+    /// does not iterate this third one.
+    ///
+    /// The second half re-measures the doc's own claim. It asserted that
+    /// `COLLATE`, `STATISTICS`, `SETTINGS` and `AUTO_INCREMENT` are all
+    /// rejected by `EXPLAIN AST` in this position, so listing them would be
+    /// dead surface. **Re-measured on 25.12.5.44, 2026-07-28:**
+    /// `STATISTICS(tdigest)` and `AUTO_INCREMENT` are **VALID** there without a
+    /// preceding type; only `COLLATE`, `SETTINGS` and `AFTER` are rejected. So
+    /// for two of the four the surface is live, their absence is an
+    /// over-approximation rather than a no-op, and these rows are what record
+    /// it as a decision.
+    #[test]
+    fn a_modify_column_property_the_parser_accepts_is_reported_not_admitted() {
+        // Non-vacuity: every listed keyword is reached by a corpus row.
+        for keyword in MODIFY_COLUMN_METADATA_KEYWORDS {
+            let reached = BENIGN_CORPUS.iter().any(|sql| {
+                let masked = mask_quoted(&normalize_statement(sql).to_ascii_uppercase());
+                alter_clauses(&masked).iter().any(|clause| {
+                    clause_operation(clause) == "MODIFY COLUMN"
+                        && column_clause_tail(clause).first().is_some_and(|first| {
+                            *first == *keyword || first.starts_with(&format!("{keyword}("))
+                        })
+                })
+            });
+            assert!(
+                reached,
+                "`MODIFY COLUMN … {keyword}` is not witnessed by any BENIGN_CORPUS row; an \
+                 unwitnessed metadata keyword is a hole in the gate, not a convenience"
+            );
+        }
+
+        // Width: the properties the parser accepts in that position and this
+        // list deliberately excludes.
+        for (sql, shape) in [
+            (
+                "ALTER TABLE moraine.events MODIFY COLUMN payload_json STATISTICS(tdigest)",
+                DeleteShape::AlterRewriteColumn,
+            ),
+            (
+                "ALTER TABLE moraine.events MODIFY COLUMN payload_json AUTO_INCREMENT",
+                DeleteShape::AlterRewriteColumn,
+            ),
+            (
+                "ALTER TABLE moraine.events MODIFY COLUMN payload_json PRIMARY KEY",
+                DeleteShape::AlterRewriteColumn,
+            ),
+            (
+                "ALTER TABLE moraine.events MODIFY COLUMN payload_json ALIAS other_col",
+                DeleteShape::AlterRewriteColumn,
+            ),
+            (
+                "ALTER TABLE moraine.events MODIFY COLUMN payload_json EPHEMERAL ''",
+                DeleteShape::AlterRewriteColumn,
+            ),
+        ] {
+            assert!(
+                benign_shape(&normalize_statement(sql)).is_none(),
+                "`{sql}` must not be admitted"
+            );
+            let findings = migration_delete_findings("999", sql);
+            assert_eq!(findings.len(), 1, "`{sql}`");
+            assert_eq!(findings[0].shape, Some(shape), "`{sql}`");
+        }
+    }
+
+    /// **G-LEXER.** Every comment and quote syntax ClickHouse 25.12.5.44
+    /// accepts, and the two the lexer did not know until round 6.
+    ///
+    /// Both were full bypasses, and both worked by opening a span the server
+    /// never opens so that [`mask_quoted`] would swallow a clause separator:
+    ///
+    /// * **`#` line comments.** `SELECT 1 # trailing` is valid (executed). The
+    ///   stripper knew `--` and `/* … */` only, so a `"` parked in a `#`
+    ///   comment opened a quoted identifier, and everything after it — comma
+    ///   included — was masked. `ALTER TABLE moraine.events ADD COLUMN c
+    ///   String # a " b⏎, DROP COLUMN payload_json` reduced to one benign
+    ///   `ADD COLUMN`. `EXPLAIN AST` reports both `ADD_COLUMN` and
+    ///   `DROP_COLUMN payload_json`; executed in `clickhouse local` it takes
+    ///   the column list from `['uid','payload_json']` to `['uid','c']`.
+    /// * **`$$…$$` / `$tag$…$tag$` heredocs.** `SELECT $tag$a'b$tag$` returns
+    ///   `a'b` (executed). One of these is a *distinct* mechanism from the
+    ///   quote-opening one: `COMMENT $$($$, DROP COLUMN payload_json` needs no
+    ///   quote at all — the unmasked `(` drove [`alter_clauses`]' paren depth
+    ///   to 1 so the top-level comma never split.
+    ///
+    /// MUTATION (executed 2026-07-28), each against an isolated copy:
+    ///   * delete the `#` arm from [`scan_statement`] => FAILS on the `#` rows.
+    ///   * delete the heredoc arm => FAILS on the `$tag$` quote-opening row.
+    ///     The `$$($$` row stays RED without it, because the unbalanced-paren
+    ///     guard catches that one independently — which is the point of having
+    ///     both.
+    ///   * delete the `unbalanced || depth != 0` guard from [`alter_clauses`]
+    ///     => FAILS on the unbalanced row below. With the heredoc arm *also*
+    ///     deleted it additionally fails on `$$($$`.
+    #[test]
+    fn the_lexer_knows_every_clickhouse_comment_and_quote_syntax() {
+        // Each of these is `EXPLAIN AST`-valid on 25.12.5.44 and carries a
+        // `DROP COLUMN` the gate has to see.
+        for sql in [
+            // `#` comment holding an unbalanced double quote, mid-statement.
+            "ALTER TABLE moraine.events ADD COLUMN c String # a \" b\n, DROP COLUMN payload_json",
+            // …a single quote, and a backtick.
+            "ALTER TABLE moraine.events ADD COLUMN c String # it's\n, DROP COLUMN payload_json",
+            "ALTER TABLE moraine.events ADD COLUMN c String # a ` b\n, DROP COLUMN payload_json",
+            // The `#!` spelling, which ClickHouse also accepts.
+            "ALTER TABLE moraine.events ADD COLUMN c String #!x '\n, DROP COLUMN payload_json",
+            // Heredoc holding a quote…
+            "ALTER TABLE moraine.events ADD COLUMN c String COMMENT $tag$a'b$tag$, DROP COLUMN \
+             payload_json",
+            // …and the paren-depth mechanism, which needs no quote.
+            "ALTER TABLE moraine.events ADD COLUMN c String COMMENT $$($$, DROP COLUMN \
+             payload_json",
+        ] {
+            let normalized = normalize_statement(sql);
+            assert!(
+                benign_shape(&normalized).is_none(),
+                "`{sql}` must not be admitted; it drops a column of canonical history"
+            );
+            let findings = migration_delete_findings("999", sql);
+            assert_eq!(findings.len(), 1, "`{sql}`");
+            assert_eq!(findings[0].table, "events");
+            assert_eq!(findings[0].shape, Some(DeleteShape::AlterDrop), "`{sql}`");
+        }
+
+        // An `ALTER` body whose parentheses do not balance did not parse, and a
+        // parser that could not finish reading must fail loudly rather than
+        // report the prefix it managed.
+        let unbalanced =
+            "ALTER TABLE moraine.events ADD COLUMN c String COMMENT 'x'), DROP COLUMN payload_json";
+        assert!(alter_clauses(&mask_quoted(&unbalanced.to_ascii_uppercase())).is_empty());
+        assert!(benign_shape(&normalize_statement(unbalanced)).is_none());
+        assert_eq!(migration_delete_findings("999", unbalanced).len(), 1);
+
+        // Bounded in the benign direction: the same syntaxes carrying nothing
+        // destructive stay admitted, or the gate would reject ordinary DDL.
+        for sql in [
+            "ALTER TABLE moraine.events ADD COLUMN c String # a trailing note\n",
+            "ALTER TABLE moraine.events ADD COLUMN c String COMMENT $$a, b$$",
+            "ALTER TABLE moraine.events ADD COLUMN c String COMMENT $x$ DROP COLUMN payload_json \
+             $x$",
+        ] {
+            assert!(
+                benign_shape(&normalize_statement(sql)).is_some(),
+                "`{sql}` must stay admitted"
+            );
+        }
+
+        // And the lexer's own answers, so a rewrite that keeps the tests above
+        // green by accident still has to reproduce these.
+        assert_eq!(
+            normalize_statement("SELECT 1 # a ' \" `\nFROM t"),
+            "SELECT 1 FROM t"
+        );
+        assert_eq!(
+            normalize_statement("SELECT '#notacomment'"),
+            "SELECT '#notacomment'"
+        );
+        // The opening `$$` survives so a masked heredoc is still visibly one;
+        // the body and the closing delimiter become `_`.
+        assert_eq!(mask_quoted("SELECT $$a,b$$"), "SELECT $$_____");
+        // An unterminated `$$` is not a heredoc open: masking to the end of the
+        // statement on one stray delimiter would blank a clause.
+        assert_eq!(mask_quoted("SELECT $$a,b"), "SELECT $$a,b");
+        // [`mask_quoted`] must reach the same answer on unnormalized input,
+        // because it is the function the `#` bypass actually ran through: the
+        // quote inside the comment opened an identifier that ClickHouse never
+        // opens, and everything after it — the comma included — was masked.
+        assert_eq!(
+            alter_clauses(&mask_quoted(
+                &"ALTER TABLE moraine.events ADD COLUMN c String # a \" b\n, DROP COLUMN \
+                  payload_json"
+                    .to_ascii_uppercase()
+            ))
+            .len(),
+            2,
+            "a quote inside a `#` comment must not open a literal that swallows the next clause"
+        );
+    }
+
+    /// **G-NORMALIZE.** A comment is a comment only outside a string literal.
+    ///
+    /// The previous normalizer cut every line at its first `--`
+    /// unconditionally. Combined with clause-head judgement that is a
+    /// laundering channel: the tail of the statement — including a whole
+    /// destructive clause — disappears, and what is left ends mid-literal and
+    /// reads as a benign metadata edit.
+    ///
+    /// MUTATION (executed 2026-07-27): restore the unconditional
+    /// `line.find("--")` cut => FAILS here on the laundering row, which becomes
+    /// `ALTER TABLE moraine.events MODIFY COLUMN c COMMENT 'a` — one benign
+    /// `MODIFY COLUMN` clause — while the statement ClickHouse executes drops
+    /// `payload_json`.
+    ///
+    /// MUTATION: delete the `/* … */` arm => FAILS on the block-comment row.
+    #[test]
+    fn comments_are_stripped_only_outside_a_string_literal() {
+        let laundered = "ALTER TABLE moraine.events MODIFY COLUMN c COMMENT 'a -- b', DROP \
+                         COLUMN payload_json";
+        let normalized = normalize_statement(laundered);
+        assert!(
+            normalized.ends_with("DROP COLUMN payload_json"),
+            "the literal must not swallow the rest of the statement: {normalized}"
+        );
+        let findings = migration_delete_findings("999", laundered);
+        assert_eq!(findings.len(), 1, "{findings:#?}");
+        assert_eq!(findings[0].table, "events");
+        assert_eq!(findings[0].shape, Some(DeleteShape::AlterDrop));
+
+        // A real trailing comment is still stripped…
+        assert_eq!(
+            normalize_statement("ALTER TABLE moraine.events ADD COLUMN x String -- why not"),
+            "ALTER TABLE moraine.events ADD COLUMN x String"
+        );
+        // …in the block spelling too, mid-statement.
+        assert_eq!(
+            normalize_statement("ALTER TABLE moraine.events /* note */ ADD COLUMN x String"),
+            "ALTER TABLE moraine.events ADD COLUMN x String"
+        );
+        // …and a block comment inside a literal is content, not a comment.
+        assert_eq!(
+            normalize_statement("SELECT '/* kept */' FROM moraine.events"),
+            "SELECT '/* kept */' FROM moraine.events"
+        );
+    }
+
+    /// **G-WRITE.** The class of the target is the whole difference between an
+    /// ordinary append and an overwrite of history.
+    ///
+    /// Both heads are benign in form; `benign_shape` consults [`classify`] for
+    /// them, and nothing else in the gate does. That makes the pair below the
+    /// only place the conditional is visible.
+    ///
+    /// MUTATION (executed 2026-07-27): drop the class test from `benign_shape`
+    /// so both heads are unconditionally benign => FAILS here and on the four
+    /// write rows of the positive corpus. MUTATION: invert it (protected
+    /// admitted, unprotected reported) => FAILS here on the derived rows and in
+    /// `no_bundled_migration_removes_protected_rows` with eight findings.
+    #[test]
+    fn a_write_into_a_protected_relation_is_a_finding_and_into_a_derived_one_is_not() {
+        for (sql, table, shape) in [
+            (
+                "INSERT INTO moraine.published_source_generations SELECT * FROM moraine.scratch",
+                "published_source_generations",
+                DeleteShape::InsertInto,
+            ),
+            (
+                "CREATE MATERIALIZED VIEW moraine.mv_x TO moraine.raw_events AS SELECT * FROM \
+                 moraine.events",
+                "raw_events",
+                DeleteShape::MaterializedViewInto,
+            ),
+        ] {
+            let findings = migration_delete_findings("999", sql);
+            assert_eq!(findings.len(), 1, "`{sql}`: {findings:#?}");
+            assert_eq!(findings[0].table, table);
+            assert_eq!(findings[0].shape, Some(shape));
+        }
+
+        // Same two statements, `Derived` targets: admitted. 034/035 rebuild
+        // the projections by insert on every run, and 027/036 install standing
+        // views into them, so this direction is the whole tree.
+        for sql in [
+            "INSERT INTO moraine.mcp_open_turns SELECT * FROM moraine.scratch",
+            "CREATE MATERIALIZED VIEW moraine.mv_x TO moraine.mcp_open_turns AS SELECT * FROM \
+             moraine.events",
+        ] {
+            assert!(
+                benign_shape(&normalize_statement(sql)).is_some(),
+                "`{sql}` writes into a rebuildable relation"
+            );
+            assert!(migration_row_removals("999", sql).is_empty(), "`{sql}`");
+        }
+
+        // An unclassified target is unknown, and unknown is protected.
+        let findings = migration_delete_findings("999", "INSERT INTO moraine.brand_new SELECT 1");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].class, TableClass::NeverDelete);
+    }
+
+    /// **G-RELATION.** A finding is never filed against a SQL keyword.
+    ///
+    /// `CREATE OR REPLACE VIEW moraine.v_live_events AS …` used to be reported
+    /// against a relation literally named `VIEW`: `is_relation_noise` eats `OR`
+    /// and `REPLACE`, the skip lands on `VIEW`, and an unknown name classifies
+    /// as `NeverDelete`. A phantom that reads like a real table is worse than
+    /// no name at all, because the reader goes looking for it.
+    ///
+    /// Fail-closed is preserved — every row below is still a finding, on
+    /// [`UNPARSED_RELATION`].
+    ///
+    /// MUTATION (executed 2026-07-27): delete the [`NEVER_A_RELATION`] check
+    /// => FAILS here with `VIEW`, `MATERIALIZED` and `DICTIONARY` as table
+    /// names.
+    #[test]
+    fn a_finding_is_never_filed_against_a_sql_keyword() {
+        for sql in [
+            // Not a benign head (`CREATE OR REPLACE TABLE` is the destructive
+            // sibling), so the parse really runs.
+            "CREATE OR REPLACE DICTIONARY moraine.d_x (a String) PRIMARY KEY a",
+            "DROP DICTIONARY IF EXISTS moraine.d_x",
+            "ATTACH MATERIALIZED VIEW moraine.mv_x",
+        ] {
+            let findings = migration_delete_findings("999", sql);
+            assert_eq!(findings.len(), 1, "`{sql}`: {findings:#?}");
+            assert_eq!(
+                findings[0].table, UNPARSED_RELATION,
+                "`{sql}` must not name a keyword"
+            );
+            assert_eq!(findings[0].class, TableClass::NeverDelete);
+        }
+
+        // And no keyword this guard covers is the name of a relation anybody
+        // classified, which is what makes the guard safe to apply.
+        for keyword in NEVER_A_RELATION {
+            assert_eq!(
+                classify(&keyword.to_ascii_lowercase()),
+                None,
+                "`{keyword}` is both a keyword and a classified table"
+            );
+        }
+    }
+
+    /// Exactly one relation per statement, except the two-operand ones. A
+    /// statement whose extraction silently returns nothing reports only
+    /// `UNPARSED_RELATION`, which loses the table name from the message.
+    ///
+    /// The unnamed-shape rows are the ones that matter now: since the
+    /// inversion, [`named_relations`] runs for statements [`delete_shape`] has
+    /// never heard of, and it has to find the table anyway.
+    #[test]
+    fn every_shape_but_rename_names_exactly_one_relation() {
+        for (sql, expected, expect_shape) in [
+            ("TRUNCATE TABLE moraine.events", "events", true),
+            ("TRUNCATE DATABASE moraine", "moraine", true),
+            ("DELETE FROM moraine.events WHERE 1", "events", true),
+            ("ALTER TABLE moraine.events DELETE WHERE 1", "events", true),
+            (
+                "ALTER TABLE moraine.events MODIFY TTL ts + INTERVAL 1 DAY",
+                "events",
+                true,
+            ),
+            (
+                "ALTER TABLE moraine.events DROP PARTITION '202601'",
+                "events",
+                true,
+            ),
+            (
+                "ALTER TABLE moraine.events CLEAR COLUMN payload_json",
+                "events",
+                true,
+            ),
+            (
+                "ALTER TABLE moraine.events UPDATE payload_json = '' WHERE 1",
+                "events",
+                true,
+            ),
+            (
+                "ALTER TABLE moraine.events DETACH PARTITION '202601'",
+                "events",
+                true,
+            ),
+            (
+                "ALTER TABLE moraine.events REPLACE PARTITION '202601' FROM moraine.scratch",
+                "events",
+                true,
+            ),
+            (
+                "ALTER TABLE moraine.events MOVE PARTITION '202601' TO TABLE moraine.trash",
+                "events",
+                true,
+            ),
+            (
+                "ALTER TABLE moraine.events MOVE PART '202601_1_1_0' TO SHARD '/ch/x'",
+                "events",
+                true,
+            ),
+            ("DROP TABLE moraine.events", "events", true),
+            (
+                "CREATE OR REPLACE TABLE moraine.events (a String)",
+                "events",
+                true,
+            ),
+            ("REPLACE TABLE moraine.events (a String)", "events", true),
+            ("OPTIMIZE TABLE moraine.events FINAL", "events", true),
+            // No named shape; the generic parse still has to find `events`.
+            (
+                "ALTER TABLE moraine.events FREEZE PARTITION '202601'",
+                "events",
+                false,
+            ),
+            (
+                "ALTER TABLE moraine.events APPLY DELETED MASK",
+                "events",
+                false,
+            ),
+            // Not ClickHouse at all. The parse takes the second token, so the
+            // "relation" is junk — which classifies as `NeverDelete` and is
+            // therefore still a finding. Fail-closed costs a wrong name in the
+            // message; fail-open would cost the finding.
+            ("SOME NEW STATEMENT KIND moraine.events", "NEW", false),
+        ] {
+            let normalized = normalize_statement(sql);
+            let shape = delete_shape(&normalized);
+            assert_eq!(shape.is_some(), expect_shape, "`{sql}` shape: {shape:?}");
+            assert_eq!(
+                named_relations(&normalized, shape),
+                vec![expected.to_string()],
+                "`{sql}` ({shape:?}) must name exactly `{expected}`"
+            );
+        }
+        assert_eq!(
+            named_relations(
+                &normalize_statement("EXCHANGE TABLES moraine.events AND moraine.mcp_open_turns"),
+                Some(DeleteShape::RenameRelation)
+            ),
+            vec!["events".to_string(), "mcp_open_turns".to_string()]
+        );
+    }
+
+    #[test]
+    fn an_unclassified_table_in_a_migration_delete_is_a_finding() {
+        // S1: unknown is not deletable. A migration that truncates a table
+        // nobody classified must fail, not pass by defaulting to derived.
+        let findings = migration_delete_findings("999", "TRUNCATE TABLE moraine.brand_new_table");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].class, TableClass::NeverDelete);
+    }
+
+    /// **G-CLASSIFY, non-vacuity.** Each of the four gap vectors names a gap
+    /// when one is planted in its input.
+    ///
+    /// `classification_and_required_schema_objects_are_mutually_exhaustive`
+    /// asserts all four vectors are empty over the shipped constants. A field
+    /// narrowed to `Vec::new()` satisfies that just as well as a working one —
+    /// and the narrowing silently disarms the *positive* mutation each side
+    /// exists to catch, so the two tests together are the pair.
+    ///
+    /// MUTATION (executed 2026-07-27), each run separately: replace the body of
+    /// `unclassified_schema_objects`, then `classified_but_unregistered`, then
+    /// `stale_view_declarations`, then `unclassified_migration_tables` with
+    /// `Vec::new()` => in **all four** cases this is the ONLY test in the
+    /// crate that fails. That is the measurement: it is the sole guard, so
+    /// before it existed each narrowing was green, and each narrowing disarms
+    /// the mutation the exhaustiveness test's own docstring relies on.
+    ///
+    /// `the_migration_side_of_exhaustiveness_actually_parses_create_table`
+    /// bounds a different thing — that `migration_created_tables` really reads
+    /// `sql/` — and does not survive this narrowing on its own.
+    #[test]
+    fn each_classification_gap_vector_names_a_planted_gap() {
+        let required: BTreeSet<&str> = ["events", "search_term_stats"].into_iter().collect();
+        let views: BTreeSet<&str> = ["search_term_stats"].into_iter().collect();
+        let unregistered: BTreeSet<&str> = BTreeSet::new();
+        let classified: BTreeSet<&str> = ["events"].into_iter().collect();
+
+        // Baseline: these inputs are mutually exhaustive, so nothing is a gap.
+        let clean = classification_gaps_between(&required, &views, &unregistered, &classified, &[]);
+        assert!(clean.is_empty(), "{clean:?}");
+
+        // 1. The schema requires an object nobody classified and nobody
+        //    declared a view.
+        let planted: BTreeSet<&str> = ["events", "search_term_stats", "reclaim_scratch"]
+            .into_iter()
+            .collect();
+        let gaps = classification_gaps_between(&planted, &views, &unregistered, &classified, &[]);
+        assert_eq!(gaps.unclassified_schema_objects, vec!["reclaim_scratch"]);
+        assert!(gaps.classified_but_unregistered.is_empty());
+        assert!(!gaps.is_empty(), "the summary must see field 1");
+
+        // 2. A classified table the handshake does not require and the
+        //    unregistered allowlist does not excuse.
+        let planted: BTreeSet<&str> = ["events", "reclaim_scratch"].into_iter().collect();
+        let gaps = classification_gaps_between(&required, &views, &unregistered, &planted, &[]);
+        assert_eq!(gaps.classified_but_unregistered, vec!["reclaim_scratch"]);
+        assert!(!gaps.is_empty(), "the summary must see field 2");
+        // …and the allowlist is what excuses it, or the field would be noise.
+        let excused: BTreeSet<&str> = ["reclaim_scratch"].into_iter().collect();
+        let gaps = classification_gaps_between(&required, &views, &excused, &planted, &[]);
+        assert!(gaps.classified_but_unregistered.is_empty(), "{gaps:?}");
+
+        // 3. A view declaration the handshake no longer requires.
+        let planted: BTreeSet<&str> = ["search_term_stats", "v_retired"].into_iter().collect();
+        let gaps =
+            classification_gaps_between(&required, &planted, &unregistered, &classified, &[]);
+        assert_eq!(gaps.stale_view_declarations, vec!["v_retired"]);
+        assert!(!gaps.is_empty(), "the summary must see field 3");
+
+        // 4. The migration side, for symmetry with the other three.
+        let gaps = classification_gaps_between(
+            &required,
+            &views,
+            &unregistered,
+            &classified,
+            &["events".to_string(), "reclaim_scratch".to_string()],
+        );
+        assert_eq!(gaps.unclassified_migration_tables, vec!["reclaim_scratch"]);
+        assert!(!gaps.is_empty(), "the summary must see field 4");
+    }
+}

--- a/crates/moraine-clickhouse/src/storage_report.rs
+++ b/crates/moraine-clickhouse/src/storage_report.rs
@@ -1,0 +1,729 @@
+//! Issue #603 WI-02 — storage observability.
+//!
+//! Before this module, nothing anywhere in the repository queried
+//! `system.disks`, `free_space`, or `total_bytes_on_disk`; `TableSummary`
+//! carried `{name, engine, is_temporary, rows}` and the operations probe
+//! selected `sum(rows)` only. The reference host filled its disk twice with no
+//! Moraine-native signal available at any point.
+//!
+//! **Nothing here deletes anything.** It is measurement, and it ships before
+//! the ledger deliberately: a reclaimer whose effect cannot be observed is a
+//! reclaimer whose effect cannot be reviewed.
+//!
+//! ## Why `oldest_retained` comes from `system.parts` and not from the data
+//!
+//! The obvious implementation is `SELECT min(ingested_at) FROM <table>` per
+//! table. That is a column scan per table on every status/health request, and
+//! plan hazard H4 is specifically about unbounded probes for sizing. Measured
+//! on the reference host (2026-07-27), `system.parts.min_time` is already
+//! populated for every table whose partition key is a time expression
+//! (`toYYYYMM(ingested_at)` / `toYYYYMM(ts)`) and holds the epoch sentinel for
+//! every other table. So the entire storage report — bytes, rows, parts, and
+//! the oldest retained timestamp — is **one** `system.parts` aggregate plus
+//! **one** `system.disks` read, and reads no user data at all.
+//!
+//! The cost of that choice is honest and documented: `oldest_retained` is
+//! `None` for tables with no time-typed partition key, rather than wrong.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use moraine_config::{ProtectedRetentionBucket, RetentionConfig, RetentionHorizon};
+use serde::{Deserialize, Serialize};
+
+use crate::storage_class::{classify, TableClass, CLASSIFIED_TABLES};
+use crate::{escape_literal, ClickHouseClient};
+
+/// `min_time` for a part in a table with no time-typed partition key. ClickHouse
+/// reports the Unix epoch rather than NULL, and an epoch timestamp presented as
+/// "oldest retained row" would be a wrong answer dressed as a precise one.
+const EPOCH_SENTINEL_SECONDS: i64 = 0;
+
+/// Per-table physical storage facts, exact at query time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StorageTableReport {
+    pub name: String,
+    /// The §1 bucket, surfaced. `None` only for a table present in the
+    /// database that [`classify`] does not know — which is itself the signal.
+    pub class: Option<TableClass>,
+    pub rows: u64,
+    pub compressed_bytes: u64,
+    pub uncompressed_bytes: u64,
+    pub active_parts: u64,
+    /// Oldest retained row, ISO-8601, for tables with a time-typed partition
+    /// key. `None` for untimed control tables and for hash-partitioned derived
+    /// tables — see the module docs.
+    pub oldest_retained: Option<String>,
+}
+
+/// Fold of [`StorageTableReport`] by ownership class.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StorageBucketReport {
+    pub class: TableClass,
+    /// Human-readable bucket name, so a JSON consumer need not re-derive it.
+    pub label: String,
+    pub tables: u64,
+    pub rows: u64,
+    pub compressed_bytes: u64,
+}
+
+/// Free/total space on the disk backing the ClickHouse data path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StorageDiskReport {
+    pub free_bytes: u64,
+    pub total_bytes: u64,
+}
+
+impl StorageDiskReport {
+    pub fn used_bytes(&self) -> u64 {
+        self.total_bytes.saturating_sub(self.free_bytes)
+    }
+}
+
+/// Where a policy value came from. A `configured` protected-bucket policy is
+/// the only thing in this report that can lead to user data being deleted, so
+/// the provenance is a first-class field rather than a rendering detail.
+pub const POLICY_SOURCE_DEFAULT: &str = "default";
+pub const POLICY_SOURCE_CONFIGURED: &str = "configured";
+
+/// One row of the effective retention policy.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RetentionPolicyEntry {
+    pub class: TableClass,
+    /// Horizon in seconds, or `None` when the class has no horizon at all
+    /// (`never_delete`) or none is configured (buckets 1 and 2 by default).
+    pub horizon_seconds: Option<f64>,
+    /// [`POLICY_SOURCE_DEFAULT`] or [`POLICY_SOURCE_CONFIGURED`].
+    pub source: String,
+    /// The config key an operator would set to change it, when there is one.
+    pub config_key: Option<String>,
+    /// A qualification the number alone would misstate, rendered inline by
+    /// every surface that prints the entry.
+    ///
+    /// Exists for exactly one entry today: bucket 4's horizon is baked into
+    /// `sql/039_telemetry_retention.sql` as static text, so `config_key` names
+    /// a key that cannot move the number. Reporting the key with no note would
+    /// invite an operator to set it and believe the answer.
+    pub note: Option<String>,
+}
+
+impl RetentionPolicyEntry {
+    /// Whether this entry authorizes deleting user history. Exactly the
+    /// condition `moraine status` promotes to a prominent line.
+    pub fn is_destructive(&self) -> bool {
+        self.class.is_protected()
+            && self.class != TableClass::NeverDelete
+            && self.horizon_seconds.is_some()
+    }
+}
+
+/// The WI-02 storage surface: per-table and per-bucket bytes, disk headroom,
+/// and the effective retention policy. Carries no estimates and no reclaim
+/// state — those belong to [`crate::reclaim::ReclaimStatusReport`], which
+/// composes this.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StorageReport {
+    pub tables: Vec<StorageTableReport>,
+    pub buckets: Vec<StorageBucketReport>,
+    pub disk: Option<StorageDiskReport>,
+    pub policy: Vec<RetentionPolicyEntry>,
+    /// Non-fatal degradations (a `system.disks` read that failed, a table in
+    /// the database that carries no class). Present so a partial report is
+    /// distinguishable from a complete one without comparing field counts.
+    pub notes: Vec<String>,
+}
+
+impl StorageReport {
+    pub fn total_compressed_bytes(&self) -> u64 {
+        self.buckets
+            .iter()
+            .map(|bucket| bucket.compressed_bytes)
+            .sum()
+    }
+
+    pub fn bucket(&self, class: TableClass) -> Option<&StorageBucketReport> {
+        self.buckets.iter().find(|bucket| bucket.class == class)
+    }
+
+    /// Policy entries that authorize deleting user history, if any.
+    pub fn destructive_policies(&self) -> Vec<&RetentionPolicyEntry> {
+        self.policy
+            .iter()
+            .filter(|entry| entry.is_destructive())
+            .collect()
+    }
+
+    /// Tables present in the database that [`classify`] does not know. An
+    /// operator-visible restatement of the §4 S1 invariant that the unit test
+    /// enforces at build time.
+    pub fn unclassified_tables(&self) -> Vec<&str> {
+        self.tables
+            .iter()
+            .filter(|table| table.class.is_none())
+            .map(|table| table.name.as_str())
+            .collect()
+    }
+}
+
+/// Provenance of a value that has a serde default, decided by comparing it to
+/// that default.
+///
+/// The two protected buckets are `Option`s, so their provenance is exact:
+/// absent means default. `derived_horizon_hours` and `telemetry_horizon_days`
+/// are not — they carry `#[serde(default = …)]` and land in the struct as
+/// plain values, so nothing downstream can distinguish "unset" from "set to
+/// the default". Reporting both as `default` unconditionally was wrong in a
+/// user-visible way: an operator who had configured either one read `default`
+/// back from `/api/v1/health` and `moraine db doctor`.
+///
+/// The residual imprecision is one-directional and stated rather than hidden:
+/// a config that sets a bucket to exactly the shipped default reads as
+/// `default`. That is the safe direction — the only entries whose provenance
+/// gates behaviour are the two protected ones, and those are exact.
+fn source_of(value: f64, default: f64) -> String {
+    if (value - default).abs() < f64::EPSILON {
+        POLICY_SOURCE_DEFAULT.to_string()
+    } else {
+        POLICY_SOURCE_CONFIGURED.to_string()
+    }
+}
+
+/// The qualification bucket 4's entry carries. See
+/// [`RetentionPolicyEntry::note`].
+pub const TELEMETRY_HORIZON_NOT_CONFIGURABLE_NOTE: &str =
+    "fixed by sql/039_telemetry_retention.sql; this key is not yet operator-configurable and a \
+     config load rejects any other value";
+
+/// Build the config-derived half of the report. Pure, so the rendering and
+/// "is any destructive policy active" logic is testable without a server.
+pub fn retention_policy_entries(retention: &RetentionConfig) -> Vec<RetentionPolicyEntry> {
+    let protected = |bucket: ProtectedRetentionBucket| {
+        let horizon = RetentionHorizon::from_config(retention, bucket);
+        RetentionPolicyEntry {
+            class: match bucket {
+                ProtectedRetentionBucket::RawAudit => TableClass::RawAudit,
+                ProtectedRetentionBucket::CanonicalHistory => TableClass::CanonicalHistory,
+            },
+            horizon_seconds: horizon.map(|horizon| horizon.seconds()),
+            source: if horizon.is_some() {
+                POLICY_SOURCE_CONFIGURED.to_string()
+            } else {
+                POLICY_SOURCE_DEFAULT.to_string()
+            },
+            config_key: Some(bucket.config_key().to_string()),
+            note: None,
+        }
+    };
+    vec![
+        protected(ProtectedRetentionBucket::CanonicalHistory),
+        protected(ProtectedRetentionBucket::RawAudit),
+        RetentionPolicyEntry {
+            class: TableClass::Derived,
+            horizon_seconds: Some(retention.derived_horizon_seconds()),
+            source: source_of(
+                retention.derived_horizon_hours,
+                moraine_config::DEFAULT_RETENTION_DERIVED_HORIZON_HOURS,
+            ),
+            config_key: Some("retention.derived_horizon_hours".to_string()),
+            note: None,
+        },
+        RetentionPolicyEntry {
+            class: TableClass::Telemetry,
+            // Reported from the constant, not from the field. The TTL that
+            // enforces this horizon is `INTERVAL 30 DAY` written four times in
+            // static migration SQL, so the field cannot move it; a
+            // programmatically built `RetentionConfig` that bypasses
+            // `validate_retention` (tests, and any future in-process caller)
+            // must not be able to make this line disagree with what ClickHouse
+            // will do.
+            horizon_seconds: Some(
+                f64::from(moraine_config::DEFAULT_RETENTION_TELEMETRY_HORIZON_DAYS) * 86_400.0,
+            ),
+            // Never `configured`: there is no value of the key that changes
+            // the applied horizon, and `configured` is a claim about effect.
+            source: POLICY_SOURCE_DEFAULT.to_string(),
+            config_key: Some("retention.telemetry_horizon_days".to_string()),
+            note: Some(TELEMETRY_HORIZON_NOT_CONFIGURABLE_NOTE.to_string()),
+        },
+        RetentionPolicyEntry {
+            class: TableClass::NeverDelete,
+            horizon_seconds: None,
+            source: POLICY_SOURCE_DEFAULT.to_string(),
+            config_key: None,
+            note: None,
+        },
+    ]
+}
+
+/// Fold per-table rows into per-bucket totals, in [`TableClass::ALL`] order so
+/// two reports of the same database are byte-comparable.
+pub fn fold_buckets(tables: &[StorageTableReport]) -> Vec<StorageBucketReport> {
+    TableClass::ALL
+        .iter()
+        .map(|class| {
+            let matching = tables
+                .iter()
+                .filter(|table| table.class == Some(*class))
+                .collect::<Vec<_>>();
+            StorageBucketReport {
+                class: *class,
+                label: class.label().to_string(),
+                tables: matching.len() as u64,
+                rows: matching.iter().map(|table| table.rows).sum(),
+                compressed_bytes: matching.iter().map(|table| table.compressed_bytes).sum(),
+            }
+        })
+        .collect()
+}
+
+/// `system.parts` aggregate for one database. Restricted to `active` parts:
+/// without that filter, inactive parts awaiting cleanup keep a table's name
+/// and byte total present long after its rows are gone, which is exactly why
+/// the pre-existing live storage assertion in `source_publication.rs` could
+/// not fail on over-deletion.
+pub(crate) fn storage_parts_sql(database: &str) -> String {
+    format!(
+        "SELECT\n  \
+           table AS name,\n  \
+           toUInt64(sum(rows)) AS rows,\n  \
+           toUInt64(sum(data_compressed_bytes)) AS compressed_bytes,\n  \
+           toUInt64(sum(data_uncompressed_bytes)) AS uncompressed_bytes,\n  \
+           toUInt64(count()) AS active_parts,\n  \
+           toInt64(toUnixTimestamp(min(min_time))) AS oldest_retained_unix,\n  \
+           formatDateTime(min(min_time), '%Y-%m-%dT%H:%i:%SZ', 'UTC') AS oldest_retained_text\n \
+         FROM system.parts\n \
+         WHERE database = {}\n   \
+           AND active\n \
+         GROUP BY table\n \
+         ORDER BY table ASC\n \
+         FORMAT JSONEachRow",
+        escape_literal(database)
+    )
+}
+
+/// Free/total bytes of the disk backing the ClickHouse data path.
+pub(crate) fn storage_disk_sql() -> &'static str {
+    "SELECT\n  \
+       toUInt64(sum(free_space)) AS free_bytes,\n  \
+       toUInt64(sum(total_space)) AS total_bytes\n \
+     FROM system.disks\n \
+     WHERE name = 'default'\n \
+     FORMAT JSONEachRow"
+}
+
+#[derive(Debug, Deserialize)]
+struct StoragePartsRow {
+    name: String,
+    rows: u64,
+    compressed_bytes: u64,
+    uncompressed_bytes: u64,
+    active_parts: u64,
+    oldest_retained_unix: i64,
+    oldest_retained_text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct StorageDiskRow {
+    free_bytes: u64,
+    total_bytes: u64,
+}
+
+/// Drop the epoch sentinel from the server-formatted timestamp. Kept separate
+/// from the query so the sentinel rule is unit testable without a server.
+pub(crate) fn oldest_retained_label(unix_seconds: i64, formatted: &str) -> Option<String> {
+    if unix_seconds <= EPOCH_SENTINEL_SECONDS || formatted.is_empty() {
+        return None;
+    }
+    Some(formatted.to_string())
+}
+
+impl ClickHouseClient {
+    /// One `system.parts` aggregate plus one `system.disks` read, folded with
+    /// the [`crate::storage_class`] ownership model and the effective
+    /// `[retention]` policy.
+    ///
+    /// Reads no user data. A `system.disks` failure degrades to
+    /// `disk: None` plus a note rather than failing the whole report, matching
+    /// the never-fails shape the core-index report established: storage state
+    /// is transient and must not fail a doctor exit code.
+    pub async fn storage_report(&self, retention: &RetentionConfig) -> Result<StorageReport> {
+        let parts: Vec<StoragePartsRow> = self
+            .query_json_each_row(&storage_parts_sql(&self.cfg.database), Some("system"))
+            .await
+            .context("failed to read per-table storage from system.parts")?;
+
+        let mut notes = Vec::new();
+        let tables: Vec<StorageTableReport> = parts
+            .into_iter()
+            .map(|row| StorageTableReport {
+                class: classify(&row.name),
+                name: row.name,
+                rows: row.rows,
+                compressed_bytes: row.compressed_bytes,
+                uncompressed_bytes: row.uncompressed_bytes,
+                active_parts: row.active_parts,
+                oldest_retained: oldest_retained_label(
+                    row.oldest_retained_unix,
+                    &row.oldest_retained_text,
+                ),
+            })
+            .collect();
+
+        let unclassified: Vec<&str> = tables
+            .iter()
+            .filter(|table| table.class.is_none())
+            .map(|table| table.name.as_str())
+            .collect();
+        if !unclassified.is_empty() {
+            notes.push(format!(
+                "unclassified tables present in the database (no reclaim scope may name them): {}",
+                unclassified.join(", ")
+            ));
+        }
+
+        let disk = match self
+            .query_json_each_row::<StorageDiskRow>(storage_disk_sql(), Some("system"))
+            .await
+        {
+            Ok(rows) => rows.into_iter().next().map(|row| StorageDiskReport {
+                free_bytes: row.free_bytes,
+                total_bytes: row.total_bytes,
+            }),
+            Err(error) => {
+                notes.push(format!("disk headroom unavailable: {error:#}"));
+                None
+            }
+        };
+
+        Ok(StorageReport {
+            buckets: fold_buckets(&tables),
+            tables,
+            disk,
+            policy: retention_policy_entries(retention),
+            notes,
+        })
+    }
+}
+
+/// Names in [`CLASSIFIED_TABLES`] that a live database is expected to carry,
+/// for the doctor's benefit. Excludes the system logs, which live in another
+/// database.
+pub fn expected_moraine_tables() -> BTreeMap<&'static str, TableClass> {
+    CLASSIFIED_TABLES
+        .iter()
+        .filter(|entry| !entry.name.starts_with("system."))
+        .map(|entry| (entry.name, entry.class))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table(name: &str, class: Option<TableClass>, rows: u64, bytes: u64) -> StorageTableReport {
+        StorageTableReport {
+            name: name.to_string(),
+            class,
+            rows,
+            compressed_bytes: bytes,
+            uncompressed_bytes: bytes * 3,
+            active_parts: 1,
+            oldest_retained: None,
+        }
+    }
+
+    #[test]
+    fn parts_query_reads_only_active_parts_and_never_the_table_itself() {
+        let sql = storage_parts_sql("moraine");
+        assert!(sql.contains("FROM system.parts"));
+        assert!(
+            sql.contains("AND active"),
+            "without the active filter, inactive parts keep a table's bytes present after its \
+             rows are gone — the exact reason the pre-existing live storage assertion could not \
+             fail on over-deletion"
+        );
+        assert!(sql.contains("database = 'moraine'"));
+        // H4: no FINAL, no read of any user relation.
+        assert!(!sql.contains("FINAL"));
+        assert!(!sql.contains("moraine."));
+        // ClickHouse's `formatDateTime` uses `%i` for minutes; `%M` is the
+        // full month NAME. Verified against the live host 2026-07-27, where
+        // `%M` rendered `2026-02-20T14:February:47Z`.
+        assert!(
+            sql.contains("'%Y-%m-%dT%H:%i:%SZ'"),
+            "minutes are %i in ClickHouse; %M renders the month name"
+        );
+        assert!(!sql.contains("%M"));
+    }
+
+    #[test]
+    fn disk_query_reads_only_system_disks() {
+        let sql = storage_disk_sql();
+        assert!(sql.contains("FROM system.disks"));
+        assert!(sql.contains("free_space"));
+        assert!(sql.contains("total_space"));
+        assert!(!sql.contains("FINAL"));
+    }
+
+    #[test]
+    fn the_epoch_sentinel_is_reported_as_no_oldest_row_rather_than_1970() {
+        // Verified on the reference host 2026-07-27: every table without a
+        // time-typed partition key reports min_time at the Unix epoch.
+        assert_eq!(oldest_retained_label(0, "1970-01-01T00:00:00Z"), None);
+        assert_eq!(oldest_retained_label(-1, "1969-12-31T23:59:59Z"), None);
+        assert_eq!(oldest_retained_label(1_771_579_005, ""), None);
+        assert_eq!(
+            oldest_retained_label(1_771_579_005, "2026-02-20T09:16:45Z"),
+            Some("2026-02-20T09:16:45Z".to_string())
+        );
+    }
+
+    #[test]
+    fn buckets_fold_every_class_even_when_empty() {
+        let tables = vec![
+            table("events", Some(TableClass::CanonicalHistory), 10, 100),
+            table("raw_events", Some(TableClass::RawAudit), 20, 200),
+            table("mcp_open_turns", Some(TableClass::Derived), 30, 300),
+            table("mcp_open_events", Some(TableClass::Derived), 40, 400),
+            table("mystery_table", None, 50, 500),
+        ];
+        let buckets = fold_buckets(&tables);
+        assert_eq!(buckets.len(), TableClass::ALL.len());
+        let derived = buckets
+            .iter()
+            .find(|bucket| bucket.class == TableClass::Derived)
+            .expect("derived bucket");
+        assert_eq!(derived.tables, 2);
+        assert_eq!(derived.rows, 70);
+        assert_eq!(derived.compressed_bytes, 700);
+        let telemetry = buckets
+            .iter()
+            .find(|bucket| bucket.class == TableClass::Telemetry)
+            .expect("telemetry bucket must be present even at zero");
+        assert_eq!(telemetry.tables, 0);
+        // The unclassified table contributes to no bucket: it must never be
+        // silently folded into "derived".
+        assert_eq!(
+            buckets.iter().map(|bucket| bucket.rows).sum::<u64>(),
+            10 + 20 + 30 + 40
+        );
+    }
+
+    /// The policy half of **G-DEFAULT**: stock configuration surfaces no
+    /// destructive policy, and a configured one is flagged as destructive.
+    ///
+    /// MUTATION (executed 2026-07-27): make `is_destructive` return
+    /// `self.horizon_seconds.is_some()` (dropping the `is_protected` guard) =>
+    /// the derived and telemetry entries become "destructive" and the
+    /// `default policy is not destructive` assertion FAILS. Bounds the
+    /// direction *a harmless policy is reported as destructive*; the
+    /// `configured` half below bounds *a destructive policy is reported as
+    /// harmless*.
+    #[test]
+    fn default_retention_surfaces_no_destructive_policy() {
+        let policy = retention_policy_entries(&RetentionConfig::default());
+        assert_eq!(policy.len(), TableClass::ALL.len());
+        assert!(
+            policy.iter().all(|entry| !entry.is_destructive()),
+            "default policy is not destructive: {policy:#?}"
+        );
+        for class in [TableClass::CanonicalHistory, TableClass::RawAudit] {
+            let entry = policy
+                .iter()
+                .find(|entry| entry.class == class)
+                .expect("protected entry");
+            assert_eq!(entry.horizon_seconds, None);
+            assert_eq!(entry.source, POLICY_SOURCE_DEFAULT);
+            assert!(entry.config_key.is_some(), "a refusal must name the key");
+        }
+        let derived = policy
+            .iter()
+            .find(|entry| entry.class == TableClass::Derived)
+            .expect("derived entry");
+        assert_eq!(derived.horizon_seconds, Some(86_400.0));
+        let never = policy
+            .iter()
+            .find(|entry| entry.class == TableClass::NeverDelete)
+            .expect("never-delete entry");
+        assert_eq!(never.horizon_seconds, None);
+        assert!(!never.is_destructive());
+    }
+
+    /// Provenance is reported for **all four** horizon buckets, not only the
+    /// two whose provenance gates deletion.
+    ///
+    /// An operator who sets `retention.derived_horizon_hours` reads the value
+    /// back from `moraine status`, `moraine db doctor`, and
+    /// `/api/v1/health`; reporting `default` next to their own number is the
+    /// kind of small lie that costs an hour of debugging at the worst moment.
+    ///
+    /// MUTATION (executed 2026-07-27): hard-code
+    /// `source: POLICY_SOURCE_DEFAULT` for the derived entry (the state this
+    /// PR shipped in) => FAILS on the configured case below. **Lower bound.**
+    ///
+    /// MUTATION (executed 2026-07-27): hard-code
+    /// `source: POLICY_SOURCE_CONFIGURED` for it => FAILS on
+    /// `default_retention_surfaces_no_destructive_policy`, which asserts
+    /// `POLICY_SOURCE_DEFAULT` under a stock config. **Upper bound.**
+    ///
+    /// Telemetry is deliberately **not** in the configured loop: its horizon
+    /// is not operator-configurable at all, and
+    /// `the_telemetry_horizon_never_reports_itself_as_configured` is its
+    /// counterpart guard.
+    #[test]
+    fn every_horizon_bucket_reports_its_own_provenance() {
+        let stock = retention_policy_entries(&RetentionConfig::default());
+        for class in TableClass::ALL {
+            let entry = stock
+                .iter()
+                .find(|entry| entry.class == class)
+                .expect("every class has a policy row");
+            assert_eq!(
+                entry.source, POLICY_SOURCE_DEFAULT,
+                "{class:?} is unconfigured under a stock config"
+            );
+        }
+
+        let configured = retention_policy_entries(&RetentionConfig {
+            derived_horizon_hours: 6.0,
+            ..RetentionConfig::default()
+        });
+        let derived = configured
+            .iter()
+            .find(|entry| entry.class == TableClass::Derived)
+            .expect("derived policy row");
+        assert_eq!(
+            derived.source, POLICY_SOURCE_CONFIGURED,
+            "a configured derived horizon must not read back as `default`"
+        );
+        assert_eq!(derived.horizon_seconds, Some(6.0 * 3_600.0));
+        // Configuring a bucket-3 horizon is still not destructive: only the
+        // two protected buckets can be.
+        assert!(!derived.is_destructive());
+
+        // The protected buckets keep their exact provenance, which is what the
+        // destructive-policy warning is derived from.
+        let protected_configured = retention_policy_entries(&RetentionConfig {
+            raw_audit_horizon_days: Some(90.0),
+            ..RetentionConfig::default()
+        });
+        let raw = protected_configured
+            .iter()
+            .find(|entry| entry.class == TableClass::RawAudit)
+            .expect("raw entry");
+        assert_eq!(raw.source, POLICY_SOURCE_CONFIGURED);
+        assert!(raw.is_destructive());
+    }
+
+    /// **G-TELEMETRY-HONESTY.** Fails for: a reported telemetry horizon that
+    /// differs from the one `sql/039_telemetry_retention.sql` actually applies,
+    /// and for reporting it as `configured`.
+    /// Denomination: exact seconds, exact source string, note present.
+    ///
+    /// The regression: `retention.telemetry_horizon_days` is reported by
+    /// `moraine db reclaim status`, `moraine db doctor` and `/api/v1/health`,
+    /// but migration 039 writes `INTERVAL 30 DAY` four times as static text.
+    /// An operator who set 90 read back "configured, 90 days" while ClickHouse
+    /// deleted at 30 — a silent shortening relative to stated intent, on the
+    /// only surface that stated it. Setting 1 was equally ineffective the
+    /// other way.
+    ///
+    /// Two mechanisms, because the config-load rejection cannot see a
+    /// `RetentionConfig` built in code. `validate_retention` refuses the key
+    /// at load (`telemetry_horizon_days_is_not_yet_configurable` in
+    /// moraine-config); this asserts the report is honest even for the
+    /// bypassed case.
+    ///
+    /// MUTATION (executed 2026-07-27): restore
+    /// `horizon_seconds: Some(f64::from(retention.telemetry_horizon_days) *
+    /// 86_400.0)` => FAILS on the 90-day case. **Lower bound.**
+    ///
+    /// MUTATION (executed 2026-07-27): restore `source: source_of(…)` for the
+    /// telemetry entry => FAILS on the source assertion for the 90-day case.
+    ///
+    /// MUTATION (executed 2026-07-27): drop the `note` => FAILS here, and
+    /// `render.rs`'s `status_lines_render_the_telemetry_horizon_caveat`
+    /// FAILS too. **Width: the caveat has to reach the operator, not just
+    /// exist in a struct.**
+    #[test]
+    fn the_telemetry_horizon_never_reports_itself_as_configured() {
+        let applied =
+            f64::from(moraine_config::DEFAULT_RETENTION_TELEMETRY_HORIZON_DAYS) * 86_400.0;
+        for days in [
+            moraine_config::DEFAULT_RETENTION_TELEMETRY_HORIZON_DAYS,
+            1,
+            90,
+        ] {
+            // Built in code, so it bypasses `validate_retention` exactly the
+            // way a future in-process caller would.
+            let policy = retention_policy_entries(&RetentionConfig {
+                telemetry_horizon_days: days,
+                ..RetentionConfig::default()
+            });
+            let entry = policy
+                .iter()
+                .find(|entry| entry.class == TableClass::Telemetry)
+                .expect("telemetry policy row");
+            assert_eq!(
+                entry.horizon_seconds,
+                Some(applied),
+                "the reported horizon must be the one migration 039 applies, not the one the \
+                 field holds (field was {days})"
+            );
+            assert_eq!(
+                entry.source, POLICY_SOURCE_DEFAULT,
+                "`configured` is a claim about effect, and this key has none (field was {days})"
+            );
+            assert_eq!(
+                entry.note.as_deref(),
+                Some(TELEMETRY_HORIZON_NOT_CONFIGURABLE_NOTE),
+                "the entry names a config key, so it must also say the key does nothing"
+            );
+            assert_eq!(
+                entry.config_key.as_deref(),
+                Some("retention.telemetry_horizon_days")
+            );
+        }
+
+        // Upper bound: the note is for this entry alone. A note on every row
+        // would make the caveat unreadable and unfalsifiable.
+        let policy = retention_policy_entries(&RetentionConfig::default());
+        let noted: Vec<TableClass> = policy
+            .iter()
+            .filter(|entry| entry.note.is_some())
+            .map(|entry| entry.class)
+            .collect();
+        assert_eq!(noted, vec![TableClass::Telemetry]);
+    }
+
+    #[test]
+    fn configured_protected_retention_is_reported_as_destructive() {
+        let retention = RetentionConfig {
+            canonical_history_horizon_days: Some(365.0),
+            ..RetentionConfig::default()
+        };
+        let policy = retention_policy_entries(&retention);
+        let canonical = policy
+            .iter()
+            .find(|entry| entry.class == TableClass::CanonicalHistory)
+            .expect("canonical entry");
+        assert_eq!(canonical.horizon_seconds, Some(365.0 * 86_400.0));
+        assert_eq!(canonical.source, POLICY_SOURCE_CONFIGURED);
+        assert!(canonical.is_destructive());
+        // Raw/audit was not configured and must stay non-destructive: one
+        // configured bucket may not imply the other.
+        let raw = policy
+            .iter()
+            .find(|entry| entry.class == TableClass::RawAudit)
+            .expect("raw entry");
+        assert!(!raw.is_destructive());
+    }
+
+    #[test]
+    fn expected_tables_exclude_system_logs() {
+        let expected = expected_moraine_tables();
+        assert!(expected.contains_key("events"));
+        assert!(expected.contains_key("storage_reclaim_ledger"));
+        assert!(!expected.keys().any(|name| name.starts_with("system.")));
+    }
+}

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -885,6 +885,343 @@ impl ValidatedQueryBudgets {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Issue #603 WI-03 — `[retention]`
+// ---------------------------------------------------------------------------
+
+/// Safety-horizon floor for rebuildable derived data (bucket 3), in hours.
+///
+/// The horizon must exceed (a) the longest legitimate publication-pin
+/// lifetime, which is one request and therefore seconds; (b) the longest
+/// legitimate projection `prepare` window before its header is written; and
+/// (c) an operator's chance to notice a bad publication and roll back. (a) and
+/// (b) argue minutes; (c) argues a day. This is the floor, not just the
+/// default: a config naming a shorter horizon is rejected at load.
+pub const RETENTION_DERIVED_HORIZON_FLOOR_HOURS: f64 = 24.0;
+
+/// Safety-horizon floor for buckets 1 and 2 (canonical history and raw/audit
+/// source data), in days. Deleting user history on a horizon shorter than a
+/// week gives an operator no realistic window to notice and stop it.
+pub const RETENTION_PROTECTED_HORIZON_FLOOR_DAYS: f64 = 7.0;
+
+/// Default safety horizon for bucket 3.
+pub const DEFAULT_RETENTION_DERIVED_HORIZON_HOURS: f64 = 24.0;
+
+/// Default TTL horizon for bucket 4 operational telemetry, in days. The only
+/// reader horizon any code depends on is `search_query_log`'s rolling 7-day
+/// hot-query window, so 30 days carries 4x headroom over it.
+///
+/// **This is currently the only permitted value.** Migration SQL is static
+/// text: `sql/039_telemetry_retention.sql` bakes `INTERVAL 30 DAY` into four
+/// `MODIFY TTL` statements, so nothing an operator writes in `[retention]`
+/// changes when ClickHouse expires a telemetry row. `validate_retention`
+/// therefore rejects any other value rather than accepting a number that has
+/// no effect — see [`RetentionValidationError::TelemetryNotYetConfigurable`].
+pub const DEFAULT_RETENTION_TELEMETRY_HORIZON_DAYS: u32 = 30;
+
+/// Upper bound on any configured horizon, in days (~10 years). A horizon
+/// beyond this is indistinguishable from "never" and is more likely a typo.
+pub const RETENTION_HORIZON_MAX_DAYS: f64 = 3_650.0;
+
+const SECONDS_PER_HOUR: f64 = 3_600.0;
+const SECONDS_PER_DAY: f64 = 86_400.0;
+
+/// `[retention]` — issue #603 §1 ownership model, as configuration.
+///
+/// **Every default in this struct is a no-op for buckets 1 and 2.** The two
+/// protected horizons are `Option` with no serde default and no `Default`
+/// value other than `None`, so a config file that does not mention them cannot
+/// produce deletion authority for canonical or raw/audit data. That is not a
+/// convention: [`RetentionHorizon`] is the only type the reclaimer accepts as
+/// authority for those buckets, it has no `Default` impl and no public
+/// constructor, and its only source is [`RetentionHorizon::from_config`],
+/// which returns `None` for an absent key. A missing setting therefore cannot
+/// *type-check* into deletion authority.
+///
+/// The regression this shape fails for: someone adds
+/// `#[serde(default = "…")]` with a finite horizon to one of the two protected
+/// fields and silently turns on canonical deletion for every existing install
+/// on upgrade. `default_config_grants_no_authority_over_user_history` fails
+/// the moment that edit lands.
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RetentionConfig {
+    /// Bucket 3 safety horizon in hours: how long a *superseded* derived row
+    /// must have been superseded before reclamation may claim it. Never
+    /// applies to a live generation — the reclaimer contains no predicate over
+    /// liveness at all, only an anti-join against the published heads.
+    #[serde(default = "default_retention_derived_horizon_hours")]
+    pub derived_horizon_hours: f64,
+    /// Bucket 4 TTL horizon in days, applied by migration 039.
+    ///
+    /// **Not yet operator-configurable.** The horizon lives in static
+    /// migration SQL, so this field cannot change what ClickHouse does;
+    /// `validate_retention` rejects every value except
+    /// [`DEFAULT_RETENTION_TELEMETRY_HORIZON_DAYS`], and every reporting
+    /// surface labels it `default`. The field exists so the shipped TTL
+    /// literal has one named home that
+    /// `migration_039_ttl_horizon_matches_the_configured_default` can compare
+    /// against, and so the key keeps its name for the change that makes it
+    /// real.
+    #[serde(default = "default_retention_telemetry_horizon_days")]
+    pub telemetry_horizon_days: u32,
+    /// Bucket 2 retention in days. **Absent by default.** Presence is the
+    /// authority; there is no "0 means forever" sentinel to get wrong.
+    pub raw_audit_horizon_days: Option<f64>,
+    /// Bucket 1 retention in days. **Absent by default.**
+    pub canonical_history_horizon_days: Option<f64>,
+}
+
+fn default_retention_derived_horizon_hours() -> f64 {
+    DEFAULT_RETENTION_DERIVED_HORIZON_HOURS
+}
+
+fn default_retention_telemetry_horizon_days() -> u32 {
+    DEFAULT_RETENTION_TELEMETRY_HORIZON_DAYS
+}
+
+impl Default for RetentionConfig {
+    fn default() -> Self {
+        Self {
+            derived_horizon_hours: DEFAULT_RETENTION_DERIVED_HORIZON_HOURS,
+            telemetry_horizon_days: DEFAULT_RETENTION_TELEMETRY_HORIZON_DAYS,
+            // Deliberately `None`. See the struct doc: this is the mechanism,
+            // not a placeholder waiting for a value.
+            raw_audit_horizon_days: None,
+            canonical_history_horizon_days: None,
+        }
+    }
+}
+
+/// Which protected bucket a [`RetentionHorizon`] is being requested for.
+///
+/// Only buckets 1 and 2 have variants: buckets 3 and 4 need no authority
+/// token, so there is deliberately no way to ask for one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProtectedRetentionBucket {
+    /// Bucket 2 — `raw_events`, `ingest_errors`.
+    RawAudit,
+    /// Bucket 1 — `events`.
+    CanonicalHistory,
+}
+
+impl ProtectedRetentionBucket {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RawAudit => "raw_audit",
+            Self::CanonicalHistory => "canonical_history",
+        }
+    }
+
+    /// The configuration key an operator must set to grant this authority.
+    /// Named so a refusal can say exactly which key is missing.
+    pub fn config_key(self) -> &'static str {
+        match self {
+            Self::RawAudit => "retention.raw_audit_horizon_days",
+            Self::CanonicalHistory => "retention.canonical_history_horizon_days",
+        }
+    }
+}
+
+/// A validated retention horizon for a protected bucket.
+///
+/// **Constructible only from configuration.** No `Default`, no `From<()>`, no
+/// `new`, no public field. The private field means a value cannot be
+/// synthesized outside this module even within this crate's own tests.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RetentionHorizon {
+    seconds: f64,
+    bucket: ProtectedRetentionBucket,
+}
+
+impl RetentionHorizon {
+    /// The horizon configured for `bucket`, or `None` when the key is absent.
+    ///
+    /// `None` is the stock-configuration answer and it is what makes "default
+    /// configuration deletes no raw or canonical user history" a type-level
+    /// property rather than a runtime check someone can forget.
+    pub fn from_config(cfg: &RetentionConfig, bucket: ProtectedRetentionBucket) -> Option<Self> {
+        let days = match bucket {
+            ProtectedRetentionBucket::RawAudit => cfg.raw_audit_horizon_days,
+            ProtectedRetentionBucket::CanonicalHistory => cfg.canonical_history_horizon_days,
+        }?;
+        // Load-time validation already rejected non-finite, non-positive, and
+        // below-floor values; this second check keeps a programmatically
+        // constructed `RetentionConfig` from bypassing the floor.
+        // NaN fails `contains` too, which is the answer we want: an
+        // unrepresentable horizon grants no authority.
+        if !(RETENTION_PROTECTED_HORIZON_FLOOR_DAYS..=RETENTION_HORIZON_MAX_DAYS).contains(&days) {
+            return None;
+        }
+        Some(Self {
+            seconds: days * SECONDS_PER_DAY,
+            bucket,
+        })
+    }
+
+    pub fn seconds(&self) -> f64 {
+        self.seconds
+    }
+
+    pub fn days(&self) -> f64 {
+        self.seconds / SECONDS_PER_DAY
+    }
+
+    pub fn bucket(&self) -> ProtectedRetentionBucket {
+        self.bucket
+    }
+}
+
+impl RetentionConfig {
+    /// Bucket 3 safety horizon in seconds.
+    pub fn derived_horizon_seconds(&self) -> f64 {
+        self.derived_horizon_hours * SECONDS_PER_HOUR
+    }
+
+    /// Whether any protected-bucket retention is configured. `moraine status`
+    /// prints a prominent line when this is true: a destructive policy is
+    /// never invisible.
+    pub fn any_protected_retention_configured(&self) -> bool {
+        self.raw_audit_horizon_days.is_some() || self.canonical_history_horizon_days.is_some()
+    }
+}
+
+/// Typed rejection from `[retention]` validation. Every variant names the
+/// offending key.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RetentionValidationError {
+    NotFinite {
+        key: &'static str,
+    },
+    BelowFloor {
+        key: &'static str,
+        value: f64,
+        floor: f64,
+        unit: &'static str,
+    },
+    AboveMax {
+        key: &'static str,
+        value: f64,
+    },
+    TelemetryZero,
+    /// `retention.telemetry_horizon_days` set to anything other than the
+    /// default.
+    ///
+    /// The TTL that enforces it is baked into `sql/039_telemetry_retention.sql`
+    /// as static text, so a configured value changes nothing. Accepting one
+    /// and then reporting it back as `configured` from `moraine db reclaim
+    /// status`, `moraine db doctor` and `/api/v1/health` would tell an
+    /// operator who wrote 90 that they have 90 days of telemetry while
+    /// ClickHouse deletes at 30 — a silent shortening relative to stated
+    /// intent, on the only surface that states it. Failing the load is the
+    /// honest answer until the horizon is templated into the migration.
+    TelemetryNotYetConfigurable {
+        value: u32,
+    },
+}
+
+impl fmt::Display for RetentionValidationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFinite { key } => {
+                write!(formatter, "{key} must be a finite number")
+            }
+            Self::BelowFloor {
+                key,
+                value,
+                floor,
+                unit,
+            } => write!(
+                formatter,
+                "{key} must be at least {floor} {unit} (got {value}); the floor is not \
+                 configurable — a shorter safety horizon can retire rows a live request is still \
+                 pinned to"
+            ),
+            Self::AboveMax { key, value } => write!(
+                formatter,
+                "{key} must be at most {RETENTION_HORIZON_MAX_DAYS} days (got {value})"
+            ),
+            Self::TelemetryZero => write!(
+                formatter,
+                "retention.telemetry_horizon_days must be at least 1; zero would mean \
+                 delete-on-write"
+            ),
+            Self::TelemetryNotYetConfigurable { value } => write!(
+                formatter,
+                "retention.telemetry_horizon_days is not yet configurable and must be \
+                 {DEFAULT_RETENTION_TELEMETRY_HORIZON_DAYS} (got {value}). The telemetry TTL is \
+                 baked into sql/039_telemetry_retention.sql as static text, so setting this key \
+                 would report a horizon Moraine does not apply. Remove the key, or set it to \
+                 {DEFAULT_RETENTION_TELEMETRY_HORIZON_DAYS}."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RetentionValidationError {}
+
+/// Fail-closed `[retention]` validation, run at config load.
+pub fn validate_retention(cfg: &RetentionConfig) -> Result<(), RetentionValidationError> {
+    if !cfg.derived_horizon_hours.is_finite() {
+        return Err(RetentionValidationError::NotFinite {
+            key: "retention.derived_horizon_hours",
+        });
+    }
+    if cfg.derived_horizon_hours < RETENTION_DERIVED_HORIZON_FLOOR_HOURS {
+        return Err(RetentionValidationError::BelowFloor {
+            key: "retention.derived_horizon_hours",
+            value: cfg.derived_horizon_hours,
+            floor: RETENTION_DERIVED_HORIZON_FLOOR_HOURS,
+            unit: "hours",
+        });
+    }
+    if cfg.derived_horizon_hours > RETENTION_HORIZON_MAX_DAYS * 24.0 {
+        return Err(RetentionValidationError::AboveMax {
+            key: "retention.derived_horizon_hours",
+            value: cfg.derived_horizon_hours,
+        });
+    }
+    if cfg.telemetry_horizon_days == 0 {
+        return Err(RetentionValidationError::TelemetryZero);
+    }
+    // Ordered after the zero check so `= 0` keeps its own, more specific
+    // message. Both reject; only the wording differs.
+    if cfg.telemetry_horizon_days != DEFAULT_RETENTION_TELEMETRY_HORIZON_DAYS {
+        return Err(RetentionValidationError::TelemetryNotYetConfigurable {
+            value: cfg.telemetry_horizon_days,
+        });
+    }
+    for (key, value) in [
+        (
+            ProtectedRetentionBucket::RawAudit.config_key(),
+            cfg.raw_audit_horizon_days,
+        ),
+        (
+            ProtectedRetentionBucket::CanonicalHistory.config_key(),
+            cfg.canonical_history_horizon_days,
+        ),
+    ] {
+        let Some(value) = value else {
+            continue;
+        };
+        if !value.is_finite() {
+            return Err(RetentionValidationError::NotFinite { key });
+        }
+        if value < RETENTION_PROTECTED_HORIZON_FLOOR_DAYS {
+            return Err(RetentionValidationError::BelowFloor {
+                key,
+                value,
+                floor: RETENTION_PROTECTED_HORIZON_FLOOR_DAYS,
+                unit: "days",
+            });
+        }
+        if value > RETENTION_HORIZON_MAX_DAYS {
+            return Err(RetentionValidationError::AboveMax { key, value });
+        }
+    }
+    Ok(())
+}
+
 const REDACTED_AUTH_TOKEN: &str = "[REDACTED]";
 
 #[derive(Clone, Deserialize)]
@@ -973,6 +1310,10 @@ pub struct AppConfig {
     pub bm25: Bm25Config,
     #[serde(default)]
     pub query_budgets: QueryBudgetsConfig,
+    /// Issue #603 WI-03. Present with defaults on every load; its two
+    /// protected-bucket horizons stay `None` unless an operator writes them.
+    #[serde(default)]
+    pub retention: RetentionConfig,
     #[serde(default)]
     pub monitor: MonitorConfig,
     #[serde(default)]
@@ -1081,6 +1422,7 @@ impl Default for AppConfig {
             backend: BackendConfig::default(),
             bm25: Bm25Config::default(),
             query_budgets: QueryBudgetsConfig::default(),
+            retention: RetentionConfig::default(),
             monitor: MonitorConfig::default(),
             runtime: RuntimeConfig::default(),
         }
@@ -2033,6 +2375,10 @@ fn normalize_config(mut cfg: AppConfig) -> Result<AppConfig> {
     // never produces a usable AppConfig (issue #600 exit gate 7).
     ValidatedQueryBudgets::from_config(&cfg.query_budgets)
         .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    // Fail closed on `[retention]` too (issue #603 §4 S2): a horizon below the
+    // non-configurable floor never produces a usable AppConfig.
+    validate_retention(&cfg.retention).map_err(|error| anyhow::anyhow!("{error}"))?;
 
     for (exclude_idx, pattern) in cfg.ingest.exclude_project_dirs.iter_mut().enumerate() {
         *pattern = expand_path(pattern.trim());
@@ -4896,6 +5242,266 @@ watch_root = "~/.pi/agent/sessions"
         assert_eq!(source.tracked_extension(), "jsonl");
     }
 
+    // ---- issue #603 WI-03 `[retention]` --------------------------------
+
+    /// **Half of G-DEFAULT (the config half).** Fails for: a default config
+    /// authorizing canonical or raw/audit deletion.
+    /// Denomination: `Option::is_none` on both protected horizons, plus
+    /// `RetentionHorizon::from_config` returning `None` for both buckets.
+    ///
+    /// The input is an **empty TOML document**, not a config that merely omits
+    /// `[retention]`: an empty document is what a fresh install and an
+    /// upgrading install both present.
+    ///
+    /// **Three document shapes, and they are not interchangeable.** An empty
+    /// document never enters `RetentionConfig`'s own `Deserialize` at all — it
+    /// takes `#[serde(default)]` on `AppConfig::retention`, i.e. the `impl
+    /// Default`. Serde FIELD defaults inside `RetentionConfig` fire only when a
+    /// `[retention]` table is present and the key is missing, which is the
+    /// shape every install that sets `telemetry_horizon_days` has. A guard that
+    /// only checks the empty document therefore cannot see the regression S2
+    /// names.
+    ///
+    /// MUTATION (executed 2026-07-27): add
+    /// `#[serde(default = "…")]` returning `Some(90.0)` to
+    /// `canonical_history_horizon_days`.
+    ///   * against the EMPTY document only => the test still **passed**. That
+    ///     is how this test was originally written, and it is exactly the
+    ///     "guard that cannot fail" shape.
+    ///   * against the present-but-partial `[retention]` document added below
+    ///     => `from_config(.., CanonicalHistory)` returns `Some(_)` and the
+    ///     test FAILS at `canonical authority (partial section)`.
+    ///
+    /// The guard bounds the direction *default or partial config gains
+    /// authority it should not have*; `configured_protected_horizon_grants_authority`
+    /// bounds the opposite direction, so a "fix" that makes `from_config`
+    /// always return `None` does not leave the suite green.
+    #[test]
+    fn default_config_grants_no_authority_over_user_history() {
+        let empty_path = write_temp_config("", "retention-empty-document");
+        let empty = load_config(&empty_path).expect("an empty config document must load");
+        std::fs::remove_file(&empty_path).ok();
+
+        // A `[retention]` section that names only a bucket-4 key. This is the
+        // shape a serde field default actually reaches.
+        let partial_path = write_temp_config(
+            "[retention]\ntelemetry_horizon_days = 30\n",
+            "retention-partial-section",
+        );
+        let partial = load_config(&partial_path).expect("a partial [retention] section must load");
+        std::fs::remove_file(&partial_path).ok();
+
+        for (label, cfg) in [("empty document", &empty), ("partial section", &partial)] {
+            assert_eq!(
+                cfg.retention.raw_audit_horizon_days, None,
+                "raw/audit horizon ({label})"
+            );
+            assert_eq!(
+                cfg.retention.canonical_history_horizon_days, None,
+                "canonical horizon ({label})"
+            );
+            assert!(
+                !cfg.retention.any_protected_retention_configured(),
+                "protected retention ({label})"
+            );
+            assert!(
+                RetentionHorizon::from_config(&cfg.retention, ProtectedRetentionBucket::RawAudit)
+                    .is_none(),
+                "raw/audit authority ({label})"
+            );
+            assert!(
+                RetentionHorizon::from_config(
+                    &cfg.retention,
+                    ProtectedRetentionBucket::CanonicalHistory
+                )
+                .is_none(),
+                "canonical authority ({label})"
+            );
+            // Buckets 3 and 4 do have defaults, and they are the documented ones.
+            assert_eq!(
+                cfg.retention.derived_horizon_hours, 24.0,
+                "derived ({label})"
+            );
+            assert_eq!(
+                cfg.retention.telemetry_horizon_days, 30,
+                "telemetry ({label})"
+            );
+            assert_eq!(
+                cfg.retention.derived_horizon_seconds(),
+                86_400.0,
+                "derived seconds ({label})"
+            );
+            assert_eq!(
+                cfg.retention,
+                RetentionConfig::default(),
+                "retention config ({label})"
+            );
+        }
+
+        // `AppConfig::default()` must agree with both: a programmatically built
+        // config is what most tests and the monitor's fallbacks use.
+        assert_eq!(AppConfig::default().retention, empty.retention);
+    }
+
+    #[test]
+    fn configured_protected_horizon_grants_authority() {
+        let path = write_temp_config(
+            "[retention]\nraw_audit_horizon_days = 90.0\ncanonical_history_horizon_days = 365.0\n",
+            "retention-configured",
+        );
+        let cfg = load_config(&path).expect("configured retention should load");
+        std::fs::remove_file(&path).ok();
+
+        assert!(cfg.retention.any_protected_retention_configured());
+        let raw = RetentionHorizon::from_config(&cfg.retention, ProtectedRetentionBucket::RawAudit)
+            .expect("raw/audit authority must be constructible once configured");
+        assert_eq!(raw.days(), 90.0);
+        assert_eq!(raw.seconds(), 90.0 * 86_400.0);
+        assert_eq!(raw.bucket(), ProtectedRetentionBucket::RawAudit);
+
+        let canonical = RetentionHorizon::from_config(
+            &cfg.retention,
+            ProtectedRetentionBucket::CanonicalHistory,
+        )
+        .expect("canonical authority must be constructible once configured");
+        assert_eq!(canonical.days(), 365.0);
+    }
+
+    #[test]
+    fn retention_floors_are_not_configurable_below_their_values() {
+        for (body, needle) in [
+            (
+                "[retention]\nderived_horizon_hours = 1.0\n",
+                "retention.derived_horizon_hours must be at least 24",
+            ),
+            (
+                "[retention]\nraw_audit_horizon_days = 1.0\n",
+                "retention.raw_audit_horizon_days must be at least 7",
+            ),
+            (
+                "[retention]\ncanonical_history_horizon_days = 0.5\n",
+                "retention.canonical_history_horizon_days must be at least 7",
+            ),
+            (
+                "[retention]\ntelemetry_horizon_days = 0\n",
+                "retention.telemetry_horizon_days must be at least 1",
+            ),
+            (
+                "[retention]\ncanonical_history_horizon_days = 100000.0\n",
+                "must be at most 3650 days",
+            ),
+        ] {
+            let path = write_temp_config(body, "retention-floor");
+            let error = load_config(&path).expect_err("below-floor retention must not load");
+            std::fs::remove_file(&path).ok();
+            let rendered = format!("{error:#}");
+            assert!(
+                rendered.contains(needle),
+                "expected `{needle}` in `{rendered}`"
+            );
+        }
+    }
+
+    /// **G-TELEMETRY-HONESTY (the config half).** Fails for: accepting a
+    /// `retention.telemetry_horizon_days` that Moraine does not apply.
+    /// Denomination: load result, per value, both directions.
+    ///
+    /// The horizon lives in `sql/039_telemetry_retention.sql` as four
+    /// `INTERVAL 30 DAY` literals in static text. Before this guard, an
+    /// operator could set 90, load cleanly, and read "configured, 90 days"
+    /// back from `moraine db reclaim status`, `moraine db doctor` and
+    /// `/api/v1/health` while ClickHouse expired rows at 30. `1` was equally
+    /// ineffective in the other direction. Refusing the load is the honest
+    /// answer until the horizon is templated into the migration; the reporting
+    /// half is `the_telemetry_horizon_never_reports_itself_as_configured`.
+    ///
+    /// MUTATION (executed 2026-07-27): delete the
+    /// `TelemetryNotYetConfigurable` check from `validate_retention` => FAILS
+    /// on the `90` and `7` cases. **Lower bound.**
+    ///
+    /// MUTATION (executed 2026-07-27): change the check to reject every value
+    /// (`if true`) => FAILS on the `30` case, and on
+    /// `default_config_grants_no_authority_over_user_history`, whose partial
+    /// document sets the key explicitly. **Upper bound: the documented default
+    /// must remain writable, because `docs/full-config.toml` ships it.**
+    #[test]
+    fn telemetry_horizon_days_is_not_yet_configurable() {
+        // The documented default is still writable: `docs/full-config.toml`
+        // and `docs/configuration.md` both show the key set to it.
+        let path = write_temp_config(
+            "[retention]\ntelemetry_horizon_days = 30\n",
+            "retention-telemetry-default",
+        );
+        let cfg = load_config(&path).expect("the documented default must load");
+        std::fs::remove_file(&path).ok();
+        assert_eq!(
+            cfg.retention.telemetry_horizon_days,
+            DEFAULT_RETENTION_TELEMETRY_HORIZON_DAYS
+        );
+
+        for value in [1_u32, 7, 29, 31, 90, 3_650] {
+            let path = write_temp_config(
+                &format!("[retention]\ntelemetry_horizon_days = {value}\n"),
+                "retention-telemetry-configured",
+            );
+            let error = load_config(&path)
+                .expect_err("a telemetry horizon Moraine cannot apply must not load");
+            std::fs::remove_file(&path).ok();
+            let rendered = format!("{error:#}");
+            assert!(
+                rendered.contains("not yet configurable"),
+                "expected a `not yet configurable` refusal for {value}, got `{rendered}`"
+            );
+            // The refusal must name the file that actually decides the
+            // horizon, or the operator has no way to check the claim.
+            assert!(
+                rendered.contains("sql/039_telemetry_retention.sql"),
+                "the refusal must name where the horizon really lives: `{rendered}`"
+            );
+        }
+
+        // Zero keeps its own, more specific message rather than being folded
+        // into the generic refusal.
+        let path = write_temp_config(
+            "[retention]\ntelemetry_horizon_days = 0\n",
+            "retention-telemetry-zero",
+        );
+        let error = load_config(&path).expect_err("zero must not load");
+        std::fs::remove_file(&path).ok();
+        assert!(format!("{error:#}").contains("must be at least 1"));
+    }
+
+    #[test]
+    fn retention_rejects_unknown_keys() {
+        let path = write_temp_config(
+            "[retention]\ncanonical_horizon_days = 365.0\n",
+            "retention-unknown-key",
+        );
+        let error = load_config(&path).expect_err("a misspelled retention key must not load");
+        std::fs::remove_file(&path).ok();
+        // A typo silently falling back to "no retention" would be benign; a
+        // typo silently falling back to *some other* default would not, and
+        // `deny_unknown_fields` is what keeps both cases loud.
+        assert!(format!("{error:#}").contains("canonical_horizon_days"));
+    }
+
+    #[test]
+    fn a_programmatic_below_floor_horizon_still_yields_no_authority() {
+        // `validate_retention` runs at load; a config built in code bypasses
+        // it. `from_config` re-checks the floor so the bypass cannot mint an
+        // authority token the loader would have refused.
+        let cfg = RetentionConfig {
+            canonical_history_horizon_days: Some(0.001),
+            raw_audit_horizon_days: Some(f64::NAN),
+            ..RetentionConfig::default()
+        };
+        assert!(
+            RetentionHorizon::from_config(&cfg, ProtectedRetentionBucket::CanonicalHistory)
+                .is_none()
+        );
+        assert!(RetentionHorizon::from_config(&cfg, ProtectedRetentionBucket::RawAudit).is_none());
+    }
+
     #[test]
     fn query_budgets_absent_section_yields_documented_defaults() {
         let path = write_temp_config("[identity]\nauthor = \"\"\n", "query-budgets-absent");
@@ -5100,5 +5706,38 @@ statement_cap = 64
             QueryBudgetsConfig::default(),
             "template [query_budgets] values must not drift from code defaults"
         );
+    }
+
+    /// The shipped template is what every fresh install starts from, so it is
+    /// the one config file whose retention posture must be checked directly
+    /// rather than inferred from `RetentionConfig::default()`.
+    ///
+    /// MUTATION (executed 2026-07-27): append
+    /// `[retention]\ncanonical_history_horizon_days = 365.0` to
+    /// `config/moraine.toml` => this test FAILS on the `raw/audit` and
+    /// `canonical` assertions. Bounds the direction *the shipped template
+    /// gains destructive authority*.
+    #[test]
+    fn shipped_template_grants_no_authority_over_user_history() {
+        let path = write_temp_config(
+            include_str!("../../../config/moraine.toml"),
+            "shipped-template-retention",
+        );
+        let cfg = load_config(&path).expect("shipped template must parse");
+        std::fs::remove_file(&path).ok();
+        assert!(
+            !cfg.retention.any_protected_retention_configured(),
+            "the shipped template must never configure bucket-1/2 retention"
+        );
+        assert!(
+            RetentionHorizon::from_config(&cfg.retention, ProtectedRetentionBucket::RawAudit)
+                .is_none()
+        );
+        assert!(RetentionHorizon::from_config(
+            &cfg.retention,
+            ProtectedRetentionBucket::CanonicalHistory
+        )
+        .is_none());
+        assert_eq!(cfg.retention, RetentionConfig::default());
     }
 }

--- a/crates/moraine-conversations/src/clickhouse_repo/operations.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/operations.rs
@@ -364,6 +364,12 @@ impl ClickHouseConversationRepository {
             core_index: StoreProbe::Failed {
                 message: "core-index probe not gathered".to_string(),
             },
+            // Placeholder: the storage-ownership probe (issue #603 WI-02) is
+            // gathered and overwritten by `read_store_health` in `repo_impl`,
+            // which owns the `[retention]`-aware accessor read.
+            storage: StoreProbe::Failed {
+                message: "storage probe not gathered".to_string(),
+            },
         })
     }
 

--- a/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
@@ -5,7 +5,7 @@ use moraine_clickhouse::{STATE_KEY_CORE_INDEXES, STATE_KEY_OPEN_V2};
 use super::*;
 use crate::domain::{
     AnalyticsRange, AnalyticsSnapshot, CoreIndexHealth, IngestHeartbeatRead, SessionAnalytics,
-    SessionAnalyticsQuery, StoreDiagnostics, StoreHealth, StoreProbe, TablePreview,
+    SessionAnalyticsQuery, StorageReport, StoreDiagnostics, StoreHealth, StoreProbe, TablePreview,
     TablePreviewQuery, TableSummaries, WebSearchEvent,
 };
 
@@ -64,6 +64,10 @@ impl ConversationRepository for ClickHouseConversationRepository {
         // report, so it degrades to the `Failed` probe variant rather than
         // propagating.
         health.core_index = self.read_core_index_health().await;
+        // Additive storage-ownership probe (issue #603 WI-02). Same
+        // best-effort contract: one `system.parts` aggregate plus one
+        // `system.disks` read, degrading to `Failed` rather than propagating.
+        health.storage = self.read_storage_probe().await;
         Ok(health)
     }
 
@@ -369,6 +373,22 @@ impl ClickHouseConversationRepository {
             Ok(health) => StoreProbe::Available(health),
             Err(error) => StoreProbe::Failed {
                 message: error.to_string(),
+            },
+        }
+    }
+
+    /// Issue #603 WI-02. Reads `system.parts` (active only) and
+    /// `system.disks`; touches no user relation, so it is safe on the health
+    /// path. A backend that cannot report storage yields `Failed` and the rest
+    /// of the health report still renders.
+    async fn read_storage_probe(&self) -> StoreProbe<StorageReport> {
+        match self.ch.storage_report(&self.cfg.retention).await {
+            Ok(report) => StoreProbe::Available(report),
+            // `{:#}` renders the whole anyhow chain: the outer context alone
+            // ("failed to read per-table storage from system.parts") tells an
+            // operator nothing about WHY it failed.
+            Err(error) => StoreProbe::Failed {
+                message: format!("{error:#}"),
             },
         }
     }

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -3,6 +3,16 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 
 pub use moraine_clickhouse::{CoreIndexAuditOutcome, PublicationDiagnostics};
+/// Issue #603 WI-02. `StorageReport` is defined in `moraine-clickhouse`
+/// alongside `classify()` and the `system.parts` probe that builds it, because
+/// the CLI reaches it through a bare `ClickHouseClient` (as `db doctor` does)
+/// while the monitor reaches it through this repository. Re-exported here so
+/// boundary crates holding only `Arc<dyn ConversationRepository>` see it in
+/// `domain`, matching how `PublicationDiagnostics` is surfaced.
+pub use moraine_clickhouse::{
+    RetentionPolicyEntry, StorageBucketReport, StorageDiskReport, StorageReport,
+    StorageTableReport, TableClass,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -1504,6 +1514,11 @@ pub struct StoreHealth {
     /// unavailable, or a repository that does not source it) yields the
     /// not-configured `Failed` variant.
     pub core_index: StoreProbe<CoreIndexHealth>,
+    /// Additive storage-ownership probe (issue #603 WI-02): per-bucket bytes,
+    /// disk headroom, and the effective retention policy. Read-only, sourced
+    /// from `system.parts`/`system.disks`, and degrades to `Failed` rather
+    /// than failing the health report — storage state is transient.
+    pub storage: StoreProbe<StorageReport>,
 }
 
 impl Default for StoreHealth {
@@ -1526,6 +1541,9 @@ impl Default for StoreHealth {
             },
             core_index: StoreProbe::Failed {
                 message: "core-index probe not configured".to_string(),
+            },
+            storage: StoreProbe::Failed {
+                message: "storage probe not configured".to_string(),
             },
         }
     }
@@ -1570,6 +1588,14 @@ pub struct RepoConfig {
     /// roots. See [`SessionOriginScope`].
     #[serde(default)]
     pub session_scope: Option<SessionOriginScope>,
+    /// Effective `[retention]` (issue #603 WI-03), carried so the store-health
+    /// storage probe reports the policy an operator actually configured rather
+    /// than the built-in defaults. A configured bucket-1/2 horizon is the only
+    /// thing in this repository that can lead to user history being deleted;
+    /// surfacing it through `/api/v1/health` is what keeps it from being
+    /// invisible. Defaults to the no-op policy.
+    #[serde(default)]
+    pub retention: moraine_config::RetentionConfig,
 }
 
 impl Default for RepoConfig {
@@ -1588,6 +1614,7 @@ impl Default for RepoConfig {
             bm25_default_min_should_match: 1,
             bm25_max_query_terms: 16,
             session_scope: None,
+            retention: moraine_config::RetentionConfig::default(),
         }
     }
 }
@@ -1622,6 +1649,9 @@ mod tests {
                 backfill_cursor_age_ms: Some(1_200),
                 audit_outcome: None,
             }),
+            storage: StoreProbe::Failed {
+                message: "storage probe not gathered".to_string(),
+            },
         };
 
         let value = serde_json::to_value(&health).expect("serialize store health");

--- a/crates/moraine-conversations/src/in_memory_repo.rs
+++ b/crates/moraine-conversations/src/in_memory_repo.rs
@@ -842,6 +842,9 @@ mod tests {
                 backfill_cursor_age_ms: Some(1_500),
                 audit_outcome: None,
             }),
+            storage: StoreProbe::Failed {
+                message: "storage probe not gathered".to_string(),
+            },
         };
         let diagnostics = StoreDiagnostics {
             healthy: true,

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -27,10 +27,11 @@ pub use domain::{
 pub use domain::{
     AnalyticsConcurrencyPoint, AnalyticsRange, AnalyticsSnapshot, AnalyticsTokenPoint,
     AnalyticsTurnPoint, AnalyticsWindow, CoreIndexAuditOutcome, CoreIndexHealth, IngestHeartbeat,
-    IngestHeartbeatRead, PublicationDiagnostics, SessionAnalytics, SessionAnalyticsQuery,
-    SessionLookback, SessionStep, SessionTurn, StoreConnectionMetrics, StoreDiagnostics,
-    StoreHealth, StoreProbe, TableColumn, TablePreview, TablePreviewQuery, TableSummaries,
-    TableSummary, ToolResult, WebSearchEvent,
+    IngestHeartbeatRead, PublicationDiagnostics, RetentionPolicyEntry, SessionAnalytics,
+    SessionAnalyticsQuery, SessionLookback, SessionStep, SessionTurn, StorageBucketReport,
+    StorageDiskReport, StorageReport, StorageTableReport, StoreConnectionMetrics, StoreDiagnostics,
+    StoreHealth, StoreProbe, TableClass, TableColumn, TablePreview, TablePreviewQuery,
+    TableSummaries, TableSummary, ToolResult, WebSearchEvent,
 };
 pub use domain::{
     CanonicalContinuation, CanonicalPageAfter, CanonicalReadAnchor, CanonicalReadOutcome,
@@ -40,6 +41,11 @@ pub use error::{RepoError, RepoResult};
 pub use in_memory_repo::{
     CanonicalSessionPageResponse, InMemoryConversationCalls, InMemoryConversationRepository,
     InMemoryConversationResponses,
+};
+/// Issue #603 WI-02 pure helpers, re-exported so boundary crates can build a
+/// `StorageReport` in tests without depending on `moraine-clickhouse`.
+pub use moraine_clickhouse::storage_report::{
+    fold_buckets, retention_policy_entries, TELEMETRY_HORIZON_NOT_CONFIGURABLE_NOTE,
 };
 // Boundary crates (MCP dispatch, monitor handlers, CLI commands) hold only
 // `Arc<dyn ConversationRepository>` and do not depend on moraine-clickhouse;

--- a/crates/moraine-conversations/tests/live_clickhouse/source_publication.rs
+++ b/crates/moraine-conversations/tests/live_clickhouse/source_publication.rs
@@ -3435,13 +3435,19 @@ pub(super) async fn run(
         );
     }
 
+    // Issue #603 WI-02 repair. This block used to read `system.parts` with NO
+    // `active` filter (only `countIf(active)` for the part count), so `rows`
+    // and `compressed_bytes` summed inactive parts too — a table's numbers
+    // stayed nonzero long after its rows were gone. Combined with an assertion
+    // that checked only that the table NAME LIST was complete, it read like a
+    // storage gate and could not fail on over-deletion.
     let control_storage: Vec<ControlStorageRow> = clickhouse
         .query_rows(
             &format!(
                 "SELECT table, toUInt64(sum(rows)) AS rows, \
-                        toUInt64(countIf(active)) AS active_parts, \
+                        toUInt64(count()) AS active_parts, \
                         toUInt64(sum(data_compressed_bytes)) AS compressed_bytes \
-                 FROM system.parts WHERE database = '{}' AND table IN ( \
+                 FROM system.parts WHERE active AND database = '{}' AND table IN ( \
                    'published_source_generations', 'ingest_checkpoint_transitions', \
                    'source_generation_publication_readiness', 'ingest_append_control', \
                    'mcp_open_publication_headers', \
@@ -3468,6 +3474,43 @@ pub(super) async fn run(
         ]
     {
         bail!("source-publication control-storage evidence is incomplete: {control_tables:?}");
+    }
+
+    // The row-count floor. `system.parts.rows` counts physically present rows,
+    // INCLUDING ones a lightweight DELETE has masked via `_row_exists`, so a
+    // floor taken from the query above could not see a delete until a merge
+    // rewrote the part. The floor therefore reads the tables directly.
+    //
+    // Restricted to the two control relations this test independently proves
+    // non-empty a few lines above: `current_head` bails when
+    // `published_source_generations` has no head row, and `ingest_append_control`
+    // is a startup prerequisite the append path has just exercised. Extending
+    // the floor to the checkpoint/readiness allocators — including the
+    // `max(checkpoint_revision)` invariant a TTL would regress — belongs to the
+    // dedicated `reclaim-truth` gate, not here.
+    //
+    // NOT EXECUTED BY THIS PR. The enclosing gate is `#[ignore]`d and needs a
+    // wrapper-owned live ClickHouse plus destructive opt-in
+    // (`MORAINE_LIVE_TEST_SANDBOX_ID`), so `cargo test --workspace` compiles
+    // this and runs none of it. Treat the floor as reviewed-but-unexercised
+    // until a sandbox run reports it green.
+    for control in ["published_source_generations", "ingest_append_control"] {
+        let live_rows = scalar_u64(
+            clickhouse,
+            database,
+            &format!(
+                "SELECT toUInt64(count()) AS value FROM `{}`.`{control}` FORMAT JSONEachRow",
+                database.as_str(),
+            ),
+        )
+        .await
+        .with_context(|| format!("failed to count live rows in {control}"))?;
+        if live_rows == 0 {
+            bail!(
+                "control relation `{control}` has no live rows; publication truth and the append \
+                 fence may never be emptied by any code path"
+            );
+        }
     }
     let derived_table_storage: Vec<ControlStorageRow> = clickhouse
         .query_rows(

--- a/crates/moraine-conversations/tests/repository_integration/health.rs
+++ b/crates/moraine-conversations/tests/repository_integration/health.rs
@@ -62,6 +62,45 @@ async fn store_health_maps_all_successful_probe_facts() {
                 &["FROM system.tables", "mcp_read_index_state"],
                 json!([{"value": "0"}]),
             ),
+            // Storage probe (issue #603 WI-02): exactly two statements — one
+            // `system.parts` aggregate and one `system.disks` read. It touches
+            // no user relation, which is what makes it safe on the health path.
+            ScriptedResponse::rows(
+                &["FROM system.parts", "AND active", "GROUP BY table"],
+                json!([
+                    {
+                        "name": "events",
+                        "rows": 1_990_776_u64,
+                        "compressed_bytes": 4_787_723_965_u64,
+                        "uncompressed_bytes": 11_420_351_515_u64,
+                        "active_parts": 24_u64,
+                        "oldest_retained_unix": 1_771_597_005_i64,
+                        "oldest_retained_text": "2026-02-20T14:16:45Z"
+                    },
+                    {
+                        "name": "mcp_open_turns",
+                        "rows": 234_694_u64,
+                        "compressed_bytes": 14_356_000_000_u64,
+                        "uncompressed_bytes": 40_000_000_000_u64,
+                        "active_parts": 303_u64,
+                        "oldest_retained_unix": 0_i64,
+                        "oldest_retained_text": "1970-01-01T00:00:00Z"
+                    },
+                    {
+                        "name": "mystery_table",
+                        "rows": 1_u64,
+                        "compressed_bytes": 2_u64,
+                        "uncompressed_bytes": 3_u64,
+                        "active_parts": 1_u64,
+                        "oldest_retained_unix": 0_i64,
+                        "oldest_retained_text": "1970-01-01T00:00:00Z"
+                    }
+                ]),
+            ),
+            ScriptedResponse::rows(
+                &["FROM system.disks"],
+                json!([{ "free_bytes": 11_780_276_224_u64, "total_bytes": 994_662_584_320_u64 }]),
+            ),
         ];
         let (repo, state) = build_scripted_repo(responses).await;
 
@@ -106,7 +145,59 @@ async fn store_health_maps_all_successful_probe_facts() {
             "unmigrated core-index probe maps to Available/all-false, got {:?}",
             health.core_index
         );
-        assert_script_consumed(&state, 8);
+        // Storage probe (issue #603 WI-02): buckets are folded from the
+        // classification, the epoch sentinel is reported as "no oldest row"
+        // rather than 1970, and an unclassified table lands in NO bucket and
+        // is surfaced by name.
+        let storage = match &health.storage {
+            StoreProbe::Available(storage) => storage,
+            other => panic!("expected an available storage report, got {other:?}"),
+        };
+        assert_eq!(storage.tables.len(), 3);
+        let events = storage
+            .tables
+            .iter()
+            .find(|table| table.name == "events")
+            .expect("events row");
+        assert_eq!(events.class, Some(TableClass::CanonicalHistory));
+        assert_eq!(
+            events.oldest_retained.as_deref(),
+            Some("2026-02-20T14:16:45Z")
+        );
+        let turns = storage
+            .tables
+            .iter()
+            .find(|table| table.name == "mcp_open_turns")
+            .expect("turns row");
+        assert_eq!(turns.class, Some(TableClass::Derived));
+        assert_eq!(
+            turns.oldest_retained, None,
+            "a hash-partitioned table reports NO oldest row, never the epoch"
+        );
+        assert_eq!(storage.unclassified_tables(), vec!["mystery_table"]);
+        assert!(storage
+            .notes
+            .iter()
+            .any(|note| note.contains("mystery_table")));
+
+        let canonical = storage
+            .bucket(TableClass::CanonicalHistory)
+            .expect("canonical bucket");
+        assert_eq!(canonical.tables, 1);
+        assert_eq!(canonical.rows, 1_990_776);
+        // The unclassified table contributes to no bucket: it must never be
+        // silently folded into "derived".
+        assert_eq!(
+            storage.total_compressed_bytes(),
+            4_787_723_965 + 14_356_000_000
+        );
+        let disk = storage.disk.expect("disk headroom");
+        assert_eq!(disk.free_bytes, 11_780_276_224);
+        assert_eq!(disk.total_bytes, 994_662_584_320);
+        // Stock configuration authorizes deleting nothing.
+        assert!(storage.destructive_policies().is_empty());
+
+        assert_script_consumed(&state, 10);
     })
     .await;
 }
@@ -128,6 +219,9 @@ async fn store_health_keeps_each_probe_failure_independent() {
                 &["FROM system.tables", "mcp_read_index_state"],
                 "health core-index failed",
             ),
+            // The storage probe's first statement fails, so the whole probe
+            // degrades to Failed without failing the health report.
+            ScriptedResponse::failure(&["FROM system.parts"], "health storage failed"),
         ];
         let (repo, state) = build_scripted_repo(responses).await;
 
@@ -160,7 +254,11 @@ async fn store_health_keeps_each_probe_failure_independent() {
             health.core_index,
             StoreProbe::Failed { ref message } if message.contains("health core-index failed")
         ));
-        assert_script_consumed(&state, 6);
+        assert!(matches!(
+            health.storage,
+            StoreProbe::Failed { ref message } if message.contains("health storage failed")
+        ));
+        assert_script_consumed(&state, 7);
     })
     .await;
 }
@@ -276,6 +374,11 @@ async fn diagnostics_maps_doctor_partial_report_and_ping_short_circuit() {
                 "v_live_search_postings",
                 "v_mcp_open_publication_headers",
                 "v_current_mcp_open_generation_readiness",
+                // issue #603 WI-04: migration 038's ledger is part of the
+                // schema handshake, so a database without it reports it
+                // missing rather than silently tolerating a reclaimer with no
+                // durable claim set.
+                "storage_reclaim_ledger",
             ]
         );
         assert_eq!(diagnostics.errors.len(), 2);

--- a/crates/moraine-conversations/tests/repository_integration/main.rs
+++ b/crates/moraine-conversations/tests/repository_integration/main.rs
@@ -11,7 +11,7 @@ use moraine_conversations::{
     McpSessionListFilter, PageRequest, QueryClass, QueryEnvelope, RepoError, SearchEventKind,
     SearchEventsQuery, SearchMcpEventsQuery, SearchStrategyHint, SessionAnalyticsQuery,
     SessionEventsDirection, SessionEventsQuery, SessionLookback, SessionSearchQuery, SessionStep,
-    StoreProbe, TablePreviewQuery, TurnListFilter,
+    StoreProbe, TableClass, TablePreviewQuery, TurnListFilter,
 };
 use serde_json::json;
 use tokio::sync::Notify;

--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -19,8 +19,8 @@ use moraine_conversations::{
     CanonicalReadOutcome, ConversationListSort, ConversationMode, CoreIndexHealth, IngestHeartbeat,
     IngestHeartbeatRead, McpSessionListFilter, McpSessionListItem, McpSessionOpen, McpTurnCompact,
     PageRequest, PublicationDiagnostics, QueryClass, QueryEnvelope, RepoError, SessionLookback,
-    SessionSearchQuery, StoreConnectionMetrics, StoreHealth, StoreProbe, TablePreviewQuery,
-    TableSummaries,
+    SessionSearchQuery, StorageReport, StoreConnectionMetrics, StoreHealth, StoreProbe,
+    TablePreviewQuery, TableSummaries,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -613,6 +613,10 @@ async fn api_health(Extension(backend): Extension<Arc<BackendRepository>>) -> Re
                     "available": false,
                     "error": "canonical read-index readiness unavailable while store health is unavailable",
                 },
+                "storage": {
+                    "available": false,
+                    "error": "storage report unavailable while store health is unavailable",
+                },
                 "query_budgets": query_budgets_payload(),
             });
             if let Some(code) = code {
@@ -624,6 +628,7 @@ async fn api_health(Extension(backend): Extension<Arc<BackendRepository>>) -> Re
     let connections = connection_payload(&health.connections);
     let publication = publication_payload(&health.publication);
     let core_index = core_index_payload(&health.core_index);
+    let storage = storage_payload(&health.storage);
 
     let ping_ms = match &health.ping {
         StoreProbe::Available(value) => *value,
@@ -634,6 +639,7 @@ async fn api_health(Extension(backend): Extension<Arc<BackendRepository>>) -> Re
                 connections,
                 publication,
                 core_index,
+                storage,
             );
         }
     };
@@ -646,6 +652,7 @@ async fn api_health(Extension(backend): Extension<Arc<BackendRepository>>) -> Re
                 connections,
                 publication,
                 core_index,
+                storage,
             );
         }
     };
@@ -661,6 +668,7 @@ async fn api_health(Extension(backend): Extension<Arc<BackendRepository>>) -> Re
             "connections": connections,
             "publication": publication,
             "core_index": core_index,
+            "storage": storage,
             "query_budgets": query_budgets_payload(),
             "ingestor": health_heartbeat_payload(&heartbeat),
         }),
@@ -674,6 +682,7 @@ fn health_failure_response(
     connections: Value,
     publication: Value,
     core_index: Value,
+    storage: Value,
 ) -> Response {
     json_response(
         json!({
@@ -684,6 +693,7 @@ fn health_failure_response(
             "connections": connections,
             "publication": publication,
             "core_index": core_index,
+            "storage": storage,
             "query_budgets": query_budgets_payload(),
         }),
         StatusCode::SERVICE_UNAVAILABLE,
@@ -765,6 +775,9 @@ fn unavailable_store_health(message: String) -> StoreHealth {
             message: "canonical read-index readiness unavailable while store health is unavailable"
                 .to_string(),
         },
+        storage: StoreProbe::Failed {
+            message: "storage report unavailable while store health is unavailable".to_string(),
+        },
     }
 }
 
@@ -837,6 +850,69 @@ fn publication_payload(probe: &StoreProbe<PublicationDiagnostics>) -> Value {
         StoreProbe::Failed { message } => json!({
             "available": false,
             "healthy": false,
+            "error": message,
+        }),
+    }
+}
+
+/// The `/api/v1/health` `storage` block (issue #603 WI-02).
+///
+/// Per-bucket bytes rather than per-table: a health response must not grow
+/// with the table count, and the bucket is the unit the ownership model is
+/// expressed in. `policy` carries the effective `[retention]` with its
+/// provenance, and `destructive_policies` is a non-empty list exactly when
+/// configuration authorizes deleting user history — a client should never have
+/// to re-derive that from horizons.
+///
+/// No byte figure here is a "reclaimable" estimate: this block reports what
+/// is on disk now. Estimates live behind `moraine db reclaim plan`, where they
+/// carry their qualifier.
+fn storage_payload(probe: &StoreProbe<StorageReport>) -> Value {
+    match probe {
+        StoreProbe::Available(report) => json!({
+            "available": true,
+            "buckets": report
+                .buckets
+                .iter()
+                .map(|bucket| json!({
+                    "class": bucket.class.as_str(),
+                    "label": bucket.label,
+                    "tables": bucket.tables,
+                    "rows": bucket.rows,
+                    "compressed_bytes": bucket.compressed_bytes,
+                }))
+                .collect::<Vec<_>>(),
+            "total_compressed_bytes": report.total_compressed_bytes(),
+            "disk": report.disk.map(|disk| json!({
+                "free_bytes": disk.free_bytes,
+                "total_bytes": disk.total_bytes,
+                "used_bytes": disk.used_bytes(),
+            })),
+            "policy": report
+                .policy
+                .iter()
+                .map(|entry| json!({
+                    "class": entry.class.as_str(),
+                    "horizon_seconds": entry.horizon_seconds,
+                    "source": entry.source,
+                    "config_key": entry.config_key,
+                    "destructive": entry.is_destructive(),
+                    // `config_key` with no qualification reads as an
+                    // invitation to set it. Bucket 4's key is inert, and this
+                    // is the API's only chance to say so.
+                    "note": entry.note,
+                }))
+                .collect::<Vec<_>>(),
+            "destructive_policies": report
+                .destructive_policies()
+                .iter()
+                .map(|entry| entry.class.as_str())
+                .collect::<Vec<_>>(),
+            "unclassified_tables": report.unclassified_tables(),
+            "notes": report.notes,
+        }),
+        StoreProbe::Failed { message } => json!({
+            "available": false,
             "error": message,
         }),
     }
@@ -2049,6 +2125,45 @@ mod tests {
                 backfill_cursor_age_ms: Some(4_200),
                 audit_outcome: None,
             }),
+            storage: StoreProbe::Available(sample_storage_report()),
+        }
+    }
+
+    /// A minimal but non-degenerate storage report: one bucket-1 table, one
+    /// bucket-3 table, real disk numbers, and the default (non-destructive)
+    /// policy. Enough for the `/api/v1/health` shape assertions.
+    fn sample_storage_report() -> StorageReport {
+        let tables = vec![
+            moraine_conversations::StorageTableReport {
+                name: "events".to_string(),
+                class: Some(moraine_conversations::TableClass::CanonicalHistory),
+                rows: 1_990_776,
+                compressed_bytes: 4_787_723_965,
+                uncompressed_bytes: 11_420_351_515,
+                active_parts: 24,
+                oldest_retained: Some("2026-02-20T14:16:45Z".to_string()),
+            },
+            moraine_conversations::StorageTableReport {
+                name: "mcp_open_turns".to_string(),
+                class: Some(moraine_conversations::TableClass::Derived),
+                rows: 234_694,
+                compressed_bytes: 14_356_000_000,
+                uncompressed_bytes: 40_000_000_000,
+                active_parts: 303,
+                oldest_retained: None,
+            },
+        ];
+        StorageReport {
+            buckets: moraine_conversations::fold_buckets(&tables),
+            tables,
+            disk: Some(moraine_conversations::StorageDiskReport {
+                free_bytes: 11_780_276_224,
+                total_bytes: 994_662_584_320,
+            }),
+            policy: moraine_conversations::retention_policy_entries(
+                &moraine_config::RetentionConfig::default(),
+            ),
+            notes: Vec::new(),
         }
     }
 
@@ -4111,6 +4226,106 @@ mod tests {
         // The additive block is present on `/status` with the same shape.
         let status = response_json(api_status(Extension(backend)).await).await;
         assert_eq!(status["core_index"], health["core_index"]);
+    }
+
+    /// Issue #603 WI-02. The `storage` block is additive, per-bucket (so the
+    /// response cannot grow with the table count), and reports a stock
+    /// configuration as authorizing no deletion.
+    #[tokio::test]
+    async fn health_exposes_the_storage_block_with_no_destructive_policy_by_default() {
+        let (backend, _) = fake_backend(InMemoryConversationResponses {
+            read_store_health: Some(Ok(sample_health())),
+            latest_ingest_heartbeat: Some(Ok(sample_heartbeat())),
+            list_table_summaries: Some(Ok(TableSummaries::default())),
+            ..Default::default()
+        })
+        .await;
+
+        let health = response_json(api_health(Extension(backend)).await).await;
+        assert_eq!(health["ok"], json!(true));
+        let storage = &health["storage"];
+        assert_eq!(storage["available"], json!(true));
+
+        // Per-bucket, never per-table: every class is present, even at zero.
+        let buckets = storage["buckets"].as_array().expect("buckets array");
+        assert_eq!(buckets.len(), 5);
+        let canonical = buckets
+            .iter()
+            .find(|bucket| bucket["class"] == json!("canonical_history"))
+            .expect("canonical bucket");
+        assert_eq!(canonical["tables"], json!(1));
+        assert_eq!(canonical["rows"], json!(1_990_776));
+        assert_eq!(canonical["compressed_bytes"], json!(4_787_723_965_u64));
+        let telemetry = buckets
+            .iter()
+            .find(|bucket| bucket["class"] == json!("telemetry"))
+            .expect("telemetry bucket present even at zero");
+        assert_eq!(telemetry["tables"], json!(0));
+
+        assert_eq!(
+            storage["total_compressed_bytes"],
+            json!(4_787_723_965_u64 + 14_356_000_000_u64)
+        );
+        assert_eq!(storage["disk"]["free_bytes"], json!(11_780_276_224_u64));
+        assert_eq!(storage["disk"]["used_bytes"], json!(982_882_308_096_u64));
+
+        // Default configuration authorizes deleting nothing, and the block
+        // says so directly rather than making a client re-derive it.
+        assert_eq!(storage["destructive_policies"], json!([]));
+        let policy = storage["policy"].as_array().expect("policy array");
+        let canonical_policy = policy
+            .iter()
+            .find(|entry| entry["class"] == json!("canonical_history"))
+            .expect("canonical policy");
+        assert_eq!(canonical_policy["horizon_seconds"], Value::Null);
+        assert_eq!(canonical_policy["source"], json!("default"));
+        assert_eq!(canonical_policy["destructive"], json!(false));
+        assert_eq!(
+            canonical_policy["config_key"],
+            json!("retention.canonical_history_horizon_days")
+        );
+        assert_eq!(canonical_policy["note"], Value::Null);
+
+        // The telemetry horizon reports a `config_key` that cannot move it, so
+        // the API must carry the caveat with the key. Without it, a client that
+        // renders `config_key` invites an operator to set a value the server
+        // will refuse — or, before the refusal existed, to set one the server
+        // accepted and never applied.
+        let telemetry_policy = policy
+            .iter()
+            .find(|entry| entry["class"] == json!("telemetry"))
+            .expect("telemetry policy");
+        assert_eq!(telemetry_policy["source"], json!("default"));
+        assert_eq!(telemetry_policy["horizon_seconds"], json!(2_592_000.0));
+        assert_eq!(
+            telemetry_policy["note"],
+            json!(moraine_conversations::TELEMETRY_HORIZON_NOT_CONFIGURABLE_NOTE)
+        );
+        assert_eq!(storage["unclassified_tables"], json!([]));
+    }
+
+    /// The probe degrades independently: an unavailable storage report must not
+    /// take the rest of health down with it.
+    #[tokio::test]
+    async fn health_reports_an_unavailable_storage_probe_without_failing() {
+        let (backend, _) = fake_backend(InMemoryConversationResponses {
+            read_store_health: Some(Ok(StoreHealth {
+                storage: StoreProbe::Failed {
+                    message: "system.parts unreadable".to_string(),
+                },
+                ..sample_health()
+            })),
+            latest_ingest_heartbeat: Some(Ok(sample_heartbeat())),
+            list_table_summaries: Some(Ok(TableSummaries::default())),
+            ..Default::default()
+        })
+        .await;
+
+        let health = response_json(api_health(Extension(backend)).await).await;
+        assert_eq!(health["ok"], json!(true), "storage is not a health gate");
+        assert_eq!(health["storage"]["available"], json!(false));
+        assert_eq!(health["storage"]["error"], json!("system.parts unreadable"));
+        assert_eq!(health["core_index"]["available"], json!(true));
     }
 
     #[tokio::test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,7 @@ future keys.
 | `[mcp]` | MCP retrieval defaults and shared backend socket settings. |
 | `[bm25]` | Search ranking defaults. |
 | `[query_budgets]` | Per-class ClickHouse query budgets (deadline, memory, spill, read allowances, statement cap) for the mandatory query envelope. |
+| `[retention]` | Storage ownership horizons. Defaults delete no raw or canonical user history. |
 | `[monitor]` | Monitor HTTP port. |
 | `[backend]` | Unified MCP socket and monitor HTTP daemon startup, HTTP bind, and experimental non-loopback guard. |
 | `[runtime]` | Runtime directories and managed ClickHouse settings. |
@@ -927,6 +928,96 @@ them after observing budget-exhaustion telemetry in monitor health/status
 summarized as a `moraine status` note when nonzero); repeated
 `deadline_exceeded` or `resource_exhausted` results indicate either an
 under-provisioned budget or a query-shape problem worth investigating.
+
+## Retention
+
+`[retention]` declares how long each class of stored data is kept. It is the
+configuration half of Moraine's storage ownership model, which sorts every
+physical table into one of five classes:
+
+| Class | Tables | Default |
+| --- | --- | --- |
+| `canonical_history` | `events` | **Kept forever.** Deletion requires an explicit key. |
+| `raw_audit` | `raw_events`, `ingest_errors` | **Kept forever.** Deletion requires an explicit key. |
+| `derived` | the `mcp_open_*` projection, the canonical read indexes, `search_documents`/`search_postings`, `tool_io`, `event_links`, `file_attention_project_roots` | Rebuildable; eligible for automatic reclamation once its replacement is verified. |
+| `telemetry` | `ingest_heartbeats`, `search_query_log`, `search_hit_log`, `search_interaction_log`, and the ClickHouse system logs | Bounded by a default TTL. |
+| `never_delete` | publication truth, revision allocators, control fences, the migration ledger, the reclaim ledger, `search_conversation_terms` | No code path may ever delete it. |
+
+`search_conversation_terms` sits in `never_delete` rather than `derived`
+because it is a `SummingMergeTree` accumulator with no tombstone path: a delete
+never decrements it, so any reclamation naming it would leave the term corpus
+permanently overstated with no way back short of a corpus-wide re-tokenize.
+
+```toml
+[retention]
+derived_horizon_hours = 24.0
+telemetry_horizon_days = 30
+# raw_audit_horizon_days = 90.0            # absent by default
+# canonical_history_horizon_days = 365.0   # absent by default
+```
+
+| Field | Default | Floor | Purpose |
+| --- | --- | --- | --- |
+| `derived_horizon_hours` | `24.0` | `24.0` | How long a **superseded** derived row must have been superseded before reclamation may claim it. It is never a predicate over live data. |
+| `telemetry_horizon_days` | `30` | — | Bucket-4 TTL horizon. **Not yet operator-configurable: `30` is the only accepted value.** |
+| `raw_audit_horizon_days` | *absent* | `7.0` | Retention for `raw_events` and `ingest_errors`. Setting it authorizes deleting them. |
+| `canonical_history_horizon_days` | *absent* | `7.0` | Retention for `events`. Setting it authorizes deleting your conversation history. |
+
+**A missing setting is never permission to delete.** The two protected horizons
+are absent by default and absence is not a value: the reclaim planner cannot
+construct deletion authority for buckets 1 or 2 without them, so an install
+that has never edited this section can never prune user history — including
+across upgrades. Setting either key is the only way to grant that authority,
+and `moraine status` then prints a prominent line naming what will be deleted.
+
+The floors are not configurable below their values. A shorter horizon can
+retire rows that a live request is still pinned to, so a config naming one
+fails to load rather than loading with a value that looks accepted.
+
+Inspect the effective policy and what it would remove:
+
+```
+moraine db reclaim status              # per-bucket bytes, disk headroom, policy, ledger
+moraine db reclaim plan [--scope S]    # dry run: row/byte ESTIMATES; writes nothing
+moraine db reclaim run --scope S --confirm
+```
+
+`run` refuses without `--confirm`, printing exactly which tables the scope
+would touch, and refuses a bucket-1/2 scope unless the matching key above is
+present — naming the missing key. Export before pruning with
+`moraine export events --format jsonl`.
+
+**In this release `run` deletes nothing at all.** No scope has a registered
+executor yet, so every `run` refuses a third time — naming the work item that
+will add one — and exits non-zero. `status` and `plan` are complete and
+useful today; treat `run` as the ceremony being reviewable before it does
+anything.
+
+Two things Moraine deliberately does **not** promise. No table is partitioned
+by source generation, so reclamation is a lightweight `DELETE` rather than a
+partition drop: bytes return only when a background merge rewrites the part.
+Reclaimed **row counts** are exact; the on-disk delta is merge-deferred and is
+reported as such.
+
+Bucket-4 TTLs arrive with migration 039 and are anchored so that their **first
+application deletes nothing**: existing rows are stamped at migration time and
+expire 30 days later, so an upgrade never silently shortens telemetry an
+operator has been keeping.
+
+`telemetry_horizon_days` is **not yet operator-configurable**, and Moraine
+refuses to load a config that sets it to anything but `30`. Migration SQL is
+static text: the horizon is written into `sql/039_telemetry_retention.sql` as
+four `INTERVAL 30 DAY` literals, so a configured `90` would change nothing
+except what `moraine db reclaim status`, `moraine db doctor` and
+`/api/v1/health` report back to you — a horizon shorter than the one they
+state, which is the failure mode the whole `[retention]` design exists to
+prevent. The key keeps its name and its documented value so that the change
+which templates the horizon into the migration does not have to rename
+anything; until then the reported policy is labelled `default` and carries the
+reason inline. The three ClickHouse system logs
+(`query_log`, `metric_log`, `asynchronous_metric_log`) are bounded separately
+by `config/clickhouse.xml`, which restores the 30-day horizon ClickHouse's own
+packaged config ships; those are ClickHouse diagnostics, not Moraine data.
 
 ## Backend Daemon
 

--- a/docs/full-config.toml
+++ b/docs/full-config.toml
@@ -360,6 +360,41 @@ bind = "127.0.0.1"
 # ignored. Non-loopback binds require this explicit true value.
 start_on_up = true
 
+[retention]
+# Storage ownership and retention policy (issue #603).
+#
+# EVERY DEFAULT HERE IS A NO-OP FOR USER HISTORY. The two protected-bucket
+# horizons below are ABSENT by default and absence is not a value: the reclaim
+# planner cannot construct deletion authority for canonical or raw/audit data
+# without them, so a config that does not mention them can never prune history.
+# Nothing is deleted by simply naming this section.
+
+# Bucket 3 (rebuildable derived data) safety horizon, in hours: how long a
+# SUPERSEDED derived row must have been superseded before reclamation may claim
+# it. Never applies to a live generation. Floor 24 (not configurable lower).
+derived_horizon_hours = 24.0
+
+# Bucket 4 (operational telemetry) TTL horizon, in days. Migration 039 applies
+# the shipped 30-day TTL to ingest_heartbeats, search_query_log, search_hit_log,
+# and search_interaction_log, anchored so its FIRST application deletes nothing.
+#
+# NOT YET OPERATOR-CONFIGURABLE. The horizon is baked into
+# sql/039_telemetry_retention.sql as static SQL text, so no value written here
+# can change when ClickHouse expires a telemetry row. Rather than accept a
+# number and then report it back as your effective policy, Moraine REFUSES TO
+# LOAD a config that sets this key to anything but 30. Every surface that prints
+# it labels it `default` and says why.
+telemetry_horizon_days = 30
+
+# Bucket 2 (raw / audit source data: raw_events, ingest_errors).
+# ABSENT BY DEFAULT — uncomment ONLY if you want this data pruned. Floor 7 days.
+# raw_audit_horizon_days = 90.0
+
+# Bucket 1 (canonical user history: events).
+# ABSENT BY DEFAULT — uncomment ONLY if you want your history pruned. Export
+# first with `moraine export events --format jsonl`. Floor 7 days.
+# canonical_history_horizon_days = 365.0
+
 [monitor]
 # Monitor HTTP port.
 port = 8080

--- a/docs/monitor-http-api.md
+++ b/docs/monitor-http-api.md
@@ -14,7 +14,7 @@ All canonical routes are `GET` routes and successful responses use JSON.
 | Route | Query | Purpose |
 | --- | --- | --- |
 | `/api/v1/capabilities` | none | Describe this server build, its observed schema migration level, and available HTTP feature groups. |
-| `/api/v1/health` | none | Probe ClickHouse health and report compact publication-readiness, query-budget, and ingest-heartbeat summaries. |
+| `/api/v1/health` | none | Probe ClickHouse health and report compact publication-readiness, storage, query-budget, and ingest-heartbeat summaries. |
 | `/api/v1/status` | none | Return the diagnostic ClickHouse, publication, database, table, connection, and ingestor snapshot used by the status dashboard, plus `known_harnesses`. |
 | `/api/v1/analytics` | `range` | Return token, turn, and concurrent-session time series for a supported window. |
 | `/api/v1/tables` | none | List tables with engine, temporary-table marker, and estimated row count. |
@@ -425,6 +425,80 @@ rows. They do not use `null` to mean an empty collection.
 
 Clients must distinguish a diagnostic value inside an HTTP `200` response from
 an endpoint failure represented by a non-2xx status.
+
+## Health Storage Block
+
+`GET /api/v1/health` carries an additive `storage` object describing what is on
+disk and the retention policy in force. It is present on both the `200` and the
+`503` shape, and like every other probe it degrades independently: a backend
+that cannot report storage yields `{"available": false, "error": "..."}` while
+the rest of the response is unaffected.
+
+```json
+{
+  "storage": {
+    "available": true,
+    "buckets": [
+      {
+        "class": "canonical_history",
+        "label": "canonical user history",
+        "tables": 1,
+        "rows": 1990776,
+        "compressed_bytes": 4787723965
+      }
+    ],
+    "total_compressed_bytes": 19143723965,
+    "disk": { "free_bytes": 11780276224, "total_bytes": 994662584320, "used_bytes": 982882308096 },
+    "policy": [
+      {
+        "class": "canonical_history",
+        "horizon_seconds": null,
+        "source": "default",
+        "config_key": "retention.canonical_history_horizon_days",
+        "destructive": false,
+        "note": null
+      }
+    ],
+    "destructive_policies": [],
+    "unclassified_tables": [],
+    "notes": []
+  }
+}
+```
+
+Field semantics:
+
+- `buckets` reports **per storage class**, not per table, so the response size
+  does not grow with the table count. `class` is one of `canonical_history`,
+  `raw_audit`, `derived`, `telemetry`, `never_delete`; every class appears even
+  at zero tables.
+- `total_compressed_bytes` is the sum over buckets. A table the server does not
+  classify contributes to **no** bucket and is named in `unclassified_tables`
+  instead — it is never folded into `derived`.
+- `disk` is `null` when `system.disks` could not be read; `notes` then explains
+  why. `notes` also names any unclassified table.
+- `policy[].source` is `default` or `configured`. `policy[].destructive` is
+  `true` exactly when configuration authorizes deleting user history for that
+  class, and `destructive_policies` lists those classes. An empty
+  `destructive_policies` means default configuration deletes no raw or
+  canonical history.
+- `horizon_seconds` is `null` for a class with no horizon (`never_delete`) and
+  for an unconfigured protected bucket. `null` is "no retention", never "zero".
+- `policy[].note` is `null` except on `telemetry`, whose horizon lives in
+  static migration SQL (`sql/039_telemetry_retention.sql`) rather than in
+  configuration. Its `config_key` is reported for discoverability, but the key
+  is not yet operator-configurable — the server refuses to load a config that
+  sets it to anything but the default — so `source` is always `default` and the
+  note says why. A client that surfaces `config_key` should surface `note` with
+  it.
+
+Every byte figure here describes what is stored **now**. The block carries no
+reclaimable estimate: estimates are available only from
+`moraine db reclaim plan`, where they are labelled as estimates, because
+nothing is partitioned by source generation and a lightweight `DELETE` returns
+bytes only when a background merge rewrites the part.
+
+Clients must treat the block as additive and tolerate new keys inside it.
 
 ## Errors and Status Codes
 

--- a/sql/038_storage_reclaim_ledger.sql
+++ b/sql/038_storage_reclaim_ledger.sql
@@ -1,0 +1,66 @@
+-- Issue #603 WI-04: the storage reclaim ledger.
+--
+-- Purely additive: one `CREATE TABLE IF NOT EXISTS`. No TRUNCATE, no DELETE,
+-- no view or materialized-view recreation, no reset of any projection state.
+-- Re-runs are no-ops. **This migration installs no executor and reclaims
+-- nothing**; it exists so that the durable state the reclaimer needs is in
+-- place, and reviewable, before anything is ever deleted.
+--
+-- WHY A LEDGER AT ALL. The existing `mcp_open` reclaim path derives its target
+-- set *from headers* and then deletes the headers first. A crash between the
+-- two statements strands the child rows forever, because the set can never be
+-- re-derived from what remains: no header means no probe can see them, and no
+-- reader can authorize them either. The reference host carries ~10.9M such
+-- rows (58% of `mcp_open_events`), still accumulating, dating from the PR-604
+-- incident.
+--
+-- Making the claimed set durable *independently of the rows it names* is what
+-- lets the new driver delete children first and the parent last. A crash then
+-- leaves an intact, still-authorizable snapshot rather than an unreachable
+-- orphan, and the next run re-drives the unit from this table. Reader safety
+-- is preserved by the safety horizon and the anti-join — a unit is already
+-- non-live before it is claimed — not by delete ordering.
+--
+-- ENGINE CHOICE. `ReplacingMergeTree(ledger_revision)` keyed on
+-- `(scope, reclaim_id)`: a phase advance is an INSERT carrying a fresher
+-- snowflake revision, never an UPDATE and never a DELETE. That keeps the whole
+-- lifecycle append-only, so a partially applied phase transition is impossible
+-- and the ledger itself needs no mutation machinery to maintain.
+--
+-- NOT PARTITIONED. The table is bounded by the number of units ever claimed
+-- and each row is a few hundred bytes; a partition key would add merge work
+-- for no reclaim benefit, and the ledger is classified `never_delete` anyway
+-- (`crates/moraine-clickhouse/src/storage_class.rs`) — a reclaimer able to
+-- delete its own ledger would reintroduce exactly the stranded-child bug this
+-- table exists to fix.
+
+CREATE TABLE IF NOT EXISTS moraine.storage_reclaim_ledger (
+  -- Snowflake, one per claimed unit.
+  reclaim_id           String,
+  -- `mcp_open_orphan` | `read_index_generation` | `canonical_generation`.
+  -- Kept as a string rather than an enum so adding a scope in a later work
+  -- item is a code change, not a schema change.
+  scope                LowCardinality(String),
+  -- Source identity for generation-scoped units. Empty/zero for units scoped
+  -- by (session, candidate generation) instead.
+  source_host          String,
+  source_name          String,
+  source_file          String,
+  source_generation    UInt32,
+  -- Session identity for snapshot-scoped units. Empty for generation-scoped
+  -- units.
+  session_id           String,
+  candidate_generation UInt64,
+  -- `claimed` | `deleting` | `done` | `abandoned`.
+  phase                LowCardinality(String),
+  -- Written at claim time from `system.parts` ranges, never from a FINAL scan.
+  -- These are estimates and every surface that reports them says so: nothing
+  -- is partitioned by `source_generation`, so a lightweight DELETE masks rows
+  -- and returns bytes only when a background merge rewrites the part.
+  estimated_rows       UInt64,
+  estimated_bytes      UInt64,
+  claimed_at           DateTime64(3) DEFAULT now64(3),
+  ledger_revision      UInt64
+)
+ENGINE = ReplacingMergeTree(ledger_revision)
+ORDER BY (scope, reclaim_id);

--- a/sql/039_telemetry_retention.sql
+++ b/sql/039_telemetry_retention.sql
@@ -1,0 +1,100 @@
+-- Issue #603 WI-08: bound bucket-4 operational telemetry.
+--
+-- There is no TTL anywhere in this repository before this migration, and no
+-- retention configuration of any kind. Four Moraine tables grow without bound
+-- and nothing reads more than the newest few rows of any of them:
+--
+--   * `ingest_heartbeats`      — only the LATEST row is read; one row every 5 s
+--                                per host (~17 280/day). 1.34M rows on the
+--                                reference host.
+--   * `search_query_log`       — the single reader is a rolling 7-day hot-query
+--                                window, so a 30-day horizon carries 4x
+--                                headroom over the only horizon any code
+--                                depends on.
+--   * `search_hit_log`         — no readers; up to `result_limit` rows per
+--                                query, so the highest-volume telemetry table
+--                                by construction.
+--   * `search_interaction_log` — no writer and no reader (migration 020 already
+--                                says so); zero active parts on the reference
+--                                host.
+--
+-- THIS MIGRATION DELETES NOTHING WHEN IT IS APPLIED (issue #603 §4 S5).
+--
+-- A plain `MODIFY TTL ts + INTERVAL 30 DAY DELETE` would, because
+-- `materialize_ttl_after_modify` defaults to 1: the ALTER mutates existing
+-- parts immediately and every row older than the horizon disappears on
+-- upgrade. That is exactly the regression S5 names — "an upgrade that silently
+-- drops three months of an operator's telemetry on first boot" — and the spec
+-- is explicit that retention is never silently shortened during upgrade.
+--
+-- So the TTL is expressed against a `retention_anchor` column rather than
+-- against the row's own timestamp:
+--
+--   1. `ADD COLUMN retention_anchor DateTime DEFAULT now()`
+--   2. `MATERIALIZE COLUMN retention_anchor` stamps every EXISTING row with
+--      the migration's own wall clock, synchronously.
+--   3. `MODIFY TTL retention_anchor + INTERVAL 30 DAY DELETE`.
+--
+-- The effective horizon for a pre-existing row is therefore
+-- `max(30 days, time since this migration ran)` measured from upgrade, and for
+-- a newly inserted row it is 30 days from insert (its anchor defaults to the
+-- insert clock). First application deletes nothing; steady state is bounded.
+-- A row inserted with a backdated `ts` lives 30 days from INSERT rather than
+-- from `ts`, which errs toward keeping data — the correct direction for a
+-- guard whose failure mode is deleting too much.
+--
+-- The plan's OQ-4 recommends S5 for `ingest_heartbeats` and `search_query_log`
+-- only, and plain TTLs for the other two "no readers, no operator
+-- expectation" tables. This migration applies S5 to all four instead: the two
+-- tables OQ-4 would treat plainly hold 7 927 and 0 rows on the reference host,
+-- so the anchor costs nothing there, and applying it uniformly makes "this
+-- migration removes no Moraine row" a property of the whole file rather than
+-- of two statements in it. The headroom WI-08 actually buys comes from the
+-- three ClickHouse system logs in `config/clickhouse.xml`, which are ~2.0 GiB
+-- of rows older than 30 days on the reference host against ~9 MiB for all four
+-- tables here.
+--
+-- `mutations_sync = 1` on the MATERIALIZE statements is load-bearing and is
+-- NOT the setting the reclaimer is forbidden to use (that prohibition is about
+-- lightweight cleanup DELETEs, which must stay cancellable). Here the TTL must
+-- not be able to observe an unmaterialized anchor, so the stamp completes
+-- before the ALTER that consumes it. Migration 020 uses the same setting for
+-- the same reason.
+--
+-- HORIZON. 30 days is baked in as a literal because migration SQL is static
+-- text. `retention.telemetry_horizon_days` reports the effective policy and is
+-- asserted equal to this literal by
+-- `migration_039_ttl_horizon_matches_the_configured_default`, so the config
+-- default and the shipped TTL cannot drift apart silently.
+--
+-- Additive otherwise: no TRUNCATE, no DELETE, no view or MV recreation, no
+-- reset of any projection state. Touches no bucket-1, bucket-2, or
+-- never-delete table.
+
+ALTER TABLE moraine.ingest_heartbeats
+  ADD COLUMN IF NOT EXISTS retention_anchor DateTime DEFAULT now();
+ALTER TABLE moraine.ingest_heartbeats
+  MATERIALIZE COLUMN retention_anchor SETTINGS mutations_sync = 1;
+ALTER TABLE moraine.ingest_heartbeats
+  MODIFY TTL retention_anchor + INTERVAL 30 DAY DELETE;
+
+ALTER TABLE moraine.search_query_log
+  ADD COLUMN IF NOT EXISTS retention_anchor DateTime DEFAULT now();
+ALTER TABLE moraine.search_query_log
+  MATERIALIZE COLUMN retention_anchor SETTINGS mutations_sync = 1;
+ALTER TABLE moraine.search_query_log
+  MODIFY TTL retention_anchor + INTERVAL 30 DAY DELETE;
+
+ALTER TABLE moraine.search_hit_log
+  ADD COLUMN IF NOT EXISTS retention_anchor DateTime DEFAULT now();
+ALTER TABLE moraine.search_hit_log
+  MATERIALIZE COLUMN retention_anchor SETTINGS mutations_sync = 1;
+ALTER TABLE moraine.search_hit_log
+  MODIFY TTL retention_anchor + INTERVAL 30 DAY DELETE;
+
+ALTER TABLE moraine.search_interaction_log
+  ADD COLUMN IF NOT EXISTS retention_anchor DateTime DEFAULT now();
+ALTER TABLE moraine.search_interaction_log
+  MATERIALIZE COLUMN retention_anchor SETTINGS mutations_sync = 1;
+ALTER TABLE moraine.search_interaction_log
+  MODIFY TTL retention_anchor + INTERVAL 30 DAY DELETE;


### PR DESCRIPTION
# feat(603): classify storage ownership and gate reclamation

Base: `epic/canonical-first-refactor` · Issue: #603 · Plan: `plans/603-reclamation.md`

## Summary

The reference host is a 46 GiB ClickHouse database that has filled its disk
twice, and until this branch nothing in the repository could answer "what is
using the space, who owns it, and what may be deleted". Nothing could answer
the second question because the answer did not exist anywhere in code — the
ownership model lived in a plan document.

This change writes the model down as code, adds the measurement, installs the
durable state a reclaimer will need, and bounds the one class of data that is
safe to bound today. **It deletes no user data and registers no executor**, and
that ordering is deliberate: the ledger, the authority types and the statement
emitter have to be reviewable *before* the first executor lands, because the
first executor is the point at which a bug costs an operator their history.

## What changed

### WI-01 — the ownership model as code (`crates/moraine-clickhouse/src/storage_class.rs`)

`classify(table) -> Option<TableClass>` over five classes:
`CanonicalHistory`, `RawAudit`, `Derived`, `Telemetry`, `NeverDelete`. The
fifth is not one of the spec's four buckets; it carries the *Auto = never* rows
of buckets 2 and 3 — publication truth, the monotone revision allocators, the
cache fence, the readiness fence — because those are control state whose
deletion breaks ingest or silently changes query results, not "audit data an
operator may configure a horizon for".

`None` means *unknown*, and unknown is a hard error at every call site that is
about to delete something. It is deliberately not "probably derived".

Exhaustiveness is asserted three ways, not two. Comparing `CLASSIFIED_TABLES`
against `REQUIRED_SCHEMA_OBJECTS` compares two hand-maintained Rust lists to
each other, and a migration that installs a table nobody ever registered leaves
both of them agreeing — which is exactly how `file_attention_project_roots`
(migration 026) came to need an exemption list. So `classification_gaps()` also
parses every `CREATE TABLE` in `bundled_migrations()`.

### WI-02 — storage observability (`storage_report.rs`)

Before this, nothing anywhere in the repository queried `system.disks`,
`free_space`, or `total_bytes_on_disk`. The whole report is **one**
`system.parts` aggregate (active parts only) plus **one** `system.disks` read,
and reads no user relation at all — so it is safe on the health path.
`oldest_retained` comes from `system.parts.min_time` rather than a per-table
`min(ingested_at)` scan, and is reported as `None` rather than `1970` for
tables with no time-typed partition key.

Surfaced by `moraine status`, `moraine db doctor`, `moraine db reclaim status`,
and the new `storage` block in `/api/v1/health`.

### WI-03 — `[retention]` (`crates/moraine-config/src/lib.rs`)

The two protected horizons (`raw_audit_horizon_days`,
`canonical_history_horizon_days`) are `Option` with **no serde default**, and
`RetentionHorizon` — the only type the reclaimer accepts as authority for those
buckets — has no `Default`, no `From<()>`, no public constructor and a private
field. A missing setting therefore cannot *type-check* into deletion authority.

`retention.telemetry_horizon_days` is documented and validated as **not yet
operator-configurable**. Migration SQL is static text: `sql/039` writes
`INTERVAL 30 DAY` four times, so a configured `90` would change nothing except
what `moraine db reclaim status`, `moraine db doctor` and `/api/v1/health`
report back — a horizon shorter than the one they state, which is the exact
failure mode `[retention]` exists to prevent. The loader refuses any value but
`30`, and the reporting surfaces read the horizon from the constant rather than
from the field so that a `RetentionConfig` built in code cannot make the line
disagree with what ClickHouse will do.

### WI-04 — the reclaim ledger and the statement surface (`reclaim.rs`, `sql/038`)

`emit_delete_statement` is the single function that constructs a `DELETE`
naming a reclaim table, and it performs three checks:

1. re-derives the table's class from `classify()` — an *independent* source
   from whatever the planner used to build the unit;
2. refuses unless handed a token that authorizes that class (each authority
   variant authorizes exactly its own bucket, and `NeverDelete` is authorized
   by nothing);
3. refuses a predicate whose text mentions none of the shape's key columns.
   `WHERE 1` is the limiting case, and the INV-2 corpus itself used to build
   every statement that way. This is `predicate_sql.contains(column)` — name
   presence, not binding; the function doc previously overstated it and now
   says so.

The ledger inverts the existing `mcp_open` reclaimer's delete order. That
reclaimer derives its target set *from headers* and deletes the headers first,
so a crash between statements strands the children forever — the reference
host's ~10.9M orphan `mcp_open_events` rows are that bug's output. Making the
claimed set durable independently of the rows it names is what lets a driver
delete children first and the parent last.

### WI-08 — bounded telemetry (`sql/039`, `config/clickhouse.xml`)

Four Moraine telemetry tables get 30-day TTLs. A plain
`MODIFY TTL ts + INTERVAL 30 DAY DELETE` would delete five months of telemetry
on upgrade, because `materialize_ttl_after_modify` defaults to 1. So the TTL is
anchored: add `retention_anchor DateTime DEFAULT now()`, `MATERIALIZE COLUMN`
it synchronously to stamp every existing row with the migration's own clock,
then `MODIFY TTL retention_anchor + INTERVAL 30 DAY DELETE`. **First
application deletes nothing**; steady state is bounded.

`config/clickhouse.xml` is rendered as the *whole* server config and launched
with `--config-file`, so ClickHouse's packaged `config.xml` — which ships
`event_date + INTERVAL 30 DAY DELETE` for each system log — was never loaded
and those three tables had no retention at all. Verified empirically against
ClickHouse 25.12.5.44 (empty TTL clause in `create_table_query` for all three;
`part_log`/`trace_log`/`text_log` are not declared). Restoring the horizon
recovers ~2.0 GiB of the 5.1 GiB those three occupy on the reference host, and
names no `moraine.*` table, so it cannot delete user history by construction.

### §4 S4 — the migration invariant, rebuilt

The guards this replaces (`clickhouse/src/lib.rs:3287-3297`, `:3329-3339`) were
substring matches on exactly one statement form *with a required trailing
semicolon*, pinned by a hard-coded `.find(|m| m.version == "034")` lookup.
`ALTER TABLE moraine.events DELETE WHERE …`, `DELETE FROM moraine.events` and
`TRUNCATE TABLE IF EXISTS moraine.events` all passed them untouched, and any
newly added migration was covered by no guard of the family at all.

The replacement is per-statement, runs over **every** bundled migration, and is
**fail-closed**: a statement is a finding unless its shape is on a benign
allowlist.

That inversion is the substantive change in this round. Four consecutive review
rounds enumerated *destructive* shapes, and each round's adversarial sweep found
shapes the previous round's list could not see — the `DROP` family, then
`MODIFY TTL`/`CLEAR COLUMN`/`MOVE … TO TABLE`/`REPLACE TABLE`/`RENAME`, then
four more that were still invisible with the list at ten shapes and the crate at
193/0:

| Missed shape | What it does |
|---|---|
| `ALTER TABLE … UPDATE <col> = <expr> WHERE …` | the standard ClickHouse overwrite; `payload_json = ''` destroys 3.52 GiB of compressed column content and keeps every row |
| `ALTER TABLE … REPLACE PARTITION <p> FROM <other>` | atomically discards the destination's partition; `events` spans six active partitions |
| `OPTIMIZE TABLE … FINAL [DEDUPLICATE [BY …]]` | `events` is a `ReplacingMergeTree`; `FINAL` applies the collapse and `DEDUPLICATE BY` collapses on an arbitrary column subset |
| `ALTER TABLE … DETACH PARTITION\|PART` | step **one** of the two-step delete whose step two (`DROP DETACHED`) the list already covered |

Enumerating destructive forms is an unbounded adversarial search against a SQL
dialect that keeps growing. Enumerating benign ones is bounded by what
migrations in this repository actually do — 294 statements across 39 migrations.
So `benign_shape` is the gate.

Two properties keep the benign list from becoming the same unbounded enumeration
wearing the other hat:

- **No entry may be speculative.** `every_benign_entry_is_witnessed_by_a_real_statement`
  fails for an entry no bundled migration and no negative-corpus row reaches.
- **A statement whose relation cannot be parsed is still a finding**, reported
  under `UNPARSED_RELATION`, which classifies as `NeverDelete`.

`DeleteShape` survives as *reporting* — "`AlterUpdate` on `events`" is a far
better failure message than "unrecognized statement" — and answering `None`
never suppresses a finding. Its arms are pinned by asserting the **label** as
well as the finding, since deleting an arm no longer changes the gate's answer.

### The clause parser (round 5)

Inverting the gate was right, but round 4's `ALTER` reducer was not a clause
parser: it matched any bare token from a nineteen-entry verb list **anywhere in
the body**. That failed in both directions at once.

| | Statement | Round 4 | Now |
|---|---|---|---|
| Fail-**closed** | `ALTER TABLE moraine.events MODIFY COLUMN payload_json COMMENT 'the payload'` | finding — a phantom `COMMENT 'THE` operation manufactured from the inline column comment | admitted |
| Fail-**open** | `ALTER TABLE moraine.events ADD COLUMN c String DEFAULT 'x TO DISK y', MOVE PARTITION '202601' TO TABLE moraine.mcp_open_turns` | **admitted** — the `MOVE` clause's tiering test searched the whole statement and the laundering substring sat in an unrelated literal | finding, `AlterMove` on `events` |

`alter_clauses` now splits the body on top-level commas over a `mask_quoted`
copy — string literals and quoted identifiers replaced by `_`, parentheses
tracked — and each clause is judged on its own text. **The verb list is gone.**
Under the whole-body scan an unlisted verb was a silent pass, so the enumeration
had to be complete; now an unrecognized clause head simply is not on the benign
list, and completing the enumeration stopped being load-bearing. A clause split
that disagrees with ClickHouse's grammar fails closed:
`UPDATE a = 1, b = 2 WHERE 1` splits into two halves and neither is benign.

`normalize_statement` was fixed in the same pass: it cut every line at its first
`--` regardless of quoting, so
`MODIFY COLUMN c COMMENT 'a -- b', DROP COLUMN payload_json` normalized to a
statement ending mid-literal — the `DROP COLUMN` disappeared. It now strips
`--` and `/* … */` only outside a literal.

### Five benign entries that could destroy bucket-1 data (round 5)

Each was executed against a bundled migration in an isolated copy, each left the
crate **GREEN at 195/0** — that crate total is the round-5 measurement and is
not comparable to the 209/0 under *Validation*, which is post-rebase and
includes this round's tests — and every statement is `EXPLAIN AST`-valid on the
deployed ClickHouse 25.12.5.44.

| Admitted statement | What it does | Now |
|---|---|---|
| `ALTER TABLE moraine.events MODIFY COLUMN payload_json String TTL ingested_at + INTERVAL 1 DAY` | a column TTL replaces expired values with the column default and removes the column from a part once every value in it has expired — `CLEAR COLUMN` on a rolling horizon. `materialize_ttl_after_modify = 1` and `merge_with_ttl_timeout = 14400` on the reference host, so it lands within 4 h, and `MATERIALIZE TTL` forces it immediately | `AlterModifyTtl` |
| `ALTER TABLE moraine.events MATERIALIZE COLUMN payload_json` | recomputes the column from its `DEFAULT` across all parts. `sql/037` documents this exact hazard against `text_digest`; `events` ships two `DEFAULT ''` columns today | `AlterRewriteColumn` |
| `ALTER TABLE moraine.events MODIFY COLUMN ingested_at DateTime` | re-declaring the type rewrites every part, here narrowing the `DateTime64(3)` column that `PARTITION BY toYYYYMM(ingested_at)` is built on | `AlterRewriteColumn` |
| `INSERT INTO moraine.events SELECT * REPLACE ('' AS payload_json, event_version + 1 AS event_version) FROM moraine.events FINAL` | `events` is `ReplacingMergeTree(event_version)` with `payload_json` outside the sort key, so this supersedes **every row of canonical history** with a blanked payload: unreachable through `FINAL`/`v_live_events` immediately, physically gone at the next merge | `InsertInto` |
| `CREATE MATERIALIZED VIEW … TO moraine.events AS …` | the same overwrite installed as standing state | `MaterializedViewInto` |

`MODIFY COLUMN` and the two write heads are now **conditional** rather than
listed. `MODIFY COLUMN` is benign only when the token after the column name is a
metadata keyword; a type there rewrites the parts, and `ALIAS`/`EPHEMERAL` there
convert a stored column into one that is not stored, which is `DROP COLUMN`
under another name. `INSERT INTO` and `CREATE MATERIALIZED VIEW … TO` are benign
only when the target is not protected — the class is exactly the difference
between an ordinary rebuild-by-insert (034/035 do it every run) and superseding
a record nothing can reconstruct.

The `MODIFY_COLUMN_METADATA_KEYWORDS` set was read off ClickHouse's own parser
error and then each candidate re-checked with `EXPLAIN AST`. **Round 6 re-ran
that check and two of the four answers were wrong.** `COLLATE`, `SETTINGS` and
`AFTER` really are invalid in that position without a preceding type, so leaving
them off is dead surface; `STATISTICS(tdigest)` and `AUTO_INCREMENT` are
**valid** there, so leaving *those* off is a live over-approximation — the gate
reports a statistics declaration and an auto-increment flag as
`AlterRewriteColumn` even though neither rewrites a column's bytes. That is the
fail-closed direction and it now says so, with the constant carrying the
measurement instead of the claim it displaced. The list also had no bound in
either direction: adding `ZAPNONSENSE`, `STATISTICS`, `AUTO_INCREMENT` or `TTL`
to it was GREEN across the whole crate.
`a_modify_column_property_the_parser_accepts_is_reported_not_admitted` is the
bound — it requires every listed keyword to be witnessed by a corpus row and
every excluded-but-valid property to be a finding.

### False findings on ordinary DDL (round 5)

`ADD PROJECTION`, `MATERIALIZE PROJECTION` and the four `STATISTICS` operations
are now admitted — the tree already had `DROP PROJECTION` and `CLEAR PROJECTION`
without their creating counterparts, so a migration could remove a projection
but not create one. So are `MODIFY COMMENT`, `RESET SETTING`,
`CREATE OR REPLACE VIEW`, and `ALTER TABLE <mv> MODIFY QUERY` on a declared
`SCHEMA_VIEW_OBJECTS` name. (`CREATE OR REPLACE VIEW` was admitted here under
the claim that "a view holds no rows"; round 6 executed that claim and it is
false — see below. It is still admitted, but only on a declared view name.)

`CREATE OR REPLACE VIEW` was additionally being filed against a **phantom
relation literally named `VIEW`**, because the relation parse skips `OR` and
`REPLACE` as noise and then takes `VIEW` as the table name — which classifies as
unknown, and unknown is protected. `NEVER_A_RELATION` now empties that parse, so
the statement is reported under `UNPARSED_RELATION` if it is reported at all.
Fail-closed is preserved; only the phantom name is gone.

### Four blocking holes and three false docstrings (round 6)

Round 5 closed every round-4 bypass; a follow-up wave of 117 independent
mutations ran 108 RED against it. Round 6 then threw 70 statements at it, every one `EXPLAIN AST`-validated on the
deployed 25.12.5.44 first and the decisive ones *executed* in `clickhouse local`
at the same version. **Fifteen destructive statements got through and three
legitimate ones got stuck.** Four distinct defects:

**W1 — `CREATE OR REPLACE VIEW` can replace a physical table, and the code said
it could not.** The head sat on `BENIGN_STATEMENT_HEADS` with no target-class
check, unlike `INSERT INTO ` and `CREATE MATERIALIZED VIEW ` two lines above it,
under a comment asserting *"A view holds no rows, so unlike `CREATE OR REPLACE
TABLE` … this one can destroy nothing."* Executed in `clickhouse local`: a
`MergeTree` with three rows, then `CREATE OR REPLACE VIEW probe.t AS SELECT 99
AS a;` — **no error**, `count()` 3 → 1, `system.tables.engine` `MergeTree` →
`View`. Repeated against a `ReplacingMergeTree(event_version)` shaped like
`moraine.events`: 2 rows → 1, engine → `View`. ClickHouse's `CREATE OR REPLACE`
builds a replacement and `EXCHANGE`s it in; it never checks that what stood
there was a view. So `CREATE OR REPLACE VIEW moraine.events AS SELECT 1` is
`TRUNCATE` and `DROP` in one statement, and it was admitted — as were the
`raw_events` and `search_documents` spellings. (The contrast is `DROP VIEW`,
which *is* safe on a table, and safe for a different reason: the server throws
`Code: 80 … is not a View`.) It is now gated on the target's class exactly as
`INSERT INTO` is, and the false sentence is gone from the code, the plan and
this document.

**W2 — the lexer did not know two ClickHouse syntaxes, and either one masked a
whole clause.** Both work by opening a span the server never opens, so
`mask_quoted` swallows the comma that separates the next clause:

| Syntax | Statement | What the gate saw |
|---|---|---|
| `#` line comment | `ALTER TABLE moraine.events ADD COLUMN c String # a " b⏎, DROP COLUMN payload_json` | one benign `ADD COLUMN` — the `"` inside the comment opened a quoted identifier |
| `$tag$` heredoc | `… COMMENT $tag$a'b$tag$, DROP COLUMN payload_json` | same, via the `'` inside the heredoc |
| `$$` heredoc, **paren depth** | `… COMMENT $$($$, DROP COLUMN payload_json` | one benign clause — no quote involved; the unmasked `(` held `alter_clauses`' depth at 1 so the top-level comma never split |

`SELECT 1 # trailing`, `SELECT $$abc$$` and `SELECT $tag$a'b$tag$` are all valid
(executed). Executed in `clickhouse local`, the first statement takes the column
list from `['uid','payload_json']` to `['uid','c']`. Seven `#` candidates and
three heredoc candidates were admitted. The fix is one lexer —
`scan_statement` classifies every character as code, quoted or comment, and
`normalize_statement` and `mask_quoted` both read it, so a comment stripper and
a literal masker cannot disagree about where either ends. **And** an `ALTER`
body whose parentheses do not balance now yields no clause at all, which
`alter_is_benign` treats as a finding: the paren mechanism is dead twice over,
and mutation W2-4 removes both at once to prove the pair is not one guard
counted twice.

**W3 — the search corpus was guarded against removals but not against
supersedes.** `benign_shape` admitted an `INSERT INTO` / `CREATE MATERIALIZED
VIEW … TO` whose target was not `is_protected()`, and both search tables are
`Derived`. But `MIGRATION_PRESERVED_DERIVED_TABLES` exists *precisely because*
`Derived` does not guard the corpus, and
`no_bundled_migration_empties_the_search_corpus` filters
`migration_row_removals`, which never saw these statements at all. Both tables
are `ReplacingMergeTree` on the reference host — the identical hazard
`PROTECTED_WRITE_HEADS` spells out for `events`. Executed:
`INSERT INTO moraine.search_documents SELECT * REPLACE ('' AS text_content,
doc_version + 1 AS doc_version) FROM moraine.search_documents FINAL` takes
`sum(length(text_content))` from **23 to 0** through `FINAL`, and it is still 0
after `OPTIMIZE … FINAL`. The `CREATE MATERIALIZED VIEW … TO` twin installs it
as standing state. The write-head check now consults
`MIGRATION_PRESERVED_DERIVED_TABLES` as well as the class, through one
`relation_is_guarded` predicate that W1's gate shares.

That change immediately produced eleven findings on legitimate statements — the
nine materialized views that *populate* the corpus (004, 011, 012, 014, 032) and
032's two backfill `INSERT`s. They are now five `MIGRATION_DELETE_ALLOWLIST`
entries with reasons, split so no entry's cross product over-grants. That is the
gate working, not the gate misfiring: nothing distinguished those statements
from the one that empties the table.

**W4 — the witness test accepted a witness the author wrote in the same
commit.** `every_benign_entry_is_witnessed_by_a_real_statement` claims the
benign list is "bounded by what this repository actually does", but it reads
`BENIGN_CORPUS` as well as `sql/`, so a corpus row added alongside an entry
satisfies it. Grepping `sql/`: **`CREATE OR REPLACE VIEW` appears in zero
bundled migrations**, and so do **16 of the 23** `BENIGN_ALTER_OPERATIONS`
entries (measured by the parser, not by grep). The single most severe hole of
the round was an entry whose only witness was written with it.

Two changes follow. `CORPUS_WITNESSED_BENIGN_ENTRIES` declares the
corpus-witnessed set with a reason per entry, pinned by **set equality**, so an
entry crossing the line in either direction is a deliberate edit.
And `BENIGN_HEAD_TARGET_RULES` pairs every benign head with either a
target-class gate or a recorded reason it cannot displace an existing relation —
where the gated arm carries a probe aimed at `moraine.events` that
`every_benign_head_answers_the_target_class_question` **executes** against the
gate. Had that rule existed, W1 could not have shipped: the head would have had
to answer the question in code rather than in a comment.

**W5 — three false findings, and they were not even exemptable.** All
`EXPLAIN AST`-valid, all rejected because `alter_clauses` split on top-level
commas that are not clause separators: `MODIFY SETTING index_granularity = 8192,
min_bytes_for_wide_part = 0` — **the ordinary spelling**, since `MODIFY SETTING`
takes a list — `MODIFY QUERY SELECT 1 AS a, 2 AS b`, and
`ADD COLUMN a2 String SETTINGS alter_sync = 2, mutations_sync = 1`. All three
reported shape `None`, and a `None` shape is categorically unexemptable, so a
migration that legitimately needed a two-setting `MODIFY SETTING` could not be
allowlisted at all — the only available fix was editing the parser.
`merge_clause_continuations` re-joins those tails. It cannot launder a command
for two independent reasons: ClickHouse rejects an alter command after a
settings list or a `MODIFY QUERY` (`MODIFY SETTING a = 8192, DROP COLUMN c`,
`RESET SETTING a, DROP COLUMN c`, `MODIFY QUERY SELECT 1, DROP COLUMN c` and the
comma-free `MODIFY SETTING a = 2 DROP COLUMN c` are all syntax errors,
executed), and structurally a continuation must be exactly `<ident> = <value>`
or a single bare `<ident>`, which `DROP COLUMN payload_json` is not. Relaxing
either half of that grammar is RED (W5-2, W5-7); the second was GREEN when the
merge first landed and is the reason the width bound exists.

**W6/W7 — three docstrings made measurably false claims about their own
guards.** Each is now corrected with the measurement rather than the claim, and
each has the bound it asserted:

| Constant | The claim | Measured | Now |
|---|---|---|---|
| `MODIFY_COLUMN_METADATA_KEYWORDS` | `COLLATE`, `STATISTICS`, `SETTINGS`, `AUTO_INCREMENT` are all rejected in that position, so listing them would be dead surface | `STATISTICS(tdigest)` and `AUTO_INCREMENT` are **valid**; only `COLLATE`, `SETTINGS`, `AFTER` are rejected | doc records the over-approximation; `a_modify_column_property_the_parser_accepts_is_reported_not_admitted` bounds the list in both directions |
| `DESTRUCTIVE_ALTER_DROP_CLAUSES` | each of three clauses is a named negative row "so widening this list by one clause turns a green test red" | adding `DROP INDEX`, `DROP CONSTRAINT` or `DROP PROJECTION` leaves the crate **GREEN** — all three are `BENIGN_ALTER_OPERATIONS` entries, so `benign_shape` admits first and `delete_shape` is never reached | `the_destructive_drop_clause_list_is_exactly_the_four_that_remove_storage` calls `alter_clause_shape` directly |
| `UNREGISTERED_PHYSICAL_TABLES` | "the exhaustiveness test names it explicitly so the exemption cannot silently grow" | adding `"events"` is GREEN; so is `"search_documents"`. The only "naming" was a failure-message string | `the_unregistered_table_exemption_is_exactly_one_table` asserts the contents |

The two sibling constants were both already bounded — `CLICKHOUSE_SYSTEM_LOGS`
by a length assertion, `SCHEMA_VIEW_OBJECTS` by `stale_view_declarations` — so
`UNREGISTERED_PHYSICAL_TABLES` was the one of its family that was not.

**The inversion and the clause fix each immediately found something.** Round 4's
inversion produced findings on migrations 012 and 013: twenty-one
`ALTER … UPDATE` statements rewriting five columns across `events`,
`raw_events`, `ingest_errors`, `event_links`, `tool_io` and the three search
projections. Round 5's corrections produced findings on five more — `009`,
`014`, `031`, `032` and `036` — of which **`014` materializes three columns
across every part of `moraine.events`**. All of them are legitimate. All of them
are now `MIGRATION_DELETE_ALLOWLIST` entries with a reason, which is the sentence
this gate exists to make somebody type.

The allowlist is keyed on **`(version, table, shape)`**. Each looser key was
fail-open one dimension at a time, and each was found by appending one statement
to a migration that already had an entry:

| Key | Appended | Result |
|---|---|---|
| `version` | `TRUNCATE TABLE moraine.search_documents;` to `sql/020` | GREEN |
| `(version, table)` | `TRUNCATE TABLE moraine.events;` to `sql/012` | GREEN — and 012's own reason says "none removes a row" |
| `(version, table)` | `DROP TABLE moraine.events;` to `sql/020` | passed the gate |
| `(version, table, shape)` | both of the above | RED (M-E6, M-E7) |

A finding whose shape is `None` is **never** exempt: an exemption licenses a
statement somebody read and described, so a form nobody has named stays a
finding inside an exempted migration (M-E10).

## Operational impact

- **No user data is deleted by anything in this change.** `moraine db reclaim
  run` refuses every scope: without `--confirm` it prints the tables the scope
  would touch and exits 1; with `--confirm` it refuses again because no
  executor is registered (`WI-05`/`WI-07`/`WI-09` add them) and still exits 1.
  A bucket-1/2 scope refuses earlier still, naming the missing `[retention]`
  key.
- **The ledger driver is descoped and gated.** `LEDGER_DRIVER_WIRED` is
  `false`; `no_executor_may_be_registered_before_the_ledger_driver_is_wired`
  fails if an executor is registered while it stays false, and fails equally if
  the constant is flipped without registering one. The four statement builders
  have zero production callers.
- **Two new migrations.** 038 is one `CREATE TABLE IF NOT EXISTS` (the ledger).
  039 adds one column and one TTL per telemetry table, anchored so the first
  application removes nothing. Neither names a bucket-1, bucket-2 or
  never-delete table. `db doctor` against the reference host reports
  `pending migrations: 037, 038, 039` and
  `missing tables: storage_reclaim_ledger`. **037 is not this branch's** — it
  arrives with the `epic/canonical-first-refactor` base and is unapplied on that
  host too; the two migrations this diff adds are 038 and 039.
- **One config template change.** `config/clickhouse.xml` gains three `<ttl>`
  elements on the system-log sections. This takes effect on ClickHouse restart
  and will expire system-log rows older than 30 days.
- **`[retention]` is new and defaults to a no-op.** An install that never edits
  it can never prune user history, including across upgrades. Setting a
  protected horizon is the only way to grant that authority, and `moraine
  status` then prints a prominent `RETENTION CONFIGURED` line naming what will
  be deleted. `telemetry_horizon_days` set to anything but `30` now fails the
  config load — no shipped release carries this key, so no existing install is
  affected.
- **New `storage` block in `/api/v1/health`.** Additive; per-bucket rather than
  per-table so the response cannot grow with the table count. Degrades to
  `{"available": false, "error": …}` rather than failing the response.

## Validation

Run in `/Users/eric/tramel-lab/projects/moraine-wt-603`, rebased onto
`origin/epic/canonical-first-refactor` at **`b37149b`**
(`feat(601): measure SQLite scans, back off failures, stamp poll triggers`).
The rebase was a fast-forward: 601 touches nine files under
`crates/moraine-ingest-core/`, none of which this diff touches, and it adds
~6.7k lines of test-bearing code — so **every count below is re-measured after
it**, not carried forward:

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets --locked -- -D warnings` | clean, **cold** (fresh `CARGO_TARGET_DIR`, run in this worktree after the final edit; 27 s with sccache warm; all 10 workspace crates checked) |
| `cargo test --workspace --locked --no-fail-fast` | **1557 passed / 0 failed / 22 ignored**, 28 targets |

Per-crate: `moraine-clickhouse` lib **209/0**, `moraine` bins 233/0,
`moraine-config` 117/0, `moraine-conversations` lib 186/0 + repository
integration 141/0, `moraine-ingest-core` **335/0**, `moraine-mcp-core` 157/0,
`moraine-monitor-core` 67/0.

The two figures the previous round published are both superseded, and neither
survived the rebase intact: 1491 → **1557** (+58 from 601's new
`moraine-ingest-core` tests, +7 from this round) and `moraine-clickhouse`
201/0 → **209/0**; `moraine-ingest-core` 277/0 → **335/0** is 601's alone.

The clippy run is cited from a log produced **in this worktree**, after the
final edit — the round-4 material cited three logs written in `moraine-wt-601`,
a different worktree on a different branch. A first attempt at this round's cold
run **failed**: `HeadTargetRule` and `BENIGN_HEAD_TARGET_RULES` are consumed
only by a test, so `-D dead-code` rejected them in the non-test build. They are
`#[cfg(test)]` now, and kept next to `BENIGN_STATEMENT_HEADS` rather than moved
into the test module, so the author adding a head reads the obligation in the
same screen.

**One intermittent failure, in code this branch does not touch.**
`managed_clickhouse::tests::healthy_untracked_endpoint_remains_unmanaged` failed
once with `failed writing clickhouse config …/runtime/clickhouse/config.xml:
No such file or directory` — `fs::write` on a path whose parent directory was
gone. It passed in isolation, single-threaded with its 26 siblings, on six
consecutive runs of the whole `moraine` binary target, and on the full-workspace
re-run above. `apps/moraine/src/managed_clickhouse.rs` is not in this diff, and
the only file this branch changes that it reads — `config/clickhouse.xml` — is
consumed by string substitution whose four placeholders are all still present.
Reported rather than re-run until it went away.

**116 mutations** were executed against an isolated copy of the tree, in three
groups, each restored by content *and* `os.utime`, with the crate's
recompilation asserted on every one — a mutation that does not force a rebuild
is not evidence — and a `diff -r` against the worktree afterwards confirming the
copy came back byte-identical. Every count here is read out of a ledger file
rather than transcribed.

| Group | Run | RED | GREEN | Claim not reproduced |
|---|---|---|---|---|
| **A** — the round-6 repairs (W1–W7 and the five new allowlist entries) | 51 | 49 | 2 | 0 |
| **B** — re-execution of every `MUTATION …` docstring claim the diff already carried | 61 | 60 | 1 | 0 |
| **C** — spot re-run of group A's head-rule mutations after the `#[cfg(test)]` change | 4 | 3 | 1 | 0 |

Group A was re-run in full against the final tree, so its numbers are not from
an intermediate state. Group B is the check the reviewer asked for and the one
that mattered: three of those docstrings were making **false** claims about
their own guards, and they are the W6/W7 table above. The four deliberate GREENs are:

| Mutation | Why GREEN |
|---|---|
| `W2-6` — `mask_quoted` emits `_` for comment characters instead of a space | a comment ends at its newline, so the `_` run becomes a clause head on no benign list. The failure direction is **over**-reporting, and the docstring now says that instead of claiming a guard |
| `W4-6` (×2, groups A and C) — rewrite `assert_eq!(benign_shape(probe), None)` into a tautology | degenerate: no test can guard its own assertion text. The property it targets — that the `ClassGated` probe is *executed* — is bounded by `W1-1`, `W1-3` and `W4-5`, all RED |
| `D-02` — restore the `!views.contains(…)` companion filter in `classification_gaps` | the filter is unreachable: `created_table` returns `None` for every `CREATE VIEW`, so no view name can arrive. Recorded as a measurement in round 3 and re-measured here |

Every RED mutation names at least one **named** test. Group A's most
load-bearing, one per finding:

| Mutation | Change | Test that catches it |
|---|---|---|
| W1-1 | delete the `PROTECTED_REPLACE_HEADS` branch from `benign_shape` | `replacing_a_relation_with_a_view_…` + `every_benign_head_answers_…` |
| W1-3 | answer `CREATE OR REPLACE VIEW `'s target-class question with a prose reason instead of a gate | `every_benign_head_answers_the_target_class_question` |
| W1-4 | let `replace_target` bail on the `VIEW` keyword (the generic parse) | 4 tests, incl. the finding naming `<unparsed>` instead of `events` |
| W2-1 | delete the `#` line-comment arm from `scan_statement` | `the_lexer_knows_every_clickhouse_comment_and_quote_syntax` |
| W2-2 | delete the heredoc arm | same |
| W2-3 | delete `alter_clauses`' unbalanced-paren guard | same |
| W2-4 | delete **both** the heredoc arm and the paren guard | same — the pair is not one guard counted twice |
| W3-1 | narrow `relation_is_guarded` back to the class check alone | `a_write_into_the_search_corpus_…` + 2 more |
| W3-2 | drop `search_documents` from `MIGRATION_PRESERVED_DERIVED_TABLES` | same |
| W4-3 | claim `CREATE OR REPLACE VIEW ` is tree-witnessed | `every_benign_entry_is_witnessed_by_a_real_statement` |
| W4-5 | add a benign head with no `BENIGN_HEAD_TARGET_RULES` entry | `every_benign_head_answers_…` + the witness test |
| W5-1 | delete `merge_clause_continuations` | `every_row_removing_shape_is_recognized_…` (the six W5 corpus rows) |
| W5-2 | relax a settings continuation from `len() == 3` to `len() >= 3` | `a_mis_split_alter_clause_fails_closed` |
| W5-7 | let `is_setting_name` accept a multi-token fragment | same — **this one was GREEN when the merge first landed** |
| W6-1a/b/c | widen `DESTRUCTIVE_ALTER_DROP_CLAUSES` by `DROP INDEX`/`CONSTRAINT`/`PROJECTION` | `the_destructive_drop_clause_list_…` (all three were GREEN before this round) |
| W6-3a/b | add `"events"` / `"search_documents"` to `UNREGISTERED_PHYSICAL_TABLES` | `the_unregistered_table_exemption_is_exactly_one_table` (both were GREEN before) |
| W7-1a–f | widen `MODIFY_COLUMN_METADATA_KEYWORDS` by `ZAPNONSENSE`/`STATISTICS`/`AUTO_INCREMENT`/`TTL`/`ALIAS`/`AFTER` | `a_modify_column_property_the_parser_accepts_…` (all six were GREEN before) |
| AL-1/2/3/4 | delete or widen one of the five new search-corpus allowlist entries | `every_allowlist_entry_is_load_bearing_…`, `no_bundled_migration_empties_the_search_corpus` |
| AL-5 | remove the declared-view filter this round added to `unexempted_relations` | `every_allowlist_entry_is_load_bearing_…` |

The gate was then swept with **109 statements** — the round-1..5 destructive
corpus, every round-6 attack (nine `CREATE OR REPLACE VIEW` targets, seven `#`
comment spellings, three heredocs, two unbalanced-paren forms, four search-corpus
supersedes, five `MODIFY COLUMN` properties the parser accepts), the five
destructive-after-a-settings-list negatives, and 39 ordinary DDL forms that must
stay admitted.

**70 reported as findings, 39 clean. Zero attacks got through and zero
legitimate statements got stuck** — against 15 and 3 respectively when the same
sweep was run on the round-5 gate. Every statement in the sweep is
`EXPLAIN AST`-valid on 25.12.5.44; the six that decided a question were executed
in `clickhouse local` at the same version.

One row deserves its own line, because `benign_shape` and the reported outcome
disagree on it by design: `DROP TABLE IF EXISTS moraine.search_term_stats` is
**rejected** by the head list and then **cleared** by
`migration_row_removals`' declared-view filter, so it raises no finding. That
filter is scoped to `DropRelation` — `truncating_a_declared_view_name_is_still_a_finding`
is what stops it widening — and round 6 found that the allowlist test's own
denominator, `unexempted_relations`, was missing it. That was invisible for as
long as no migration dropping a declared view name also had an allowlist entry;
adding 004's search-corpus entry made it visible immediately.

Live, **read-only**, against the 46 GiB reference host (ClickHouse 25.12.5.44):

- `moraine db reclaim status` — classifies every table present (no
  `UNCLASSIFIED TABLES` line), reports `canonical_history 4.48 GiB /
  raw_audit 4.16 GiB / derived 39.57 GiB / telemetry 9.46 MiB /
  never_delete 386.47 MiB`, `disk free 11.66 GiB of 926.35 GiB`, no destructive
  policy, and renders the telemetry caveat inline.
- `moraine db doctor` — same block, plus `pending migrations: 037, 038, 039`
  and `missing tables: storage_reclaim_ledger`.
- `moraine db reclaim run --scope {mcp_open_orphan,read_index_generation,
  canonical_generation}` with and without `--confirm` — all six invocations
  refuse and exit 1.

  **These six are not live-host evidence and are not offered as such.**
  `cmd_db_reclaim_run` refuses *before any I/O*: an unconfigured bucket-1/2
  scope refuses on the missing `retention.canonical_history_horizon_days` key,
  and a configured scope refuses on `LEDGER_DRIVER_WIRED`/no registered
  executor. Both paths are reached before a connection is opened, and a
  reviewer reproduced byte-identical output pointing the client at
  `http://127.0.0.1:1`. What they demonstrate is that the refusal is
  unconditional, which is the claim worth making; the host they ran against is
  irrelevant to it, and `reclaim_run_refuses_a_registered_scope_without_reaching_clickhouse`
  is the test that pins it.

Every statement form in the corpus was validated as real ClickHouse syntax with
`EXPLAIN AST` against the live server; nothing was executed. **Three rows were
not valid ClickHouse and have been corrected**, which means three predicate
disjuncts had been pinned by statements the server rejects:

| Row | Verdict | Fix |
|---|---|---|
| `DELETE FROM moraine.events` | syntax error — lightweight delete requires a `WHERE` | `… WHERE 1` |
| `ALTER TABLE … MOVE PART 'p' TO TABLE t` | syntax error — `MOVE PART` takes `TO DISK\|VOLUME\|SHARD`, not `TO TABLE` | replaced with `MOVE PART 'p' TO SHARD '…'`, which is valid and destructive |
| `ALTER TABLE … REPLACE PART 'p' FROM t` | syntax error — there is no `REPLACE PART` | row and disjunct removed |

Round 5 caught two more the same way, both authored *in this round*:
`ALTER TABLE … MODIFY COLUMN <c> TTL <expr>` is rejected without a preceding
type, so both corpus rows written that way were corrected to carry one. That
turned out to matter beyond the corpus: because the type is mandatory, the
absence of `TTL` from `MODIFY_COLUMN_METADATA_KEYWORDS` guards nothing on its
own — the *type* check is what catches a column TTL. Adding `"TTL"` to that list
left the whole crate GREEN when round 5 measured it, because **nothing bounded
that constant in either direction**; round 6 added the bound, and the same
mutation is now RED. Both measurements are recorded at the constant.

`EXPLAIN AST` was also used constructively: ClickHouse's parser error for that
statement enumerates every property keyword it accepts after a column name, and
each was re-checked individually. **Round 6 re-ran that check and corrected two
of its answers.** `COLLATE`, `SETTINGS` and `AFTER` are invalid there without a
type and are left off as dead surface; `ALIAS`, `EPHEMERAL` and `PRIMARY KEY`
are valid and are left off deliberately, because the first two convert a stored
column into one that is not stored and the third rewrites the parts. So are
`STATISTICS(<type>)` and `AUTO_INCREMENT`, which round 5 recorded as invalid and
which are in fact **valid** — a live over-approximation rather than dead surface,
and the constant now says so.

The `AlterMove` predicate is now written as the **negation** of the two tiering
destinations rather than as a list of the removing ones, so it covers
`MOVE PARTITION … TO TABLE` and `MOVE PART … TO SHARD` without having to be
revisited the next time ClickHouse adds a destination. A companion assertion
pins that a tiering move has no `DeleteShape` at all — without it, widening
`AlterMove` to every `MOVE` is invisible, because those rows are already benign
and nothing asks `delete_shape` about them.

**Not run.** `pytest` and `mkdocs` are not installed on this host, so the docs
build was not exercised. **Docker is unavailable on this host** — the daemon is
wedged and does not restart — so no dev sandbox was booted:
`scripts/ci/e2e-stack.sh` and the live gates in plan §7.2 did not run, and in
particular the new row-count floor added to
`tests/live_clickhouse/source_publication.rs` is compiled but not executed (the
enclosing gate is `#[ignore]`d and needs `MORAINE_LIVE_TEST_SANDBOX_ID`). Treat
it as reviewed-but-unexercised. Everything above that says "live" is a
**read-only** query or an `EXPLAIN AST` against the already-running reference
ClickHouse, not a sandbox.

## Review history

This branch has been through five adversarial review rounds and each one found
something the previous round's prose had already declared safe. Recording that
is more useful than smoothing it over, because the pattern *is* the finding: it
is what justifies inverting the gate — and round 6 shows the pattern has not
stopped, it has only moved from the gate's *shape list* to the gate's *lexer*
and to the sentences the code tells about itself.

Round 2 found the §4 S4 shape list was a three-form enumeration that missed the
whole `DROP` family — `DROP TABLE moraine.events` removes strictly more
canonical history than the `TRUNCATE` the list did catch, and bundling any of
four `DROP`-shaped statements into a migration left the suite green.

Round 3 found that the repaired list — now six forms, with prose declaring it
"deliberately not the forms this plan happened to anticipate" — still could not
see `ALTER … MODIFY TTL`, the one destructive shape **this branch itself
introduces** into `sql/`, four times. The blindness was a whitespace accident:
`MODIFY TTL … DELETE WHERE 1` matched `" DELETE "` while `MODIFY TTL … DELETE`,
the exact form `sql/039` ships, did not. A TTL expression with no action clause
defaults to `DELETE` anyway, so the shape destroys rows even when the word is
absent. Round 3 also found that the negative-corpus row pinning that hole open
sat in the *positive* corpus's blind spot, that several negative rows named
`Derived` tables and were therefore vacuous (the class filter discards them
before the shape is ever consulted), that `telemetry_horizon_days` was reported
as `configured` while changing nothing, and that one filter in
`classification_gaps` was unreachable dead code.

Round 4 verified round 3's repairs independently — plan §1 row by row, INV-2,
the `LEDGER_DRIVER_WIRED` gate in both directions, and all six `reclaim run`
refusals (which, as noted under Validation, refuse before any I/O and are not
host-dependent) — and then swept the *ten*-shape list
and found four more destructive forms, all real syntax on the deployed
ClickHouse 25.12.5.44, all leaving the crate at 193/0: `ALTER … UPDATE`,
`REPLACE PARTITION`, `OPTIMIZE … FINAL [DEDUPLICATE BY]`, and `DETACH
PARTITION` — the last of which is step one of the two-step delete whose step two
the list already covered, and the first of which is the general form of a shape
added *in the same round* for precisely the reason it applies. Rather than add
four more, this round **inverted the gate**: the benign list is bounded by what
this repository does, the destructive list is not.

Round 5 found that the inversion's `ALTER` reducer was not a clause parser, and
that the defect had two faces: six destructive statements got **through** the
gate and eight ordinary ones got **stuck in** it. It also found that the
`(version, table)` re-key round 4 introduced as a safety improvement was itself
unguarded — replacing the per-table filter with a version-only equivalent left
the suite GREEN at 195/0 — and that five entries on the benign list admitted
statements that destroy bucket-1 data. All of that is above; the clause parser,
the conditional benign entries, and the third key dimension are this round's
work.

Round 6 is above in full. In short: five of its findings were the gate's own
lexer and gate-shape, and three were the code's docstrings claiming guards they
did not have. The pattern the earlier rounds established — *the prose is ahead
of the code* — held for a sixth round, which is why round 6's repairs are
structural rather than additive: `BENIGN_HEAD_TARGET_RULES` makes the
target-class question unanswerable in prose, `CORPUS_WITNESSED_BENIGN_ENTRIES`
makes "witnessed" mean something a single commit cannot manufacture, and the
three unbounded constants now have bounds that call the function under test
directly instead of relying on a corpus row that never reaches it.

Round 5 also reconciled the round-4 reporting against its own evidence file.
That round's PR text said "42 mutations … including three deliberate GREENs";
the ledger it was drawn from records **43**, of which **four** are GREEN — the
omitted one is `M-E7`, the control that appends
`TRUNCATE TABLE moraine.mcp_open_turns;` to `sql/003` and stays green because
`Derived` is reclaimable. The round summary's own "43" was right and the PR
material had not been reconciled against it. The numbers above are read
directly out of this round's ledger file rather than transcribed.

Round 6 threw 70 statements at the round-5 gate, with every candidate
`EXPLAIN AST`-validated on the deployed 25.12.5.44 first and the decisive ones
*executed* in `clickhouse local` at the same version. **Fifteen destructive
statements got through and three legitimate ones got stuck**, across four
distinct defects — a benign head with no target-class check, two comment/quote
syntaxes the lexer did not know, a `Derived` floor the write heads never
consulted, and a witness test satisfied by a witness written in the same
commit — plus three docstrings whose claims about their own guards were
measurably false. All of that is under *§4 S4* above.

Every claim of the form "removing this breaks a named test" in the source
docstrings was executed as a mutation against an isolated copy of the tree. That
was said in round 5 as well; round 6 re-executed all of them and **three were
false** — the three in the W6/W7 table. The deliberate GREEN results are
recorded alongside the RED ones rather than only the flattering half.

## Known residuals

Stated rather than hidden.

- **§4 S3's "two independent checks" has two exceptions.** §1 marks
  `search_documents`, `search_postings`, `tool_io` and `event_links` opt-in,
  but the code classes all four `Derived`, so the emitter authorizes them under
  the stock `DerivedOnly` token and only the planner's table list keeps them
  unreachable — for those four the two checks collapse to one. Tightening it
  needs a fifth class with its own token; deferred, not overlooked.
  Separately, `mcp_open_projection::reclaim_orphan_delete_statements` and
  `canonical_indexes::reset_canonical_read_indexes` construct row-removing SQL
  directly and predate #603. Both name only bucket-3 tables, and
  `every_table_the_rebuild_truncates_directly_is_bucket_three` now pins that.
- **Three deliberate over-approximations.**
  `MODIFY TTL … TO DISK|TO VOLUME|RECOMPRESS` moves bytes without removing a
  row and is reported anyway (there is no storage policy in this deployment, so
  a carve-out would be untested surface). `RENAME`/`EXCHANGE` reports both
  operands, since the displaced relation may be either one. And a benign form
  nobody has written yet is a finding until somebody adds it to the benign list
  with a witnessing corpus row. That is the trade the inversion makes.
- **`MODIFY COLUMN <col> <type>` is reported even when the type is unchanged.**
  The gate has no schema, so it cannot tell a no-op re-declaration from
  `MODIFY COLUMN ingested_at DateTime` narrowing the `DateTime64(3)` column the
  partition key is built on. The false-positive rate over the whole tree is
  currently **zero**: the one migration this catches, `sql/032`, really does
  convert `source_name` to `LowCardinality(String)` across every part. Closing
  it properly needs the live schema at gate time.
- **`MATERIALIZE TTL` stays benign.** It forces an already-declared TTL to apply
  now. Every way to declare one is a finding — `MODIFY TTL`, and now
  `MODIFY COLUMN … TTL` — *except* a `TTL` clause inside a `CREATE TABLE`. No
  bundled `CREATE TABLE` carries one.
- **An exemption's licence is the cross product of its `tables` and `shapes`.**
  Every pair in that product must be witnessed by a real statement of the
  migration, which is what forced `sql/032` into two separate entries, so the
  product is exact today.
- **The settings-continuation grammar is three tokens.**
  `merge_clause_continuations` re-joins a `MODIFY SETTING` / `RESET SETTING` /
  `SETTINGS` tail only when the fragment is exactly `<ident> = <value>` or a
  single bare `<ident>`. A settings value written as an arithmetic expression
  (`index_granularity_bytes = 10 * 1024`) is five tokens and becomes a finding.
  Fail-closed, one allowlist line, and no bundled migration writes one.
  Widening it is what W5-2 shows is unsafe.
- **`MODIFY QUERY` swallows every fragment to the end of the statement.** Its
  tail is a whole `SELECT`, so nothing short of a SQL parser finds its end. Sound
  because the clause is benign only on a declared `SCHEMA_VIEW_OBJECTS` name and
  every clause of an `ALTER` applies to the one relation the `ALTER` names — a
  view, which holds no rows — and because ClickHouse rejects an alter command
  after a `MODIFY QUERY` (executed).
- **The heredoc tag charset is a measured subset**, `[A-Za-z0-9_.+-]`, read off
  25.12.5.44 one character at a time. A tag character outside it leaves the body
  read as code: fail-closed for a comma, and for a parenthesis the
  unbalanced-body guard catches it independently. W2-4 removes both mechanisms
  at once to show they are two guards, not one counted twice.
- **`#` starts a comment wherever it appears outside a literal**, where
  ClickHouse wants `# ` or `#!` and rejects `SELECT 1#2` outright. The over-broad
  reading discards the tail of a statement the server would refuse anyway.
- **Eighteen benign entries are corpus-witnessed only** —
  `CREATE OR REPLACE VIEW `, `SELECT `, and 16 of the 23 `ALTER` operations. They
  are promises about forms this repository has not written, and one of them being
  wrong is exactly what W1 was. `every_benign_head_answers_the_target_class_question`
  is the structural mitigation and it is per-*head*; there is no equivalent for an
  `ALTER` operation, because an operation cannot name a second relation.
- **`CREATE OR REPLACE VIEW` now requires a declared view name.** A future
  migration installing a *new* view with the atomic spelling pays a
  `SCHEMA_VIEW_OBJECTS` registration for it. Zero bundled migrations use the head
  at all, so the cost is hypothetical; the alternative is admitting a head that,
  executed, turns a populated `MergeTree` into a `View`.
- **`split_sql_statements` is not block-comment aware.** `normalize_statement`
  now is, but the splitter that runs before it still ends a statement at any `;`
  outside a single-quoted literal, including one inside `/* … */`. Fail-closed
  (both fragments fail the gate), and no bundled migration uses block comments.
- **The ledger cannot yet hold a uid set.** `ReclaimPredicate::UidSet` is the
  shape `tool_io`/`event_links` require, and its liveness must be captured
  before the parent delete runs, but `sql/038` has no column for it. WI-09 will
  need a schema change.
- **`UNIT_STMT_MAX_TABLES` assumes one statement per table per unit** while
  `RECLAIM_DELETE_CHUNK` is 1 000, so a unit with more keys than one chunk
  would need a wider cap. Unreachable today; a WI-05 concern.
- **The emitter's predicate check is name-presence, not binding.**
  `predicate_sql.contains(column)` refuses a predicate that never mentions a key
  column; it cannot tell a bound tuple from a mention, so `WHERE (session_id,
  candidate_generation) IN ()` passes. The function doc previously overstated
  this as binding the unit and has been corrected. A real binding check needs a
  predicate the emitter *builds*, which is WI-09's shape.
- **The `Blocked` outcome's rendered string is unguarded.**
  `render_reclaim_outcome` builds its lines in-function and writes them to
  stdout, so no test reads them; the 18-space run this round removed from that
  literal was found by reading, not by a failure. Unreachable in this build —
  `Blocked` requires a registered executor and none exists until WI-05.
- **OQ-1 and OQ-2 remain open.** `search_conversation_terms` stays
  `NeverDelete` until OQ-1 decides whether it is dropped or rebuilt, and
  `search_interaction_log` (no writer, no reader, zero active parts) is kept
  with a TTL rather than dropped.
