### PR TITLE
fix(ci): close post-merge functional races

### DIFF
--- a/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/file_attention.rs
@@ -151,8 +151,9 @@ impl ClickHouseConversationRepository {
 
         let limit_plus = query.max_rows.saturating_add(1);
         let max_execution_time = query.execution_budget_secs.max(1).to_string();
+        let exact_query_id = format!("{}-exact", query.cancellation_token);
         let params = [
-            ("query_id", query.cancellation_token.as_str()),
+            ("query_id", exact_query_id.as_str()),
             ("max_execution_time", max_execution_time.as_str()),
             ("join_use_nulls", "1"),
         ];
@@ -462,8 +463,9 @@ SELECT {}, arrayJoin([{roots}]), toUInt64(toUnixTimestamp64Milli(now64(3)))",
 
         let limit_plus = query.max_rows.saturating_add(1);
         let max_execution_time = query.execution_budget_secs.max(1).to_string();
+        let suffix_query_id = format!("{}-suffix", query.cancellation_token);
         let params = [
-            ("query_id", query.cancellation_token.as_str()),
+            ("query_id", suffix_query_id.as_str()),
             ("max_execution_time", max_execution_time.as_str()),
             ("join_use_nulls", "1"),
         ];

--- a/crates/moraine-conversations/tests/repository_integration/file_attention.rs
+++ b/crates/moraine-conversations/tests/repository_integration/file_attention.rs
@@ -149,6 +149,20 @@ async fn file_attention_merges_normalized_exact_lookup_with_suffix_fallback() {
             "legacy root guard must reject {fragment}: {fallback_query}"
         );
     }
+    let query_ids = state
+        .query_ids
+        .lock()
+        .expect("query ids lock")
+        .iter()
+        .filter_map(Clone::clone)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        query_ids,
+        [
+            "test-file-attention-normalized-exact",
+            "test-file-attention-normalized-suffix",
+        ]
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -1831,7 +1831,7 @@ PY
   # The normalized truncation row can become visible before every raw insert
   # from the same queued scan. Establish the no-op baseline only after the raw
   # count has remained unchanged across consecutive poll intervals.
-  nac_raw_rows_before_noop="$(wait_for_clickhouse_scalar_stable "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.raw_events WHERE source_name = 'ci-nac'" 30 3)"
+  nac_raw_rows_before_noop="$(wait_for_clickhouse_scalar_stable "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.raw_events WHERE source_name = 'ci-nac'" 120 3)"
   nac_checkpoint_updated_at_before_noop="$(clickhouse_scalar "$clickhouse_url" "SELECT toString(max(updated_at)) FROM ${clickhouse_database}.ingest_checkpoints WHERE source_name = 'ci-nac'")"
   nac_heartbeat_before_touch="$(clickhouse_scalar "$clickhouse_url" "SELECT toString(max(ts)) FROM ${clickhouse_database}.ingest_heartbeats")"
   "$python_bin" - "$nac_fixture_file" <<'PY'
@@ -2293,6 +2293,7 @@ print(f"nac:{namespace}:{raw_session_id}")
 PY
 )"
   wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-nac' AND source_generation = 2 AND session_id = '${nac_replacement_session_id}' AND position(text_content, '${nac_replacement_keyword}') > 0" 120
+  wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.ingest_checkpoints FINAL WHERE source_name = 'ci-nac' AND source_generation = 2" 120
   assert_clickhouse_count "$clickhouse_url" "nac replacement advances source generation" "SELECT count() FROM ${clickhouse_database}.ingest_checkpoints FINAL WHERE source_name = 'ci-nac' AND source_generation = 2" "1"
   wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM (SELECT session_id, generation, dirty_revision, total_events FROM ${clickhouse_database}.mcp_open_sessions FINAL WHERE session_id = '${nac_replacement_session_id}') AS projected INNER JOIN (SELECT session_id, dirty_revision FROM ${clickhouse_database}.mcp_open_dirty_sessions FINAL WHERE session_id = '${nac_replacement_session_id}') AS dirty USING (session_id) WHERE projected.total_events = 8 AND projected.dirty_revision = dirty.dirty_revision" 120
   wait_for_clickhouse_scalar_stable "$clickhouse_url" "SELECT concat(toString(slot), ':', toString(generation), ':', toString(source_revision), ':', toString(dirty_revision), ':', toString(total_events)) FROM ${clickhouse_database}.mcp_open_sessions FINAL WHERE session_id = '${nac_replacement_session_id}' LIMIT 1" 60 5 >/dev/null


### PR DESCRIPTION
## Description

**What.** Closes all three timing failures exposed after PR #622 merged:

- Gives the sequential exact and suffix `file_attention` ClickHouse reads distinct `-exact` and `-suffix` child query IDs under the existing cancellation-token prefix.
- Waits for the generation-2 NAC ingest checkpoint to become visible before retaining the existing exact-cardinality assertion.
- Allows the existing NAC raw-row stabilization barrier up to 120 seconds on slow macOS x86_64 runners; it still requires three consecutive equal observations and retains the later exact no-op assertions.

**Why.** Main run https://github.com/eric-tramel/moraine/actions/runs/30600824664 exposed two independent races. Linux x86_64 returned `QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING` when the suffix query started before ClickHouse retired the completed exact query ID. macOS x86_64 observed generation-2 events before the independently committed checkpoint row. The first exact-commit rerun then exposed a third existing bound: macOS x86_64 needed more than 30 seconds for queued raw inserts to settle before the stat-only no-op baseline.

The query IDs remain children of the original token, so the existing prefix-based `KILL QUERY` cancellation continues to cover both reads.

## Usage

No user-facing usage or configuration change.

## Changelog

None. This fixes internal ClickHouse query attribution and functional CI synchronization without changing the public API.

## Validation

`cargo test -p moraine-conversations --test repository_integration file_attention_merges_normalized_exact_lookup_with_suffix_fallback --locked` passed.

`cargo test -p moraine-conversations --locked` passed: 167 tests passed across four suites; four ignored.

`bash -n scripts/ci/e2e-stack.sh` passed.

The first full matrix rerun, https://github.com/eric-tramel/moraine/actions/runs/30635896863, made aarch64 Linux, aarch64 macOS, and x86_64 Linux green and exposed the slow x86_64 macOS raw-row stabilization bound. After extending that existing convergence window, exact-commit run https://github.com/eric-tramel/moraine/actions/runs/30637684130 passed all four jobs: aarch64 Linux, aarch64 macOS, x86_64 Linux, and x86_64 macOS. Each job ran format, strict clippy, locked workspace build/tests, and installed-artifact stack + MCP smoke.

A seven-persona delegated review completed with no findings. Correctness, completeness, and scope reviewers also rechecked the added slow-run timeout change with no findings.