### PR TITLE
feat(601): sweep reconcile slices, budget fast paths, degrade every ceiling

### DIFF
--- a/config/moraine.toml
+++ b/config/moraine.toml
@@ -57,6 +57,24 @@ debounce_ms = 50
 reconcile_interval_seconds = 30.0
 heartbeat_interval_seconds = 5.0
 
+# Per-poll work budgets for SQLite-backed sources (Cursor, NAC, OpenCode).
+# These are per-poll budgets, not history ceilings: exceeding one is never an
+# error — the scan commits what it read newest-first, reports degraded
+# coverage, and the remainder is covered by later polls and the sweep.
+# The published maximum complete-sweep interval is
+#   ceil(relevant_payload_bytes / sweep_slice_max_payload_bytes)
+#     * sweep_slice_min_interval_seconds
+# = 6 slices * 300 s = 1800 s (30 min) for a 48 MB relevant keyspace at these
+# defaults.
+[ingest.sqlite]
+fast_path_max_payload_bytes = 16777216
+fast_path_max_payload_rows = 2000
+fast_path_max_census_rows = 250000
+sweep_slice_max_payload_bytes = 8388608
+sweep_slice_max_payload_rows = 1000
+sweep_slice_max_millis = 250
+sweep_slice_min_interval_seconds = 300
+
 [[ingest.sources]]
 name = "codex"
 harness = "codex"

--- a/crates/moraine-config/src/lib.rs
+++ b/crates/moraine-config/src/lib.rs
@@ -253,6 +253,93 @@ pub struct IngestConfig {
     /// sequence, SHA-256 event-identity digests, and a monotonic timestamp.
     #[serde(default)]
     pub ack_observation: bool,
+    #[serde(default)]
+    pub sqlite: SqliteIngestConfig,
+}
+
+/// Per-poll work budgets for SQLite-backed sources (issue #601 §2.1/§2.2).
+///
+/// These are **per-poll work** budgets, not history-size ceilings: exceeding
+/// one is never an error. The scan commits what it read in newest-first order,
+/// reports `coverage_degraded`, and the remainder is covered by later polls
+/// and by the reconciliation sweep. The sweep keys are what §2.2's published
+/// maximum complete-sweep interval is denominated on:
+///
+/// ```text
+/// projected_full_sweep_seconds
+///   = ceil(relevant_payload_bytes / sweep_slice_max_payload_bytes)
+///     * sweep_slice_min_interval_seconds
+/// ```
+///
+/// At the defaults (8 MiB slices every 300 s) the 48.2 MB reference Cursor
+/// host sweeps completely in 6 slices = 1,800 s (30 min).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SqliteIngestConfig {
+    /// Payload bytes one poll's fast path may materialize before it degrades.
+    #[serde(default = "default_sqlite_fast_path_max_payload_bytes")]
+    pub fast_path_max_payload_bytes: u64,
+    /// Rows whose payload one poll's fast path may materialize.
+    #[serde(default = "default_sqlite_fast_path_max_payload_rows")]
+    pub fast_path_max_payload_rows: u64,
+    /// Census rows (narrow, index-backed reads) one poll may walk; guards
+    /// pathological keyspaces, not payload cost.
+    #[serde(default = "default_sqlite_fast_path_max_census_rows")]
+    pub fast_path_max_census_rows: u64,
+    /// Payload bytes one reconciliation sweep slice may read.
+    #[serde(default = "default_sqlite_sweep_slice_max_payload_bytes")]
+    pub sweep_slice_max_payload_bytes: u64,
+    /// Rows whose payload one sweep slice may read.
+    #[serde(default = "default_sqlite_sweep_slice_max_payload_rows")]
+    pub sweep_slice_max_payload_rows: u64,
+    /// Wall-clock budget for one sweep slice, inside the blocking scan task.
+    #[serde(default = "default_sqlite_sweep_slice_max_millis")]
+    pub sweep_slice_max_millis: u64,
+    /// Minimum interval between sweep slices of one database.
+    #[serde(default = "default_sqlite_sweep_slice_min_interval_seconds")]
+    pub sweep_slice_min_interval_seconds: u64,
+}
+
+fn default_sqlite_fast_path_max_payload_bytes() -> u64 {
+    16 * 1024 * 1024
+}
+
+fn default_sqlite_fast_path_max_payload_rows() -> u64 {
+    2_000
+}
+
+fn default_sqlite_fast_path_max_census_rows() -> u64 {
+    250_000
+}
+
+fn default_sqlite_sweep_slice_max_payload_bytes() -> u64 {
+    8 * 1024 * 1024
+}
+
+fn default_sqlite_sweep_slice_max_payload_rows() -> u64 {
+    1_000
+}
+
+fn default_sqlite_sweep_slice_max_millis() -> u64 {
+    250
+}
+
+fn default_sqlite_sweep_slice_min_interval_seconds() -> u64 {
+    300
+}
+
+impl Default for SqliteIngestConfig {
+    fn default() -> Self {
+        Self {
+            fast_path_max_payload_bytes: default_sqlite_fast_path_max_payload_bytes(),
+            fast_path_max_payload_rows: default_sqlite_fast_path_max_payload_rows(),
+            fast_path_max_census_rows: default_sqlite_fast_path_max_census_rows(),
+            sweep_slice_max_payload_bytes: default_sqlite_sweep_slice_max_payload_bytes(),
+            sweep_slice_max_payload_rows: default_sqlite_sweep_slice_max_payload_rows(),
+            sweep_slice_max_millis: default_sqlite_sweep_slice_max_millis(),
+            sweep_slice_min_interval_seconds: default_sqlite_sweep_slice_min_interval_seconds(),
+        }
+    }
 }
 
 /// The configured `[mcp] open_reader` selector for the `open` tool family
@@ -1445,6 +1532,7 @@ impl Default for IngestConfig {
             reconcile_interval_seconds: default_reconcile_interval_seconds(),
             heartbeat_interval_seconds: default_heartbeat_interval_seconds(),
             ack_observation: false,
+            sqlite: SqliteIngestConfig::default(),
         }
     }
 }
@@ -2379,6 +2467,45 @@ fn normalize_config(mut cfg: AppConfig) -> Result<AppConfig> {
     // Fail closed on `[retention]` too (issue #603 §4 S2): a horizon below the
     // non-configurable floor never produces a usable AppConfig.
     validate_retention(&cfg.retention).map_err(|error| anyhow::anyhow!("{error}"))?;
+
+    // Fail closed on `[ingest.sqlite]` (issue #601 §2.1/§2.2): a zero work
+    // budget is not "no work", it is a poll that degrades on its first row
+    // forever, and a zero sweep interval turns every reconcile tick into a
+    // sweep slice. `sweep_slice_max_millis` is deliberately exempt — zero is
+    // the meaningful "one item per slice" floor and the slice driver's
+    // forward-progress rule makes it safe.
+    for (key, value) in [
+        (
+            "fast_path_max_payload_bytes",
+            cfg.ingest.sqlite.fast_path_max_payload_bytes,
+        ),
+        (
+            "fast_path_max_payload_rows",
+            cfg.ingest.sqlite.fast_path_max_payload_rows,
+        ),
+        (
+            "fast_path_max_census_rows",
+            cfg.ingest.sqlite.fast_path_max_census_rows,
+        ),
+        (
+            "sweep_slice_max_payload_bytes",
+            cfg.ingest.sqlite.sweep_slice_max_payload_bytes,
+        ),
+        (
+            "sweep_slice_max_payload_rows",
+            cfg.ingest.sqlite.sweep_slice_max_payload_rows,
+        ),
+        (
+            "sweep_slice_min_interval_seconds",
+            cfg.ingest.sqlite.sweep_slice_min_interval_seconds,
+        ),
+    ] {
+        if value == 0 {
+            return Err(anyhow::anyhow!(
+                "ingest.sqlite.{key} must be greater than zero"
+            ));
+        }
+    }
 
     for (exclude_idx, pattern) in cfg.ingest.exclude_project_dirs.iter_mut().enumerate() {
         *pattern = expand_path(pattern.trim());
@@ -4286,6 +4413,118 @@ watch_root = "~/.cursor/projects"
         assert_eq!(cfg.backend.bind, "127.0.0.1");
         assert_eq!(cfg.backend.auth_token, None);
         assert!(cfg.mcp.use_central_server);
+    }
+
+    /// Issue #601 WI-04. The shipped `[ingest.sqlite]` block and the code
+    /// defaults are two statements of the same budgets; this is the guard that
+    /// keeps them from drifting. It fails when either side moves alone —
+    /// including any one-token scaling of a default budget constant, in either
+    /// direction, because the template pins the exact number.
+    #[test]
+    fn shipped_template_sqlite_budgets_match_the_code_defaults() {
+        let path = write_temp_config(
+            include_str!("../../../config/moraine.toml"),
+            "shipped-template-sqlite-budgets",
+        );
+        let cfg = load_config(&path).expect("shipped template must parse");
+        std::fs::remove_file(&path).ok();
+
+        let raw: toml::Value = toml::from_str(include_str!("../../../config/moraine.toml"))
+            .expect("shipped template must be TOML");
+        let block = raw
+            .get("ingest")
+            .and_then(|ingest| ingest.get("sqlite"))
+            .expect("template must ship the [ingest.sqlite] block");
+        let shipped = |key: &str| {
+            block
+                .get(key)
+                .and_then(toml::Value::as_integer)
+                .unwrap_or_else(|| panic!("template must ship ingest.sqlite.{key}"))
+                as u64
+        };
+
+        let defaults = SqliteIngestConfig::default();
+        for (key, loaded, default) in [
+            (
+                "fast_path_max_payload_bytes",
+                cfg.ingest.sqlite.fast_path_max_payload_bytes,
+                defaults.fast_path_max_payload_bytes,
+            ),
+            (
+                "fast_path_max_payload_rows",
+                cfg.ingest.sqlite.fast_path_max_payload_rows,
+                defaults.fast_path_max_payload_rows,
+            ),
+            (
+                "fast_path_max_census_rows",
+                cfg.ingest.sqlite.fast_path_max_census_rows,
+                defaults.fast_path_max_census_rows,
+            ),
+            (
+                "sweep_slice_max_payload_bytes",
+                cfg.ingest.sqlite.sweep_slice_max_payload_bytes,
+                defaults.sweep_slice_max_payload_bytes,
+            ),
+            (
+                "sweep_slice_max_payload_rows",
+                cfg.ingest.sqlite.sweep_slice_max_payload_rows,
+                defaults.sweep_slice_max_payload_rows,
+            ),
+            (
+                "sweep_slice_max_millis",
+                cfg.ingest.sqlite.sweep_slice_max_millis,
+                defaults.sweep_slice_max_millis,
+            ),
+            (
+                "sweep_slice_min_interval_seconds",
+                cfg.ingest.sqlite.sweep_slice_min_interval_seconds,
+                defaults.sweep_slice_min_interval_seconds,
+            ),
+        ] {
+            assert_eq!(
+                shipped(key),
+                default,
+                "template ingest.sqlite.{key} must state the code default"
+            );
+            assert_eq!(
+                loaded, default,
+                "loaded ingest.sqlite.{key} must round-trip the default"
+            );
+        }
+    }
+
+    /// A zero work budget is a poll that degrades on its first row forever,
+    /// and a zero sweep interval is a sweep on every reconcile tick; both fail
+    /// closed at load. `sweep_slice_max_millis = 0` stays loadable on purpose:
+    /// it is the one-item-per-slice floor the driver's forward-progress rule
+    /// makes meaningful.
+    #[test]
+    fn zero_sqlite_budgets_are_rejected_at_load() {
+        for key in [
+            "fast_path_max_payload_bytes",
+            "fast_path_max_payload_rows",
+            "fast_path_max_census_rows",
+            "sweep_slice_max_payload_bytes",
+            "sweep_slice_max_payload_rows",
+            "sweep_slice_min_interval_seconds",
+        ] {
+            let contents = format!("[ingest.sqlite]\n{key} = 0\n");
+            let path = write_temp_config(&contents, &format!("sqlite-zero-{key}"));
+            let err = load_config(&path).expect_err("zero budget must fail closed");
+            std::fs::remove_file(&path).ok();
+            assert!(
+                format!("{err:#}").contains(&format!("ingest.sqlite.{key}")),
+                "error must name the offending key, got: {err:#}"
+            );
+        }
+
+        let path = write_temp_config(
+            "[ingest.sqlite]\nsweep_slice_max_millis = 0\n",
+            "sqlite-zero-millis",
+        );
+        let cfg = load_config(&path).expect("zero millis is the one-item floor, not an error");
+        std::fs::remove_file(&path).ok();
+        assert_eq!(cfg.ingest.sqlite.sweep_slice_max_millis, 0);
     }
 
     #[test]

--- a/crates/moraine-ingest-core/src/lib.rs
+++ b/crates/moraine-ingest-core/src/lib.rs
@@ -249,6 +249,17 @@ pub(crate) struct Metrics {
     /// observed-scan denominator the failure-backoff gate asserts on;
     /// `ingest_errors` rows are rate-limited and cannot count scans.
     pub(crate) sqlite_scan_failures_total: AtomicU64,
+    /// Payload rows read by reconciliation sweep slices (issue #601 §2.2) — a
+    /// subset of `sqlite_poll_payload_rows_total`, folded from the ledger's
+    /// sweep axes so G6a-class gates can assert "no sweep ran" on it.
+    pub(crate) sqlite_sweep_rows_total: AtomicU64,
+    /// Payload bytes read by sweep slices.
+    pub(crate) sqlite_sweep_bytes_total: AtomicU64,
+    /// Committed sweep slices, counted where the slice's checkpoint persists.
+    pub(crate) sqlite_sweep_slices_total: AtomicU64,
+    /// Scans that committed with degraded coverage (issue #601 §2.3): a work
+    /// budget bound, a census truncated, or checkpoint state was evicted.
+    pub(crate) sqlite_coverage_degraded_scans_total: AtomicU64,
     pub(crate) last_error: Mutex<String>,
 }
 

--- a/crates/moraine-ingest-core/src/sqlite_poll.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll.rs
@@ -28,7 +28,7 @@ use crate::dispatch::source_inode_for_file;
 use crate::model::{Checkpoint, RowBatch};
 use crate::normalize::normalize_record;
 use crate::sources::shared::format_record_ts;
-use crate::{Metrics, SinkMessage, WorkItem};
+use crate::{Metrics, SinkMessage, WorkItem, WorkTrigger};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use moraine_config::{AppConfig, SOURCE_FORMAT_CURSOR_SQLITE};
@@ -39,7 +39,7 @@ use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, warn};
 
@@ -55,9 +55,6 @@ pub(crate) use opencode::process_opencode_sqlite_db;
 /// `ItemTable` — which holds live auth tokens) is deliberately out of scope
 /// for v1; see issue #361 and the field census in PR discussion.
 const RELEVANT_PREFIXES: &[&str] = &["bubbleId:", "composerData:"];
-
-/// Issue #361: bail out rather than persist an oversized checkpoint payload.
-const MAX_RELEVANT_KEYS: usize = 10_000;
 
 /// Strings longer than this inside tool params/results are elided before the
 /// synthetic record is built. Cursor stores base64 screenshots (~1.2 MB each)
@@ -76,9 +73,29 @@ pub(crate) const SCAN_PAGE_MAX_BYTES: usize = 32 * 1024 * 1024;
 
 const CURSOR_STATE_VERSION: u32 = 1;
 
+/// Ceiling on the serialized Cursor cursor payload (issue #601 §2.3), the
+/// successor to `MAX_RELEVANT_KEYS`' hard latch. Enforced by **eviction** of
+/// the oldest kv hashes, never by failing the scan: an evicted key re-detects
+/// as never-read and is re-read (and re-emitted) by a later poll, which is
+/// safe because Cursor records are content-addressed at stable logical
+/// coordinates (§6). The bound matters beyond memory: `cursor_json` is
+/// persisted on every persisting poll and hashed into the #602 transition
+/// digest (§2.6), so without it the payload grows with the keyspace up to
+/// `fast_path_max_census_rows` entries — tens of MB at the 250 k default.
+const MAX_CURSOR_CHECKPOINT_BYTES: usize = 8 * 1024 * 1024;
+
 const ERROR_KIND_OPEN: &str = "sqlite_open_error";
 const ERROR_KIND_SCHEMA: &str = "sqlite_schema_mismatch";
+/// Retired from every scan path by issue #601 §2.3: history size is now a
+/// degradation (`coverage_degraded`), never a failure. The constant remains
+/// because `record_scan_failure_outcome`'s routing width is pinned per kind
+/// (`each_error_kind_routes_to_exactly_one_backoff_clock`) and because
+/// historical `ingest_errors` rows carry it.
 const ERROR_KIND_TOO_LARGE: &str = "sqlite_cursor_too_large";
+/// One genuinely un-processable single row (issue #601 §2.3): larger than
+/// `SCAN_PAGE_MAX_BYTES`. Reported as one `ingest_errors` row for that row
+/// alone; the scan skips it and advances past it — never fails.
+pub(crate) const ERROR_KIND_ROW_TOO_LARGE: &str = "sqlite_row_too_large";
 const ERROR_KIND_SCAN: &str = "sqlite_scan_error";
 const ERROR_KIND_MIXED_SNAPSHOT: &str = "sqlite_mixed_snapshot";
 
@@ -109,6 +126,22 @@ struct CursorState {
     /// mode once instead of once per reconcile tick.
     #[serde(default)]
     last_error: String,
+    /// Durable reconciliation-sweep cursor (issue #601 §2.2). Additive to the
+    /// payload — skipped while default, so `cursor_json` stays byte-identical
+    /// for sources that have never swept, and structural-deterministic, so it
+    /// rides the #602 transition digest safely (§2.6).
+    #[serde(default, skip_serializing_if = "SweepState::is_default")]
+    sweep: SweepState,
+    /// True while some censused key has never been read in this generation
+    /// (a budget/census-cap remainder) — §2.3's persisted resume marker. The
+    /// cheap stat short-circuit must not fire while this is set, or a quiet
+    /// database's cold-ingest remainder is hidden forever: nothing will move
+    /// the stat, so nothing would ever scan again. Structural and
+    /// deterministic (a function of the committed census vs the committed
+    /// hash map), and skipped while false so `cursor_json` stays
+    /// byte-identical for fully-covered sources (§2.6).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pending_coverage: bool,
 }
 
 impl CursorState {
@@ -137,6 +170,59 @@ impl CursorState {
 
     fn serialize(&self) -> String {
         serde_json::to_string(self).unwrap_or_default()
+    }
+
+    /// Evict the oldest kv hashes until the serialized payload fits
+    /// `max_bytes`, returning how many were dropped (issue #601 §2.3). The
+    /// mirror of `NacState::evict_to_fit`: the ceiling degrades — an evicted
+    /// key re-detects as never-read, so a later poll re-reads and re-emits it
+    /// (safe under §6's content-addressed identity) — instead of latching the
+    /// whole database the way `MAX_RELEVANT_KEYS` did.
+    ///
+    /// "Oldest" is §2.3's adapter recency ordering, `rowid`, as this poll's
+    /// census saw it: entries the census did not cover evict first (their age
+    /// is unknowable here, and a truncated census's uncovered tail is where
+    /// carried-forward entries come from), then ascending `rowid`, then key
+    /// for determinism. The persisted state carries no rowid until WI-08's
+    /// `KvEntry { hash, rowid }`, which owns replacing this census-scoped
+    /// view with a durable one. Removal is in batches of one-eighth of the
+    /// map per round, so a pathological many-small-entries payload does not
+    /// re-serialize per entry.
+    fn evict_to_fit(&mut self, max_bytes: usize, census: &[CensusRow]) -> u64 {
+        // As in `NacState::evict_to_fit`: measured through `serde_json`
+        // directly, because `self.serialize()` on a `&mut self` receiver
+        // resolves to serde's blanket `impl Serialize for &mut T` before the
+        // inherent method.
+        let raw_len = |state: &Self| {
+            serde_json::to_string(state)
+                .map(|raw| raw.len())
+                .unwrap_or(0)
+        };
+        let mut evicted = 0u64;
+        if raw_len(self) <= max_bytes {
+            return evicted;
+        }
+        let rowid_by_key: HashMap<&str, i64> = census
+            .iter()
+            .map(|row| (row.key.as_str(), row.rowid))
+            .collect();
+        loop {
+            if raw_len(self) <= max_bytes || self.kv_hashes.is_empty() {
+                return evicted;
+            }
+            // `None` sorts before `Some`, so un-censused entries evict first.
+            let mut by_age: Vec<(Option<i64>, String)> = self
+                .kv_hashes
+                .keys()
+                .map(|key| (rowid_by_key.get(key.as_str()).copied(), key.clone()))
+                .collect();
+            by_age.sort();
+            let batch = (self.kv_hashes.len().div_ceil(8)).max(1);
+            for (_, key) in by_age.into_iter().take(batch) {
+                self.kv_hashes.remove(&key);
+                evicted += 1;
+            }
+        }
     }
 }
 
@@ -292,6 +378,11 @@ struct VolatilePollEntry {
     /// it exists at all — see `failure_retry_due`.
     last_contended_at: Option<Instant>,
     consecutive_contended_scans: u32,
+    /// When this database last committed a sweep slice (issue #601 §2.2,
+    /// eligibility condition 2). Volatile on purpose: losing it on restart
+    /// costs at most one early slice per database, while persisting it would
+    /// put a wall clock in `cursor_json` (the §2.6 trap).
+    last_sweep_at: Option<Instant>,
 }
 
 /// Base delay after one failed scan, doubling per consecutive failure.
@@ -442,6 +533,7 @@ impl VolatilePollMap {
                 last_scan_at: Instant::now(),
                 last_contended_at: None,
                 consecutive_contended_scans: 0,
+                last_sweep_at: None,
             });
         entry.source_generation = source_generation;
         entry.stat = Some(stat);
@@ -471,8 +563,40 @@ impl VolatilePollMap {
     /// crash recovery must never be suppressed by stale volatile state.
     /// Error-marker checkpoints deliberately do not clear — the failure path
     /// keeps the entry and refreshes its clock via `record_failed_scan`.
+    ///
+    /// **The sweep interval clock survives the wipe.** `last_sweep_at` is not
+    /// scan coverage — it is §2.2's minimum-interval clock — and every
+    /// persisting scan lands here, so a clock that lived and died with the
+    /// entry was erased by any emitting poll between slices: the next quiet
+    /// reconcile poll saw no entry, `sweep_slice_due` answered `true`, and a
+    /// database with interleaved writes (the typical agent-session shape, and
+    /// every multi-poll cold ingest) swept at up to the reconcile cadence —
+    /// up to ~10× the configured minimum — instead of the §4 interval. The
+    /// skeleton an armed clock leaves behind is inert to every other reader:
+    /// `stat` is `None` and the streaks are zero, so `should_skip_poll`
+    /// answers `false` and `failure_retry_due` answers `true`
+    /// (`failure_backoff(0)` and `contention_backoff(0)` are both
+    /// `Duration::ZERO`), exactly as they do for a missing entry. NAC and
+    /// OpenCode share this call site and never arm the clock (no sweep until
+    /// WI-06/WI-07), so their entries still clear whole.
+    /// `a_second_reconcile_poll_inside_the_sweep_interval_attaches_no_slice`
+    /// fails on its emitting-poll interleave if the carry goes.
     fn clear(&self, cp_key: &str) {
-        self.lock().remove(cp_key);
+        let mut map = self.lock();
+        let keep_sweep_clock = map
+            .get(cp_key)
+            .is_some_and(|entry| entry.last_sweep_at.is_some());
+        if !keep_sweep_clock {
+            map.remove(cp_key);
+            return;
+        }
+        if let Some(entry) = map.get_mut(cp_key) {
+            entry.stat = None;
+            entry.consecutive_noop_scans = 0;
+            entry.consecutive_failed_scans = 0;
+            entry.consecutive_contended_scans = 0;
+            entry.last_contended_at = None;
+        }
     }
 
     /// Entering a durably blocked replay is a scan failure for backoff
@@ -574,6 +698,7 @@ impl VolatilePollMap {
                 last_scan_at: Instant::now(),
                 last_contended_at: None,
                 consecutive_contended_scans: 0,
+                last_sweep_at: None,
             });
         entry.source_generation = source_generation;
         entry.stat = None;
@@ -612,11 +737,60 @@ impl VolatilePollMap {
                 last_scan_at: Instant::now(),
                 last_contended_at: None,
                 consecutive_contended_scans: 0,
+                last_sweep_at: None,
             });
         entry.source_generation = source_generation;
         entry.stat = None;
         entry.consecutive_contended_scans = entry.consecutive_contended_scans.saturating_add(1);
         entry.last_contended_at = Some(Instant::now());
+    }
+
+    /// True when `cp_key` is due another sweep slice: no slice has ever been
+    /// recorded (fresh process — one early slice per restart is the accepted
+    /// price of keeping this clock volatile), the generation changed, or the
+    /// configured minimum interval has elapsed since the last committed slice.
+    fn sweep_slice_due(
+        &self,
+        cp_key: &str,
+        source_generation: u32,
+        min_interval: Duration,
+    ) -> bool {
+        let map = self.lock();
+        let Some(entry) = map.get(cp_key) else {
+            return true;
+        };
+        if entry.source_generation != source_generation {
+            return true;
+        }
+        match entry.last_sweep_at {
+            Some(at) => at.elapsed() >= min_interval,
+            None => true,
+        }
+    }
+
+    /// Record a committed sweep slice for `cp_key`, starting the interval
+    /// clock. Called **after** the durable-persist path's `clear` — a slice
+    /// always persists a checkpoint, and until the first slice arms the clock
+    /// `clear` removes the entry whole, so arming before it would be wiped
+    /// and every slice would restart the interval empty
+    /// (`a_second_reconcile_poll_inside_the_sweep_interval_attaches_no_slice`
+    /// fails if this call or its ordering goes). Once armed, the clock also
+    /// survives `clear` itself — see `clear` for why that carry is
+    /// load-bearing on databases with interleaved writes.
+    fn record_sweep_slice(&self, cp_key: &str, source_generation: u32) {
+        let mut map = self.lock();
+        let entry = map.entry(cp_key.to_string()).or_insert(VolatilePollEntry {
+            source_generation,
+            stat: None,
+            consecutive_noop_scans: 0,
+            consecutive_failed_scans: 0,
+            last_scan_at: Instant::now(),
+            last_contended_at: None,
+            consecutive_contended_scans: 0,
+            last_sweep_at: None,
+        });
+        entry.source_generation = source_generation;
+        entry.last_sweep_at = Some(Instant::now());
     }
 
     /// Consecutive failed scans recorded for `cp_key`; zero when no entry
@@ -656,6 +830,11 @@ impl VolatilePollMap {
             // vice versa).
             entry.last_contended_at = entry
                 .last_contended_at
+                .map(|at| at.checked_sub(by).unwrap_or(at));
+            // The sweep clock too: an interval test that could not age it
+            // would have to really sleep through the configured interval.
+            entry.last_sweep_at = entry
+                .last_sweep_at
                 .map(|at| at.checked_sub(by).unwrap_or(at));
         }
     }
@@ -706,11 +885,26 @@ pub(crate) struct ScanLedger {
     pub(crate) payload_bytes: u64,
     /// Synthetic records produced by the scan.
     pub(crate) rows_emitted: u64,
-    // `sweep_rows` / `sweep_bytes` deliberately do **not** exist yet. Nothing
-    // charges a sweep until WI-04 introduces one, so a field carrying a
-    // permanent zero would be a field G6a could assert on and never fail —
-    // the exact unfailable-guard shape this issue is removing. WI-04 adds them
-    // together with the code that charges them.
+    /// Subset of `payload_rows` attributable to a reconciliation sweep slice.
+    /// Charged only through `absorb_sweep_slice`, which is the slice driver's
+    /// single commit point — a sweep read is a payload read *and* a sweep
+    /// read, never one or the other.
+    pub(crate) sweep_rows: u64,
+    /// Subset of `payload_bytes` attributable to a sweep slice.
+    pub(crate) sweep_bytes: u64,
+    /// True when this poll committed less than full coverage of its source:
+    /// a work budget bound first, a census was truncated, or checkpoint state
+    /// was evicted to fit its ceiling (issue #601 §2.3). Never an error — the
+    /// remainder is covered by later polls and by the sweep.
+    pub(crate) coverage_degraded: bool,
+    /// Rows the scan knew about and deliberately did not read this poll.
+    pub(crate) skipped_rows: u64,
+    /// Payload bytes known to have been skipped. Zero when the skipped size is
+    /// unknowable without decoding (Cursor values: §1.1 finding 2 — `length()`
+    /// is not a cheap probe), which under-reports rather than fabricates.
+    pub(crate) skipped_bytes: u64,
+    /// Checkpoint-state entries evicted to fit a state ceiling (§2.3).
+    pub(crate) evicted_entries: u64,
 }
 
 impl ScanLedger {
@@ -738,6 +932,230 @@ impl ScanLedger {
     pub(crate) fn charge_aggregate_payload_bytes(&mut self, bytes: u64) {
         self.payload_bytes = self.payload_bytes.saturating_add(bytes);
     }
+
+    /// Record deliberately-skipped coverage (§2.3): a budget bound before the
+    /// scan finished, or a census was truncated. Charged where the skip is
+    /// decided, with whatever counts are known there.
+    pub(crate) fn mark_degraded(&mut self, skipped_rows: u64, skipped_bytes: u64) {
+        self.coverage_degraded = true;
+        self.skipped_rows = self.skipped_rows.saturating_add(skipped_rows);
+        self.skipped_bytes = self.skipped_bytes.saturating_add(skipped_bytes);
+    }
+
+    /// Record checkpoint-state eviction (§2.3): entries dropped to fit a state
+    /// ceiling. Eviction is degraded coverage — the evicted entries are
+    /// re-covered (and re-emitted) by a later poll.
+    pub(crate) fn mark_evicted(&mut self, evicted_entries: u64) {
+        if evicted_entries == 0 {
+            return;
+        }
+        self.coverage_degraded = true;
+        self.evicted_entries = self.evicted_entries.saturating_add(evicted_entries);
+    }
+
+    /// Fold one committed sweep slice's ledger into the poll's ledger. This is
+    /// the **only** writer of the sweep axes: the slice's reads charge its own
+    /// slice-scoped ledger at the read site (through the same sanctioned
+    /// helpers as every other read), and this fold states that those payload
+    /// rows/bytes were sweep work. Payload axes are folded too — a sweep read
+    /// is still a payload read, and hiding it from the payload axes would let
+    /// a sweep evade every fast-path budget assertion.
+    pub(crate) fn absorb_sweep_slice(&mut self, slice: &ScanLedger) {
+        self.payload_rows = self.payload_rows.saturating_add(slice.payload_rows);
+        self.payload_bytes = self.payload_bytes.saturating_add(slice.payload_bytes);
+        self.census_rows = self.census_rows.saturating_add(slice.census_rows);
+        self.census_bytes = self.census_bytes.saturating_add(slice.census_bytes);
+        self.sweep_rows = self.sweep_rows.saturating_add(slice.payload_rows);
+        self.sweep_bytes = self.sweep_bytes.saturating_add(slice.payload_bytes);
+        // `rows_emitted` is deliberately not folded: the slice driver pushes
+        // its synthetic records into the scan's shared `records` vec, so the
+        // slice-scoped ledger never charges the field, and the scan assigns
+        // `ledger.rows_emitted = records.len()` wholesale after the slice —
+        // a fold here would be dead on one end and double-counted on the
+        // other the moment either of those facts changed.
+    }
+}
+
+/// One poll's read budget (issue #601 §2.1/§2.2), instantiated per scan from
+/// `[ingest.sqlite]`. Exhaustion is never an error: the caller commits what it
+/// has and records `coverage_degraded`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ScanBudget {
+    pub(crate) max_payload_bytes: u64,
+    pub(crate) max_payload_rows: u64,
+}
+
+impl ScanBudget {
+    pub(crate) fn fast_path(config: &moraine_config::SqliteIngestConfig) -> Self {
+        Self {
+            max_payload_bytes: config.fast_path_max_payload_bytes,
+            max_payload_rows: config.fast_path_max_payload_rows,
+        }
+    }
+
+    pub(crate) fn sweep_slice(config: &moraine_config::SqliteIngestConfig) -> Self {
+        Self {
+            max_payload_bytes: config.sweep_slice_max_payload_bytes,
+            max_payload_rows: config.sweep_slice_max_payload_rows,
+        }
+    }
+
+    /// The replacement-replay budget: none. A budget-degraded replay would
+    /// finalize an incomplete generation through #602's publication path —
+    /// see `CursorScanPlan::unbudgeted` for the argument. Ordinary polls
+    /// must never take this.
+    pub(crate) fn unbounded() -> Self {
+        Self {
+            max_payload_bytes: u64::MAX,
+            max_payload_rows: u64::MAX,
+        }
+    }
+
+    /// True when the charged work has reached either axis of this budget.
+    /// `>=` on both axes on purpose: a budget of N rows means the N-th row is
+    /// the last one read, and a byte budget binds the moment it is met — the
+    /// row that crossed it was still committed (§2.1: commit what was read).
+    pub(crate) fn is_exhausted_by(&self, payload_rows: u64, payload_bytes: u64) -> bool {
+        payload_rows >= self.max_payload_rows || payload_bytes >= self.max_payload_bytes
+    }
+
+    /// True when at least half of either axis is consumed — sweep-eligibility
+    /// condition 3 (§2.2): a database whose fast path is doing real work does
+    /// not also pay sweep cost this poll. `>=`, so the exact midpoint already
+    /// binds — one half is the threshold, not the last admissible value.
+    pub(crate) fn is_half_consumed_by(&self, payload_rows: u64, payload_bytes: u64) -> bool {
+        payload_rows.saturating_mul(2) >= self.max_payload_rows
+            || payload_bytes.saturating_mul(2) >= self.max_payload_bytes
+    }
+}
+
+/// Durable reconciliation-sweep cursor (issue #601 §2.2), persisted inside the
+/// adapter's `cursor_json`. Structural, deterministic state only — every field
+/// advances exactly when a slice commits work, so it rides the #602 transition
+/// digest safely (§2.6). Poll health/telemetry must NOT be added here.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub(crate) struct SweepState {
+    /// Resume position in the adapter's sweep ordering (Cursor: kv key).
+    /// Empty = start of a cycle.
+    #[serde(default)]
+    pub(crate) cursor: String,
+    /// Unix ms at which the in-progress cycle started.
+    #[serde(default)]
+    pub(crate) cycle_started_unix_ms: u64,
+    /// Unix ms at which the last *complete* cycle finished. 0 = never.
+    #[serde(default)]
+    pub(crate) last_complete_unix_ms: u64,
+    /// Completed cycles since the generation began.
+    #[serde(default)]
+    pub(crate) completed_cycles: u64,
+    /// Payload bytes covered so far by the in-progress cycle.
+    #[serde(default)]
+    pub(crate) cycle_payload_bytes: u64,
+    /// Payload bytes the last completed cycle covered — the denominator of
+    /// `projected_full_sweep_seconds` (§2.2's published interval).
+    #[serde(default)]
+    pub(crate) last_cycle_payload_bytes: u64,
+}
+
+impl SweepState {
+    /// True for a state no slice has ever advanced; used to keep `cursor_json`
+    /// byte-identical for sources that have never swept.
+    pub(crate) fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
+    /// §2.2's published maximum complete-sweep interval — a projection from
+    /// the last completed cycle, `None` until one exists. The *observed*
+    /// interval (`last_complete_unix_ms`) is surfaced alongside it by WI-09,
+    /// because the projection is a model and the observation is the truth.
+    pub(crate) fn projected_full_sweep_seconds(
+        &self,
+        slice_max_payload_bytes: u64,
+        slice_min_interval_seconds: u64,
+    ) -> Option<u64> {
+        if self.completed_cycles == 0 || slice_max_payload_bytes == 0 {
+            return None;
+        }
+        let slices = self
+            .last_cycle_payload_bytes
+            .div_ceil(slice_max_payload_bytes)
+            // An empty (or sub-slice) cycle still costs one slice.
+            .max(1);
+        Some(slices.saturating_mul(slice_min_interval_seconds))
+    }
+}
+
+/// One processed item in an adapter's sweep ordering.
+pub(crate) struct SweepItem {
+    /// This item's position; becomes the resume cursor once processed.
+    pub(crate) position: String,
+    /// Payload bytes the item charged, accumulated into the cycle total.
+    pub(crate) payload_bytes: u64,
+}
+
+/// What one driven slice did, for the caller to commit. Cycle completion is
+/// readable off the state itself (`cursor` wrapped to empty, `completed_cycles`
+/// advanced), so the report carries no separate flag to drift from it.
+pub(crate) struct SweepSliceReport {
+    pub(crate) state: SweepState,
+}
+
+/// The shared slice driver (issue #601 §2.2, WI-04): owns budget binding,
+/// forward progress, cursor advancement and cycle bookkeeping, so every
+/// adapter's sweep obeys one set of rules. The adapter supplies `next_item`,
+/// which reads (and charges to `slice`) the first item strictly after the
+/// given position in its sweep ordering, or `None` at the end of the ordering.
+///
+/// Rules, each load-bearing:
+/// - **Budget binds between items, never before the first** — a slice always
+///   makes forward progress, so a single item larger than the whole byte
+///   budget is processed and the cursor advances past it (G6c). The same rule
+///   makes `max_millis = 0` mean "one item per slice", not "no progress".
+/// - **A cycle ends the slice.** On wrap the cursor resets to empty, the cycle
+///   stamps advance, and the slice stops — cycle completion is the durable
+///   commit point G5b counts.
+/// - The driver never touches the cursor except through processed items, so a
+///   rejected scan (mixed snapshot) discards the whole advance with the rest
+///   of the scan's state.
+pub(crate) fn drive_sweep_slice<E>(
+    prior: &SweepState,
+    budget: &ScanBudget,
+    max_millis: u64,
+    now_unix_ms: u64,
+    slice: &mut ScanLedger,
+    mut next_item: impl FnMut(&str, &mut ScanLedger) -> std::result::Result<Option<SweepItem>, E>,
+) -> std::result::Result<SweepSliceReport, E> {
+    let started = Instant::now();
+    let mut state = prior.clone();
+    if state.cursor.is_empty() {
+        state.cycle_started_unix_ms = now_unix_ms;
+        state.cycle_payload_bytes = 0;
+    }
+    let mut items = 0u64;
+    loop {
+        if items > 0
+            && (budget.is_exhausted_by(slice.payload_rows, slice.payload_bytes)
+                || started.elapsed() >= Duration::from_millis(max_millis))
+        {
+            break;
+        }
+        match next_item(&state.cursor, slice)? {
+            Some(item) => {
+                items += 1;
+                state.cursor = item.position;
+                state.cycle_payload_bytes =
+                    state.cycle_payload_bytes.saturating_add(item.payload_bytes);
+            }
+            None => {
+                state.last_cycle_payload_bytes = state.cycle_payload_bytes;
+                state.last_complete_unix_ms = now_unix_ms;
+                state.completed_cycles = state.completed_cycles.saturating_add(1);
+                state.cursor = String::new();
+                break;
+            }
+        }
+    }
+    Ok(SweepSliceReport { state })
 }
 
 /// The only sanctioned way to materialize a variable-length payload column:
@@ -832,6 +1250,26 @@ pub(crate) fn record_scan_ledger(metrics: &Arc<Metrics>, ledger: &ScanLedger) {
     metrics
         .sqlite_poll_census_bytes_total
         .fetch_add(ledger.census_bytes, std::sync::atomic::Ordering::Relaxed);
+    metrics
+        .sqlite_sweep_rows_total
+        .fetch_add(ledger.sweep_rows, std::sync::atomic::Ordering::Relaxed);
+    metrics
+        .sqlite_sweep_bytes_total
+        .fetch_add(ledger.sweep_bytes, std::sync::atomic::Ordering::Relaxed);
+    if ledger.coverage_degraded {
+        metrics
+            .sqlite_coverage_degraded_scans_total
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// One committed sweep slice. Counted at the commit site — after the slice's
+/// checkpoint persisted — never where the slice merely ran, so a slice whose
+/// scan lost the mixed-snapshot bracket is not counted as coverage.
+pub(crate) fn record_sweep_slice_committed(metrics: &Arc<Metrics>) {
+    metrics
+        .sqlite_sweep_slices_total
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 }
 
 /// Reads one table's `CREATE TABLE` text out of `sqlite_master`, charging it
@@ -936,9 +1374,15 @@ pub struct SyntheticRecord {
 enum ScanOutcome {
     Scanned {
         records: Vec<SyntheticRecord>,
-        new_state: CursorState,
+        /// Boxed so the `Failed` variant is not forced to carry a
+        /// `CursorState`'s footprint.
+        new_state: Box<CursorState>,
         schema_fingerprint: u64,
         relevant_keys: u64,
+        /// True when this scan ran a sweep slice whose advance is carried in
+        /// `new_state.sweep`. The caller commits it (metrics + interval
+        /// clock) only after the checkpoint persists.
+        swept: bool,
     },
     Failed {
         error_kind: &'static str,
@@ -1218,7 +1662,16 @@ pub(crate) async fn process_cursor_sqlite_db(
     // disjunct is added; `a_contended_replacement_replay_throttles_its_barrier`
     // bounds the other direction (the durable barrier *is* throttled). See the
     // deviation record in `plans/601-delta-sqlite.md` §7 WI-10.
-    if state.stat == current_stat && state.last_error.is_empty() {
+    //
+    // The `!state.pending_coverage` conjunct is §2.3's "continue next poll":
+    // while a cold-ingest remainder exists, an unchanged stat must not end
+    // the poll, because a quiet database's stat never changes again and the
+    // remainder would be unreachable forever. The resume terminates — every
+    // resumed scan reads never-read keys first, so the debt strictly shrinks
+    // and the flag clears durably with the covering scan's checkpoint
+    // (`a_degraded_cold_ingest_completes_without_new_writes` fails if this
+    // conjunct or the never-read-first ordering goes).
+    if state.stat == current_stat && state.last_error.is_empty() && !state.pending_coverage {
         return Ok(());
     }
 
@@ -1232,11 +1685,35 @@ pub(crate) async fn process_cursor_sqlite_db(
         return Ok(());
     }
 
+    // Sweep eligibility, conditions 1, 2 and 4 (issue #601 §2.2/§2.4): only a
+    // `Reconcile`-triggered poll — the provenance WI-03 established, including
+    // the owed-tick upgrades `arm_owed_reconcile` performs — of a database
+    // that is not replaying and whose per-database interval clock has expired
+    // requests a slice. Condition 3 (a quiet, cheap fast path) is decided
+    // inside the scan, where this poll's ledger exists.
+    let sweep_requested = work.trigger == WorkTrigger::Reconcile
+        && !replacement_replay
+        && poll_state.sweep_slice_due(
+            &cp_key,
+            checkpoint.source_generation,
+            Duration::from_secs(config.ingest.sqlite.sweep_slice_min_interval_seconds),
+        );
+    // A replacement replay is unbudgeted (see `CursorScanPlan::unbudgeted`):
+    // its finalize publishes the generation whole, so degrading it would
+    // publish a hole.
+    let plan = if replacement_replay {
+        CursorScanPlan::unbudgeted()
+    } else {
+        CursorScanPlan::from_config(
+            config,
+            sweep_requested.then(|| SweepPlan::from_config(config)),
+        )
+    };
     let scan_db_path = source_file.clone();
     let scan_state = state.clone();
     let (outcome, ledger) = tokio::task::spawn_blocking(move || {
         let mut ledger = ScanLedger::default();
-        let outcome = scan_database(&scan_db_path, &scan_state, &mut ledger);
+        let outcome = scan_database(&scan_db_path, &scan_state, &plan, &mut ledger);
         (outcome, ledger)
     })
     .await
@@ -1249,6 +1726,7 @@ pub(crate) async fn process_cursor_sqlite_db(
             mut new_state,
             schema_fingerprint,
             relevant_keys,
+            swept,
         } => {
             new_state.stat = current_stat;
             new_state.last_error = String::new();
@@ -1270,7 +1748,7 @@ pub(crate) async fn process_cursor_sqlite_db(
                 && !retry_blocked_replay
                 && records.is_empty()
                 && checkpoint.status == "active"
-                && new_state == prior_state_covered
+                && *new_state == prior_state_covered
                 && schema_fingerprint == checkpoint.schema_fingerprint
                 && relevant_keys == checkpoint.last_line_no;
             if scan_is_noop {
@@ -1370,7 +1848,7 @@ pub(crate) async fn process_cursor_sqlite_db(
                 } else {
                     "active".to_string()
                 },
-                cursor_json: new_state.serialize(),
+                cursor_json: (*new_state).serialize(),
                 source_fingerprint: inode,
                 schema_fingerprint,
                 policy_fingerprint: policy_fingerprint.clone(),
@@ -1417,6 +1895,26 @@ pub(crate) async fn process_cursor_sqlite_db(
                 .await?;
             }
             poll_state.clear(&cp_key);
+            if swept {
+                // Commit the slice only now — after its checkpoint persisted
+                // and after `clear` wiped the entry — so the interval clock
+                // survives the wipe and a slice whose scan failed or lost the
+                // mixed-snapshot bracket is neither counted nor throttling
+                // the retry.
+                poll_state.record_sweep_slice(&cp_key, checkpoint.source_generation);
+                record_sweep_slice_committed(metrics);
+                debug!(
+                    "{}:{} sweep slice committed (cursor {:?}, cycles {}, projected full sweep {:?}s)",
+                    work.source_name,
+                    source_file,
+                    new_state.sweep.cursor,
+                    new_state.sweep.completed_cycles,
+                    new_state.sweep.projected_full_sweep_seconds(
+                        config.ingest.sqlite.sweep_slice_max_payload_bytes,
+                        config.ingest.sqlite.sweep_slice_min_interval_seconds,
+                    ),
+                );
+            }
 
             if emitted > 0 {
                 debug!(
@@ -1522,12 +2020,98 @@ pub(crate) async fn process_cursor_sqlite_db(
     }
 }
 
-/// Blocking phase: open the database read-only, validate schema, scan the
-/// relevant key ranges, and synthesize records for new/changed keys.
+/// Per-scan work plan for the Cursor adapter (issue #601 §2.1/§2.2): the
+/// fast-path budget, the census cap, and — on sweep-eligible polls only — the
+/// sweep slice request. Built once per poll from `[ingest.sqlite]` in
+/// `process_cursor_sqlite_db` and passed whole into the blocking scan, so
+/// every budget the scan enforces arrived through one auditable argument.
+pub(crate) struct CursorScanPlan {
+    fast_budget: ScanBudget,
+    max_census_rows: u64,
+    /// Ceiling on the serialized cursor payload (§2.3), enforced by eviction
+    /// after the scan's reads — a *state* bound, never a work budget, which
+    /// is why `unbudgeted()` keeps it.
+    max_checkpoint_bytes: usize,
+    sweep: Option<SweepPlan>,
+}
+
+impl CursorScanPlan {
+    pub(crate) fn from_config(config: &AppConfig, sweep: Option<SweepPlan>) -> Self {
+        Self {
+            fast_budget: ScanBudget::fast_path(&config.ingest.sqlite),
+            max_census_rows: config.ingest.sqlite.fast_path_max_census_rows,
+            max_checkpoint_bytes: MAX_CURSOR_CHECKPOINT_BYTES,
+            sweep,
+        }
+    }
+
+    /// The replacement-replay plan: no budget, no census cap, no sweep.
+    ///
+    /// A replay's `FinalizeReplay` publishes the new generation over the old
+    /// one, so a budget-degraded replay would publish an *incomplete*
+    /// generation — a transient data loss #602's old-complete/new-complete
+    /// contract exists to forbid. The replay therefore pays the pre-#601
+    /// cost, once, per genuine replacement; ordinary polls never take this
+    /// plan. `a_replacement_replay_reads_past_the_fast_path_budget` fails if
+    /// a budget sneaks back in.
+    ///
+    /// The checkpoint ceiling **does** apply here: it is a *state* bound
+    /// enforced by eviction after the replay's reads and emissions, so it
+    /// bounds what is persisted without un-reading anything — the no-hole
+    /// argument above is about reads, not state size, and an evicted key's
+    /// records were already emitted by this replay.
+    pub(crate) fn unbudgeted() -> Self {
+        Self {
+            fast_budget: ScanBudget::unbounded(),
+            max_census_rows: u64::MAX,
+            max_checkpoint_bytes: MAX_CURSOR_CHECKPOINT_BYTES,
+            sweep: None,
+        }
+    }
+}
+
+/// One requested sweep slice: its budget, wall-clock cap, and the unix-ms
+/// stamp its cycle bookkeeping commits (§2.2).
+pub(crate) struct SweepPlan {
+    budget: ScanBudget,
+    max_millis: u64,
+    now_unix_ms: u64,
+}
+
+impl SweepPlan {
+    pub(crate) fn from_config(config: &AppConfig) -> Self {
+        Self {
+            budget: ScanBudget::sweep_slice(&config.ingest.sqlite),
+            max_millis: config.ingest.sqlite.sweep_slice_max_millis,
+            now_unix_ms: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
+        }
+    }
+}
+
+/// Blocking phase: open the database read-only, validate schema, census the
+/// relevant keyspace, and materialize candidate payloads newest-first under
+/// the fast-path budget.
 ///
 /// The caller owns `ledger` so that every early return — including each
 /// failure arm — still reports the bytes this scan had already paid for.
-fn scan_database(db_path: &str, prior: &CursorState, ledger: &mut ScanLedger) -> ScanOutcome {
+///
+/// **Ceiling degradation (issue #601 §2.3).** This scan has no history-size
+/// failure mode: `MAX_RELEVANT_KEYS` and its `sqlite_cursor_too_large` error
+/// are retired. What bounds a poll is per-poll work — `plan.fast_budget` on
+/// the payload axes and `plan.max_census_rows` on the census — and exceeding
+/// either commits what was read (newest-first, by `rowid DESC`: §1.1 shows
+/// rowid is a sound recency ordering even though it is not a watermark),
+/// records `coverage_degraded`, and leaves the rest to later polls and the
+/// sweep.
+fn scan_database(
+    db_path: &str,
+    prior: &CursorState,
+    plan: &CursorScanPlan,
+    ledger: &mut ScanLedger,
+) -> ScanOutcome {
     let connection = match open_read_only(db_path) {
         Ok(connection) => connection,
         Err(exc) => {
@@ -1560,24 +2144,38 @@ fn scan_database(db_path: &str, prior: &CursorState, ledger: &mut ScanLedger) ->
         }
     };
 
-    match count_relevant_keys(&connection) {
-        Ok(count) if count > MAX_RELEVANT_KEYS => {
-            return ScanOutcome::Failed {
-                error_kind: ERROR_KIND_TOO_LARGE,
-                error_text: format!(
-                    "{count} relevant keys exceed the {MAX_RELEVANT_KEYS} checkpoint ceiling; \
-                     use Cursor agent transcripts (JSONL) for this history"
-                ),
-            };
-        }
-        Ok(_) => {}
+    // The census: `(rowid, key)` over both relevant ranges, covering-index
+    // backed (§1.1: ~0.1 ms / ~19 KB for the whole reference keyspace). It is
+    // the exact change detector for inserts and deletes and the recency
+    // ordering for the candidate read below.
+    let (census, truncation) = match census_relevant_keys(&connection, plan.max_census_rows, ledger)
+    {
+        Ok(result) => result,
         Err(exc) => {
             return ScanOutcome::Failed {
                 error_kind: ERROR_KIND_SCAN,
                 error_text: format!("{exc:#}"),
-            };
+            }
+        }
+    };
+    if truncation.is_some() {
+        // Best-effort size of the un-censused remainder, so the degradation
+        // is quantified rather than merely flagged. The count is a covering
+        // index aggregate (charged on neither axis per the ledger rules).
+        match count_relevant_keys(&connection) {
+            Ok(total) => {
+                let skipped = (total as u64).saturating_sub(census.len() as u64);
+                ledger.mark_degraded(skipped, 0);
+            }
+            Err(exc) => {
+                return ScanOutcome::Failed {
+                    error_kind: ERROR_KIND_SCAN,
+                    error_text: format!("{exc:#}"),
+                }
+            }
         }
     }
+    let relevant_keys = census.len() as u64;
 
     let mut new_state = CursorState {
         version: CURSOR_STATE_VERSION,
@@ -1586,44 +2184,175 @@ fn scan_database(db_path: &str, prior: &CursorState, ledger: &mut ScanLedger) ->
         project_exclusions_hash: prior.project_exclusions_hash,
         kv_hashes: BTreeMap::new(),
         last_error: String::new(),
+        sweep: prior.sweep.clone(),
+        pending_coverage: false,
     };
     let mut records = Vec::<SyntheticRecord>::new();
-    let mut relevant_keys = 0u64;
     let mut workspace_cache = HashMap::<String, Option<String>>::new();
 
-    for prefix in RELEVANT_PREFIXES {
-        let scan = scan_prefix(
-            &connection,
-            prefix,
-            &prior.kv_hashes,
-            &mut new_state.kv_hashes,
-            &mut records,
-            &mut workspace_cache,
-            ledger,
-        );
-        match scan {
-            Ok(seen) => relevant_keys += seen,
+    // Candidate read: never-read keys first, then `rowid DESC` within each
+    // class. `rowid DESC` is the §2.3 recency heuristic — it chooses ORDER
+    // only. Skipping is justified solely by the budget below, and every
+    // skipped key stays covered (prior hash carried) or re-detected (new key
+    // stays absent from the state) on later polls.
+    //
+    // Never-read-first is what makes a budget-degraded ingest *converge*: a
+    // plain recency order re-reads the same newest slice on every poll, so a
+    // database larger than one budget would keep its cold tail forever. With
+    // unknown keys ahead of re-verification, each resumed poll retires at
+    // least one budget's worth of never-read debt, and recency is undisturbed
+    // where it matters — a genuinely new key has no prior hash, so it is in
+    // the first class already, newest first.
+    let mut candidates = census;
+    candidates.sort_by(|a, b| {
+        let known_a = prior.kv_hashes.contains_key(&a.key);
+        let known_b = prior.kv_hashes.contains_key(&b.key);
+        known_a.cmp(&known_b).then_with(|| b.rowid.cmp(&a.rowid))
+    });
+    for idx in 0..candidates.len() {
+        if plan
+            .fast_budget
+            .is_exhausted_by(ledger.payload_rows, ledger.payload_bytes)
+        {
+            // Commit what was read (§2.1): the remainder keeps its prior
+            // hash — "unread this poll", never "deleted" — and new keys stay
+            // absent so the next poll re-detects them, newest-first again.
+            // Skipped bytes are unknowable without decoding (§1.1 finding 2),
+            // so rows are counted and bytes honestly under-reported as zero.
+            let remaining = &candidates[idx..];
+            ledger.mark_degraded(remaining.len() as u64, 0);
+            for skipped in remaining {
+                if let Some(hash) = prior.kv_hashes.get(&skipped.key) {
+                    new_state
+                        .kv_hashes
+                        .insert(skipped.key.clone(), hash.clone());
+                }
+            }
+            break;
+        }
+        let key = &candidates[idx].key;
+        let value = match read_value_for_key(&connection, key, ledger) {
+            Ok(Some(value)) => value,
+            // The row vanished between census and read: a mid-scan commit the
+            // data_version bracket below will reject; nothing to record here.
+            Ok(None) => continue,
             Err(exc) => {
                 return ScanOutcome::Failed {
                     error_kind: ERROR_KIND_SCAN,
                     error_text: format!("{exc:#}"),
-                };
+                }
+            }
+        };
+        let bytes = value.unwrap_or_default();
+        let hash = format!("{:016x}", hash_bytes(&bytes));
+        let unchanged = prior.kv_hashes.get(key) == Some(&hash);
+        if !unchanged && !bytes.is_empty() {
+            if let Some(mut record) = synthesize_cursor_sqlite_record(key, &bytes) {
+                stamp_bubble_workspace(&connection, &mut workspace_cache, &mut record, ledger);
+                records.push(record);
             }
         }
-        // Re-check the ceiling against what the scan actually saw: the count
-        // ran in its own read transaction, so keys written in between could
-        // otherwise grow cursor_json past the checkpoint payload budget.
-        if new_state.kv_hashes.len() > MAX_RELEVANT_KEYS {
-            return ScanOutcome::Failed {
-                error_kind: ERROR_KIND_TOO_LARGE,
-                error_text: format!(
-                    "{} relevant keys exceed the {MAX_RELEVANT_KEYS} checkpoint ceiling; \
-                     use Cursor agent transcripts (JSONL) for this history",
-                    new_state.kv_hashes.len()
-                ),
-            };
+        new_state.kv_hashes.insert(key.clone(), hash);
+    }
+
+    if let Some(truncation) = &truncation {
+        // Deletion pruning is exact only against a complete census. Carry
+        // every prior entry beyond the truncation point so an un-censused key
+        // reads "unverified this poll", never silently "deleted".
+        for (key, hash) in &prior.kv_hashes {
+            if !census_covered(truncation, key) {
+                new_state
+                    .kv_hashes
+                    .entry(key.clone())
+                    .or_insert_with(|| hash.clone());
+            }
         }
     }
+
+    // Optional sweep slice (§2.2). Conditions 1 (reconcile trigger), 2
+    // (interval clock) and 4 (not replaying) were decided by the caller —
+    // `plan.sweep` exists only when they held. Condition 3 is decided here,
+    // where the fast path's cost is known: a poll that emitted anything, was
+    // budget-degraded, or consumed half its budget does not also pay sweep
+    // cost. The slice runs inside the data_version bracket, so a mixed
+    // snapshot discards its advance with the rest of the scan.
+    let mut swept = false;
+    if let Some(sweep_plan) = &plan.sweep {
+        // §2.2 condition 3, with one deliberate widening: a *degraded* poll is
+        // sweep-eligible even though it consumed its whole budget. On a source
+        // larger than one fast-path budget every poll is degraded and every
+        // poll consumes the full budget, so the plan's literal half-budget
+        // clause would block the sweep on exactly the sources whose tail only
+        // the sweep can cover — §0's coverage guarantee outranks §2.2's
+        // politeness. The emission clause is kept: an emitting poll defers its
+        // slice to the next quiet reconcile tick.
+        let eligible = records.is_empty()
+            && (ledger.coverage_degraded
+                || !plan
+                    .fast_budget
+                    .is_half_consumed_by(ledger.payload_rows, ledger.payload_bytes));
+        if eligible {
+            let mut slice = ScanLedger::default();
+            let driven = drive_sweep_slice(
+                &prior.sweep,
+                &sweep_plan.budget,
+                sweep_plan.max_millis,
+                sweep_plan.now_unix_ms,
+                &mut slice,
+                |after, slice| {
+                    next_cursor_sweep_item(
+                        &connection,
+                        after,
+                        &mut new_state.kv_hashes,
+                        &mut records,
+                        &mut workspace_cache,
+                        slice,
+                    )
+                },
+            );
+            // The slice's reads are paid whether or not it completed; fold
+            // them before inspecting the outcome so a failure arm still
+            // reports them.
+            ledger.absorb_sweep_slice(&slice);
+            match driven {
+                Ok(report) => {
+                    new_state.sweep = report.state;
+                    swept = true;
+                }
+                Err(exc) => {
+                    return ScanOutcome::Failed {
+                        error_kind: ERROR_KIND_SCAN,
+                        error_text: format!("sweep slice failed: {exc:#}"),
+                    }
+                }
+            }
+        }
+    }
+
+    // The checkpoint-state ceiling (issue #601 §2.3): evict the oldest kv
+    // hashes until the persisted payload fits — never fail the scan. This is
+    // `MAX_RELEVANT_KEYS`' replacement, and the bound that keeps
+    // `cursor_json` (hashed into the #602 transition digest, §2.6) from
+    // growing with the keyspace. It runs after the sweep slice so it bounds
+    // everything this poll would persist, and before the resume marker below
+    // so an evicted *censused* key re-opens `pending_coverage` structurally —
+    // censused-but-absent is exactly what the marker scans for. (An evicted
+    // key the census did not cover only exists when the census truncated, and
+    // `truncation.is_some()` already holds the marker open.)
+    let evicted = new_state.evict_to_fit(plan.max_checkpoint_bytes, &candidates);
+    ledger.mark_evicted(evicted);
+
+    // §2.3's persisted resume marker, computed after the sweep slice so keys
+    // the slice just read count as covered. A censused key absent from the
+    // hash map has never been read in this generation; a truncated census may
+    // hide more of them. Either keeps the cheap stat short-circuit open until
+    // a scan covers everything (see the conjunct in
+    // `process_cursor_sqlite_db`), at which point the flag clears with that
+    // scan's checkpoint.
+    new_state.pending_coverage = truncation.is_some()
+        || candidates
+            .iter()
+            .any(|row| !new_state.kv_hashes.contains_key(&row.key));
 
     let data_version_after = match sqlite_data_version(&connection) {
         Ok(value) => value,
@@ -1684,9 +2413,10 @@ fn scan_database(db_path: &str, prior: &CursorState, ledger: &mut ScanLedger) ->
     ledger.rows_emitted = records.len() as u64;
     ScanOutcome::Scanned {
         records,
-        new_state,
+        new_state: Box::new(new_state),
         schema_fingerprint,
         relevant_keys,
+        swept,
     }
 }
 
@@ -1806,18 +2536,21 @@ fn validate_schema(
     Ok(hash_str(&schema_sql))
 }
 
-/// The relevant-key census, shared with the plan assertion in
-/// `cursor_relevant_key_count_is_a_covering_index_scan` so the statement that
-/// test certifies is the statement this adapter actually runs. A copy in the
+/// The two census statements, shared with the plan assertion in
+/// `cursor_relevant_key_count_is_a_covering_index_scan` so the statements that
+/// test certifies are the statements this adapter actually runs. A copy in the
 /// test would let the two drift and the certification would mean nothing.
 ///
-/// Strictly greater, matching `scan_prefix`'s seed of the bare prefix — a key
-/// exactly equal to the prefix is never scanned and must not count toward the
-/// ceiling. The projection stays `count(*)` over indexed columns only: adding
-/// any reference to `value` costs the covering index and turns a 0.056 ms /
-/// 19 KB read into a 55 ms / 48 MB one (§1.1).
+/// Strictly greater, matching the census seed of the bare prefix — a key
+/// exactly equal to the prefix is never scanned and must not be counted. Both
+/// projections touch indexed columns only (`rowid` rides inside the unique
+/// `key` index): adding any reference to `value` costs the covering index and
+/// turns a 0.1 ms / 19 KB read into a 55 ms / 48 MB one (§1.1).
 const CURSOR_RELEVANT_KEY_COUNT_SQL: &str =
     "SELECT count(*) FROM cursorDiskKV WHERE key > ?1 AND key < ?2";
+
+const CURSOR_CENSUS_SQL: &str =
+    "SELECT rowid, key FROM cursorDiskKV WHERE key > ?1 AND key < ?2 ORDER BY key LIMIT ?3";
 
 fn count_relevant_keys(connection: &Connection) -> Result<usize> {
     let mut total = 0usize;
@@ -1834,90 +2567,184 @@ fn count_relevant_keys(connection: &Connection) -> Result<usize> {
     Ok(total)
 }
 
-/// Pages through one key prefix, recording content hashes for every key and
-/// synthesizing records for keys that are new or changed. Paging keeps each
-/// implicit read transaction short (issue #361 decision 4), and synthesizing
-/// page-by-page keeps raw value bytes from accumulating: sanitization
-/// (toolCallBinary drop, long-string elision) shrinks the retained record by
-/// orders of magnitude for media-heavy bubbles, so the scan's peak raw-byte
-/// buffer is one page, additionally capped by `SCAN_PAGE_MAX_BYTES`.
-fn scan_prefix(
-    connection: &Connection,
-    prefix: &str,
-    prior_hashes: &BTreeMap<String, String>,
-    new_hashes: &mut BTreeMap<String, String>,
-    records: &mut Vec<SyntheticRecord>,
-    workspace_cache: &mut HashMap<String, Option<String>>,
-    ledger: &mut ScanLedger,
-) -> Result<u64> {
-    let range_end = prefix_range_end(prefix);
-    let mut last_key = prefix.to_string();
-    let mut seen = 0u64;
+/// One censused relevant row: its key and the recency hint the candidate read
+/// orders by. `rowid` is a sound positive mutation signal and a usable recency
+/// ordering, **not** a watermark (§1.1) — nothing here skips on it.
+struct CensusRow {
+    rowid: i64,
+    key: String,
+}
 
-    loop {
-        let mut page: Vec<(String, Option<Vec<u8>>)> = Vec::new();
-        let mut page_bytes = 0usize;
-        {
+/// Where a capped census stopped, in walk order: the index of the prefix
+/// being walked and the last key actually included. Everything at or before
+/// this point was censused; everything after was not.
+struct CensusTruncation {
+    prefix_idx: usize,
+    last_key: String,
+}
+
+/// True when `key` falls inside the region a truncated census did cover, i.e.
+/// its absence from the census genuinely means deletion.
+fn census_covered(truncation: &CensusTruncation, key: &str) -> bool {
+    let Some(idx) = RELEVANT_PREFIXES
+        .iter()
+        .position(|prefix| key.starts_with(prefix))
+    else {
+        // A stale entry from a key family this adapter no longer tracks: a
+        // complete census would drop it, so a truncated one does too.
+        return true;
+    };
+    idx < truncation.prefix_idx
+        || (idx == truncation.prefix_idx && key <= truncation.last_key.as_str())
+}
+
+/// Walks both relevant key ranges over the covering `key` index, charging one
+/// census row per key. Stops at `max_census_rows` — the §2.1 guard against
+/// pathological keyspaces — returning the truncation point so the caller can
+/// degrade coverage instead of failing.
+///
+/// `RELEVANT_PREFIXES` is walked in declaration order, which is also
+/// lexicographic order of the ranges; the sweep ordering
+/// (`next_cursor_sweep_item`) depends on the two agreeing.
+fn census_relevant_keys(
+    connection: &Connection,
+    max_census_rows: u64,
+    ledger: &mut ScanLedger,
+) -> Result<(Vec<CensusRow>, Option<CensusTruncation>)> {
+    let mut census = Vec::new();
+    for (prefix_idx, prefix) in RELEVANT_PREFIXES.iter().enumerate() {
+        let range_end = prefix_range_end(prefix);
+        let mut last_key = prefix.to_string();
+        loop {
+            let mut page_rows = 0usize;
             let mut stmt = connection
-                .prepare_cached(
-                    "SELECT key, value FROM cursorDiskKV \
-                     WHERE key > ?1 AND key < ?2 ORDER BY key LIMIT ?3",
-                )
-                .context("failed to prepare prefix scan")?;
+                .prepare_cached(CURSOR_CENSUS_SQL)
+                .context("failed to prepare census scan")?;
             let mut rows = stmt
                 .query(rusqlite::params![
                     last_key,
                     range_end,
                     SCAN_PAGE_SIZE as i64
                 ])
-                .context("prefix scan query failed")?;
-            while let Some(row) = rows.next().context("prefix scan row failed")? {
-                // This projection includes `value`, so the whole row is a
-                // payload read: the key bytes are materialized alongside it
-                // and are charged on the same axis. Cursor has no census read
-                // today (issue #601 §3.3 Change 1 adds one), so `census_rows`
-                // stays zero here rather than borrowing this read's rows.
-                ledger.charge_payload_row();
-                let key = take_payload_required_string(ledger, row, 0)
-                    .context("prefix scan key failed")?;
-                // Cursor writes JSON documents as TEXT even though the
-                // column is declared BLOB; accept any storage class instead
-                // of trusting the declared affinity.
-                let value =
-                    take_payload_blob(ledger, row, 1).context("prefix scan value failed")?;
-                page_bytes += value.as_ref().map_or(0, Vec::len);
-                page.push((key, value));
-                if page_bytes >= SCAN_PAGE_MAX_BYTES {
-                    break;
+                .context("census scan query failed")?;
+            while let Some(row) = rows.next().context("census scan row failed")? {
+                let rowid: i64 = row.get(0).context("census rowid failed")?;
+                let key: String = row.get(1).context("census key failed")?;
+                // The key was materialized either way; charge it before the
+                // cap decides whether it is included.
+                ledger.charge_census_row(key.len());
+                page_rows += 1;
+                if census.len() as u64 >= max_census_rows {
+                    return Ok((
+                        census,
+                        Some(CensusTruncation {
+                            prefix_idx,
+                            last_key,
+                        }),
+                    ));
                 }
+                last_key = key.clone();
+                census.push(CensusRow { rowid, key });
             }
-        }
-
-        // A row-capped page may have more rows behind it; so may a
-        // byte-capped one.
-        let more = page.len() == SCAN_PAGE_SIZE || page_bytes >= SCAN_PAGE_MAX_BYTES;
-
-        for (key, value) in page {
-            seen += 1;
-            let bytes = value.unwrap_or_default();
-            let hash = format!("{:016x}", hash_bytes(&bytes));
-            let unchanged = prior_hashes.get(&key) == Some(&hash);
-            if !unchanged && !bytes.is_empty() {
-                if let Some(mut record) = synthesize_cursor_sqlite_record(&key, &bytes) {
-                    stamp_bubble_workspace(connection, workspace_cache, &mut record, ledger);
-                    records.push(record);
-                }
+            if page_rows < SCAN_PAGE_SIZE {
+                break;
             }
-            new_hashes.insert(key.clone(), hash);
-            last_key = key;
-        }
-
-        if !more {
-            break;
         }
     }
+    Ok((census, None))
+}
 
-    Ok(seen)
+/// The candidate point read: one key's value, charged on the payload axis at
+/// the read site. `Ok(None)` means the row vanished between census and read —
+/// a mid-scan commit the data_version bracket rejects.
+fn read_value_for_key(
+    connection: &Connection,
+    key: &str,
+    ledger: &mut ScanLedger,
+) -> Result<Option<Option<Vec<u8>>>> {
+    let mut row_ledger = ScanLedger::default();
+    let read = {
+        let mut stmt = connection
+            .prepare_cached("SELECT value FROM cursorDiskKV WHERE key = ?1")
+            .context("failed to prepare candidate read")?;
+        stmt.query_row(rusqlite::params![key], |row| {
+            row_ledger.charge_payload_row();
+            take_payload_blob(&mut row_ledger, row, 0)
+        })
+    };
+    // Charged unconditionally: a row that materialized bytes and then failed
+    // still cost them.
+    ledger.payload_rows = ledger.payload_rows.saturating_add(row_ledger.payload_rows);
+    ledger.payload_bytes = ledger
+        .payload_bytes
+        .saturating_add(row_ledger.payload_bytes);
+    match read {
+        Ok(value) => Ok(Some(value)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(exc) => Err(exc).context("candidate read failed"),
+    }
+}
+
+/// The Cursor adapter's sweep reader: the first relevant key strictly after
+/// `after` in key order, read in full, verified against this poll's hash view,
+/// and re-emitted when it disagrees (§2.2). With today's exhaustive fast path
+/// the disagreement arm is reachable only through hashes carried forward by an
+/// earlier degraded poll; WI-08's census fast path makes it the sweep's whole
+/// job (G5d), and the driver contract here does not change when it does.
+fn next_cursor_sweep_item(
+    connection: &Connection,
+    after: &str,
+    hashes: &mut BTreeMap<String, String>,
+    records: &mut Vec<SyntheticRecord>,
+    workspace_cache: &mut HashMap<String, Option<String>>,
+    slice: &mut ScanLedger,
+) -> Result<Option<SweepItem>> {
+    for prefix in RELEVANT_PREFIXES {
+        let range_end = prefix_range_end(prefix);
+        if after >= range_end.as_str() {
+            continue;
+        }
+        let start = if after < *prefix { prefix } else { after };
+        let read = {
+            let mut stmt = connection
+                .prepare_cached(
+                    "SELECT key, value FROM cursorDiskKV \
+                     WHERE key > ?1 AND key < ?2 ORDER BY key LIMIT 1",
+                )
+                .context("failed to prepare sweep read")?;
+            stmt.query_row(rusqlite::params![start, range_end], |row| {
+                // This projection includes `value`, so the whole row is a
+                // payload read charged to the slice at the read site.
+                slice.charge_payload_row();
+                let key = take_payload_required_string(slice, row, 0)?;
+                let value = take_payload_blob(slice, row, 1)?;
+                Ok((key, value))
+            })
+        };
+        match read {
+            Ok((key, value)) => {
+                let bytes = value.unwrap_or_default();
+                let payload_bytes = bytes.len() as u64;
+                let hash = format!("{:016x}", hash_bytes(&bytes));
+                if hashes.get(&key) != Some(&hash) {
+                    if !bytes.is_empty() {
+                        if let Some(mut record) = synthesize_cursor_sqlite_record(&key, &bytes) {
+                            stamp_bubble_workspace(connection, workspace_cache, &mut record, slice);
+                            records.push(record);
+                        }
+                    }
+                    hashes.insert(key.clone(), hash);
+                }
+                return Ok(Some(SweepItem {
+                    position: key,
+                    payload_bytes,
+                }));
+            }
+            Err(rusqlite::Error::QueryReturnedNoRows) => continue,
+            Err(exc) => return Err(exc).context("sweep read failed"),
+        }
+    }
+    Ok(None)
 }
 
 /// Builds the synthetic record for one changed kv row, or `None` when the row
@@ -2325,6 +3152,12 @@ mod tests {
         std::env::temp_dir().join(format!("moraine-sqlite-poll-{name}-{suffix}.vscdb"))
     }
 
+    /// The shipped-default scan plan, no sweep: what a non-reconcile poll of
+    /// a production config runs with.
+    fn default_scan_plan() -> CursorScanPlan {
+        CursorScanPlan::from_config(&moraine_config::AppConfig::default(), None)
+    }
+
     fn create_kv_db(path: &PathBuf) -> Connection {
         let connection = Connection::open(path).expect("create fixture db");
         connection
@@ -2457,6 +3290,81 @@ mod tests {
         }
     }
 
+    fn reconcile_work(path: &Path) -> WorkItem {
+        WorkItem {
+            trigger: WorkTrigger::Reconcile,
+            ..sqlite_work(path)
+        }
+    }
+
+    static TOUCH_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    /// Move the database's stat fingerprint without touching any relevant key
+    /// — the production shape of Cursor's constant `ItemTable` churn — so a
+    /// test can drive repeated polls past the cheap stat short-circuit.
+    fn touch_irrelevant(path: &Path) {
+        let sequence = TOUCH_SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let connection = Connection::open(path).expect("open fixture for irrelevant touch");
+        connection
+            .execute(
+                "INSERT INTO ItemTable (key, value) VALUES (?1, ?2)",
+                rusqlite::params![format!("touch-{sequence}"), "x"],
+            )
+            .expect("insert irrelevant row");
+    }
+
+    /// `count` relevant keys whose values are deliberately non-JSON, so every
+    /// scan of them emits nothing: the quiet-database shape sweep eligibility
+    /// condition 3 requires, with real payload bytes for the slices to read.
+    /// Keys are zero-padded so key order equals numeric order.
+    fn seed_junk_fixture(path: &PathBuf, count: usize, value_bytes: usize) -> Vec<String> {
+        let db = create_kv_db(path);
+        let mut keys = Vec::new();
+        for idx in 0..count {
+            let key = format!("bubbleId:{COMPOSER_ID}:k{idx:03}");
+            // Exactly `value_bytes` per value, so byte-denominated assertions
+            // (cycle totals, projections) stay arithmetic rather than fuzzy.
+            let prefix = format!("junk-{idx:03}-");
+            let value = format!("{prefix}{}", "j".repeat(value_bytes - prefix.len()));
+            db.execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+                rusqlite::params![key, value],
+            )
+            .expect("insert junk kv row");
+            keys.push(key);
+        }
+        keys
+    }
+
+    fn sweep_slices(metrics: &Arc<Metrics>) -> u64 {
+        metrics
+            .sqlite_sweep_slices_total
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn sweep_rows(metrics: &Arc<Metrics>) -> u64 {
+        metrics
+            .sqlite_sweep_rows_total
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn degraded_scans(metrics: &Arc<Metrics>) -> u64 {
+        metrics
+            .sqlite_coverage_degraded_scans_total
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// The persisted sweep cursor for `work`'s committed checkpoint.
+    async fn persisted_sweep(
+        checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
+        work: &WorkItem,
+    ) -> SweepState {
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let map = checkpoints.read().await;
+        let checkpoint = map.get(&cp_key).expect("committed checkpoint");
+        CursorState::parse(&checkpoint.cursor_json).sweep
+    }
+
     async fn drain_batches(rx: &mut mpsc::Receiver<SinkMessage>) -> Vec<RowBatch> {
         let mut out = Vec::new();
         while let Ok(Some(SinkMessage::Batch(batch))) =
@@ -2497,10 +3405,28 @@ mod tests {
         poll_state: &VolatilePollMap,
         metrics: &Arc<Metrics>,
     ) -> Vec<RowBatch> {
-        let config = moraine_config::AppConfig::default();
+        run_poll_with_config(
+            &moraine_config::AppConfig::default(),
+            work,
+            checkpoints,
+            poll_state,
+            metrics,
+        )
+        .await
+    }
+
+    /// The fully-parameterized runner: budget and sweep tests inject their
+    /// `[ingest.sqlite]` values here, exactly as an operator's config would.
+    async fn run_poll_with_config(
+        config: &moraine_config::AppConfig,
+        work: &WorkItem,
+        checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
+        poll_state: &VolatilePollMap,
+        metrics: &Arc<Metrics>,
+    ) -> Vec<RowBatch> {
         let (sink_tx, mut sink_rx) = mpsc::channel::<SinkMessage>(64);
         let process = process_cursor_sqlite_db(
-            &config,
+            config,
             work,
             checkpoints.clone(),
             poll_state,
@@ -2939,7 +3865,12 @@ mod tests {
         let db_path = path.to_string_lossy().to_string();
         contention_injection::arm(&db_path, 1);
         let mut ledger = ScanLedger::default();
-        let outcome = scan_database(&db_path, &CursorState::fresh(), &mut ledger);
+        let outcome = scan_database(
+            &db_path,
+            &CursorState::fresh(),
+            &default_scan_plan(),
+            &mut ledger,
+        );
         assert!(
             matches!(
                 outcome,
@@ -2965,7 +3896,12 @@ mod tests {
         // database succeeds, so nothing leaks into another test.
         let mut clean = ScanLedger::default();
         assert!(matches!(
-            scan_database(&db_path, &CursorState::fresh(), &mut clean),
+            scan_database(
+                &db_path,
+                &CursorState::fresh(),
+                &default_scan_plan(),
+                &mut clean
+            ),
             ScanOutcome::Scanned { .. }
         ));
 
@@ -3195,30 +4131,42 @@ mod tests {
         let db = seed_fixture_db(&path);
 
         for prefix in RELEVANT_PREFIXES {
-            let plan: Vec<String> = {
-                let mut stmt = db
-                    .prepare(&format!(
-                        "EXPLAIN QUERY PLAN {CURSOR_RELEVANT_KEY_COUNT_SQL}"
-                    ))
-                    .expect("prepare explain");
-                let rows = stmt
-                    .query_map(rusqlite::params![prefix, prefix_range_end(prefix)], |row| {
+            for (statement, uses_limit) in [
+                (CURSOR_RELEVANT_KEY_COUNT_SQL, false),
+                // The row census projects `(rowid, key)`: rowid rides inside
+                // the unique key index, so it must stay covering too.
+                (CURSOR_CENSUS_SQL, true),
+            ] {
+                let plan: Vec<String> = {
+                    let mut stmt = db
+                        .prepare(&format!("EXPLAIN QUERY PLAN {statement}"))
+                        .expect("prepare explain");
+                    let mut params: Vec<rusqlite::types::Value> = vec![
+                        rusqlite::types::Value::from((*prefix).to_string()),
+                        rusqlite::types::Value::from(prefix_range_end(prefix)),
+                    ];
+                    if uses_limit {
+                        params.push(rusqlite::types::Value::from(SCAN_PAGE_SIZE as i64));
+                    }
+                    stmt.query_map(rusqlite::params_from_iter(params), |row| {
                         row.get::<_, String>(3)
                     })
-                    .expect("query plan");
-                rows.map(|row| row.expect("plan detail")).collect()
-            };
-            let detail = plan.join("; ");
-            assert!(
-                detail.contains("COVERING INDEX"),
-                "the relevant-key census must stay index-covered for {prefix}; \
-                 plan was: {detail}"
-            );
-            assert!(
-                !detail.contains("SCAN cursorDiskKV"),
-                "the census must never degrade to a table scan for {prefix}; \
-                 plan was: {detail}"
-            );
+                    .expect("query plan")
+                    .map(|row| row.expect("plan detail"))
+                    .collect()
+                };
+                let detail = plan.join("; ");
+                assert!(
+                    detail.contains("COVERING INDEX"),
+                    "the relevant-key census must stay index-covered for {prefix}; \
+                     plan was: {detail}"
+                );
+                assert!(
+                    !detail.contains("SCAN cursorDiskKV"),
+                    "the census must never degrade to a table scan for {prefix}; \
+                     plan was: {detail}"
+                );
+            }
         }
 
         drop(db);
@@ -4408,20 +5356,27 @@ mod tests {
         drop(db);
 
         let composer_text = serde_json::to_string(&composer).expect("serialize composer");
-        let expected_bytes =
-            (composer_key.len() + composer_text.len() + junk_key.len() + junk.len()) as u64;
+        // Keys are census material now (§3.3 Change 1): the change detector
+        // walks `(rowid, key)` over the covering index and only the candidate
+        // point reads materialize values, so the payload axis carries value
+        // bytes alone.
+        let expected_bytes = (composer_text.len() + junk.len()) as u64;
+        let expected_census_key_bytes = (composer_key.len() + junk_key.len()) as u64;
         let db_path = path.to_string_lossy().to_string();
 
         let mut ledger = ScanLedger::default();
-        let ScanOutcome::Scanned { new_state, .. } =
-            scan_database(&db_path, &CursorState::fresh(), &mut ledger)
-        else {
+        let ScanOutcome::Scanned { new_state, .. } = scan_database(
+            &db_path,
+            &CursorState::fresh(),
+            &default_scan_plan(),
+            &mut ledger,
+        ) else {
             panic!("cold ledger scan should succeed");
         };
 
         assert_eq!(
             ledger.payload_bytes, expected_bytes,
-            "payload bytes must be the exact key+value length SQLite materialized"
+            "payload bytes must be the exact value length SQLite materialized"
         );
         assert_eq!(ledger.payload_rows, 2, "both relevant keys were read");
         assert_eq!(
@@ -4433,35 +5388,32 @@ mod tests {
             "the fixture must read far more than it emits, or the two axes are \
              interchangeable and neither is tested"
         );
-        // The census axis carries exactly one thing today: schema validation.
-        // Cursor *also* runs a census-shaped read on every poll —
-        // `count_relevant_keys` walks both relevant key ranges over the unique
-        // `key` index (0.056 ms / 19 KB / 247 keys on the reference host,
-        // §1.1) — but it is a scalar aggregate, so by the charging rules on
-        // `ScanLedger` it materializes no row and is charged on neither axis.
-        //
-        // That silence is deliberate and it is **not** a claim the aggregate is
-        // free: `cursor_relevant_key_count_is_a_covering_index_scan` is what
-        // keeps it honest. WI-08 replaces the aggregate with a
-        // row-materializing census and retires `MAX_RELEVANT_KEYS`; until it
-        // does, G1a's `census_rows == 201` may not be read as Cursor's total
-        // census cost.
+        // The census axis carries schema validation plus the real key census
+        // (§3.3 Change 1): one row per relevant key, charged its key bytes.
+        // The two axes must not bleed into each other — a candidate value read
+        // miscounted as census would deflate every payload budget.
         let schema_census = {
             let connection = open_read_only(&db_path).expect("reopen for schema census");
             expected_schema_census(&connection, &["cursorDiskKV"])
         };
         assert!(schema_census.census_rows > 0);
         assert_eq!(
-            ledger.census_rows, schema_census.census_rows,
-            "schema validation is the only charged census read; the payload \
-             read must not be miscounted as one"
+            ledger.census_rows,
+            schema_census.census_rows + 2,
+            "census rows are schema validation plus one row per relevant key"
         );
-        assert_eq!(ledger.census_bytes, schema_census.census_bytes);
+        assert_eq!(
+            ledger.census_bytes,
+            schema_census.census_bytes + expected_census_key_bytes,
+            "census bytes are the schema text plus the key bytes"
+        );
 
         // Nothing changed, so nothing is emitted — but every byte is still
         // read. This is the assertion an emit-site ledger cannot survive.
         let mut second = ScanLedger::default();
-        let ScanOutcome::Scanned { .. } = scan_database(&db_path, &new_state, &mut second) else {
+        let ScanOutcome::Scanned { .. } =
+            scan_database(&db_path, &new_state, &default_scan_plan(), &mut second)
+        else {
             panic!("warm ledger scan should succeed");
         };
         assert_eq!(
@@ -4499,18 +5451,19 @@ mod tests {
 
         let composer_text = serde_json::to_string(&composer).expect("serialize composer");
         let bubble_text = serde_json::to_string(&user_bubble_value()).expect("serialize bubble");
-        // The composer value is materialized twice: once by the prefix scan,
-        // once by the workspace lookup the bubble triggers.
-        let expected_bytes = (composer_key.len()
-            + composer_text.len()
-            + bubble_key.len()
-            + bubble_text.len()
-            + composer_text.len()) as u64;
+        // The composer value is materialized twice: once by the candidate
+        // read, once by the workspace lookup the bubble triggers. Keys are
+        // census material and charge no payload bytes.
+        let expected_bytes = (composer_text.len() + bubble_text.len() + composer_text.len()) as u64;
+        let _ = (&composer_key, &bubble_key);
 
         let mut ledger = ScanLedger::default();
-        let ScanOutcome::Scanned { records, .. } =
-            scan_database(&path.to_string_lossy(), &CursorState::fresh(), &mut ledger)
-        else {
+        let ScanOutcome::Scanned { records, .. } = scan_database(
+            &path.to_string_lossy(),
+            &CursorState::fresh(),
+            &default_scan_plan(),
+            &mut ledger,
+        ) else {
             panic!("workspace-lookup scan should succeed");
         };
         assert!(
@@ -4881,41 +5834,1407 @@ mod tests {
         cleanup(&path);
     }
 
+    /// Issue #601 §2.3 / gate G4 (Cursor). This REWRITES the retired latch
+    /// test `oversized_key_space_is_skipped_with_an_error`, inverting every
+    /// assertion it made:
+    ///
+    /// - it asserted exactly one `sqlite_cursor_too_large` error row — now
+    ///   zero error rows of any kind, because history size is a degradation,
+    ///   never a failure;
+    /// - it asserted zero events — now the *newest* record must be emitted,
+    ///   because bounded progress is newest-first (`rowid DESC`);
+    /// - it asserted no durable progress — now a checkpoint must persist, so
+    ///   the poll's coverage is committed rather than discarded.
+    ///
+    /// **[DIVERGENT FIXTURE]** (§8 G4): the newest row by `rowid` carries the
+    /// key that sorts LAST, so the old any-order (key-ascending) scan would
+    /// reach it dead last — a budget bolted onto key-order truncation emits
+    /// the oldest keys and misses the newest record, and this test fails.
+    /// Fails for: a budget that fails the scan instead of degrading, bounded
+    /// progress that is not newest-first, and restoring the `TooLarge` arm.
     #[tokio::test(flavor = "multi_thread")]
-    async fn oversized_key_space_is_skipped_with_an_error() {
-        let path = unique_db_path("too-large");
+    async fn a_cursor_keyspace_over_budget_still_ingests_recent_work() {
+        let path = unique_db_path("over-budget-recent");
         let db = create_kv_db(&path);
-        {
-            let tx_value = json!({"type": 1, "text": "x"});
-            let blob = serde_json::to_vec(&tx_value).expect("serialize");
-            let mut stmt = db
-                .prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)")
-                .expect("prepare");
-            db.execute_batch("BEGIN").expect("begin");
-            for idx in 0..(MAX_RELEVANT_KEYS + 1) {
-                stmt.execute(rusqlite::params![
-                    format!("bubbleId:{COMPOSER_ID}:k{idx:05}"),
-                    blob
-                ])
-                .expect("insert");
-            }
-            db.execute_batch("COMMIT").expect("commit");
+        for idx in 0..6 {
+            // Old history: keys sort first, rowids are lowest.
+            let bubble = json!({
+                "_v": 3,
+                "type": 1,
+                "bubbleId": format!("aaaaaaaa-1111-4111-8111-nnnnnnnn{idx:04}"),
+                "createdAt": format!("2026-05-01T02:04:{idx:02}.000Z"),
+                "text": format!("old bubble {idx}"),
+            });
+            put(&db, &format!("bubbleId:{COMPOSER_ID}:a{idx:03}"), &bubble);
         }
+        // The newest row: inserted last (highest rowid), key sorts last.
+        let newest = json!({
+            "_v": 3,
+            "type": 1,
+            "bubbleId": "ffffffff-9999-4999-8999-999999999999",
+            "createdAt": "2026-05-08T02:04:37.835Z",
+            "text": "the newest bubble",
+        });
+        put(&db, &format!("bubbleId:{COMPOSER_ID}:zz-newest"), &newest);
+        drop(db);
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.fast_path_max_payload_rows = 2;
 
         let work = sqlite_work(&path);
         let checkpoints = Arc::new(RwLock::new(HashMap::new()));
-        let batches = run_poll(&work, &checkpoints).await;
+        let metrics = Arc::new(Metrics::default());
+        let batches = run_poll_with_config(
+            &config,
+            &work,
+            &checkpoints,
+            &VolatilePollMap::new(),
+            &metrics,
+        )
+        .await;
 
-        let errors: Vec<Value> = batches
+        let rows = all_event_rows(&batches);
+        let texts: Vec<&str> = rows
             .iter()
-            .flat_map(|batch| batch.error_rows.iter().cloned())
+            .filter_map(|row| row.get("text_content").and_then(Value::as_str))
             .collect();
-        assert_eq!(errors.len(), 1);
-        assert_eq!(
-            errors[0].get("error_kind").and_then(Value::as_str),
-            Some(ERROR_KIND_TOO_LARGE)
+        assert!(
+            texts.contains(&"the newest bubble"),
+            "bounded progress must reach the newest record first; got {texts:?}"
         );
+        assert_eq!(
+            rows.len(),
+            2,
+            "a 2-row budget commits exactly the two newest records"
+        );
+        assert!(
+            !texts.contains(&"old bubble 0"),
+            "key-order truncation would emit the oldest key; newest-first must not"
+        );
+        let error_rows: usize = batches.iter().map(|batch| batch.error_rows.len()).sum();
+        assert_eq!(
+            error_rows, 0,
+            "crossing the former ceiling is a degradation, never an error"
+        );
+        assert_eq!(
+            degraded_scans(&metrics),
+            1,
+            "the skipped remainder must be reported as degraded coverage"
+        );
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let map = checkpoints.read().await;
+        let checkpoint = map
+            .get(&cp_key)
+            .expect("degraded poll persists a checkpoint");
+        assert_eq!(checkpoint.status, "active");
+
+        cleanup(&path);
+    }
+
+    /// The runaway side of the same budget (§8 non-negotiable: bounds bound
+    /// from both sides). G4 above proves the budget cannot starve the newest
+    /// record; this proves it cannot be exceeded: the scan reads exactly its
+    /// row budget and accounts for every candidate it skipped.
+    #[test]
+    fn a_cursor_scan_over_budget_reads_no_more_than_its_budget() {
+        let path = unique_db_path("over-budget-upper");
+        seed_junk_fixture(&path, 7, 64);
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.fast_path_max_payload_rows = 2;
+        let plan = CursorScanPlan::from_config(&config, None);
+        let mut ledger = ScanLedger::default();
+        let ScanOutcome::Scanned { relevant_keys, .. } = scan_database(
+            &path.to_string_lossy(),
+            &CursorState::fresh(),
+            &plan,
+            &mut ledger,
+        ) else {
+            panic!("an over-budget scan must degrade, not fail");
+        };
+        assert_eq!(relevant_keys, 7, "the census still covers every key");
+        assert_eq!(
+            ledger.payload_rows, 2,
+            "the candidate read stops exactly at its row budget"
+        );
+        assert!(ledger.coverage_degraded);
+        assert_eq!(
+            ledger.skipped_rows, 5,
+            "every unread candidate is accounted for"
+        );
+
+        cleanup(&path);
+    }
+
+    /// §2.1's census cap: a pathological keyspace truncates the census and
+    /// degrades instead of failing, and every prior entry beyond the
+    /// truncation point is carried — "un-censused" must never read "deleted".
+    /// A complete census keeps exact deletion pruning (asserted here too, so
+    /// the carry cannot silently widen into never-pruning).
+    #[test]
+    fn a_census_past_its_cap_truncates_and_degrades_instead_of_failing() {
+        let path = unique_db_path("census-cap");
+        let keys = seed_junk_fixture(&path, 6, 64);
+
+        // Full scan first, so the prior state holds all six hashes.
+        let full_plan = default_scan_plan();
+        let mut full_ledger = ScanLedger::default();
+        let ScanOutcome::Scanned {
+            new_state: full_state,
+            ..
+        } = scan_database(
+            &path.to_string_lossy(),
+            &CursorState::fresh(),
+            &full_plan,
+            &mut full_ledger,
+        )
+        else {
+            panic!("cold scan should succeed");
+        };
+        assert_eq!(full_state.kv_hashes.len(), 6);
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.fast_path_max_census_rows = 3;
+        let capped_plan = CursorScanPlan::from_config(&config, None);
+        let mut ledger = ScanLedger::default();
+        let ScanOutcome::Scanned {
+            new_state,
+            relevant_keys,
+            ..
+        } = scan_database(
+            &path.to_string_lossy(),
+            &full_state,
+            &capped_plan,
+            &mut ledger,
+        )
+        else {
+            panic!("a capped census must degrade, not fail");
+        };
+        assert_eq!(relevant_keys, 3, "three keys were censused");
+        assert!(ledger.coverage_degraded);
+        assert_eq!(
+            ledger.skipped_rows, 3,
+            "the un-censused remainder is counted"
+        );
+        assert_eq!(
+            new_state.kv_hashes.len(),
+            6,
+            "prior entries beyond the truncation are carried, not dropped"
+        );
+
+        // A complete census still prunes deletions exactly.
+        let db = Connection::open(&path).expect("reopen fixture");
+        db.execute(
+            "DELETE FROM cursorDiskKV WHERE key = ?1",
+            rusqlite::params![&keys[0]],
+        )
+        .expect("delete one key");
+        drop(db);
+        let mut pruned_ledger = ScanLedger::default();
+        let ScanOutcome::Scanned {
+            new_state: pruned, ..
+        } = scan_database(
+            &path.to_string_lossy(),
+            &full_state,
+            &full_plan,
+            &mut pruned_ledger,
+        )
+        else {
+            panic!("post-delete scan should succeed");
+        };
+        assert!(
+            !pruned.kv_hashes.contains_key(&keys[0]),
+            "a complete census must still detect the deletion exactly"
+        );
+        assert_eq!(pruned.kv_hashes.len(), 5);
+
+        cleanup(&path);
+    }
+
+    /// Issue #601 §2.3 / gate G4 (Cursor checkpoint-state ceiling): crossing
+    /// `max_checkpoint_bytes` evicts the **oldest** kv hashes until the
+    /// payload fits — never fails the scan — and reports the eviction as
+    /// degraded coverage. This is `MAX_RELEVANT_KEYS`' replacement: the old
+    /// bound latched the whole database dead; the ceiling degrades, and the
+    /// evicted key re-detects as never-read on a later poll (§6's
+    /// content-addressed identity makes the re-emission safe). `cursor_json`
+    /// rides the #602 transition digest, so this ceiling is also what keeps
+    /// that digest's input bounded.
+    ///
+    /// MUTATION (executed 2026-07-31): make `evict_to_fit` return 0 without
+    /// evicting — fails (the persisted payload exceeds its ceiling and
+    /// nothing is evicted). Reverse the age sort (evict newest-first) —
+    /// fails (the newest key's hash is dropped instead of the oldest's).
+    #[test]
+    fn a_cursor_state_over_its_ceiling_evicts_the_oldest_keys_instead_of_failing() {
+        let path = unique_db_path("cursor-ceiling-upper");
+        let keys = seed_junk_fixture(&path, 6, 64);
+
+        let full_plan = default_scan_plan();
+        let mut full_ledger = ScanLedger::default();
+        let ScanOutcome::Scanned {
+            new_state: full_state,
+            ..
+        } = scan_database(
+            &path.to_string_lossy(),
+            &CursorState::fresh(),
+            &full_plan,
+            &mut full_ledger,
+        )
+        else {
+            panic!("cold scan should succeed");
+        };
+        let full_len = (*full_state).serialize().len();
+
+        // One byte under the full payload: eviction must fire, and one round
+        // of the one-eighth batch (a single entry at six keys) fits.
+        let ceiling = full_len - 1;
+        let mut plan = default_scan_plan();
+        plan.max_checkpoint_bytes = ceiling;
+        let mut ledger = ScanLedger::default();
+        let ScanOutcome::Scanned { new_state, .. } =
+            scan_database(&path.to_string_lossy(), &full_state, &plan, &mut ledger)
+        else {
+            panic!("a state ceiling must degrade, not fail");
+        };
+        assert_eq!(ledger.evicted_entries, 1, "one round of the oldest eighth");
+        assert!(ledger.coverage_degraded);
+        assert!(
+            !new_state.kv_hashes.contains_key(&keys[0]),
+            "eviction is oldest-first by census rowid"
+        );
+        assert!(
+            new_state.kv_hashes.contains_key(&keys[5]),
+            "the newest key's hash survives"
+        );
+        assert!(
+            (*new_state).serialize().len() <= ceiling,
+            "the persisted payload must fit its ceiling"
+        );
+        assert!(
+            new_state.pending_coverage,
+            "an evicted key is a durable coverage debt"
+        );
+
+        cleanup(&path);
+    }
+
+    /// The starvation side of the Cursor state ceiling: a payload **at** the
+    /// ceiling evicts nothing — the fit check is `<=`, the map is untouched,
+    /// coverage is not degraded, and the serialized payload is byte-identical
+    /// to the un-ceilinged scan's (§2.6: `cursor_json` must stay stable for
+    /// fully-covered sources). The upper test alone cannot see a ceiling that
+    /// over-evicts by one boundary token; this one pins the boundary.
+    ///
+    /// MUTATION (executed 2026-07-31): `<=` → `<` in `evict_to_fit`'s fit
+    /// checks — fails (a payload exactly at its ceiling is evicted).
+    #[test]
+    fn a_cursor_state_at_its_ceiling_evicts_nothing() {
+        let path = unique_db_path("cursor-ceiling-lower");
+        seed_junk_fixture(&path, 6, 64);
+
+        let full_plan = default_scan_plan();
+        let mut full_ledger = ScanLedger::default();
+        let ScanOutcome::Scanned {
+            new_state: full_state,
+            ..
+        } = scan_database(
+            &path.to_string_lossy(),
+            &CursorState::fresh(),
+            &full_plan,
+            &mut full_ledger,
+        )
+        else {
+            panic!("cold scan should succeed");
+        };
+        let full_len = (*full_state).serialize().len();
+
+        let mut plan = default_scan_plan();
+        plan.max_checkpoint_bytes = full_len;
+        let mut ledger = ScanLedger::default();
+        let ScanOutcome::Scanned { new_state, .. } =
+            scan_database(&path.to_string_lossy(), &full_state, &plan, &mut ledger)
+        else {
+            panic!("an at-ceiling scan should succeed");
+        };
+        assert_eq!(ledger.evicted_entries, 0, "at the boundary nothing evicts");
+        assert!(!ledger.coverage_degraded);
+        assert_eq!(new_state.kv_hashes.len(), 6);
+        assert!(!new_state.pending_coverage);
+        assert_eq!(
+            (*new_state).serialize(),
+            (*full_state).serialize(),
+            "the persisted payload is byte-identical at the boundary"
+        );
+
+        cleanup(&path);
+    }
+
+    /// Gate G5a (§8): the sweep cursor is durable. Slices advance it
+    /// mid-keyspace, the process "restarts" (fresh volatile state, only the
+    /// persisted checkpoint survives), and the next slice resumes from the
+    /// persisted position — not from the start of the cycle and not from the
+    /// newest end. Fails for: a volatile-only sweep cursor, or a fast path
+    /// that resets it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sweep_cursor_survives_restart_and_resumes_mid_cycle() {
+        let path = unique_db_path("sweep-restart");
+        let keys = seed_junk_fixture(&path, 6, 64);
+        let work = reconcile_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.sweep_slice_max_payload_rows = 2;
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 0;
+
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        touch_irrelevant(&path);
+        run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(sweep_slices(&metrics), 2);
+        assert_eq!(
+            persisted_sweep(&checkpoints, &work).await.cursor,
+            keys[3],
+            "two 2-row slices leave the persisted cursor mid-keyspace"
+        );
+
+        // Restart: only durable state survives. A fresh VolatilePollMap and
+        // fresh metrics stand in for the new process.
+        let restarted_state = VolatilePollMap::new();
+        let restarted_metrics = Arc::new(Metrics::default());
+        touch_irrelevant(&path);
+        run_poll_with_config(
+            &config,
+            &work,
+            &checkpoints,
+            &restarted_state,
+            &restarted_metrics,
+        )
+        .await;
+        assert_eq!(sweep_slices(&restarted_metrics), 1);
+        let resumed = persisted_sweep(&checkpoints, &work).await;
+        assert_eq!(
+            resumed.cursor, keys[5],
+            "the restarted slice must resume at the persisted position: from \
+             {} it covers exactly the fifth and sixth keys — restarting the \
+             cycle would leave the cursor at {}, and starting from the newest \
+             end would leave it at {}",
+            keys[3], keys[1], keys[4],
+        );
+        assert_eq!(resumed.completed_cycles, 0);
+
+        cleanup(&path);
+    }
+
+    /// Gate G5b (§8): a cycle completes in exactly the projected number of
+    /// slices, and `projected_full_sweep_seconds` matches the realized cycle.
+    /// Five 1,000-byte values under a 2-row / 2,000-byte slice budget need
+    /// ceil(5000/2000) = 3 slices; the third slice reads the last key, finds
+    /// the ordering exhausted, and wraps. Fails for: a sweep that revisits or
+    /// skips regions, or a projection that does not match observation. Every
+    /// slice-carrying poll must persist a checkpoint (the durable commit the
+    /// F1 `new_state == prior_state_covered` conjunct guards).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sweep_completes_a_full_cycle_within_the_projected_interval() {
+        let path = unique_db_path("sweep-cycle");
+        seed_junk_fixture(&path, 5, 1000);
+        let work = reconcile_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.sweep_slice_max_payload_rows = 2;
+        config.ingest.sqlite.sweep_slice_max_payload_bytes = 2000;
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 7;
+
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        for slice in 0..3 {
+            if slice > 0 {
+                touch_irrelevant(&path);
+                poll_state.age_for_tests(&cp_key, Duration::from_secs(7));
+            }
+            let batches =
+                run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+            assert!(
+                batches
+                    .last()
+                    .and_then(|batch| batch.checkpoint.as_ref())
+                    .is_some(),
+                "slice {slice} must persist its advance durably"
+            );
+            assert_eq!(sweep_slices(&metrics), slice + 1);
+        }
+
+        let state = persisted_sweep(&checkpoints, &work).await;
+        assert_eq!(
+            state.completed_cycles, 1,
+            "the third slice completes the cycle"
+        );
+        assert_eq!(state.cursor, "", "a completed cycle wraps to the start");
+        assert_eq!(
+            state.last_cycle_payload_bytes, 5000,
+            "the cycle covered every value byte exactly once"
+        );
+        assert!(state.last_complete_unix_ms > 0);
+        let projected = state
+            .projected_full_sweep_seconds(
+                config.ingest.sqlite.sweep_slice_max_payload_bytes,
+                config.ingest.sqlite.sweep_slice_min_interval_seconds,
+            )
+            .expect("a completed cycle yields a projection");
+        assert_eq!(
+            projected,
+            3 * config.ingest.sqlite.sweep_slice_min_interval_seconds,
+            "the projection must match the realized cycle: 3 slices at the \
+             configured interval"
+        );
+
+        cleanup(&path);
+    }
+
+    /// Gate G6c (§8): a single row larger than the whole slice byte budget is
+    /// still processed and the cursor advances past it — otherwise one
+    /// oversized row is a permanent sweep stall, the same latch class §2.3
+    /// retires. The follow-up slice proves the cursor really moved past it.
+    /// Also the runaway side: the slice's reads are bounded by the budget plus
+    /// that one first row, and both ledger folds (sweep and payload axes) must
+    /// carry them.
+    #[test]
+    fn sweep_slice_stops_at_its_budget_and_still_advances() {
+        let path = unique_db_path("sweep-oversized");
+        let db = create_kv_db(&path);
+        let big_key = format!("bubbleId:{COMPOSER_ID}:a-big");
+        let small_key = format!("bubbleId:{COMPOSER_ID}:z-small");
+        db.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            rusqlite::params![&big_key, format!("junk-big-{}", "b".repeat(10_000))],
+        )
+        .expect("insert oversized row");
+        db.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            rusqlite::params![&small_key, "junk-small"],
+        )
+        .expect("insert small row");
+        drop(db);
+        let db_path = path.to_string_lossy().to_string();
+
+        let mut cold_ledger = ScanLedger::default();
+        let ScanOutcome::Scanned {
+            new_state: cold, ..
+        } = scan_database(
+            &db_path,
+            &CursorState::fresh(),
+            &default_scan_plan(),
+            &mut cold_ledger,
+        )
+        else {
+            panic!("cold scan should succeed");
+        };
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.sweep_slice_max_payload_bytes = 100;
+        let sweep_plan = SweepPlan::from_config(&config);
+        let plan = CursorScanPlan::from_config(&config, Some(sweep_plan));
+        let mut ledger = ScanLedger::default();
+        let ScanOutcome::Scanned {
+            new_state: after_big,
+            swept,
+            ..
+        } = scan_database(&db_path, &cold, &plan, &mut ledger)
+        else {
+            panic!("sweep scan should succeed");
+        };
+        assert!(swept);
+        assert_eq!(
+            after_big.sweep.cursor, big_key,
+            "the oversized row is processed and the cursor advances past it"
+        );
+        assert_eq!(
+            ledger.sweep_rows, 1,
+            "the slice stops after the row that exhausted its budget"
+        );
+        assert!(
+            ledger.sweep_bytes > 10_000,
+            "the oversized row's bytes are charged to the sweep axis; got {}",
+            ledger.sweep_bytes
+        );
+        assert!(
+            ledger.payload_bytes >= ledger.sweep_bytes,
+            "sweep reads are payload reads too — hiding them from the payload \
+             axes would let a sweep evade every fast-path budget"
+        );
+
+        // The next slice starts strictly after the oversized row: it reads
+        // exactly the one remaining key (never the oversized row again),
+        // discovers the ordering exhausted, and wraps the cycle.
+        let plan = CursorScanPlan::from_config(&config, Some(SweepPlan::from_config(&config)));
+        let mut second = ScanLedger::default();
+        let ScanOutcome::Scanned {
+            new_state: after_small,
+            ..
+        } = scan_database(&db_path, &after_big, &plan, &mut second)
+        else {
+            panic!("second sweep scan should succeed");
+        };
+        assert_eq!(
+            second.sweep_rows, 1,
+            "the follow-up slice reads only the key beyond the oversized row"
+        );
+        assert!(
+            second.sweep_bytes < 1_000,
+            "re-reading the oversized row would show here; got {}",
+            second.sweep_bytes
+        );
+        assert_eq!(after_small.sweep.completed_cycles, 1);
+        assert_eq!(after_small.sweep.cursor, "", "the completed cycle wraps");
+        let _ = small_key;
+
+        cleanup(&path);
+    }
+
+    /// The wall-clock budget's call site, and the starvation side of the
+    /// forward-progress rule: `sweep_slice_max_millis = 0` binds before any
+    /// second item, yet the slice still processes exactly one. Fails for:
+    /// checking the deadline before the first item, or dropping the deadline
+    /// term from the driver.
+    #[test]
+    fn a_zero_millis_sweep_budget_still_makes_forward_progress() {
+        let path = unique_db_path("sweep-zero-millis");
+        let keys = seed_junk_fixture(&path, 3, 64);
+        let db_path = path.to_string_lossy().to_string();
+
+        let mut cold_ledger = ScanLedger::default();
+        let ScanOutcome::Scanned {
+            new_state: cold, ..
+        } = scan_database(
+            &db_path,
+            &CursorState::fresh(),
+            &default_scan_plan(),
+            &mut cold_ledger,
+        )
+        else {
+            panic!("cold scan should succeed");
+        };
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.sweep_slice_max_millis = 0;
+        let plan = CursorScanPlan::from_config(&config, Some(SweepPlan::from_config(&config)));
+        let mut ledger = ScanLedger::default();
+        let ScanOutcome::Scanned {
+            new_state, swept, ..
+        } = scan_database(&db_path, &cold, &plan, &mut ledger)
+        else {
+            panic!("sweep scan should succeed");
+        };
+        assert!(swept);
+        assert_eq!(
+            ledger.sweep_rows, 1,
+            "one item per slice at a zero deadline"
+        );
+        assert_eq!(new_state.sweep.cursor, keys[0]);
+
+        cleanup(&path);
+    }
+
+    /// Gate G6a (§8): sweep eligibility is keyed on trigger provenance and on
+    /// nothing else. Watcher polls — however many, however quiet the database
+    /// — never attach a slice; the first reconcile poll does. Denominated on
+    /// the ledger's sweep axes, not on total rows, so a sweep hidden inside a
+    /// fast path would still be caught.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sweep_does_not_run_on_watcher_triggered_polls() {
+        let path = unique_db_path("sweep-watcher");
+        seed_junk_fixture(&path, 3, 64);
+        let watcher = sqlite_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 0;
+
+        let cp_key = checkpoint_key(&watcher.source_name, &watcher.path);
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        for _ in 0..5 {
+            run_poll_with_config(&config, &watcher, &checkpoints, &poll_state, &metrics).await;
+            touch_irrelevant(&path);
+            // Past the no-op rescan throttle, so every driven poll genuinely
+            // scans — a skipped poll proves nothing about sweep eligibility.
+            poll_state.age_for_tests(&cp_key, Duration::from_secs(16));
+        }
+        assert_eq!(
+            sweep_rows(&metrics),
+            0,
+            "watcher-triggered polls must never attach a sweep slice"
+        );
+        assert_eq!(sweep_slices(&metrics), 0);
+
+        let reconcile = reconcile_work(&path);
+        run_poll_with_config(&config, &reconcile, &checkpoints, &poll_state, &metrics).await;
+        assert!(
+            sweep_rows(&metrics) > 0,
+            "the first reconcile-triggered poll of a quiet database sweeps"
+        );
+        assert_eq!(sweep_slices(&metrics), 1);
+
+        cleanup(&path);
+    }
+
+    /// Eligibility condition 2, upper side: the per-database interval clock
+    /// throttles slices even though every one of these polls is reconcile-
+    /// triggered and the database stays quiet — and the clock **survives an
+    /// emitting poll between slices**. Every persisting scan calls `clear`,
+    /// so a clock that lives and dies with the volatile entry is wiped by the
+    /// first interleaved write, and the next quiet reconcile poll re-sweeps
+    /// at the reconcile cadence — up to ~10× the configured minimum on
+    /// databases with interleaved writes, the typical agent-session shape.
+    /// Noop polls alone cannot see that: they preserve the entry. Fails for:
+    /// dropping the interval term, losing the clock to the slice's own
+    /// checkpoint persist (the `record_sweep_slice` re-arm ordering), or
+    /// losing it to a later emitting poll's persist (`clear`'s clock carry).
+    ///
+    /// MUTATION (executed 2026-07-31): revert `clear` to a bare
+    /// `self.lock().remove(cp_key)` — the post-emission assertion fails
+    /// (slice #2 attaches inside the interval) while the pre-emission half
+    /// stays green, which is why the emitting interleave exists.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_second_reconcile_poll_inside_the_sweep_interval_attaches_no_slice() {
+        let path = unique_db_path("sweep-interval-upper");
+        seed_junk_fixture(&path, 3, 64);
+        let work = reconcile_work(&path);
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 3600;
+
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(sweep_slices(&metrics), 1, "the first slice is immediate");
+        for _ in 0..3 {
+            touch_irrelevant(&path);
+            run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        }
+        assert_eq!(
+            sweep_slices(&metrics),
+            1,
+            "no further slice inside the configured interval"
+        );
+
+        // A real bubble arrives: the watcher poll emits and persists its own
+        // checkpoint, which calls `clear`. The interval clock must ride
+        // through that wipe, or the next quiet reconcile poll re-sweeps at
+        // the reconcile cadence. Aged past the no-op rescan throttle first —
+        // three quiet polls made the entry stat-noisy, and a skipped poll
+        // would prove nothing about the clock (16 s is far inside the 3600 s
+        // sweep interval, so this cannot arm the slice by itself).
+        poll_state.age_for_tests(&cp_key, Duration::from_secs(16));
+        {
+            let db = Connection::open(&path).expect("reopen fixture");
+            put(
+                &db,
+                &format!("bubbleId:{COMPOSER_ID}:{USER_BUBBLE_ID}"),
+                &user_bubble_value(),
+            );
+        }
+        let watcher = sqlite_work(&path);
+        let batches =
+            run_poll_with_config(&config, &watcher, &checkpoints, &poll_state, &metrics).await;
+        assert!(
+            !all_event_rows(&batches).is_empty(),
+            "the bubble must actually emit for the interleave to mean anything"
+        );
+        for _ in 0..2 {
+            touch_irrelevant(&path);
+            run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        }
+        assert_eq!(
+            sweep_slices(&metrics),
+            1,
+            "an emitting poll between slices must not re-arm the interval clock"
+        );
+
+        cleanup(&path);
+    }
+
+    /// Eligibility condition 2, lower side: once the interval elapses the
+    /// next reconcile poll is armed again — including when the interval was
+    /// spent under continuous **emitting** polls, each of whose checkpoint
+    /// persists called `clear`. Together with the upper test this bounds the
+    /// interval clock from both directions: it must survive every wipe (no
+    /// early slice) and it must still expire (no starvation).
+    ///
+    /// MUTATION (executed 2026-07-31): `sweep_slice_due`'s armed arm
+    /// (`Some(at) => at.elapsed() >= min_interval`) → `Some(_) => false` —
+    /// the final assertion fails (an armed clock never expires) while the
+    /// upper test stays green, which is why the pair exists.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_expired_sweep_interval_arms_the_next_reconcile_poll() {
+        let path = unique_db_path("sweep-interval-lower");
+        seed_junk_fixture(&path, 3, 64);
+        let work = reconcile_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 3600;
+
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(sweep_slices(&metrics), 1);
+
+        // Continuous emitting polls inside the interval: each edit persists a
+        // checkpoint and calls `clear`, and none of that may starve the sweep
+        // once the interval has genuinely elapsed.
+        let watcher = sqlite_work(&path);
+        for idx in 0..2 {
+            {
+                let db = Connection::open(&path).expect("reopen fixture");
+                let mut value = user_bubble_value();
+                value["text"] = json!(format!("edit {idx}"));
+                put(
+                    &db,
+                    &format!("bubbleId:{COMPOSER_ID}:{USER_BUBBLE_ID}"),
+                    &value,
+                );
+            }
+            let batches =
+                run_poll_with_config(&config, &watcher, &checkpoints, &poll_state, &metrics).await;
+            assert!(
+                !all_event_rows(&batches).is_empty(),
+                "each interleaved poll must actually emit"
+            );
+        }
+        assert_eq!(sweep_slices(&metrics), 1, "still inside the interval");
+
+        poll_state.age_for_tests(&cp_key, Duration::from_secs(3600));
+        touch_irrelevant(&path);
+        run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            sweep_slices(&metrics),
+            2,
+            "an expired interval arms the next reconcile poll even under emitting-poll churn"
+        );
+
+        cleanup(&path);
+    }
+
+    /// Eligibility condition 3 (§2.2): a poll whose fast path emitted records
+    /// does not also pay sweep cost — and the very next quiet reconcile poll
+    /// does, so the block is provably the emission and not something else.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_poll_that_emits_records_attaches_no_sweep_slice() {
+        let path = unique_db_path("sweep-busy");
+        let _db = seed_fixture_db(&path);
+        let work = reconcile_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 0;
+
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        let batches =
+            run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert!(
+            !all_event_rows(&batches).is_empty(),
+            "the cold poll must actually emit for this test to mean anything"
+        );
+        assert_eq!(
+            sweep_slices(&metrics),
+            0,
+            "an emitting fast path blocks the slice"
+        );
+
+        touch_irrelevant(&path);
+        run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            sweep_slices(&metrics),
+            1,
+            "the next quiet reconcile poll sweeps"
+        );
+
+        cleanup(&path);
+    }
+
+    /// Eligibility condition 4 (§2.2): a replacement replay never attaches a
+    /// slice. The fixture's relevant keyspace is empty so conditions 1-3 all
+    /// hold and only the replay stands between the poll and a slice — a
+    /// non-empty fixture would block on condition 3 (the replay re-emits
+    /// everything) and this guard could not fail.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_replacement_replay_poll_attaches_no_sweep_slice() {
+        let path = unique_db_path("sweep-replay");
+        {
+            let db = create_kv_db(&path);
+            db.execute(
+                "INSERT INTO ItemTable (key, value) VALUES ('seed', 'x')",
+                [],
+            )
+            .expect("seed irrelevant row");
+        }
+        let work = reconcile_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 0;
+
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            sweep_slices(&metrics),
+            1,
+            "an empty keyspace sweeps (and wraps) immediately"
+        );
+
+        // A changed exclusion set starts a replacement replay.
+        let mut replaying = config.clone();
+        replaying.ingest.exclude_project_dirs = vec!["/no/such/dir/**".to_string()];
+        touch_irrelevant(&path);
+        run_poll_with_config(&replaying, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            sweep_slices(&metrics),
+            1,
+            "a replacement replay poll must not attach a slice"
+        );
+
+        cleanup(&path);
+    }
+
+    /// Plan §7.2 F2, the widening direction, at the Cursor call site: an
+    /// `error`-status checkpoint with **no block reason** is an ordinary
+    /// transient failure marker, and the poll it precedes is an ordinary poll.
+    /// Widening `retry_blocked_replay` to a bare `status == "error"` turns it
+    /// into a blocked-replacement retry: the cursor state is reset and every
+    /// unchanged row re-emits behind a fresh `BeginReplay`. The unchanged
+    /// fixture emits nothing on the correct path, so any re-emission fails
+    /// this test.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_error_marker_without_a_block_reason_is_not_retried_as_a_blocked_replay() {
+        let path = unique_db_path("error-marker-width");
+        let _db = seed_fixture_db(&path);
+        let work = sqlite_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+
+        let first = run_poll(&work, &checkpoints).await;
+        assert!(!all_event_rows(&first).is_empty());
+
+        // Rewrite the committed checkpoint into a transient-error marker: the
+        // shape `record_scan_failure_outcome`'s non-replay arm persists.
+        {
+            let mut map = checkpoints.write().await;
+            let checkpoint = map.get_mut(&cp_key).expect("committed checkpoint");
+            checkpoint.status = "error".to_string();
+            checkpoint.block_reason.clear();
+            let mut state = CursorState::parse(&checkpoint.cursor_json);
+            state.last_error = ERROR_KIND_SCAN.to_string();
+            checkpoint.cursor_json = state.serialize();
+        }
+
+        let batches = run_poll(&work, &checkpoints).await;
+        assert!(
+            all_event_rows(&batches).is_empty(),
+            "an ordinary error marker must clear through an ordinary scan; \
+             re-emission means the poll was retried as a blocked replay"
+        );
+        let map = checkpoints.read().await;
+        assert_eq!(
+            map.get(&cp_key).expect("checkpoint").status,
+            "active",
+            "the transient marker clears once a scan succeeds"
+        );
+
+        cleanup(&path);
+    }
+
+    /// §2.2's fairness sentence, literally: "fast-path activity never resets
+    /// the sweep cursor." A slice leaves the cursor mid-cycle; a genuinely
+    /// *emitting* watcher poll then persists a checkpoint of its own, and the
+    /// persisted sweep cursor must ride through it unchanged. This is the only
+    /// test that observes `sweep: prior.sweep.clone()` in the fast path's
+    /// state constructor — every slice-carrying poll overwrites that field
+    /// from the driver's report, so G5a cannot see it.
+    ///
+    /// MUTATION (executed 2026-07-31): `sweep: prior.sweep.clone()` →
+    /// `sweep: SweepState::default()` in `scan_database` — this test fails
+    /// (the emitting poll wipes the mid-cycle cursor) while G5a and G5b stay
+    /// green, which is why this test exists.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fast_path_activity_never_resets_the_sweep_cursor() {
+        let path = unique_db_path("sweep-fastpath-preserves");
+        let keys = seed_junk_fixture(&path, 6, 64);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.sweep_slice_max_payload_rows = 2;
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 3600;
+
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        let reconcile = reconcile_work(&path);
+        run_poll_with_config(&config, &reconcile, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(sweep_slices(&metrics), 1);
+        assert_eq!(
+            persisted_sweep(&checkpoints, &reconcile).await.cursor,
+            keys[1],
+            "one 2-row slice leaves the cursor mid-cycle"
+        );
+
+        // A real bubble arrives: the watcher poll emits and persists its own
+        // checkpoint, with no slice attached (interval far in the future).
+        {
+            let db = Connection::open(&path).expect("reopen fixture");
+            put(
+                &db,
+                &format!("bubbleId:{COMPOSER_ID}:{USER_BUBBLE_ID}"),
+                &user_bubble_value(),
+            );
+        }
+        let watcher = sqlite_work(&path);
+        let batches =
+            run_poll_with_config(&config, &watcher, &checkpoints, &poll_state, &metrics).await;
+        assert!(
+            !all_event_rows(&batches).is_empty(),
+            "the bubble must actually emit for this test to mean anything"
+        );
+        assert_eq!(sweep_slices(&metrics), 1, "no slice on the emitting poll");
+        assert_eq!(
+            persisted_sweep(&checkpoints, &reconcile).await.cursor,
+            keys[1],
+            "fast-path activity must never reset the sweep cursor"
+        );
+
+        cleanup(&path);
+    }
+
+    /// Eligibility condition 1's width, the direction G6a cannot see: mutating
+    /// `trigger == Reconcile` to `trigger != Watcher` keeps
+    /// `sweep_does_not_run_on_watcher_triggered_polls` green while making
+    /// every startup poll sweep-eligible — the §2.4 inversion D1c refuses at
+    /// the dispatcher, and the cost plan §7.2 F4 warns the tee/backfill sites
+    /// about. This is F4's closure: eligibility is now denominated on
+    /// something a test observes at the poll itself, so a call site
+    /// re-introducing its own trigger stamp has a named failure here.
+    ///
+    /// MUTATION (executed 2026-07-31): `work.trigger == WorkTrigger::Reconcile`
+    /// → `work.trigger != WorkTrigger::Watcher` in `process_cursor_sqlite_db`
+    /// — this test fails (a startup poll attaches a slice) while G6a stays
+    /// green, which is why this test exists; both RED and green were
+    /// confirmed in a filtered run of the pair, so suite-wide isolation is
+    /// not claimed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_startup_poll_attaches_no_sweep_slice() {
+        let path = unique_db_path("sweep-startup");
+        seed_junk_fixture(&path, 3, 64);
+        let startup = WorkItem {
+            trigger: WorkTrigger::Startup,
+            ..sqlite_work(&path)
+        };
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 0;
+
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        run_poll_with_config(&config, &startup, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            sweep_slices(&metrics),
+            0,
+            "a startup poll must never attach a sweep slice"
+        );
+        assert_eq!(sweep_rows(&metrics), 0);
+
+        // The identical poll under a reconcile trigger sweeps, so the block
+        // above is provably the trigger and nothing else.
+        touch_irrelevant(&path);
+        let reconcile = reconcile_work(&path);
+        run_poll_with_config(&config, &reconcile, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(sweep_slices(&metrics), 1);
+
+        cleanup(&path);
+    }
+
+    /// Eligibility condition 3's budget clause, and the width of its ×2:
+    /// a poll that consumed at least half its fast-path budget — without
+    /// emitting and without degrading — attaches no slice, and the identical
+    /// poll under an ample budget does. Three 64-byte values against a
+    /// 300-byte budget is 192 bytes: over one half, under the whole, so this
+    /// test separates the half-consumed clause from the degraded override
+    /// beside it and from exhaustion.
+    ///
+    /// MUTATION (executed 2026-07-31): drop the `is_half_consumed_by` clause
+    /// from the eligibility check in `scan_database` — fails. Drop the
+    /// `saturating_mul(2)` (making it a full-budget check) — fails, because
+    /// 192 < 300. Each RED was confirmed in a filtered run, so suite-wide
+    /// isolation is not claimed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_poll_that_spent_half_its_budget_attaches_no_sweep_slice() {
+        let path = unique_db_path("sweep-half-budget");
+        seed_junk_fixture(&path, 3, 64);
+        let work = reconcile_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 0;
+        config.ingest.sqlite.fast_path_max_payload_bytes = 300;
+
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            degraded_scans(&metrics),
+            0,
+            "192 of 300 bytes is not exhaustion"
+        );
+        assert_eq!(
+            sweep_slices(&metrics),
+            0,
+            "a half-spent fast path must not also pay sweep cost"
+        );
+
+        // The same quiet database under the default budget sweeps at once.
+        let ample = moraine_config::AppConfig::default();
+        let mut ample_sqlite = ample;
+        ample_sqlite.ingest.sqlite.sweep_slice_min_interval_seconds = 0;
+        touch_irrelevant(&path);
+        run_poll_with_config(&ample_sqlite, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(sweep_slices(&metrics), 1);
+
+        cleanup(&path);
+    }
+
+    /// The deliberate widening of condition 3 (recorded in the plan's §7.1):
+    /// a *degraded* poll is sweep-eligible even though it consumed its whole
+    /// budget. On a source larger than one fast-path budget every poll is
+    /// degraded and fully spent, so the literal half-budget clause would
+    /// block the sweep on exactly the sources whose cold tail only the sweep
+    /// can reach — §0's coverage guarantee outranks §2.2's politeness. Here
+    /// the slice covers, in one poll, the very keys the fast path's budget
+    /// skipped.
+    ///
+    /// MUTATION (executed 2026-07-31): drop `ledger.coverage_degraded ||`
+    /// from the eligibility check in `scan_database` — this test fails (no
+    /// slice attaches); RED was confirmed in a filtered run,
+    /// so suite-wide isolation is not claimed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_budget_degraded_poll_still_attaches_its_sweep_slice() {
+        let path = unique_db_path("sweep-degraded");
+        seed_junk_fixture(&path, 4, 64);
+        let work = reconcile_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 0;
+        config.ingest.sqlite.fast_path_max_payload_rows = 2;
+
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(degraded_scans(&metrics), 1, "two of four keys is degraded");
+        assert_eq!(
+            sweep_slices(&metrics),
+            1,
+            "the degraded poll still sweeps — that is the whole point"
+        );
+        assert!(
+            sweep_rows(&metrics) >= 2,
+            "the slice reads keys the fast path skipped; got {}",
+            sweep_rows(&metrics)
+        );
+        let state = persisted_sweep(&checkpoints, &work).await;
+        assert_eq!(
+            state.completed_cycles, 1,
+            "four small keys fit one slice, so the cycle completes"
+        );
+
+        cleanup(&path);
+    }
+
+    /// §2.3's "persist the resume position, continue next poll", end to end,
+    /// with **no further writes to the database** — the case the cheap stat
+    /// short-circuit would otherwise seal forever. Three properties in one
+    /// deliberate sequence:
+    ///
+    /// 1. **Progress**: each resumed poll reads never-read keys first, so a
+    ///    6-key database under a 2-row budget is fully covered in exactly 3
+    ///    polls (a recency-only order re-reads the same 2 newest keys and
+    ///    never converges).
+    /// 2. **Termination**: once coverage completes, `pending_coverage`
+    ///    clears durably and the next poll short-circuits — the resume
+    ///    cannot become a 30 s busy loop on a quiet database.
+    /// 3. **§2.6 serialization**: while pending, the marker rides
+    ///    `cursor_json`; after completion (never having swept) the payload
+    ///    carries neither `pending_coverage` nor `sweep`, byte-identical to a
+    ///    source that never degraded.
+    ///
+    /// MUTATION (executed 2026-07-31): drop the `!state.pending_coverage`
+    /// conjunct from the cheap short-circuit — fails at the poll-2 coverage
+    /// assertion (the unchanged stat ends every later poll). Drop the
+    /// never-read-first class from the candidate sort (plain `rowid DESC`) —
+    /// fails at the same assertion (polls re-read `k5,k4` forever). Each RED
+    /// was confirmed in a filtered run, so suite-wide isolation is not
+    /// claimed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_degraded_cold_ingest_completes_without_new_writes() {
+        let path = unique_db_path("cold-ingest-converges");
+        seed_junk_fixture(&path, 6, 64);
+        let work = sqlite_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.fast_path_max_payload_rows = 2;
+
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        {
+            let map = checkpoints.read().await;
+            let checkpoint = map.get(&cp_key).expect("cold poll persists");
+            assert!(
+                checkpoint.cursor_json.contains("pending_coverage"),
+                "the resume marker must be durable, not volatile"
+            );
+            let state = CursorState::parse(&checkpoint.cursor_json);
+            assert_eq!(state.kv_hashes.len(), 2, "the cold poll covered its budget");
+        }
+
+        // No touches: the stat never moves again. Two more polls must still
+        // scan, and must retire never-read debt rather than re-verify.
+        for expected_covered in [4usize, 6] {
+            run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+            let map = checkpoints.read().await;
+            let checkpoint = map.get(&cp_key).expect("resumed poll persists");
+            let state = CursorState::parse(&checkpoint.cursor_json);
+            assert_eq!(
+                state.kv_hashes.len(),
+                expected_covered,
+                "each resumed poll must retire one budget of never-read keys"
+            );
+        }
+        {
+            let map = checkpoints.read().await;
+            let checkpoint = map.get(&cp_key).expect("covering poll persists");
+            assert!(
+                !checkpoint.cursor_json.contains("pending_coverage"),
+                "completed coverage must clear the marker durably"
+            );
+            assert!(
+                !checkpoint.cursor_json.contains("\"sweep\""),
+                "a never-swept source's cursor_json stays byte-compatible (§2.6)"
+            );
+        }
+
+        // Quiesce: with coverage complete and the stat unchanged, the next
+        // poll must not scan at all.
+        let rows_before = payload_rows(&metrics);
+        let census_before = metrics
+            .sqlite_poll_census_rows_total
+            .load(std::sync::atomic::Ordering::Relaxed);
+        run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            payload_rows(&metrics),
+            rows_before,
+            "a covered, unchanged database must short-circuit"
+        );
+        assert_eq!(
+            metrics
+                .sqlite_poll_census_rows_total
+                .load(std::sync::atomic::Ordering::Relaxed),
+            census_before,
+            "not even the census may run"
+        );
+
+        cleanup(&path);
+    }
+
+    /// A replacement replay reads the whole database regardless of the
+    /// fast-path budget: its `FinalizeReplay` publishes the new generation
+    /// over the old one, so a budget-degraded replay would publish a hole —
+    /// the transient data loss #602's old-complete/new-complete contract
+    /// forbids. The replay pays the pre-#601 cost, once, per genuine
+    /// replacement.
+    ///
+    /// MUTATION (executed 2026-07-31): make `process_cursor_sqlite_db` use
+    /// `CursorScanPlan::from_config` for replays too — this test fails (the
+    /// replay covers 2 of 7 keys); RED was confirmed in a filtered run,
+    /// so suite-wide isolation is not claimed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_replacement_replay_reads_past_the_fast_path_budget() {
+        let path = unique_db_path("replay-unbudgeted");
+        seed_junk_fixture(&path, 7, 64);
+        let work = sqlite_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.fast_path_max_payload_rows = 2;
+
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        run_poll_with_config(&config, &work, &checkpoints, &poll_state, &metrics).await;
+
+        // A changed exclusion set starts a replacement replay under the same
+        // tight budget. The replay must ignore it.
+        let mut replaying = config.clone();
+        replaying.ingest.exclude_project_dirs = vec!["/no/such/dir/**".to_string()];
+        touch_irrelevant(&path);
+        run_poll_with_config(&replaying, &work, &checkpoints, &poll_state, &metrics).await;
+
+        let map = checkpoints.read().await;
+        let checkpoint = map.get(&cp_key).expect("finalized replay checkpoint");
+        let state = CursorState::parse(&checkpoint.cursor_json);
+        assert_eq!(
+            state.kv_hashes.len(),
+            7,
+            "the replay must cover every key, budget notwithstanding"
+        );
+        assert!(
+            !checkpoint.cursor_json.contains("pending_coverage"),
+            "a finalized replay owes nothing"
+        );
+        assert_eq!(checkpoint.status, "active");
+
+        cleanup(&path);
+    }
+
+    /// The byte axis of the fast-path budget at its exact boundary: two
+    /// 64-byte values against a 128-byte budget stop the scan at precisely
+    /// two rows. `is_exhausted_by` is `>=` on purpose — the row that *meets*
+    /// the budget is the last row read (§2.1: commit what was read) — and
+    /// this fixture sits exactly on the boundary so the one-token narrowing
+    /// to `>` reads a third row and fails here.
+    ///
+    /// MUTATION (executed 2026-07-31): `payload_bytes >= self.max_payload_bytes`
+    /// → `>` — this test fails (3 rows read); the row-axis twin `>=` → `>`
+    /// fails `a_cursor_scan_over_budget_reads_no_more_than_its_budget` (3
+    /// rows against its 2-row budget). Dropping the byte disjunct entirely
+    /// also fails here (all 4 rows read).
+    #[test]
+    fn a_cursor_byte_budget_binds_exactly_at_its_boundary() {
+        let path = unique_db_path("byte-budget-boundary");
+        seed_junk_fixture(&path, 4, 64);
+
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.sqlite.fast_path_max_payload_bytes = 128;
+        let plan = CursorScanPlan::from_config(&config, None);
+        let mut ledger = ScanLedger::default();
+        let ScanOutcome::Scanned { .. } = scan_database(
+            &path.to_string_lossy(),
+            &CursorState::fresh(),
+            &plan,
+            &mut ledger,
+        ) else {
+            panic!("an over-budget scan must degrade, not fail");
+        };
+        assert_eq!(
+            ledger.payload_rows, 2,
+            "the row that meets the byte budget is the last row read"
+        );
+        assert_eq!(ledger.payload_bytes, 128);
+        assert!(ledger.coverage_degraded);
+        assert_eq!(ledger.skipped_rows, 2);
+
+        cleanup(&path);
+    }
+
+    /// Plan §7.2 F1, the `new_state == prior_state_covered` conjunct of
+    /// `scan_is_noop` — the one whose failure mode is a durable-state change
+    /// suppressed forever. A value mutation that synthesizes no record (junk
+    /// payloads) moves only the hash map: every other conjunct says "no-op",
+    /// and only the structural comparison notices. Suppress it and the
+    /// mutation is re-discovered on every later poll and never durably
+    /// recorded.
+    ///
+    /// MUTATION (executed 2026-07-31): drop `new_state == prior_state_covered`
+    /// from `scan_is_noop` — this test fails (the persisted hash never
+    /// moves); RED was confirmed in a filtered run, so suite-wide isolation
+    /// is not claimed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_changed_value_that_emits_no_records_still_persists_its_checkpoint() {
+        let path = unique_db_path("noop-width-state");
+        let keys = seed_junk_fixture(&path, 2, 64);
+        let work = sqlite_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+
+        run_poll(&work, &checkpoints).await;
+        let hash_before = {
+            let map = checkpoints.read().await;
+            let state = CursorState::parse(&map.get(&cp_key).expect("cold checkpoint").cursor_json);
+            state.kv_hashes.get(&keys[0]).cloned().expect("covered key")
+        };
+
+        // A plain UPDATE to another non-JSON payload: no record synthesizes,
+        // only the content hash moves.
+        {
+            let db = Connection::open(&path).expect("reopen fixture");
+            db.execute(
+                "UPDATE cursorDiskKV SET value = 'junk-mutated' WHERE key = ?1",
+                rusqlite::params![&keys[0]],
+            )
+            .expect("mutate value in place");
+        }
+        let batches = run_poll(&work, &checkpoints).await;
+        assert!(
+            all_event_rows(&batches).is_empty(),
+            "junk payloads must not synthesize records"
+        );
+        let map = checkpoints.read().await;
+        let state = CursorState::parse(&map.get(&cp_key).expect("checkpoint").cursor_json);
+        assert_ne!(
+            state.kv_hashes.get(&keys[0]),
+            Some(&hash_before),
+            "the moved hash must be recorded durably, not re-discovered forever"
+        );
+
+        cleanup(&path);
+    }
+
+    /// Plan §7.2 F1, the `schema_fingerprint == checkpoint.schema_fingerprint`
+    /// conjunct: a schema change with no row changes moves nothing else — no
+    /// records, no state, no census count — so only this conjunct keeps the
+    /// scan from being classed a no-op, and only its checkpoint records the
+    /// new fingerprint durably.
+    ///
+    /// MUTATION (executed 2026-07-31): drop the conjunct from `scan_is_noop`
+    /// — this test fails (the persisted fingerprint never moves); RED was
+    /// confirmed in a filtered run, so suite-wide isolation is not claimed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_schema_change_with_no_row_changes_still_persists_its_checkpoint() {
+        let path = unique_db_path("noop-width-schema");
+        seed_junk_fixture(&path, 1, 64);
+        let work = sqlite_work(&path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+
+        run_poll(&work, &checkpoints).await;
+        let fingerprint_before = {
+            let map = checkpoints.read().await;
+            map.get(&cp_key)
+                .expect("cold checkpoint")
+                .schema_fingerprint
+        };
+
+        {
+            let db = Connection::open(&path).expect("reopen fixture");
+            db.execute("ALTER TABLE cursorDiskKV ADD COLUMN moraine_probe TEXT", [])
+                .expect("alter schema without touching rows");
+        }
+        let batches = run_poll(&work, &checkpoints).await;
         assert!(all_event_rows(&batches).is_empty());
+        let map = checkpoints.read().await;
+        assert_ne!(
+            map.get(&cp_key).expect("checkpoint").schema_fingerprint,
+            fingerprint_before,
+            "the new schema fingerprint must be recorded durably"
+        );
 
         cleanup(&path);
     }

--- a/crates/moraine-ingest-core/src/sqlite_poll/nac.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/nac.rs
@@ -20,18 +20,33 @@ use url::Origin;
 use super::{
     hash_str, open_read_only, record_scan_failure, record_scan_ledger, sqlite_data_version,
     stat_fingerprint, take_payload_nullable_string, take_payload_required_string,
-    take_payload_text, truncate_chars_local, ScanLedger, StatFingerprint, SyntheticRecord,
-    VolatilePollMap, ERROR_KIND_MIXED_SNAPSHOT, ERROR_KIND_OPEN, ERROR_KIND_SCAN,
-    ERROR_KIND_SCHEMA, ERROR_KIND_TOO_LARGE, SCAN_PAGE_MAX_BYTES, SCAN_PAGE_SIZE,
+    take_payload_text, truncate_chars_local, ScanBudget, ScanLedger, StatFingerprint,
+    SyntheticRecord, VolatilePollMap, ERROR_KIND_MIXED_SNAPSHOT, ERROR_KIND_OPEN,
+    ERROR_KIND_ROW_TOO_LARGE, ERROR_KIND_SCAN, ERROR_KIND_SCHEMA, SCAN_PAGE_MAX_BYTES,
+    SCAN_PAGE_SIZE,
 };
 
 const NAC_CURSOR_VERSION: u32 = 1;
-const MAX_NAC_SESSIONS: u64 = 10_000;
-const MAX_NAC_EPISODES: u64 = 100_000;
-const MAX_NAC_SCAN_BYTES: u64 = 256 * 1024 * 1024;
+/// Per-poll cap on synthetic records built. A *degradation* bound, not a
+/// failure (issue #601 §2.3): reaching it stops further reads for this poll
+/// with `coverage_degraded`, and per-session overflow truncates the part list.
 const MAX_NAC_SYNTHETIC_RECORDS: usize = 200_000;
 const ERROR_KIND_NORMALIZED_ROW_TOO_LARGE: &str = "nac_normalized_row_too_large";
+/// One episode referencing a session that exists nowhere in `sessions`.
+/// Reachable in production — the live schema FKs episodes to `threads`, not
+/// `sessions` (§1.3) — and passed exactly once, because `episode_high_water`
+/// advances over it (§3.2).
+const ERROR_KIND_ORPHAN_EPISODE: &str = "nac_orphan_episode";
+/// Ceiling on the serialized cursor payload. Enforced by **eviction** of the
+/// oldest session cursors (issue #601 §2.3), never by failing the scan; an
+/// evicted session re-emits on a later poll, which is safe because NAC
+/// records are content-addressed at stable logical coordinates (§6).
 const MAX_NAC_CHECKPOINT_BYTES: usize = 8 * 1024 * 1024;
+/// `NacSessionCursor.metadata_hash` marker for a session row too large to
+/// process (> `SCAN_PAGE_MAX_BYTES`). Structural state: it suppresses the
+/// per-poll re-emission of the row error while the row stays oversized, and
+/// any real hash differs from it, so a shrunk row re-emits normally.
+const OVERSIZED_SESSION_MARKER: &str = "oversized-row";
 const MAX_NAC_TEXT_CHARS: usize = 200_000;
 
 const REQUIRED_SESSION_COLUMNS: &[&str] = &[
@@ -78,6 +93,15 @@ struct NacState {
     project_exclusions_hash: u64,
     #[serde(default)]
     last_error: String,
+    /// True while some censused session has never been read in this
+    /// generation (a budget remainder or an eviction), or the episode
+    /// watermark trails `max(episodes.id)` — §2.3's persisted resume marker.
+    /// The cheap stat short-circuit must not fire while this is set, or a
+    /// quiet store's cold-ingest remainder is unreachable forever. Skipped
+    /// while false so `cursor_json` stays byte-identical for fully-covered
+    /// stores (§2.6).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pending_coverage: bool,
 }
 
 impl Default for NacState {
@@ -92,6 +116,7 @@ impl Default for NacState {
             worker_threads: BTreeSet::new(),
             project_exclusions_hash: 0,
             last_error: String::new(),
+            pending_coverage: false,
         }
     }
 }
@@ -110,15 +135,37 @@ impl NacState {
     }
 
     fn serialize(&self) -> Result<String> {
-        let raw = serde_json::to_string(self).context("failed to serialize NAC cursor")?;
-        if raw.len() > MAX_NAC_CHECKPOINT_BYTES {
-            anyhow::bail!(
-                "NAC cursor is {} bytes, exceeding the {} byte checkpoint ceiling",
-                raw.len(),
-                MAX_NAC_CHECKPOINT_BYTES
-            );
+        serde_json::to_string(self).context("failed to serialize NAC cursor")
+    }
+
+    /// Evict the oldest session cursors (by `created_at`, then id) until the
+    /// serialized payload fits `max_bytes`, returning how many were dropped
+    /// (issue #601 §2.3). Eviction replaces the old serialize-time failure:
+    /// the ceiling degrades — an evicted session is re-detected and re-emitted
+    /// by a later poll — instead of latching the whole database. Removal is in
+    /// batches of one-eighth of the map per round, so a pathological
+    /// many-small-entries payload does not re-serialize per entry.
+    fn evict_to_fit(&mut self, max_bytes: usize) -> u64 {
+        let mut evicted = 0u64;
+        loop {
+            let raw_len = serde_json::to_string(self)
+                .map(|raw| raw.len())
+                .unwrap_or(0);
+            if raw_len <= max_bytes || self.sessions.is_empty() {
+                return evicted;
+            }
+            let mut by_age: Vec<(String, String)> = self
+                .sessions
+                .iter()
+                .map(|(id, cursor)| (cursor.created_at.clone(), id.clone()))
+                .collect();
+            by_age.sort();
+            let batch = (self.sessions.len().div_ceil(8)).max(1);
+            for (_, id) in by_age.into_iter().take(batch) {
+                self.sessions.remove(&id);
+                evicted += 1;
+            }
         }
-        Ok(raw)
     }
 }
 
@@ -139,7 +186,6 @@ struct NacSessionRow {
     token_usages: Value,
     created_at: String,
     updated_at: String,
-    estimated_bytes: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -166,6 +212,10 @@ enum NacScanOutcome {
         state: NacState,
         schema_fingerprint: u64,
         relevant_rows: u64,
+        /// Per-row skips (§2.3): an un-processable single row — oversized, or
+        /// an orphan episode — is reported once and advanced past, never
+        /// allowed to fail the scan.
+        row_errors: Vec<NacRowError>,
     },
     Failed {
         error_kind: &'static str,
@@ -275,11 +325,17 @@ pub(crate) async fn process_nac_sqlite_db(
     // throttle for the sweep slice must read the fault ladder alone.
     // `an_ordinary_poll_of_a_contended_nac_store_is_not_throttled` fails if it
     // is added. See `plans/601-delta-sqlite.md` §7 WI-10.
+    // The `!pending_coverage` conjunct is §2.3's "continue next poll": while
+    // a cold-ingest remainder exists an unchanged stat must not end the poll
+    // (a quiet store's stat never moves again). Terminates because resumed
+    // scans read never-read sessions first, so the debt strictly shrinks
+    // (`a_degraded_nac_cold_ingest_completes_without_new_writes`).
     if !starts_replacement
         && !retry_blocked_replay
         && scan_state.stat == current_stat
         && scan_state.schema_fingerprint != 0
         && scan_state.last_error.is_empty()
+        && !scan_state.pending_coverage
     {
         return Ok(());
     }
@@ -291,6 +347,16 @@ pub(crate) async fn process_nac_sqlite_db(
     let scan_path = source_file.clone();
     let scan_source_name = work.source_name.clone();
     let prior_scan_state = scan_state.clone();
+    // The fast-path work budget (issue #601 §2.1), from `[ingest.sqlite]`.
+    // Exceeding it degrades coverage newest-first; it never fails the scan.
+    // A replacement replay is unbudgeted: its finalize publishes the
+    // generation whole, so degrading it would publish a hole through #602
+    // (`a_nac_replacement_replay_reads_past_the_fast_path_budget`).
+    let budget = if replacement_replay {
+        ScanBudget::unbounded()
+    } else {
+        ScanBudget::fast_path(&config.ingest.sqlite)
+    };
     let (mut outcome, ledger) = tokio::task::spawn_blocking(move || {
         let mut ledger = ScanLedger::default();
         let outcome = scan_nac_database(
@@ -300,6 +366,8 @@ pub(crate) async fn process_nac_sqlite_db(
             inode,
             current_stat,
             &prior_scan_state,
+            &budget,
+            MAX_NAC_CHECKPOINT_BYTES,
             &mut ledger,
         );
         (outcome, ledger)
@@ -362,6 +430,7 @@ pub(crate) async fn process_nac_sqlite_db(
             state: mut new_state,
             schema_fingerprint,
             relevant_rows,
+            row_errors,
         } => {
             new_state.project_exclusions_hash = current_exclusions_hash;
             let cursor_json = new_state.serialize()?;
@@ -394,6 +463,23 @@ pub(crate) async fn process_nac_sqlite_db(
             }
 
             let mut batch = RowBatch::default();
+            // Per-row skips (§2.3): one `ingest_errors` row each. Oversized
+            // rows repeat-suppress via their cursor marker; orphan episodes
+            // are one-shot because the watermark advances past them.
+            for row_error in &row_errors {
+                batch.push_error_row(json!({
+                    "source_name": work.source_name,
+                    "harness": work.harness,
+                    "source_file": source_file,
+                    "source_inode": inode,
+                    "source_generation": source_generation,
+                    "source_line_no": row_error.source_line_no,
+                    "source_offset": 0u64,
+                    "error_kind": row_error.error_kind,
+                    "error_text": row_error.error_text,
+                    "raw_fragment": "",
+                }));
+            }
             let mut replay_block_reason = None::<String>;
             for synthetic in &records {
                 if crate::dispatch::record_project_dir_is_excluded(
@@ -604,6 +690,8 @@ fn scan_nac_database(
     expected_inode: u64,
     pre_scan_stat: StatFingerprint,
     prior: &NacState,
+    budget: &ScanBudget,
+    checkpoint_ceiling_bytes: usize,
     ledger: &mut ScanLedger,
 ) -> NacScanOutcome {
     let connection = match open_read_only(db_path) {
@@ -663,20 +751,15 @@ fn scan_nac_database(
         source_generation,
         &schema,
         prior,
+        budget,
         ledger,
     );
-    let (records, mut state, relevant_rows) = match result {
+    let (records, mut state, relevant_rows, row_errors) = match result {
         Ok(value) => value,
         Err(NacScanError::Scan(exc)) => {
             return NacScanOutcome::Failed {
                 error_kind: ERROR_KIND_SCAN,
                 error_text: format!("{exc:#}"),
-            }
-        }
-        Err(NacScanError::TooLarge(error_text)) => {
-            return NacScanOutcome::Failed {
-                error_kind: ERROR_KIND_TOO_LARGE,
-                error_text,
             }
         }
     };
@@ -705,17 +788,22 @@ fn scan_nac_database(
     state.stat = pre_scan_stat;
     state.schema_fingerprint = schema.fingerprint;
     state.last_error.clear();
-    if let Err(exc) = state.serialize() {
-        return NacScanOutcome::Failed {
-            error_kind: ERROR_KIND_TOO_LARGE,
-            error_text: format!("NAC cursor failed size/serialization checks: {exc:#}"),
-        };
+    // The checkpoint-state ceiling degrades by evicting the oldest session
+    // cursors (issue #601 §2.3); it never fails the scan. Evicted sessions are
+    // re-emitted by a later poll — safe under §6's content-addressed identity.
+    // An eviction is a coverage debt by construction (the evicted session is
+    // censused but no longer carried), so the resume marker must reflect it.
+    let evicted = state.evict_to_fit(checkpoint_ceiling_bytes);
+    ledger.mark_evicted(evicted);
+    if evicted > 0 {
+        state.pending_coverage = true;
     }
     NacScanOutcome::Scanned {
         records,
         state,
         schema_fingerprint: schema.fingerprint,
         relevant_rows,
+        row_errors,
     }
 }
 
@@ -763,10 +851,17 @@ fn inspect_schema(
     })
 }
 
+/// One skipped row, destined for a single `ingest_errors` row.
+#[derive(Debug, Clone)]
+struct NacRowError {
+    source_line_no: u64,
+    error_kind: &'static str,
+    error_text: String,
+}
+
 #[derive(Debug)]
 enum NacScanError {
     Scan(anyhow::Error),
-    TooLarge(String),
 }
 
 impl From<anyhow::Error> for NacScanError {
@@ -789,8 +884,9 @@ fn scan_nac_rows(
     source_generation: u32,
     schema: &NacSchema,
     prior: &NacState,
+    budget: &ScanBudget,
     ledger: &mut ScanLedger,
-) -> std::result::Result<(Vec<SyntheticRecord>, NacState, u64), NacScanError> {
+) -> std::result::Result<(Vec<SyntheticRecord>, NacState, u64, Vec<NacRowError>), NacScanError> {
     let canonical_db = std::fs::canonicalize(db_path)
         .unwrap_or_else(|_| std::path::PathBuf::from(db_path))
         .to_string_lossy()
@@ -798,6 +894,7 @@ fn scan_nac_rows(
     let namespace = namespace_prefix(source_name, &canonical_db, source_generation);
     let projection = session_projection(&schema.session_columns);
     let mut records = Vec::new();
+    let mut row_errors = Vec::new();
     let mut next_state = NacState {
         episode_high_water: prior.episode_high_water,
         worker_threads: prior.worker_threads.clone(),
@@ -805,64 +902,139 @@ fn scan_nac_rows(
         ..NacState::default()
     };
     let mut contexts = BTreeMap::<String, NacSessionRow>::new();
-    let mut last_session_id = String::new();
-    let mut total_rows = 0u64;
-    let mut total_bytes = 0u64;
 
-    loop {
-        let sql = format!(
-            "SELECT {projection} FROM sessions WHERE session_id > ?1 ORDER BY session_id LIMIT ?2"
-        );
-        let mut stmt = connection.prepare_cached(&sql)?;
-        let mut rows = stmt.query(params![&last_session_id, SCAN_PAGE_SIZE as i64])?;
-        let mut page_rows = 0usize;
-        while let Some(row) = rows.next()? {
-            let session = read_session_row(row, &schema.session_columns, ledger)?;
-            page_rows += 1;
-            total_rows = total_rows.saturating_add(1);
-            if total_rows > MAX_NAC_SESSIONS {
-                return Err(NacScanError::TooLarge(format!(
-                    "{total_rows} NAC sessions exceed the {MAX_NAC_SESSIONS} session scan ceiling"
-                )));
-            }
-            let row_bytes = estimated_session_bytes(&session);
-            if row_bytes > SCAN_PAGE_MAX_BYTES {
-                return Err(NacScanError::TooLarge(format!(
-                    "NAC session {} is {row_bytes} bytes, exceeding the {SCAN_PAGE_MAX_BYTES} byte row ceiling",
-                    session.raw_session_id
-                )));
-            }
-            total_bytes = total_bytes.saturating_add(row_bytes as u64);
-            if total_bytes > MAX_NAC_SCAN_BYTES {
-                return Err(NacScanError::TooLarge(format!(
-                    "NAC scan bytes exceed the {MAX_NAC_SCAN_BYTES} byte ceiling"
-                )));
-            }
-            let normalized_session_id = format!("{namespace}:{}", session.raw_session_id);
-            let (mut session_records, cursor) = synthesize_session(
-                &session,
-                &normalized_session_id,
-                prior.sessions.get(&session.raw_session_id),
-                MAX_NAC_SYNTHETIC_RECORDS.saturating_sub(records.len()),
+    // Census (issue #601 §3.2): the narrow, `idx_sessions_updated_at`-cheap
+    // read that identifies every session without materializing payloads. It
+    // is the exact deletion detector and the newest-first ordering source;
+    // nothing is ever *skipped* on its say-so alone.
+    let census = {
+        let mut census = Vec::<(String, String)>::new();
+        let mut last_session_id = String::new();
+        loop {
+            let mut stmt = connection.prepare_cached(
+                "SELECT session_id, updated_at FROM sessions \
+                 WHERE session_id > ?1 ORDER BY session_id LIMIT ?2",
             )?;
-            records.append(&mut session_records);
-            next_state
-                .sessions
-                .insert(session.raw_session_id.clone(), cursor);
-            last_session_id = session.raw_session_id.clone();
-            contexts.insert(session.raw_session_id.clone(), session);
-            enforce_record_limit(records.len())?;
+            let mut rows = stmt.query(params![&last_session_id, SCAN_PAGE_SIZE as i64])?;
+            let mut page_rows = 0usize;
+            while let Some(row) = rows.next()? {
+                let session_id: String = row.get(0)?;
+                let updated_at: String = row.get::<_, Option<String>>(1)?.unwrap_or_default();
+                ledger.charge_census_row(session_id.len() + updated_at.len());
+                page_rows += 1;
+                last_session_id = session_id.clone();
+                census.push((session_id, updated_at));
+            }
+            if page_rows < SCAN_PAGE_SIZE {
+                break;
+            }
         }
-        if page_rows < SCAN_PAGE_SIZE {
+        census
+    };
+    let census_ids: BTreeSet<String> = census.iter().map(|(id, _)| id.clone()).collect();
+    let relevant_sessions = census.len() as u64;
+
+    // Candidate read: never-read sessions first, then newest-first by
+    // `updated_at` within each class (§2.3): a heuristic ordering — the
+    // schema has no trigger guaranteeing it (§1.3) — so it chooses priority
+    // only. Never-read-first is what makes a budget-degraded ingest converge
+    // (see the Cursor twin in `scan_database`): a plain recency order
+    // re-reads the same newest sessions on every poll and a store larger
+    // than one budget keeps its cold tail forever. The tie-break on
+    // session_id keeps the order deterministic.
+    let mut candidates = census;
+    candidates.sort_by(|a, b| {
+        let known_a = prior.sessions.contains_key(&a.0);
+        let known_b = prior.sessions.contains_key(&b.0);
+        known_a
+            .cmp(&known_b)
+            .then_with(|| b.1.cmp(&a.1))
+            .then_with(|| a.0.cmp(&b.0))
+    });
+    let mut point_read = connection.prepare_cached(&format!(
+        "SELECT {projection} FROM sessions WHERE session_id = ?1"
+    ))?;
+    for idx in 0..candidates.len() {
+        let over_budget = budget.is_exhausted_by(ledger.payload_rows, ledger.payload_bytes);
+        let over_records = records.len() >= MAX_NAC_SYNTHETIC_RECORDS;
+        if over_budget || over_records {
+            // Commit what was read (§2.1/§2.3): every skipped session keeps
+            // its prior cursor — "unread this poll", never "deleted" — and a
+            // skipped new session stays absent so a later poll detects it.
+            let remaining = &candidates[idx..];
+            ledger.mark_degraded(remaining.len() as u64, 0);
+            for (session_id, _) in remaining {
+                if let Some(cursor) = prior.sessions.get(session_id) {
+                    next_state
+                        .sessions
+                        .insert(session_id.clone(), cursor.clone());
+                }
+            }
             break;
         }
+        let session_id = &candidates[idx].0;
+        let session = {
+            let mut rows = point_read.query(params![session_id])?;
+            let Some(row) = rows.next()? else {
+                // Vanished between census and read: a mid-scan commit the
+                // data_version bracket rejects.
+                continue;
+            };
+            match read_session_row(row, &schema.session_columns, ledger)? {
+                NacSessionRead::Row(session) => *session,
+                NacSessionRead::Oversized { estimated_bytes } => {
+                    // An un-processable single row (§2.3): report it once,
+                    // mark it in the cursor so the report does not repeat
+                    // every poll, and keep scanning. A shrunk row hashes
+                    // differently from the marker and re-emits normally.
+                    let marker = NacSessionCursor {
+                        metadata_hash: format!("{OVERSIZED_SESSION_MARKER}:{estimated_bytes}"),
+                        created_at: String::new(),
+                        part_hashes: BTreeMap::new(),
+                    };
+                    if prior.sessions.get(session_id) != Some(&marker) {
+                        row_errors.push(NacRowError {
+                            source_line_no: 0,
+                            error_kind: ERROR_KIND_ROW_TOO_LARGE,
+                            error_text: format!(
+                                "NAC session {session_id} is {estimated_bytes} bytes, exceeding \
+                                 the {SCAN_PAGE_MAX_BYTES} byte row ceiling; row skipped"
+                            ),
+                        });
+                    }
+                    next_state.sessions.insert(session_id.clone(), marker);
+                    continue;
+                }
+            }
+        };
+        let normalized_session_id = format!("{namespace}:{}", session.raw_session_id);
+        let (mut session_records, cursor, parts_truncated) = synthesize_session(
+            &session,
+            &normalized_session_id,
+            prior.sessions.get(&session.raw_session_id),
+            MAX_NAC_SYNTHETIC_RECORDS.saturating_sub(records.len()),
+        )?;
+        if parts_truncated {
+            ledger.mark_degraded(0, 0);
+        }
+        records.append(&mut session_records);
+        next_state
+            .sessions
+            .insert(session.raw_session_id.clone(), cursor);
+        contexts.insert(session.raw_session_id.clone(), session);
     }
+    drop(point_read);
 
+    // Prune worker threads against the census keyset — the complete session
+    // id set — never against the per-poll `contexts` map, which a budget-
+    // bounded read leaves partial (issue #601 §3.2: the prune bug that
+    // resurrected pruned worker rows becomes a deletion bug under budgets).
     next_state.worker_threads.retain(|key| {
         key.split_once('\n')
-            .map(|(session_id, _)| contexts.contains_key(session_id))
+            .map(|(session_id, _)| census_ids.contains(session_id))
             .unwrap_or(false)
     });
+
     let max_episode_id: i64 =
         connection.query_row("SELECT coalesce(max(id), 0) FROM episodes", [], |row| {
             row.get(0)
@@ -874,6 +1046,7 @@ fn scan_nac_rows(
         prior.episode_high_water
     };
     let mut last_episode_id = scan_from;
+    let mut episodes_processed = 0u64;
     let episode_bytes = "length(CAST(COALESCE(thread_name, '') AS BLOB)) + \
         length(CAST(COALESCE(session_id, '') AS BLOB)) + \
         length(CAST(COALESCE(action, '') AS BLOB)) + \
@@ -893,27 +1066,64 @@ fn scan_nac_rows(
         guarded_episode("content"),
         guarded_episode("created_at")
     );
-    loop {
+    'episodes: loop {
         let mut stmt = connection.prepare_cached(&episode_sql)?;
         let mut rows = stmt.query(params![last_episode_id, SCAN_PAGE_SIZE as i64])?;
         let mut page_rows = 0usize;
         while let Some(row) = rows.next()? {
+            // The episode watermark is an exact, durable resume position, so
+            // bounded progress here is oldest-first *of the new tail* with
+            // `episode_high_water` as the committed cursor — not newest-first,
+            // which would tear a hole in the watermark (§2.3's newest-first
+            // rule exists for orderings without a resume position). At least
+            // one episode is processed per poll, so a backlog can never stall.
+            let over_budget = budget.is_exhausted_by(ledger.payload_rows, ledger.payload_bytes);
+            let over_records = records.len() >= MAX_NAC_SYNTHETIC_RECORDS;
+            if episodes_processed > 0 && (over_budget || over_records) {
+                // The row `rows.next()` just handed over was materialized —
+                // the projection includes `content`, so SQLite decoded it
+                // before the budget was consulted — and the ledger's headline
+                // rule charges at the point bytes leave SQLite (the oversize
+                // arm below makes the same call). One row per bound poll, on
+                // the rows axis only: its columns are never taken, so no
+                // bytes are charged. It still counts inside `remaining` — the
+                // watermark did not advance past it, so it is coverage debt
+                // and the next poll materializes it again. Cost and debt are
+                // different axes; one row on both is the honest ledger.
+                ledger.charge_payload_row();
+                let remaining =
+                    u64::try_from(max_episode_id.saturating_sub(last_episode_id)).unwrap_or(0);
+                ledger.mark_degraded(remaining, 0);
+                break 'episodes;
+            }
             // This projection includes `content`, so the whole episode row is
             // charged on the payload axis where SQLite hands it over. The row
-            // charge lands **before** the oversize check, matching
-            // `read_session_row`: SQLite had already decoded every column to
-            // evaluate `estimated_bytes`, so a ceiling arm reporting zero rows
-            // would contradict the ledger's headline guarantee. Bytes are
-            // still not charged from `estimated_bytes` — the guarded
-            // projection hands Rust NULL for an oversized row, and the ledger
-            // reports what was materialized, not what SQLite touched.
+            // charge lands **before** the oversize check: SQLite had already
+            // decoded every column to evaluate `estimated_bytes`, so a skip
+            // arm reporting zero rows would contradict the ledger's headline
+            // guarantee. Bytes are still not charged from `estimated_bytes` —
+            // the guarded projection hands Rust NULL for an oversized row, and
+            // the ledger reports what was materialized.
             let id: i64 = row.get(0)?;
             ledger.charge_payload_row();
+            page_rows += 1;
             let row_bytes = checked_row_bytes(row.get(6)?, "NAC episode", id)?;
             if row_bytes > SCAN_PAGE_MAX_BYTES {
-                return Err(NacScanError::TooLarge(format!(
-                    "NAC episode {id} is {row_bytes} bytes, exceeding the {SCAN_PAGE_MAX_BYTES} byte row ceiling"
-                )));
+                // Un-processable single row (§2.3): one error row, skip it,
+                // advance the watermark past it. The watermark makes the
+                // report one-shot — this episode is never read again.
+                row_errors.push(NacRowError {
+                    source_line_no: id as u64,
+                    error_kind: ERROR_KIND_ROW_TOO_LARGE,
+                    error_text: format!(
+                        "NAC episode {id} is {row_bytes} bytes, exceeding the \
+                         {SCAN_PAGE_MAX_BYTES} byte row ceiling; row skipped"
+                    ),
+                });
+                last_episode_id = id;
+                next_state.episode_high_water = id;
+                episodes_processed += 1;
+                continue;
             }
             // Every one of these is NOT NULL in the live `episodes` schema and
             // load-bearing downstream (thread/session identity, the action tag
@@ -924,25 +1134,41 @@ fn scan_nac_rows(
             let action = take_payload_required_string(ledger, row, 3)?;
             let content = take_payload_required_string(ledger, row, 4)?;
             let created_at_raw = take_payload_required_string(ledger, row, 5)?;
-            page_rows += 1;
-            total_rows = total_rows.saturating_add(1);
-            if total_rows > MAX_NAC_SESSIONS.saturating_add(MAX_NAC_EPISODES) {
-                return Err(NacScanError::TooLarge(format!(
-                    "NAC session and episode rows exceed the {} row ceiling",
-                    MAX_NAC_SESSIONS + MAX_NAC_EPISODES
-                )));
+            // Resolve the parent on demand (issue #601 §3.2): a budget-
+            // bounded session read makes "not in `contexts`" ordinary, and a
+            // point lookup is ~free (§1.3). Only a session absent from the
+            // *database* is an orphan — reported once and advanced past,
+            // because the live schema's FK points at `threads`, not
+            // `sessions`, so this is reachable in production and must never
+            // latch the adapter.
+            if !contexts.contains_key(&raw_session_id) {
+                let mut lookup = connection.prepare_cached(&format!(
+                    "SELECT {projection} FROM sessions WHERE session_id = ?1"
+                ))?;
+                let mut lookup_rows = lookup.query(params![&raw_session_id])?;
+                if let Some(session_row) = lookup_rows.next()? {
+                    match read_session_row(session_row, &schema.session_columns, ledger)? {
+                        NacSessionRead::Row(session) => {
+                            contexts.insert(raw_session_id.clone(), *session);
+                        }
+                        NacSessionRead::Oversized { .. } => {}
+                    }
+                }
             }
-            total_bytes = total_bytes.saturating_add(row_bytes as u64);
-            if total_bytes > MAX_NAC_SCAN_BYTES {
-                return Err(NacScanError::TooLarge(format!(
-                    "NAC scan bytes exceed the {MAX_NAC_SCAN_BYTES} byte ceiling"
-                )));
-            }
-            let parent = contexts.get(&raw_session_id).ok_or_else(|| {
-                NacScanError::Scan(anyhow::anyhow!(
-                    "episode {id} references missing session {raw_session_id}"
-                ))
-            })?;
+            let Some(parent) = contexts.get(&raw_session_id) else {
+                row_errors.push(NacRowError {
+                    source_line_no: id as u64,
+                    error_kind: ERROR_KIND_ORPHAN_EPISODE,
+                    error_text: format!(
+                        "episode {id} references missing session {raw_session_id}; \
+                         episode skipped"
+                    ),
+                });
+                last_episode_id = id;
+                next_state.episode_high_water = id;
+                episodes_processed += 1;
+                continue;
+            };
             let parent_id = format!("{namespace}:{raw_session_id}");
             let worker_id = format!(
                 "{parent_id}:nac-worker:{}",
@@ -985,15 +1211,26 @@ fn scan_nac_rows(
             ));
             last_episode_id = id;
             next_state.episode_high_water = id;
-            enforce_record_limit(records.len())?;
+            episodes_processed += 1;
         }
         if page_rows < SCAN_PAGE_SIZE {
             break;
         }
     }
 
+    // §2.3's persisted resume marker: a censused session absent from the
+    // carried cursor set has never been read in this generation, and an
+    // episode watermark short of `max(episodes.id)` is an unread episode
+    // tail. Either keeps the cheap stat short-circuit open (see the conjunct
+    // in `process_nac_sqlite_db`) until a scan covers everything.
+    next_state.pending_coverage = next_state.episode_high_water < max_episode_id
+        || census_ids
+            .iter()
+            .any(|id| !next_state.sessions.contains_key(id));
+
     ledger.rows_emitted = records.len() as u64;
-    Ok((records, next_state, total_rows))
+    let relevant_rows = relevant_sessions.saturating_add(episodes_processed);
+    Ok((records, next_state, relevant_rows, row_errors))
 }
 
 fn session_projection(columns: &BTreeSet<String>) -> String {
@@ -1075,13 +1312,14 @@ fn read_session_row(
     row: &rusqlite::Row<'_>,
     columns: &BTreeSet<String>,
     ledger: &mut ScanLedger,
-) -> std::result::Result<NacSessionRow, NacScanError> {
+) -> std::result::Result<NacSessionRead, NacScanError> {
     ledger.charge_payload_row();
     let estimated_bytes = checked_row_bytes(row.get(15)?, "NAC session row", 0)?;
     if estimated_bytes > SCAN_PAGE_MAX_BYTES {
-        return Err(NacScanError::TooLarge(format!(
-            "NAC session row is {estimated_bytes} bytes, exceeding the {SCAN_PAGE_MAX_BYTES} byte row ceiling"
-        )));
+        // The guarded projection already NULLed every column, so nothing was
+        // materialized beyond the row itself; the caller skips-and-reports
+        // per §2.3 instead of failing the scan.
+        return Ok(NacSessionRead::Oversized { estimated_bytes });
     }
     // NOT NULL in the live `sessions` schema; a NULL is schema drift and must
     // fail the scan. `session_id` and `created_at`/`updated_at` below feed
@@ -1117,7 +1355,7 @@ fn read_session_row(
             "NAC messages_json must contain an array"
         )));
     }
-    Ok(NacSessionRow {
+    Ok(NacSessionRead::Row(Box::new(NacSessionRow {
         raw_session_id,
         cwd,
         cwd_scope: if !columns.contains("host_id") {
@@ -1147,12 +1385,16 @@ fn read_session_row(
         )?,
         created_at,
         updated_at,
-        estimated_bytes,
-    })
+    })))
 }
 
-fn estimated_session_bytes(session: &NacSessionRow) -> usize {
-    session.estimated_bytes
+/// What one session point read produced: a full row, or the §2.3
+/// un-processable-row marker for a row past the byte ceiling. The row is
+/// boxed so the marker variant is not forced to carry a `NacSessionRow`'s
+/// footprint.
+enum NacSessionRead {
+    Row(Box<NacSessionRow>),
+    Oversized { estimated_bytes: usize },
 }
 
 fn checked_row_bytes(
@@ -1182,35 +1424,36 @@ fn synthesize_session(
     normalized_session_id: &str,
     prior: Option<&NacSessionCursor>,
     record_budget: usize,
-) -> std::result::Result<(Vec<SyntheticRecord>, NacSessionCursor), NacScanError> {
+) -> std::result::Result<(Vec<SyntheticRecord>, NacSessionCursor, bool), NacScanError> {
     let created_at = normalize_nac_timestamp(&session.created_at, true)?;
     let updated_at = normalize_nac_timestamp(&session.updated_at, true)?;
     let metadata = session_metadata_value(session, normalized_session_id, &created_at, &updated_at);
     let metadata_hash = value_hash(&metadata);
     let mut records = Vec::new();
+    let mut truncated = false;
     let created_changed = prior
         .map(|cursor| cursor.created_at != created_at)
         .unwrap_or(true);
     if prior.map(|cursor| cursor.metadata_hash.as_str()) != Some(metadata_hash.as_str()) {
         if records.len() >= record_budget {
-            return Err(NacScanError::TooLarge(format!(
-                "NAC synthetic records exceed the {MAX_NAC_SYNTHETIC_RECORDS} record ceiling"
-            )));
+            truncated = true;
+        } else {
+            records.push(SyntheticRecord {
+                record: metadata,
+                project_dir: project_dir_for(session),
+                source_line_no: 0,
+                source_offset: 0,
+            });
         }
-        records.push(SyntheticRecord {
-            record: metadata,
-            project_dir: project_dir_for(session),
-            source_line_no: 0,
-            source_offset: 0,
-        });
     }
 
-    let logical_parts = logical_message_parts(
+    let (logical_parts, parts_truncated) = logical_message_parts(
         session,
         normalized_session_id,
         &created_at,
         record_budget.saturating_sub(records.len()),
     )?;
+    truncated = truncated || parts_truncated;
     let mut part_hashes = BTreeMap::new();
     for (logical_id, record, line, offset) in logical_parts {
         let hash = value_hash(&record);
@@ -1236,6 +1479,7 @@ fn synthesize_session(
             created_at,
             part_hashes,
         },
+        truncated,
     ))
 }
 
@@ -1277,26 +1521,34 @@ struct ToolRequestContext {
     source_offset: u64,
 }
 
+/// Push one part unless the per-session budget is spent; returns `false` when
+/// the budget bound. A bound is bounded progress, not a failure (issue #601
+/// §2.3): the caller keeps the prefix it built, reports `coverage_degraded`,
+/// and the un-built suffix stays undetected until the budget allows it —
+/// which is degraded coverage, never an unbounded vector and never a latch.
 fn push_logical_part(
     parts: &mut Vec<(String, Value, u64, u64)>,
     part: (String, Value, u64, u64),
     record_budget: usize,
-) -> std::result::Result<(), NacScanError> {
+) -> bool {
     if parts.len() >= record_budget {
-        return Err(NacScanError::TooLarge(format!(
-            "NAC synthetic records exceed the {MAX_NAC_SYNTHETIC_RECORDS} record ceiling"
-        )));
+        return false;
     }
     parts.push(part);
-    Ok(())
+    true
 }
+
+/// The built parts of one session — `(logical_id, record, source_line_no,
+/// source_offset)` each — plus whether the record budget truncated the list
+/// (§2.3: truncation is reported, never silent).
+type LogicalParts = (Vec<(String, Value, u64, u64)>, bool);
 
 fn logical_message_parts(
     session: &NacSessionRow,
     normalized_session_id: &str,
     timestamp: &str,
     record_budget: usize,
-) -> std::result::Result<Vec<(String, Value, u64, u64)>, NacScanError> {
+) -> std::result::Result<LogicalParts, NacScanError> {
     let messages = session
         .messages
         .as_array()
@@ -1362,11 +1614,13 @@ fn logical_message_parts(
                 if let Some(details) = object.get("reasoning_details") {
                     record.insert("reasoning_details".to_string(), bounded_json(details));
                 }
-                push_logical_part(
+                if !push_logical_part(
                     &mut parts,
                     (logical_id, Value::Object(record), 0, offset),
                     record_budget,
-                )?;
+                ) {
+                    return Ok((parts, true));
+                }
             }
         }
 
@@ -1394,11 +1648,13 @@ fn logical_message_parts(
                         }
                     }
                 }
-                push_logical_part(
+                if !push_logical_part(
                     &mut parts,
                     (logical_id, Value::Object(record), 1, offset),
                     record_budget,
-                )?;
+                ) {
+                    return Ok((parts, true));
+                }
             }
         }
 
@@ -1436,11 +1692,13 @@ fn logical_message_parts(
                             source_offset: offset,
                         },
                     );
-                    push_logical_part(
+                    if !push_logical_part(
                         &mut parts,
                         (logical_id, Value::Object(record), source_line_no, offset),
                         record_budget,
-                    )?;
+                    ) {
+                        return Ok((parts, true));
+                    }
                 }
             }
         } else if role == "tool" {
@@ -1488,14 +1746,16 @@ fn logical_message_parts(
                     .and_then(Value::as_bool)
                     .unwrap_or(false)),
             );
-            push_logical_part(
+            if !push_logical_part(
                 &mut parts,
                 (logical_id, Value::Object(record), 3, offset),
                 record_budget,
-            )?;
+            ) {
+                return Ok((parts, true));
+            }
         }
     }
-    Ok(parts)
+    Ok((parts, false))
 }
 
 fn completed_terminal_indices(messages: &[Value]) -> Vec<usize> {
@@ -1729,16 +1989,6 @@ fn project_dir_for(session: &NacSessionRow) -> String {
         session.cwd.clone()
     } else {
         String::new()
-    }
-}
-
-fn enforce_record_limit(records: usize) -> std::result::Result<(), NacScanError> {
-    if records > MAX_NAC_SYNTHETIC_RECORDS {
-        Err(NacScanError::TooLarge(format!(
-            "{records} NAC logical records exceed the {MAX_NAC_SYNTHETIC_RECORDS} record ceiling"
-        )))
-    } else {
-        Ok(())
     }
 }
 
@@ -2263,9 +2513,7 @@ mod tests {
             let error = outcome
                 .err()
                 .unwrap_or_else(|| panic!("a NULL {name} must fail the scan, not become \"\""));
-            let NacScanError::Scan(error) = error else {
-                panic!("a NULL {name} is schema drift, not an oversized row");
-            };
+            let NacScanError::Scan(error) = error;
             assert!(
                 format!("{error:#}").contains("Invalid column type"),
                 "a NULL {name} must surface as a column-type error; got {error:#}"
@@ -2330,6 +2578,8 @@ mod tests {
             inode,
             stat,
             &NacState::default(),
+            &default_nac_budget(),
+            MAX_NAC_CHECKPOINT_BYTES,
             &mut ledger,
         );
         match outcome {
@@ -2376,6 +2626,12 @@ mod tests {
         path
     }
 
+    /// The shipped-default fast-path budget: what a production poll runs
+    /// with when nothing in `[ingest.sqlite]` is overridden.
+    fn default_nac_budget() -> ScanBudget {
+        ScanBudget::fast_path(&moraine_config::SqliteIngestConfig::default())
+    }
+
     fn scan_fixture(path: &Path, prior: &NacState) -> (Vec<SyntheticRecord>, NacState, u64) {
         let (records, state, relevant_rows, _) = scan_fixture_with_ledger(path, prior);
         (records, state, relevant_rows)
@@ -2397,6 +2653,8 @@ mod tests {
             inode,
             stat,
             prior,
+            &default_nac_budget(),
+            MAX_NAC_CHECKPOINT_BYTES,
             &mut ledger,
         ) {
             NacScanOutcome::Scanned {
@@ -2429,7 +2687,6 @@ mod tests {
             token_usages: json!([]),
             created_at: "2026-07-18 12:00:00.000000000".to_string(),
             updated_at: "2026-07-18 12:00:00.000000000".to_string(),
-            estimated_bytes: 0,
         }
     }
 
@@ -2478,6 +2735,8 @@ mod tests {
             inode,
             stat,
             &NacState::default(),
+            &default_nac_budget(),
+            MAX_NAC_CHECKPOINT_BYTES,
             &mut ledger,
         );
         let NacScanOutcome::Failed { error_kind, .. } = outcome else {
@@ -2499,18 +2758,21 @@ mod tests {
         std::fs::remove_file(format!("{}-shm", path.display())).ok();
     }
 
-    /// Issue #601 §2.0, the episode arm. `read_session_row` charges its row
-    /// *before* the oversize check; the episode loop charged it *after*, so the
-    /// `TooLarge` arm reported zero rows and zero bytes for a row SQLite had
-    /// already fully decoded to compute `estimated_bytes` — contradicting the
-    /// headline guarantee on the very ceiling the ledger is meant to denominate.
+    /// Issue #601 §2.0 + §2.3, the episode arm. The row charge lands *before*
+    /// the oversize check — SQLite fully decoded the row to evaluate
+    /// `estimated_bytes` — and the oversized row itself is an un-processable
+    /// single row: one `ingest_errors` row, skipped, watermark advanced past
+    /// it. This REWRITES the old `TooLarge` latch assertions: the scan used to
+    /// fail outright, which stalled `episode_high_water` forever on one bad
+    /// row — the latch class §2.3 retires.
     ///
     /// **[DIVERGENT FIXTURE]** the oversized episode is not the first row read,
     /// so the byte axis is non-zero for reasons independent of the row charge,
     /// and the two axes stay distinguishable.
     ///
     /// Fails for: moving the episode `charge_payload_row` back below the
-    /// ceiling check.
+    /// oversize check, restoring the `TooLarge` failure, or a skip that does
+    /// not advance the watermark.
     #[test]
     fn an_oversized_episode_still_charges_the_row_it_decoded() {
         let path = fixture_db();
@@ -2538,14 +2800,33 @@ mod tests {
             inode,
             stat,
             &NacState::default(),
+            &default_nac_budget(),
+            MAX_NAC_CHECKPOINT_BYTES,
             &mut ledger,
         );
-        let NacScanOutcome::Failed { error_kind, .. } = outcome else {
-            panic!("an episode past the row ceiling must fail the scan");
+        let NacScanOutcome::Scanned {
+            state, row_errors, ..
+        } = outcome
+        else {
+            panic!("an oversized episode degrades per §2.3; it must not fail the scan");
         };
-        assert_eq!(error_kind, ERROR_KIND_TOO_LARGE);
+        assert_eq!(row_errors.len(), 1, "one error row for the skipped episode");
+        assert_eq!(
+            row_errors[0].error_kind,
+            super::super::ERROR_KIND_ROW_TOO_LARGE
+        );
+        let max_episode_id: i64 = {
+            let connection = Connection::open(&path).expect("reopen fixture for counting");
+            connection
+                .query_row("SELECT max(id) FROM episodes", [], |row| row.get(0))
+                .expect("max episode id")
+        };
+        assert_eq!(
+            state.episode_high_water, max_episode_id,
+            "the watermark advances past the skipped row, so the report is one-shot"
+        );
 
-        // Every session, every earlier episode, **and** the rejected episode.
+        // Every session, every earlier episode, **and** the skipped episode.
         let expected_rows = {
             let connection = Connection::open(&path).expect("reopen fixture for counting");
             let sessions: i64 = connection
@@ -2558,8 +2839,8 @@ mod tests {
         };
         assert_eq!(
             ledger.payload_rows, expected_rows,
-            "the rejected episode was decoded in full to evaluate its size, so \
-             the ceiling arm must charge it like any other row"
+            "the skipped episode was decoded in full to evaluate its size, so \
+             the skip arm must charge it like any other row"
         );
         assert!(
             ledger.payload_bytes > 0,
@@ -2612,17 +2893,35 @@ mod tests {
              columns; got {} against {messages_bytes} of messages alone",
             ledger.payload_bytes
         );
-        // Schema validation is the only charged census read today; §3.2's
-        // `updated_at` fast path adds NAC's own. The payload read must not be
-        // miscounted as one.
+        // The census axis carries schema validation plus the §3.2 session
+        // census: one narrow `(session_id, updated_at)` row per session. The
+        // payload read must not be miscounted as census, or every payload
+        // budget deflates.
+        let census_key_bytes: i64 = {
+            let connection = Connection::open(&path).expect("reopen for census bytes");
+            connection
+                .query_row(
+                    "SELECT coalesce(sum(length(CAST(session_id AS BLOB)) +                      length(CAST(coalesce(updated_at, '') AS BLOB))), 0) FROM sessions",
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("sum census bytes")
+        };
         let schema_census = {
             let connection =
                 super::open_read_only(&path.to_string_lossy()).expect("reopen for schema census");
             crate::sqlite_poll::expected_schema_census(&connection, &["sessions", "episodes"])
         };
         assert!(schema_census.census_rows > 0);
-        assert_eq!(ledger.census_rows, schema_census.census_rows);
-        assert_eq!(ledger.census_bytes, schema_census.census_bytes);
+        assert_eq!(
+            ledger.census_rows,
+            schema_census.census_rows + sessions as u64,
+            "census rows are schema validation plus one narrow row per session"
+        );
+        assert_eq!(
+            ledger.census_bytes,
+            schema_census.census_bytes + census_key_bytes as u64
+        );
 
         let (second_records, second_state, _, second) = scan_fixture_with_ledger(&path, &state);
         assert!(
@@ -2683,6 +2982,7 @@ mod tests {
             10,
         )
         .expect("synthesize original parts")
+        .0
         .into_iter()
         .map(|(id, _, line, offset)| (id, (line, offset)))
         .collect::<BTreeMap<_, _>>();
@@ -2693,6 +2993,7 @@ mod tests {
             10,
         )
         .expect("synthesize updated parts")
+        .0
         .into_iter()
         .map(|(id, _, line, offset)| (id, (line, offset)))
         .collect::<BTreeMap<_, _>>();
@@ -2701,22 +3002,579 @@ mod tests {
         }
     }
 
+    /// Issue #601 §2.3. REWRITES `logical_part_budget_fails_before_building_
+    /// an_unbounded_vector`, whose `TooLarge` failure latched the whole scan
+    /// on one over-budget session. The budget still bounds the vector — that
+    /// was the old test's live property and it is kept — but overflow now
+    /// truncates: the built prefix is committed and the truncation is
+    /// reported, so the session degrades instead of stopping the adapter.
     #[test]
-    fn logical_part_budget_fails_before_building_an_unbounded_vector() {
+    fn a_logical_part_budget_truncates_the_parts_instead_of_failing() {
         let session = session_with_messages(json!([{
             "role": "assistant",
             "reasoning_text": "reasoning",
             "content": "answer"
         }]));
-        assert!(matches!(
-            logical_message_parts(
-                &session,
-                "nac:stable-session",
-                "2026-07-18T12:00:00.000000000Z",
-                1,
-            ),
-            Err(NacScanError::TooLarge(_))
-        ));
+        let (parts, truncated) = logical_message_parts(
+            &session,
+            "nac:stable-session",
+            "2026-07-18T12:00:00.000000000Z",
+            1,
+        )
+        .expect("an over-budget session truncates, it does not fail");
+        assert_eq!(parts.len(), 1, "the budget still bounds the vector");
+        assert!(truncated, "and the truncation is reported, not silent");
+
+        let (all_parts, untruncated) = logical_message_parts(
+            &session,
+            "nac:stable-session",
+            "2026-07-18T12:00:00.000000000Z",
+            usize::MAX,
+        )
+        .expect("an unbounded budget builds every part");
+        assert!(all_parts.len() > 1);
+        assert!(!untruncated);
+    }
+
+    /// `scan_fixture_with_ledger`, parameterized: the budget/ceiling tests
+    /// inject their `[ingest.sqlite]` values here, exactly as an operator's
+    /// config would arrive through `process_nac_sqlite_db`.
+    #[allow(clippy::type_complexity)]
+    fn scan_fixture_with_budget(
+        path: &Path,
+        prior: &NacState,
+        budget: &ScanBudget,
+        checkpoint_ceiling_bytes: usize,
+    ) -> (Vec<SyntheticRecord>, NacState, Vec<NacRowError>, ScanLedger) {
+        let stat = stat_fingerprint(path.to_str().expect("UTF-8 fixture path"))
+            .expect("fixture stat fingerprint");
+        let metadata = std::fs::metadata(path).expect("fixture metadata");
+        let inode = source_inode_for_file(path.to_str().expect("UTF-8 fixture path"), &metadata);
+        let mut ledger = ScanLedger::default();
+        match scan_nac_database(
+            path.to_str().expect("UTF-8 fixture path"),
+            "nac-fixture",
+            1,
+            inode,
+            stat,
+            prior,
+            budget,
+            checkpoint_ceiling_bytes,
+            &mut ledger,
+        ) {
+            NacScanOutcome::Scanned {
+                records,
+                state,
+                row_errors,
+                ..
+            } => (records, state, row_errors, ledger),
+            NacScanOutcome::Failed {
+                error_kind,
+                error_text,
+            } => panic!("budgeted fixture scan must degrade, not fail: {error_kind}: {error_text}"),
+        }
+    }
+
+    fn cleanup_fixture(path: &Path) {
+        std::fs::remove_file(path).ok();
+        std::fs::remove_file(format!("{}-wal", path.display())).ok();
+        std::fs::remove_file(format!("{}-shm", path.display())).ok();
+    }
+
+    /// Issue #601 §2.3 / gate G4 (NAC work budget — replaces the retired
+    /// `MAX_NAC_SESSIONS` / `MAX_NAC_SCAN_BYTES` ceilings). **[DIVERGENT
+    /// FIXTURE]** (§8 G4): the newest session by `updated_at`
+    /// (`session-remote`) sorts *last* in `session_id` order — the census
+    /// order a broken recency sort would fall back to — so a 1-row budget
+    /// reads it only if newest-first ordering actually works. Episodes are
+    /// watermarked past so the session ordering is observed in isolation.
+    /// Fails for: a budget that fails the scan instead of degrading (the old
+    /// `TooLarge` latch), bounded progress that is not newest-first, and any
+    /// error row minted for history size.
+    ///
+    /// MUTATION (executed 2026-07-31): restore census (`session_id ASC`)
+    /// candidate order by deleting the `sort_by` — fails here (the oldest
+    /// session is read instead). Reverting degradation to a `TooLarge`
+    /// failure fails at the panic in `scan_fixture_with_budget`.
+    #[test]
+    fn a_nac_store_over_budget_still_ingests_the_newest_session_first() {
+        let path = fixture_db();
+        let prior = NacState {
+            episode_high_water: 3,
+            ..NacState::default()
+        };
+        let budget = ScanBudget {
+            max_payload_rows: 1,
+            max_payload_bytes: u64::MAX,
+        };
+        let (records, state, row_errors, ledger) =
+            scan_fixture_with_budget(&path, &prior, &budget, MAX_NAC_CHECKPOINT_BYTES);
+
+        assert!(!records.is_empty(), "the newest session must still emit");
+        let serialized: Vec<String> = records
+            .iter()
+            .map(|record| serde_json::to_string(&record.record).expect("serialize record"))
+            .collect();
+        assert!(
+            serialized.iter().any(|raw| raw.contains("session-remote")),
+            "bounded progress must reach the newest session first"
+        );
+        assert!(
+            !serialized.iter().any(|raw| raw.contains("session-local")),
+            "census-order truncation would emit the oldest session; newest-first must not"
+        );
+        assert!(row_errors.is_empty(), "history size is never an error row");
+        assert!(ledger.coverage_degraded);
+        assert_eq!(
+            ledger.payload_rows, 1,
+            "the read stops exactly at its budget"
+        );
+        assert_eq!(
+            ledger.skipped_rows, 1,
+            "the unread session is accounted for"
+        );
+        assert!(state.sessions.contains_key("session-remote"));
+        assert!(
+            !state.sessions.contains_key("session-local"),
+            "an unread session must stay absent so a later poll detects it"
+        );
+        assert!(state.pending_coverage, "the remainder is a durable debt");
+
+        cleanup_fixture(&path);
+    }
+
+    /// The forward-progress rule of the episode loop, bounded from both
+    /// sides: a poll whose session reads already exhausted the budget still
+    /// processes **exactly one** episode — zero would let a busy session set
+    /// starve the episode watermark forever (the §2.5 latch class), and more
+    /// than one would ignore the budget (the runaway side). The ledger's side
+    /// of the break is pinned too: the row the break leaves unprocessed was
+    /// still materialized (the projection includes `content`), so it is
+    /// charged on the rows axis *and* counted in `skipped_rows` — cost and
+    /// debt are different axes.
+    ///
+    /// MUTATION (executed 2026-07-31): drop `episodes_processed > 0 &&` from
+    /// the episode-loop budget check — fails (high water stays 0). Delete
+    /// the budget break entirely — fails (high water reaches 3). Drop the
+    /// break arm's `charge_payload_row` — fails (`payload_rows` reads 3, not
+    /// 4). Each RED was confirmed in a filtered run, so suite-wide isolation
+    /// is not claimed.
+    #[test]
+    fn an_exhausted_session_budget_still_advances_the_episode_watermark() {
+        let path = fixture_db();
+        let budget = ScanBudget {
+            max_payload_rows: 1,
+            max_payload_bytes: u64::MAX,
+        };
+        let (records, state, row_errors, ledger) = scan_fixture_with_budget(
+            &path,
+            &NacState::default(),
+            &budget,
+            MAX_NAC_CHECKPOINT_BYTES,
+        );
+
+        assert_eq!(
+            state.episode_high_water, 1,
+            "exactly one episode advances per exhausted poll"
+        );
+        assert!(
+            serde_json::to_string(&records.iter().map(|r| &r.record).collect::<Vec<_>>())
+                .expect("serialize records")
+                .contains("worker-a"),
+            "the advanced episode's worker records must emit"
+        );
+        assert!(row_errors.is_empty());
+        assert!(ledger.coverage_degraded);
+        assert_eq!(
+            ledger.skipped_rows, 3,
+            "one unread session and two deferred episodes are accounted for"
+        );
+        assert_eq!(
+            ledger.payload_rows, 4,
+            "one budgeted session read, the processed episode plus its \
+             parent's point lookup, and the episode the break left behind: a \
+             materialized row is charged even when the budget defers it, and \
+             the deferred row also sits inside `skipped_rows` — cost and \
+             debt are different axes"
+        );
+        assert!(state.pending_coverage, "the episode tail is a durable debt");
+
+        cleanup_fixture(&path);
+    }
+
+    /// The **byte** axis of the same budget, at both NAC call sites. The
+    /// rows-axis tests above cannot see a call site that stops feeding the
+    /// byte argument (`is_exhausted_by(ledger.payload_rows, 0)` survives
+    /// them), and the shared-`ScanBudget` boundary test only pins the
+    /// predicate's implementation — this pins NAC's use of it. A 1-byte
+    /// budget binds after the first session *and* after the first episode:
+    /// the same commit/degrade/forward-progress shape as the rows axis.
+    ///
+    /// MUTATION (executed 2026-07-31): pass `0` for the byte argument at the
+    /// session-loop call site — fails (both sessions read). Same at the
+    /// episode-loop call site — fails (every episode read).
+    #[test]
+    fn a_nac_byte_budget_binds_at_both_call_sites() {
+        let path = fixture_db();
+        let budget = ScanBudget {
+            max_payload_rows: u64::MAX,
+            max_payload_bytes: 1,
+        };
+        let (_, state, row_errors, ledger) = scan_fixture_with_budget(
+            &path,
+            &NacState::default(),
+            &budget,
+            MAX_NAC_CHECKPOINT_BYTES,
+        );
+
+        assert_eq!(
+            state.sessions.len(),
+            1,
+            "the byte budget binds after the first session read"
+        );
+        assert!(state.sessions.contains_key("session-remote"));
+        assert_eq!(
+            state.episode_high_water, 1,
+            "one episode still advances, then the byte budget binds"
+        );
+        assert!(ledger.coverage_degraded);
+        assert!(row_errors.is_empty());
+        assert!(state.pending_coverage);
+
+        cleanup_fixture(&path);
+    }
+
+    /// Issue #601 §2.3 / gate G4 (NAC checkpoint-state ceiling): crossing
+    /// `MAX_NAC_CHECKPOINT_BYTES` evicts the **oldest** session cursors until
+    /// the payload fits — never fails the scan — and reports the eviction as
+    /// degraded coverage. Emission happens before eviction, so recent
+    /// sessions still emit; the evicted session is re-covered (and re-emits)
+    /// on a later poll, which §6's content-addressed identity makes safe.
+    ///
+    /// MUTATION (executed 2026-07-31): make `evict_to_fit` a no-op returning
+    /// 0 — fails (the state exceeds its ceiling and nothing is evicted).
+    /// Evict newest-first (`by_age.sort` descending) — fails (the newest
+    /// session is dropped instead of the oldest).
+    #[test]
+    fn a_checkpoint_over_its_ceiling_evicts_the_oldest_sessions_instead_of_failing() {
+        let path = fixture_db();
+        let (_, full_state, _) = scan_fixture(&path, &NacState::default());
+        let full_len = full_state.serialize().expect("serialize full state").len();
+
+        // One byte under the full payload: eviction must fire, and dropping
+        // the single oldest session cursor is enough to fit.
+        let ceiling = full_len - 1;
+        let (records, state, row_errors, ledger) =
+            scan_fixture_with_budget(&path, &NacState::default(), &default_nac_budget(), ceiling);
+
+        assert_eq!(ledger.evicted_entries, 1, "one round of the oldest eighth");
+        assert!(ledger.coverage_degraded);
+        assert!(
+            row_errors.is_empty(),
+            "a state ceiling is never an error row"
+        );
+        assert!(
+            !state.sessions.contains_key("session-local"),
+            "eviction is oldest-first by created_at"
+        );
+        assert!(
+            state.sessions.contains_key("session-remote"),
+            "the newest session's cursor survives"
+        );
+        assert!(
+            state.serialize().expect("serialize evicted state").len() <= ceiling,
+            "the persisted payload must fit its ceiling"
+        );
+        assert!(
+            serde_json::to_string(&records.iter().map(|r| &r.record).collect::<Vec<_>>())
+                .expect("serialize records")
+                .contains("session-local"),
+            "emission precedes eviction: recent work is not withheld"
+        );
+        assert!(
+            state.pending_coverage,
+            "an evicted session is a durable coverage debt"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// §2.3's "continue next poll" for NAC, end to end, with **no further
+    /// writes to the store**: a 1-row budget against two sessions and three
+    /// episodes converges to full coverage across resumed polls — never-read
+    /// sessions first, one episode per poll — then clears the durable marker
+    /// and quiesces on the cheap stat short-circuit.
+    ///
+    /// MUTATION (executed 2026-07-31): drop the `!scan_state.pending_coverage`
+    /// conjunct from the short-circuit — fails at the convergence loop (the
+    /// unchanged stat ends every later poll). Drop the never-read-first
+    /// class from the candidate sort — fails the same way (every poll
+    /// re-reads `session-remote`).
+    #[tokio::test]
+    async fn a_degraded_nac_cold_ingest_completes_without_new_writes() {
+        let path = fixture_db();
+        {
+            // The fixture ships in WAL mode, where the scan's own read-only
+            // open can touch `-shm` and keep the stat moving. Pin DELETE
+            // journal mode so "no further writes" really means an unchanged
+            // stat — otherwise sidecar churn, not the durable resume marker,
+            // would keep the polls alive and this test could not fail.
+            let connection = Connection::open(&path).expect("open fixture for journal change");
+            connection
+                .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))
+                .expect("checkpoint fixture WAL");
+            connection
+                .query_row("PRAGMA journal_mode = DELETE", [], |_| Ok(()))
+                .expect("switch fixture to DELETE journal mode");
+        }
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-cold-converges".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        let mut config = AppConfig::default();
+        config.ingest.sqlite.fast_path_max_payload_rows = 1;
+
+        let (first, _) =
+            drive_nac_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        let error_rows: usize = first.iter().map(|batch| batch.error_rows.len()).sum();
+        assert_eq!(error_rows, 0, "a work budget is never an error");
+        {
+            let map = checkpoints.read().await;
+            let checkpoint = map.get(&cp_key).expect("cold poll persists");
+            assert_eq!(checkpoint.status, "active");
+            assert!(
+                checkpoint.cursor_json.contains("pending_coverage"),
+                "the resume marker must be durable"
+            );
+        }
+
+        // No touches: convergence must come from the marker alone.
+        let mut polls = 1;
+        loop {
+            drive_nac_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+            polls += 1;
+            let map = checkpoints.read().await;
+            let state = NacState::parse(&map.get(&cp_key).expect("checkpoint").cursor_json);
+            if !state.pending_coverage {
+                assert_eq!(state.sessions.len(), 2, "every session covered");
+                assert_eq!(state.episode_high_water, 3, "every episode covered");
+                break;
+            }
+            assert!(
+                polls <= 8,
+                "a 1-row budget against 2 sessions and 3 episodes must converge; \
+                 still pending after {polls} polls"
+            );
+        }
+
+        // Quiesce: coverage complete, stat unchanged — the next poll must
+        // not scan.
+        let rows_before = metrics
+            .sqlite_poll_payload_rows_total
+            .load(std::sync::atomic::Ordering::Relaxed);
+        drive_nac_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            metrics
+                .sqlite_poll_payload_rows_total
+                .load(std::sync::atomic::Ordering::Relaxed),
+            rows_before,
+            "a covered, unchanged store must short-circuit"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// The NAC twin of `a_replacement_replay_reads_past_the_fast_path_budget`:
+    /// a replacement replay ignores the fast-path budget, because its
+    /// finalize publishes the generation whole and a degraded replay would
+    /// publish a hole through #602.
+    ///
+    /// MUTATION (executed 2026-07-31): make `process_nac_sqlite_db` pass the
+    /// fast-path budget on replays too — this test fails (one session and
+    /// one episode covered); RED was confirmed in a filtered run,
+    /// so suite-wide isolation is not claimed.
+    #[tokio::test]
+    async fn a_nac_replacement_replay_reads_past_the_fast_path_budget() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-replay-unbudgeted".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let mut config = AppConfig::default();
+        config.ingest.sqlite.fast_path_max_payload_rows = 1;
+
+        drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+
+        // A changed exclusion set starts a replacement replay under the same
+        // tight budget; the replay must ignore it.
+        let mut replaying = config.clone();
+        replaying.ingest.exclude_project_dirs = vec!["/no/such/dir/**".to_string()];
+        let (_, transitions) = drive_nac_poll(&replaying, &work, &checkpoints, &poll_state).await;
+        assert_eq!(transitions.len(), 2, "begin and final replay barriers");
+
+        let map = checkpoints.read().await;
+        let checkpoint = map.get(&cp_key).expect("finalized replay checkpoint");
+        let state = NacState::parse(&checkpoint.cursor_json);
+        assert_eq!(
+            state.sessions.len(),
+            2,
+            "the replay must cover every session, budget notwithstanding"
+        );
+        assert_eq!(state.episode_high_water, 3);
+        assert!(!state.pending_coverage, "a finalized replay owes nothing");
+        assert_eq!(checkpoint.status, "active");
+
+        cleanup_fixture(&path);
+    }
+
+    /// Plan §7.2 F2, the widening direction, at the NAC call site: an
+    /// `error`-status checkpoint with no block reason is an ordinary
+    /// transient failure marker. Widening `retry_blocked_replay` to a bare
+    /// `status == "error"` turns the next poll into a blocked-replacement
+    /// retry — cursor reset, full re-read, every unchanged row re-emitted
+    /// behind a fresh `BeginReplay`. The unchanged fixture emits nothing on
+    /// the correct path, so any re-emission or barrier fails this test.
+    ///
+    /// MUTATION (executed 2026-07-31): drop
+    /// `&& !checkpoint.block_reason.is_empty()` from NAC's
+    /// `retry_blocked_replay` — this test fails (rows re-emit behind a
+    /// barrier); RED was confirmed in a filtered run,
+    /// so suite-wide isolation is not claimed.
+    #[tokio::test]
+    async fn an_error_marker_without_a_block_reason_is_not_retried_as_a_blocked_nac_replay() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-error-marker-width".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let config = AppConfig::default();
+
+        let (first, _) = drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        assert!(!first.last().expect("cold batch").raw_rows.is_empty());
+
+        // Rewrite the committed checkpoint into a transient-error marker:
+        // the shape the non-replay failure arm persists.
+        {
+            let mut map = checkpoints.write().await;
+            let checkpoint = map.get_mut(&cp_key).expect("committed checkpoint");
+            checkpoint.status = "error".to_string();
+            checkpoint.block_reason.clear();
+            let mut state = NacState::parse(&checkpoint.cursor_json);
+            state.last_error = ERROR_KIND_SCAN.to_string();
+            checkpoint.cursor_json = state.serialize().expect("serialize error marker");
+        }
+
+        let (batches, transitions) =
+            drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        assert!(
+            transitions.is_empty(),
+            "an ordinary error marker must not raise a replay barrier"
+        );
+        let raw_rows: usize = batches.iter().map(|batch| batch.raw_rows.len()).sum();
+        assert_eq!(
+            raw_rows, 0,
+            "re-emission means the poll was retried as a blocked replay"
+        );
+        let map = checkpoints.read().await;
+        assert_eq!(
+            map.get(&cp_key).expect("checkpoint").status,
+            "active",
+            "the transient marker clears once a scan succeeds"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// Plan §7.2 F1, the `new_state == prior_state_covered` conjunct of NAC's
+    /// `scan_is_noop`: a session deletion moves the cursor map and nothing
+    /// else — no records, same schema, same stat class — so only the
+    /// structural comparison keeps the deletion's checkpoint from being
+    /// suppressed, re-discovered on every later poll, and never durably
+    /// recorded. The census is the deletion detector (§3.2), so this guard
+    /// belongs to the census's owner.
+    ///
+    /// MUTATION (executed 2026-07-31): drop `new_state == prior_state_covered`
+    /// from NAC's `scan_is_noop` — this test fails (the deleted session's
+    /// cursor survives forever); RED was confirmed in a filtered run,
+    /// so suite-wide isolation is not claimed.
+    #[tokio::test]
+    async fn a_deleted_nac_session_is_dropped_from_the_cursor_durably() {
+        let path = fixture_db();
+        {
+            let connection = Connection::open(&path).expect("open fixture for insert");
+            connection
+                .execute(
+                    "INSERT INTO sessions (session_id, cwd, model, base_url, messages_json, \
+                     created_at, updated_at) VALUES ('zz-observed', '/workspace/zz', 'model-z', \
+                     'https://api.example', '[{\"role\":\"user\",\"content\":\"zz\"}]', \
+                     '2026-07-19 09:00:00', '2026-07-19 09:00:01')",
+                    [],
+                )
+                .expect("insert observed session");
+        }
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-deletion-durable".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let config = AppConfig::default();
+
+        drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        {
+            let map = checkpoints.read().await;
+            let state = NacState::parse(&map.get(&cp_key).expect("checkpoint").cursor_json);
+            assert!(state.sessions.contains_key("zz-observed"));
+        }
+
+        {
+            let connection = Connection::open(&path).expect("open fixture for delete");
+            connection
+                .execute("DELETE FROM sessions WHERE session_id = 'zz-observed'", [])
+                .expect("delete observed session");
+        }
+        let (batches, _) = drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        let raw_rows: usize = batches.iter().map(|batch| batch.raw_rows.len()).sum();
+        assert_eq!(raw_rows, 0, "a deletion emits nothing — only state moves");
+        let map = checkpoints.read().await;
+        let state = NacState::parse(&map.get(&cp_key).expect("checkpoint").cursor_json);
+        assert!(
+            !state.sessions.contains_key("zz-observed"),
+            "the deletion must be recorded durably, not re-discovered forever"
+        );
+
+        cleanup_fixture(&path);
     }
 
     #[test]
@@ -2820,6 +3678,8 @@ mod tests {
                 inode ^ 1,
                 stat,
                 &NacState::default(),
+                &default_nac_budget(),
+                MAX_NAC_CHECKPOINT_BYTES,
                 &mut ScanLedger::default(),
             ),
             NacScanOutcome::Failed {

--- a/crates/moraine-ingest-core/src/sqlite_poll/opencode/tests.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/opencode/tests.rs
@@ -2721,3 +2721,54 @@ async fn a_crash_interrupted_opencode_replay_resumes_from_its_replaying_status()
 
     cleanup(&path);
 }
+
+/// Plan §7.2 F2, the widening direction, at the OpenCode call site: an
+/// `error`-status checkpoint with **no block reason** is an ordinary
+/// transient failure marker, and the poll it precedes is an ordinary poll.
+/// Widening `retry_blocked_replay` to a bare `status == "error"` turns it
+/// into a blocked-replacement retry: the watermark resets and every event
+/// replays behind a fresh `BeginReplay`. The unchanged fixture emits nothing
+/// on the correct path, so any re-emission fails this test.
+///
+/// MUTATION (executed 2026-07-31): drop
+/// `&& !checkpoint.block_reason.is_empty()` from OpenCode's
+/// `retry_blocked_replay` — this test fails (events replay); RED was confirmed
+/// in a filtered run, so suite-wide isolation is not claimed.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_error_marker_without_a_block_reason_is_not_retried_as_a_blocked_opencode_replay() {
+    let path = unique_opencode_db_path("error-marker-width");
+    let _db = seed_opencode_db(&path);
+    let work = opencode_sqlite_work(&path);
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+
+    let first = run_opencode_poll(&work, &checkpoints).await;
+    assert!(!all_event_rows(&first).is_empty());
+
+    // Rewrite the committed checkpoint into a transient-error marker: the
+    // shape the non-replay failure arm persists.
+    {
+        let mut map = checkpoints.write().await;
+        let checkpoint = map.get_mut(&cp_key).expect("committed checkpoint");
+        checkpoint.status = "error".to_string();
+        checkpoint.block_reason.clear();
+        let mut state = OpenCodeState::parse(&checkpoint.cursor_json);
+        state.last_error = crate::sqlite_poll::ERROR_KIND_SCAN.to_string();
+        checkpoint.cursor_json = state.serialize();
+    }
+
+    let batches = run_opencode_poll(&work, &checkpoints).await;
+    assert!(
+        all_event_rows(&batches).is_empty(),
+        "an ordinary error marker must clear through an ordinary scan; \
+         re-emission means the poll was retried as a blocked replay"
+    );
+    let map = checkpoints.read().await;
+    assert_eq!(
+        map.get(&cp_key).expect("checkpoint").status,
+        "active",
+        "the transient marker clears once a scan succeeds"
+    );
+
+    cleanup(&path);
+}


### PR DESCRIPTION
# feat(601): sweep reconcile slices, budget fast paths, degrade every ceiling

PR B of the #601 delta-polling epic: **WI-04** (reconciliation sweep slices) and **WI-05**
(ceiling degradation) on top of PR A's ledger/backoff/trigger-provenance groundwork.

## What changed and why

**Sweep slices (WI-04).** A `Reconcile`-triggered poll of a quiet, non-replaying database whose
per-database interval clock has expired attaches one budgeted sweep slice to its scan. The slice
driver makes forward progress without spinning, binds on rows, bytes, or its deadline, and
persists its cursor inside `cursor_json`, so a restart resumes mid-cycle instead of from the
newest end. Eligibility is denominated on trigger provenance (WI-03), the interval clock, the
replay flag, and the poll's own ledger (emission blocks a slice; a degraded quiet poll stays
eligible — plan §7.1 D7).

**Budget degradation (WI-05).** Fast-path budgets and the census cap commit what was read, record
`coverage_degraded` / `skipped_rows` / `skipped_bytes`, order never-read keys first so a
budget-degraded cold ingest converges, and persist a structural `pending_coverage` marker that
keeps the cheap stat short-circuit open until a scan covers everything.
`sqlite_cursor_too_large` is retired from the scan path (the constant survives for backoff-routing
width and historical rows).

**Checkpoint-state ceilings (WI-05).** NAC's serialized cursor is bounded at
`MAX_NAC_CHECKPOINT_BYTES` by oldest-first eviction. The same mechanism now bounds Cursor's
`kv_hashes` at `MAX_CURSOR_CHECKPOINT_BYTES` (8 MiB): eviction is oldest-first by the census's
`rowid` view (census-absent entries first) until WI-08's `KvEntry { hash, rowid }` persists
recency; an evicted key re-detects as never-read and re-emits safely under content addressing.
Plan §7.1 D10 records the interim ordering and the residual churn on a genuinely over-ceiling
database.

**Accounting and doc honesty.** NAC's episode budget break charges the row it had already
materialized before deferring it (pinned by `an_exhausted_session_budget_still_advances_the_
episode_watermark`, `payload_rows == 4`); `is_half_consumed_by`'s doc matches its `>=` behavior;
`absorb_sweep_slice` drops a dead `rows_emitted` fold; mutation-ledger entries now claim
"named test fails under mutation in a filtered run", never suite-wide isolation.

## Review history (honest)

Round 1 (multi-persona) confirmed the trigger-width pins, non-spinning slice driver, read-site
charging, commit-and-carry degradation, restart-safe sweep cursors, and the four gates on the
diff — and raised two blockers plus four nits, all resolved here:

- **S1 (blocking, probe-executed):** `VolatilePollMap::clear` deleted the sweep interval clock
  with the entry, so any emitting poll between slices re-armed the sweep on the next quiet
  reconcile poll — sweeps at up to the reconcile cadence (~10× the configured minimum) on
  databases with interleaved writes, and §2.2/§4's projected-interval arithmetic no longer bounded
  realized cost. The existing interval guard interleaved only noop polls (which preserve the
  entry) and could not see it. **Fix:** the clock survives `clear` (the carried skeleton entry is
  provably inert to `should_skip_poll` / `failure_retry_due`; NAC and OpenCode never arm the
  clock, so their entries still clear whole). Both directions are now guarded by named tests with
  executed mutations:
  `a_second_reconcile_poll_inside_the_sweep_interval_attaches_no_slice` gained an emitting-poll
  interleave (runaway side — RED under a bare-`remove` mutant at exactly that assertion),
  `an_expired_sweep_interval_arms_the_next_reconcile_poll` now expires the interval under
  continuous emitting polls (starvation side — RED under a `Some(_) => false` never-expires
  mutant while the upper test stays green).
- **S2 (blocking):** round 1 retired Cursor's `MAX_RELEVANT_KEYS` hard bound with no replacement
  and no §7.1 disclosure, leaving `cursor_json` (hashed into the #602 transition digest) bounded
  only by the 250k census cap. **Fix:** the §2.3 eviction ceiling ships for Cursor in this PR
  (see above), bounded from both sides:
  `a_cursor_state_over_its_ceiling_evicts_the_oldest_keys_instead_of_failing` (RED under a
  no-op-evict mutant and under a newest-first mutant) and
  `a_cursor_state_at_its_ceiling_evicts_nothing` (RED under a `<=`→`<` boundary mutant; also
  pins §2.6 byte-identity at the boundary). Plan §7.1 D10 + §8 updated.
- **S3 (nits):** episode-break row charge (executed mutation: dropping it reads
  `payload_rows` 3, not 4), `is_half_consumed_by` doc/behavior alignment, dead
  `rows_emitted` fold removed, and the plan/test mutation ledger restated to filtered-run
  claims — "was the only failure" suite-wide claims are withdrawn where full-suite isolation was
  not verified.

## Operational impact

- No schema, migration, or service-topology changes.
- New `[ingest.sqlite]` budget keys (shipped defaults in `config/moraine.toml`, zero-values
  rejected at load; template pinned to code defaults by test).
- Sweep read cost is bounded by `sweep_slice_max_payload_{bytes,rows}` / `sweep_slice_max_millis`
  and throttled by `sweep_slice_min_interval_seconds` per database — now honored across
  interleaved writes (S1).
- Replacement replays remain unbudgeted (plan §7.1 D5); the new state ceiling still applies to
  them, after their reads and emissions, so no published hole.
- Worst-case Cursor checkpoint payload drops from ~tens of MB (250k-entry map) to 8 MiB.

## Validation

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- `cargo test --workspace --locked` — green: 1592 passed, 0 failed, 22 ignored across the
  workspace (moraine-ingest-core: 367 passed / 0 failed).
- Executed width mutations for every new bound, both directions, recorded in plan §8's
  WI-04/WI-05 table (RED confirmed in filtered runs, in an isolated content copy of the
  worktree; suite-wide isolation deliberately not claimed).
- Sandbox-denominated live gates (G1d, G1-oracle, G2, G7, G8d) are **unwritten**: they are
  WI-11's deliverable. Round 1 recorded a Docker limitation as the reason; that limitation has
  cleared, and the accurate reason is scope — plan §8's live-gate paragraph updated accordingly.
  `scripts/ci/e2e-stack.sh` runs in CI on every PR.

Issue: #601 (WI-04, WI-05). Plan: `plans/601-delta-sqlite.md` (local, ignored) — §7.1 D10 and §8
updated in this round.
