### PR TITLE
fix(ci): accept retried cold cache misses

### DIFF
--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -443,11 +443,16 @@ while time.monotonic() < deadline:
                     f"{line}"
                 )
             observed.append(hit_match.group(1) == "true")
-    if len(observed) >= 2:
-        if observed[:2] == [False, True]:
+    # The cold smoke retries retryable read-model transitions, so it may emit
+    # several misses before succeeding. The next fresh process must then hit
+    # the shared cache: accept exactly one-or-more misses followed by hits.
+    if True in observed:
+        first_hit = observed.index(True)
+        if first_hit > 0 and all(observed[first_hit:]):
             raise SystemExit(0)
         raise SystemExit(
-            "post-baseline mcp_search_cache markers were not ordered miss then hit: "
+            "post-baseline mcp_search_cache markers were not ordered as "
+            "one or more misses followed by one or more hits: "
             f"{observed}; lines={relevant[-10:]}"
         )
     time.sleep(0.2)


### PR DESCRIPTION
## Description

**What.** Updates the functional stack cache assertion to accept one or more cold misses followed by one or more warm hits.

**Why.** Retryable read-model transitions can produce multiple `cache_hit=false` markers before the cold request succeeds and populates the shared cache.

The assertion still rejects a warm hit without a preceding cold miss and rejects any miss after the first hit.

## Bug Evidence

Main `ci-functional` run https://github.com/eric-tramel/moraine/actions/runs/30598521717 failed on both ARM jobs while both x86_64 jobs passed. Linux ARM emitted `[False, False, True]`; macOS ARM emitted `[False, False, False, False, False, False, True]`.

`mcp_smoke.py::call_tool` retries structured retryable errors. Each retry logs a cold miss; the eventual stable result populates the cache, and the second fresh MCP process logs a hit. `wait_for_mcp_cache_sequence` incorrectly required the first two markers to be exactly `[False, True]`.

## Usage

No user-facing usage change.

## Changelog

None. This changes CI validation only; runtime behavior is unchanged.

## Validation

`bash -n scripts/ci/e2e-stack.sh` passed. Executed the embedded cache assertion against both failing ARM sequences and negative warm-only / miss-after-hit cases; all classifications matched expectations.

Triggered the full `ci-functional` workflow on this commit: https://github.com/eric-tramel/moraine/actions/runs/30600017915. All four jobs passed: aarch64 Linux, aarch64 macOS, x86_64 Linux, and x86_64 macOS. Each job ran format, strict clippy, locked workspace build/tests, and the installed-artifact stack + MCP smoke.

A seven-persona delegated review completed with no findings.