### PR TITLE
feat(601): cut OpenCode and NAC over to watermark-first delta polling

### DIFF
--- a/crates/moraine-ingest-core/src/sqlite_poll.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll.rs
@@ -86,11 +86,13 @@ const MAX_CURSOR_CHECKPOINT_BYTES: usize = 8 * 1024 * 1024;
 
 const ERROR_KIND_OPEN: &str = "sqlite_open_error";
 const ERROR_KIND_SCHEMA: &str = "sqlite_schema_mismatch";
-/// Retired from every scan path by issue #601 §2.3: history size is now a
-/// degradation (`coverage_degraded`), never a failure. The constant remains
+/// Retired from every scan path by issue #601 §2.3 (WI-05 for Cursor and NAC,
+/// WI-06 for OpenCode — the last producer): history size is now a degradation
+/// (`coverage_degraded`), never a failure. The constant remains, test-only,
 /// because `record_scan_failure_outcome`'s routing width is pinned per kind
 /// (`each_error_kind_routes_to_exactly_one_backoff_clock`) and because
 /// historical `ingest_errors` rows carry it.
+#[cfg(test)]
 const ERROR_KIND_TOO_LARGE: &str = "sqlite_cursor_too_large";
 /// One genuinely un-processable single row (issue #601 §2.3): larger than
 /// `SCAN_PAGE_MAX_BYTES`. Reported as one `ingest_errors` row for that row
@@ -107,6 +109,14 @@ struct StatFingerprint {
     wal_mtime_ns: u64,
     shm_len: u64,
     shm_mtime_ns: u64,
+}
+
+impl StatFingerprint {
+    /// For `skip_serializing_if`: keeps `cursor_json` byte-identical for
+    /// states that never set an optional fingerprint field (§2.6).
+    pub(crate) fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
 }
 
 /// Persisted poll cursor (the checkpoint's `cursor_json` payload).
@@ -865,11 +875,12 @@ impl VolatilePollMap {
 ///   charged nothing, but an aggregate over a payload column
 ///   (`sum(length(data))`) forces SQLite to decode every byte of that column —
 ///   §1.1 finding 2 measured `length()` on a TEXT-affine column at 48.5 ms /
-///   48 MB, so it is emphatically not a cheap probe — and those bytes are
-///   charged on the payload axis through `charge_aggregate_payload_bytes`.
-///   Without that rule a cold OpenCode scan under-reports its true byte cost by
-///   roughly 2×, and the ledger could be used to argue an aggregate preflight
-///   is free. It is not.
+///   48 MB, so it is emphatically not a cheap probe — and those bytes must be
+///   charged on the payload axis. No such read remains: WI-06 removed the last
+///   one (OpenCode's per-aggregate `sum(length(data))` preflight, which
+///   double-charged a cold scan by ~2×), and with it the ledger's
+///   `charge_aggregate_payload_bytes` helper. Any new payload-column aggregate
+///   must bring the helper back rather than call itself free.
 ///
 /// Both axes are always recorded: rows cannot catch content growth, bytes
 /// cannot catch a full scan of narrow rows.
@@ -923,14 +934,6 @@ impl ScanLedger {
 
     fn charge_payload_bytes(&mut self, bytes: usize) {
         self.payload_bytes = self.payload_bytes.saturating_add(bytes as u64);
-    }
-
-    /// Bytes a scalar aggregate over a payload column forced SQLite to decode.
-    /// No row is charged — none was materialized — but the bytes were really
-    /// paid, so a byte budget must see them. See the aggregate rule on
-    /// `ScanLedger`.
-    pub(crate) fn charge_aggregate_payload_bytes(&mut self, bytes: u64) {
-        self.payload_bytes = self.payload_bytes.saturating_add(bytes);
     }
 
     /// Record deliberately-skipped coverage (§2.3): a budget bound before the

--- a/crates/moraine-ingest-core/src/sqlite_poll/nac.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/nac.rs
@@ -18,10 +18,11 @@ use tracing::{debug, warn};
 use url::Origin;
 
 use super::{
-    hash_str, open_read_only, record_scan_failure, record_scan_ledger, sqlite_data_version,
-    stat_fingerprint, take_payload_nullable_string, take_payload_required_string,
-    take_payload_text, truncate_chars_local, ScanBudget, ScanLedger, StatFingerprint,
-    SyntheticRecord, VolatilePollMap, ERROR_KIND_MIXED_SNAPSHOT, ERROR_KIND_OPEN,
+    drive_sweep_slice, hash_str, open_read_only, record_scan_failure, record_scan_ledger,
+    record_sweep_slice_committed, sqlite_data_version, stat_fingerprint,
+    take_payload_nullable_string, take_payload_required_string, take_payload_text,
+    truncate_chars_local, ScanBudget, ScanLedger, StatFingerprint, SweepItem, SweepPlan,
+    SweepState, SyntheticRecord, VolatilePollMap, ERROR_KIND_MIXED_SNAPSHOT, ERROR_KIND_OPEN,
     ERROR_KIND_ROW_TOO_LARGE, ERROR_KIND_SCAN, ERROR_KIND_SCHEMA, SCAN_PAGE_MAX_BYTES,
     SCAN_PAGE_SIZE,
 };
@@ -94,14 +95,44 @@ struct NacState {
     #[serde(default)]
     last_error: String,
     /// True while some censused session has never been read in this
-    /// generation (a budget remainder or an eviction), or the episode
-    /// watermark trails `max(episodes.id)` — §2.3's persisted resume marker.
-    /// The cheap stat short-circuit must not fire while this is set, or a
-    /// quiet store's cold-ingest remainder is unreachable forever. Skipped
-    /// while false so `cursor_json` stays byte-identical for fully-covered
-    /// stores (§2.6).
+    /// generation (a budget remainder or an eviction), a fast-path candidate
+    /// was budget-skipped, or the episode watermark trails `max(episodes.id)`
+    /// — §2.3's persisted resume marker. The cheap stat short-circuit must not
+    /// fire while this is set, or a quiet store's cold-ingest remainder is
+    /// unreachable forever. Skipped while false so `cursor_json` stays
+    /// byte-identical for fully-covered stores (§2.6).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pending_coverage: bool,
+    /// §3.2's fast-path watermark, the `(updated_at, session_id)` keyset
+    /// position: sessions at or before it in the census are not re-read by the
+    /// fast path — a skip justified by the sweep's coverage guarantee (§0),
+    /// never by `updated_at` itself, which is ordering-only (no trigger
+    /// maintains it — §1.3). Empty means no watermark: every known session is
+    /// a candidate, which is both the fresh-generation state and the upgrade
+    /// path from a pre-watermark cursor (one exhaustive, hash-suppressed
+    /// re-read establishes it). Deterministic structural state (§2.6): it
+    /// advances only to positions a committed scan covered.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    updated_at_high_water: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    updated_at_high_water_session: String,
+    /// §2.2's durable reconciliation-sweep cursor over `session_id` order.
+    /// The sweep is what detects a session mutated without an `updated_at`
+    /// bump (G5c) — the coverage the fast path's skip borrows against.
+    /// Episodes need no sweep: their id watermark is exact and append-only.
+    #[serde(default, skip_serializing_if = "SweepState::is_default")]
+    sweep: SweepState,
+    /// The stat fingerprint as of the moment the current (or last) sweep
+    /// cycle **started** — the content state that cycle is walking. A due
+    /// reconcile poll owes a new cycle while this trails the current stat:
+    /// content changed after the last cycle began, and the fast path may have
+    /// carried some of it unverified (an emitting poll defers its slice, so
+    /// without this debt marker the deferral would never land on a store that
+    /// then goes quiet — §0's coverage guarantee closed from the emitting
+    /// side). Structural, deterministic state in the same class as `stat`
+    /// above (§2.6): it advances only when a committed slice starts a cycle.
+    #[serde(default, skip_serializing_if = "StatFingerprint::is_default")]
+    sweep_baseline: StatFingerprint,
 }
 
 impl Default for NacState {
@@ -117,8 +148,63 @@ impl Default for NacState {
             project_exclusions_hash: 0,
             last_error: String::new(),
             pending_coverage: false,
+            updated_at_high_water: String::new(),
+            updated_at_high_water_session: String::new(),
+            sweep: SweepState::default(),
+            sweep_baseline: StatFingerprint::default(),
         }
     }
+}
+
+/// §3.2's format guard, half one: the fixed-width `YYYY-MM-DD?HH:MM:SS` shape
+/// a NAC `updated_at` must have for lexicographic comparison to be
+/// chronologically meaningful, returning its separator byte. Mixed
+/// *precisions* are safe (the fraction is a suffix on the fixed-width prefix);
+/// mixed *separators* are not (`'T'` 0x54 > `' '` 0x20 dominates every digit
+/// after position 10), and a malformed value is comparable to nothing.
+fn nac_timestamp_shape(value: &str) -> Option<u8> {
+    let bytes = value.as_bytes();
+    if bytes.len() < 19 {
+        return None;
+    }
+    let separator = bytes[10];
+    if separator != b' ' && separator != b'T' {
+        return None;
+    }
+    let digits = [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18]
+        .iter()
+        .all(|&index| bytes[index].is_ascii_digit());
+    let punctuation =
+        bytes[4] == b'-' && bytes[7] == b'-' && bytes[13] == b':' && bytes[16] == b':';
+    (digits && punctuation).then_some(separator)
+}
+
+/// §3.2's format guard, half two: two `updated_at` values may be ordered only
+/// when both are well-formed **and share one separator**. Everything else is
+/// incomparable, and the fast path must never skip on an incomparable value —
+/// it reads the row instead (fail open). "Skip the fast path and let the sweep
+/// carry it" is the plan's wording; reading the row now is strictly safer than
+/// deferring it to the sweep interval, and no silent cross-format comparison
+/// ever happens either way.
+fn nac_updated_at_comparable(a: &str, b: &str) -> bool {
+    matches!(
+        (nac_timestamp_shape(a), nac_timestamp_shape(b)),
+        (Some(left), Some(right)) if left == right
+    )
+}
+
+/// Strict keyset order: is `(updated_at, session_id)` after the watermark?
+/// Callers must have established comparability first. The session-id tiebreak
+/// is what splits a same-timestamp write burst across bound polls — §3.2's
+/// inclusive-bound race on a second-precision store
+/// (`a_same_timestamp_nac_write_burst_resumes_through_the_session_id_tiebreak`).
+fn nac_keyset_after(
+    updated_at: &str,
+    session_id: &str,
+    high_water: &str,
+    high_water_session: &str,
+) -> bool {
+    updated_at > high_water || (updated_at == high_water && session_id > high_water_session)
 }
 
 impl NacState {
@@ -209,13 +295,17 @@ impl CwdScope {
 enum NacScanOutcome {
     Scanned {
         records: Vec<SyntheticRecord>,
-        state: NacState,
+        state: Box<NacState>,
         schema_fingerprint: u64,
         relevant_rows: u64,
         /// Per-row skips (§2.3): an un-processable single row — oversized, or
         /// an orphan episode — is reported once and advanced past, never
         /// allowed to fail the scan.
         row_errors: Vec<NacRowError>,
+        /// True when this scan drove a sweep slice whose advance is carried in
+        /// `state.sweep`; the caller commits the interval clock only after the
+        /// checkpoint persisted (mirroring the Cursor adapter's ordering).
+        swept: bool,
     },
     Failed {
         error_kind: &'static str,
@@ -269,7 +359,53 @@ pub(crate) async fn process_nac_sqlite_db(
     // fails if it goes.
     let retry_blocked_replay = checkpoint.status == "replaying"
         || (checkpoint.status == "error" && !checkpoint.block_reason.is_empty());
-    let starts_replacement = generation_changed || exclusions_changed;
+    // A NAC database stuck in `retry_blocked_replay` previously re-scanned the
+    // whole store and re-sent `BeginReplay` on every tick with zero throttle,
+    // because the volatile check was skipped during replay. Throttle *before*
+    // the durable barrier so the barrier always has a scan behind it
+    // (issue #601 §2.1(2), §2.5) — and before the episode preflight below, so
+    // a durably blocked store does not pay a read per tick either (the
+    // OpenCode rewind-preflight rule). This gate now sits *above* the
+    // generation bump, so — exactly as at the OpenCode site — both bypass
+    // conjuncts are load-bearing: drop either and a store whose file was
+    // replaced, or whose exclusion set changed, is ignored for up to
+    // `FAILURE_BACKOFF_MAX`.
+    // `a_replaced_nac_database_bypasses_the_blocked_replay_throttle` and
+    // `an_exclusion_change_bypasses_the_nac_blocked_replay_throttle` fail, one
+    // per conjunct.
+    if retry_blocked_replay
+        && !generation_changed
+        && !exclusions_changed
+        && !poll_state.failure_retry_due(&cp_key, checkpoint.source_generation)
+    {
+        return Ok(());
+    }
+
+    // §3.2: an episode rewind (`max(episodes.id)` behind the committed
+    // watermark) is a truncation of history and must route through #602's
+    // replacement path — generation bump, `BeginReplay` barrier, `sessions`
+    // reset — never the old in-place `worker_threads.clear()` that exposed
+    // partially replayed worker history beside live data in one generation
+    // (G8c, `nac_episode_rewind_routes_through_generation_replay`). Detected
+    // by preflight, like OpenCode's sequence rewind, so the bump-then-barrier
+    // ordering is preserved; the race where the rewind lands between this
+    // read and the scan is closed by the scan failing (see `scan_nac_rows`)
+    // and this preflight catching it on the retry.
+    let episode_rewound = if had_committed
+        && current_stat != committed_state.stat
+        && committed_state.episode_high_water > 0
+    {
+        let scan_db_path = source_file.clone();
+        let high_water = committed_state.episode_high_water;
+        tokio::task::spawn_blocking(move || nac_episodes_rewound(&scan_db_path, high_water))
+            .await
+            .context("nac_sqlite episode preflight panicked")?
+            .unwrap_or(false)
+    } else {
+        false
+    };
+
+    let starts_replacement = generation_changed || exclusions_changed || episode_rewound;
     if starts_replacement {
         checkpoint.source_generation =
             crate::publication::checked_next_generation(checkpoint.source_generation)
@@ -297,22 +433,23 @@ pub(crate) async fn process_nac_sqlite_db(
         .last_offset
         .checked_add(1)
         .context("nac_sqlite poll sequence exhausted")?;
-    // A NAC database stuck in `retry_blocked_replay` previously re-scanned the
-    // whole store and re-sent `BeginReplay` on every tick with zero throttle,
-    // because the volatile check was skipped during replay. Throttle *before*
-    // the durable barrier so the barrier always has a scan behind it
-    // (issue #601 §2.1(2), §2.5); a genuine replacement bumped the generation
-    // above and is never throttled.
-    if retry_blocked_replay
-        && !starts_replacement
-        && !poll_state.failure_retry_due(&cp_key, source_generation)
-    {
-        return Ok(());
-    }
     if replacement_replay {
         super::begin_database_replay(&sink_tx, &checkpoint, scan_boundary, &policy_fingerprint)
             .await?;
     }
+
+    // Sweep eligibility, conditions 1, 2 and 4 (issue #601 §2.2/§2.4): only a
+    // `Reconcile`-triggered poll of a database that is not replaying and whose
+    // per-database interval clock has expired requests a slice. Condition 3
+    // (a quiet, cheap fast path) is decided inside the scan, where this poll's
+    // ledger exists — same split as the Cursor adapter.
+    let sweep_requested = work.trigger == crate::WorkTrigger::Reconcile
+        && !replacement_replay
+        && poll_state.sweep_slice_due(
+            &cp_key,
+            source_generation,
+            std::time::Duration::from_secs(config.ingest.sqlite.sweep_slice_min_interval_seconds),
+        );
     // §2.5's `|| !failure_retry_due` disjunct is absent and **must stay absent
     // while the contention clock lives in `failure_retry_due`** — WI-04 must
     // not add it. It is no longer outcome-redundant with `should_skip_poll`'s
@@ -330,18 +467,50 @@ pub(crate) async fn process_nac_sqlite_db(
     // (a quiet store's stat never moves again). Terminates because resumed
     // scans read never-read sessions first, so the debt strictly shrinks
     // (`a_degraded_nac_cold_ingest_completes_without_new_writes`).
+    //
+    // The sweep-debt conjunct: a durably covered stat proves nothing changed
+    // since the last *persisting* scan, but that scan's fast path may have
+    // carried sessions unverified — an `updated_at`-silent mutation in the
+    // same write burst as an emitting change, or a cycle still mid-keyspace.
+    // A due reconcile poll therefore proceeds while the cycle is in progress
+    // (`cursor` non-empty) or a new cycle is owed (`sweep_baseline` trails
+    // the current stat: content changed after the last cycle started).
+    // Terminates: each due slice advances the cursor, the wrap empties it,
+    // the baseline catches up to the stat, and this conjunct then stands
+    // aside (`a_quiet_nac_store_finishes_its_sweep_cycle_and_then_goes_idle`
+    // bounds both sides).
+    // Width note (§7.2 F3): `!starts_replacement` and `!retry_blocked_replay`
+    // are equivalent mutants here — a replay's `scan_state` is
+    // `NacState::default()`, whose default stat fingerprint can never equal a
+    // real file's, so the stat conjunct already fails for them. They stay as
+    // documentation of intent, not as guarded width.
+    // `schema_fingerprint != 0` is not equivalent and is pinned by
+    // `a_legacy_cursor_without_a_schema_fingerprint_is_rescanned_once`.
     if !starts_replacement
         && !retry_blocked_replay
         && scan_state.stat == current_stat
         && scan_state.schema_fingerprint != 0
         && scan_state.last_error.is_empty()
         && !scan_state.pending_coverage
+        && (!sweep_requested
+            || (scan_state.sweep.cursor.is_empty() && scan_state.sweep_baseline == current_stat))
     {
         return Ok(());
     }
     if !replacement_replay && poll_state.should_skip_poll(&cp_key, source_generation, &current_stat)
     {
-        return Ok(());
+        // A due sweep may override a *stat-covered or noop-throttled* skip —
+        // that cover is volatile bookkeeping over the fast path, and the fast
+        // path is exactly what an `updated_at`-silent mutation evades (§0): a
+        // mutation noop-covered by a watcher poll would otherwise never be
+        // swept on a store that then goes quiet. It must never override a
+        // failure or contention backoff, which is what `failure_retry_due`
+        // preserves (`a_due_sweep_does_not_override_a_failure_backoff`; the
+        // override's lower bound is G5c, whose watcher poll noop-covers the
+        // mutation first).
+        if !(sweep_requested && poll_state.failure_retry_due(&cp_key, source_generation)) {
+            return Ok(());
+        }
     }
 
     let scan_path = source_file.clone();
@@ -357,6 +526,7 @@ pub(crate) async fn process_nac_sqlite_db(
     } else {
         ScanBudget::fast_path(&config.ingest.sqlite)
     };
+    let sweep_plan = sweep_requested.then(|| SweepPlan::from_config(config));
     let (mut outcome, ledger) = tokio::task::spawn_blocking(move || {
         let mut ledger = ScanLedger::default();
         let outcome = scan_nac_database(
@@ -367,6 +537,7 @@ pub(crate) async fn process_nac_sqlite_db(
             current_stat,
             &prior_scan_state,
             &budget,
+            sweep_plan.as_ref(),
             MAX_NAC_CHECKPOINT_BYTES,
             &mut ledger,
         );
@@ -376,19 +547,29 @@ pub(crate) async fn process_nac_sqlite_db(
     .context("nac_sqlite scan task panicked")?;
     record_scan_ledger(metrics, &ledger);
 
-    let oversized_row = match &mut outcome {
+    // Normalize once (§3.2's double-normalize cleanup): the oversized
+    // pre-check used to normalize every record and throw the result away, and
+    // the emit loop then normalized everything again. One pass now feeds both;
+    // its peak memory is the poll's normalized output, which the fast-path
+    // budget bounds on ordinary polls (a replacement replay already holds the
+    // full store in `records`, so the replay's peak moves by a constant
+    // factor, not a class).
+    let (prepared, oversized_row) = match &mut outcome {
         NacScanOutcome::Scanned { records, .. } => {
             link_tool_responses(records, &source_file, source_generation);
-            records.iter().find_map(|synthetic| {
+            let mut prepared = Vec::with_capacity(records.len());
+            let mut oversized = None;
+            for synthetic in records.iter() {
                 if crate::dispatch::record_project_dir_is_excluded(
                     config,
                     &work.harness,
                     &synthetic.record,
                     &synthetic.project_dir,
                 ) {
-                    return None;
+                    prepared.push(NacPreparedRecord::Excluded);
+                    continue;
                 }
-                normalize_record(
+                match normalize_record(
                     &synthetic.record,
                     &work.source_name,
                     &work.harness,
@@ -400,17 +581,24 @@ pub(crate) async fn process_nac_sqlite_db(
                     "",
                     "",
                     "",
-                )
-                .ok()
-                .and_then(|normalized| {
-                    crate::dispatch::largest_serialized_normalized_row(&normalized)
-                })
-                .filter(|row_size| {
-                    row_size.bytes > crate::dispatch::CLICKHOUSE_JSON_OBJECT_BYTE_LIMIT
-                })
-            })
+                ) {
+                    Ok(normalized) => {
+                        if oversized.is_none() {
+                            oversized =
+                                crate::dispatch::largest_serialized_normalized_row(&normalized)
+                                    .filter(|row_size| {
+                                        row_size.bytes
+                                            > crate::dispatch::CLICKHOUSE_JSON_OBJECT_BYTE_LIMIT
+                                    });
+                        }
+                        prepared.push(NacPreparedRecord::Normalized(Box::new(normalized)));
+                    }
+                    Err(exc) => prepared.push(NacPreparedRecord::Error(exc.to_string())),
+                }
+            }
+            (prepared, oversized)
         }
-        NacScanOutcome::Failed { .. } => None,
+        NacScanOutcome::Failed { .. } => (Vec::new(), None),
     };
     if let Some(row_size) = oversized_row {
         outcome = NacScanOutcome::Failed {
@@ -431,9 +619,10 @@ pub(crate) async fn process_nac_sqlite_db(
             schema_fingerprint,
             relevant_rows,
             row_errors,
+            swept,
         } => {
             new_state.project_exclusions_hash = current_exclusions_hash;
-            let cursor_json = new_state.serialize()?;
+            let cursor_json = (*new_state).serialize()?;
             let prior_state_covered = {
                 let mut prior = scan_state.clone();
                 prior.stat = current_stat;
@@ -445,7 +634,7 @@ pub(crate) async fn process_nac_sqlite_db(
                 && !retry_blocked_replay
                 && records.is_empty()
                 && checkpoint.status == "active"
-                && new_state == prior_state_covered
+                && *new_state == prior_state_covered
                 && schema_fingerprint == checkpoint.schema_fingerprint;
             if scan_is_noop {
                 poll_state.record_noop_scan(&cp_key, source_generation, current_stat);
@@ -481,41 +670,22 @@ pub(crate) async fn process_nac_sqlite_db(
                 }));
             }
             let mut replay_block_reason = None::<String>;
-            for synthetic in &records {
-                if crate::dispatch::record_project_dir_is_excluded(
-                    config,
-                    &work.harness,
-                    &synthetic.record,
-                    &synthetic.project_dir,
-                ) {
-                    continue;
-                }
-                let raw_json =
-                    serde_json::to_string(&synthetic.record).unwrap_or_else(|_| "{}".to_string());
-                match normalize_record(
-                    &synthetic.record,
-                    &work.source_name,
-                    &work.harness,
-                    &source_file,
-                    inode,
-                    source_generation,
-                    synthetic.source_line_no,
-                    synthetic.source_offset,
-                    "",
-                    "",
-                    "",
-                ) {
-                    Ok(normalized) => {
-                        batch.extend_normalized(normalized);
+            for (synthetic, prepared) in records.iter().zip(prepared) {
+                match prepared {
+                    NacPreparedRecord::Excluded => continue,
+                    NacPreparedRecord::Normalized(normalized) => {
+                        batch.extend_normalized(*normalized);
                         batch.lines_processed = batch.lines_processed.saturating_add(1);
                     }
-                    Err(exc) => {
+                    NacPreparedRecord::Error(error_text) => {
                         if replacement_replay && replay_block_reason.is_none() {
                             replay_block_reason = Some(format!(
-                                "nac_sqlite row {} failed normalization: {exc}",
+                                "nac_sqlite row {} failed normalization: {error_text}",
                                 synthetic.source_line_no
                             ));
                         }
+                        let raw_json = serde_json::to_string(&synthetic.record)
+                            .unwrap_or_else(|_| "{}".to_string());
                         batch.push_error_row(json!({
                             "source_name": work.source_name,
                             "harness": work.harness,
@@ -525,7 +695,7 @@ pub(crate) async fn process_nac_sqlite_db(
                             "source_line_no": synthetic.source_line_no,
                             "source_offset": synthetic.source_offset,
                             "error_kind": "normalize_error",
-                            "error_text": exc.to_string(),
+                            "error_text": error_text,
                             "raw_fragment": truncate_chars_local(&raw_json, 20_000),
                         }));
                     }
@@ -598,6 +768,22 @@ pub(crate) async fn process_nac_sqlite_db(
                 .await?;
             }
             poll_state.clear(&cp_key);
+            if swept {
+                // Commit the slice only now — after its checkpoint persisted
+                // and after `clear` wiped the entry — so the interval clock
+                // survives the wipe and a slice whose scan failed or lost the
+                // mixed-snapshot bracket is neither counted nor throttling
+                // the retry. Same ordering as the Cursor adapter.
+                poll_state.record_sweep_slice(&cp_key, source_generation);
+                record_sweep_slice_committed(metrics);
+                debug!(
+                    "{}:{} nac_sqlite sweep slice committed (cursor {:?}, cycles {})",
+                    work.source_name,
+                    source_file,
+                    new_state.sweep.cursor,
+                    new_state.sweep.completed_cycles,
+                );
+            }
             if emitted > 0 {
                 debug!(
                     "{}:{} nac_sqlite emitted {} changed records ({} relevant rows, \
@@ -691,6 +877,7 @@ fn scan_nac_database(
     pre_scan_stat: StatFingerprint,
     prior: &NacState,
     budget: &ScanBudget,
+    sweep: Option<&SweepPlan>,
     checkpoint_ceiling_bytes: usize,
     ledger: &mut ScanLedger,
 ) -> NacScanOutcome {
@@ -752,9 +939,10 @@ fn scan_nac_database(
         &schema,
         prior,
         budget,
+        sweep,
         ledger,
     );
-    let (records, mut state, relevant_rows, row_errors) = match result {
+    let scan = match result {
         Ok(value) => value,
         Err(NacScanError::Scan(exc)) => {
             return NacScanOutcome::Failed {
@@ -763,6 +951,13 @@ fn scan_nac_database(
             }
         }
     };
+    let NacRowsScan {
+        records,
+        mut state,
+        relevant_rows,
+        row_errors,
+        swept,
+    } = scan;
     let data_version_after = match sqlite_data_version(&connection) {
         Ok(value) => value,
         Err(exc) => {
@@ -788,6 +983,16 @@ fn scan_nac_database(
     state.stat = pre_scan_stat;
     state.schema_fingerprint = schema.fingerprint;
     state.last_error.clear();
+    // A slice that started a fresh cycle stamps the content state that cycle
+    // is walking; writes that land during the cycle move the stat past the
+    // baseline, so the wrap leaves a follow-up cycle owed — self-correcting.
+    // The cycle-start conjunct is load-bearing: a mid-cycle re-stamp would
+    // advance the baseline past a silent write behind the sweep cursor and
+    // erase that owed cycle
+    // (`a_silent_write_behind_the_sweep_cursor_owes_a_follow_up_cycle`).
+    if swept && prior.sweep.cursor.is_empty() {
+        state.sweep_baseline = pre_scan_stat;
+    }
     // The checkpoint-state ceiling degrades by evicting the oldest session
     // cursors (issue #601 §2.3); it never fails the scan. Evicted sessions are
     // re-emitted by a later poll — safe under §6's content-addressed identity.
@@ -800,10 +1005,11 @@ fn scan_nac_database(
     }
     NacScanOutcome::Scanned {
         records,
-        state,
+        state: Box::new(state),
         schema_fingerprint: schema.fingerprint,
         relevant_rows,
         row_errors,
+        swept,
     }
 }
 
@@ -859,6 +1065,60 @@ struct NacRowError {
     error_text: String,
 }
 
+/// One record's single normalization outcome (§3.2's double-normalize
+/// cleanup), shared by the oversized pre-check and the emit loop. Boxed so the
+/// vector's spine stays lean.
+enum NacPreparedRecord {
+    Excluded,
+    Normalized(Box<crate::model::NormalizedRecord>),
+    Error(String),
+}
+
+/// The §3.2 episode-rewind preflight: `max(episodes.id)` behind the committed
+/// watermark means episode rows vanished — which splits two ways on the id
+/// ceiling below. `episodes.id` is `AUTOINCREMENT`, so while `sqlite_sequence`
+/// still covers the watermark, ids never recycle: nothing can ever be written
+/// at the vanished coordinates, the disappearance is a **deletion**, and
+/// deletion is archival — the scan emits nothing and the watermark stands
+/// (the e2e's "nac deleted remote metadata remains archived"). Only a ceiling
+/// *behind* the watermark — a recreated table, a reset sequence, a schema
+/// without `AUTOINCREMENT` — makes those coordinates re-allocatable, and that
+/// is the true rewind that must route through #602's generation replacement.
+/// Fixed-width scalar aggregates: charged on neither ledger axis (see the
+/// `ScanLedger` rules), which is why no ledger threads through here.
+fn nac_episodes_rewound(db_path: &str, episode_high_water: i64) -> Result<bool> {
+    let connection = open_read_only(db_path)?;
+    let max_episode_id: i64 =
+        connection.query_row("SELECT coalesce(max(id), 0) FROM episodes", [], |row| {
+            row.get(0)
+        })?;
+    if max_episode_id >= episode_high_water {
+        return Ok(false);
+    }
+    Ok(nac_episode_id_ceiling(&connection)? < episode_high_water)
+}
+
+/// The largest `episodes.id` SQLite has ever allocated: `sqlite_sequence.seq`
+/// for the `AUTOINCREMENT` table. Returns 0 when the sequence row — or the
+/// whole `sqlite_sequence` table — is absent: absent means ids are reusable,
+/// so no vanished tail is ever provably a deletion and the rewind arm stays
+/// fail-closed (`the_episode_id_ceiling_is_zero_without_autoincrement`).
+fn nac_episode_id_ceiling(connection: &Connection) -> rusqlite::Result<i64> {
+    let sequence_table_exists: bool = connection.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_sequence')",
+        [],
+        |row| row.get(0),
+    )?;
+    if !sequence_table_exists {
+        return Ok(0);
+    }
+    connection.query_row(
+        "SELECT coalesce((SELECT seq FROM sqlite_sequence WHERE name = 'episodes'), 0)",
+        [],
+        |row| row.get(0),
+    )
+}
+
 #[derive(Debug)]
 enum NacScanError {
     Scan(anyhow::Error),
@@ -876,6 +1136,15 @@ impl From<rusqlite::Error> for NacScanError {
     }
 }
 
+/// What one `scan_nac_rows` call produced.
+struct NacRowsScan {
+    records: Vec<SyntheticRecord>,
+    state: NacState,
+    relevant_rows: u64,
+    row_errors: Vec<NacRowError>,
+    swept: bool,
+}
+
 #[allow(clippy::too_many_arguments)]
 fn scan_nac_rows(
     connection: &Connection,
@@ -885,8 +1154,9 @@ fn scan_nac_rows(
     schema: &NacSchema,
     prior: &NacState,
     budget: &ScanBudget,
+    sweep: Option<&SweepPlan>,
     ledger: &mut ScanLedger,
-) -> std::result::Result<(Vec<SyntheticRecord>, NacState, u64, Vec<NacRowError>), NacScanError> {
+) -> std::result::Result<NacRowsScan, NacScanError> {
     let canonical_db = std::fs::canonicalize(db_path)
         .unwrap_or_else(|_| std::path::PathBuf::from(db_path))
         .to_string_lossy()
@@ -899,6 +1169,12 @@ fn scan_nac_rows(
         episode_high_water: prior.episode_high_water,
         worker_threads: prior.worker_threads.clone(),
         project_exclusions_hash: prior.project_exclusions_hash,
+        updated_at_high_water: prior.updated_at_high_water.clone(),
+        updated_at_high_water_session: prior.updated_at_high_water_session.clone(),
+        // Fast-path activity never resets the sweep cursor (§2.2); a slice
+        // below overwrites this from the driver's report when one runs.
+        sweep: prior.sweep.clone(),
+        sweep_baseline: prior.sweep_baseline,
         ..NacState::default()
     };
     let mut contexts = BTreeMap::<String, NacSessionRow>::new();
@@ -934,26 +1210,62 @@ fn scan_nac_rows(
     let census_ids: BTreeSet<String> = census.iter().map(|(id, _)| id.clone()).collect();
     let relevant_sessions = census.len() as u64;
 
-    // Candidate read: never-read sessions first, then newest-first by
-    // `updated_at` within each class (§2.3): a heuristic ordering — the
-    // schema has no trigger guaranteeing it (§1.3) — so it chooses priority
-    // only. Never-read-first is what makes a budget-degraded ingest converge
-    // (see the Cursor twin in `scan_database`): a plain recency order
-    // re-reads the same newest sessions on every poll and a store larger
-    // than one budget keeps its cold tail forever. The tie-break on
-    // session_id keeps the order deterministic.
-    let mut candidates = census;
+    // The §3.2 keyset fast path. Each census row is classified against the
+    // `(updated_at, session_id)` watermark:
+    //
+    // - **never read** (absent from the prior cursor set) → candidate, first
+    //   class — cold debt, newest-first within the class (D6). This disjunct
+    //   is what admits a new session whose `updated_at` sits at or below the
+    //   watermark (clock skew, an imported store) — nothing else does
+    //   (`a_new_session_backdated_below_the_watermark_is_read_first_class`);
+    // - **incomparable** (format guard: malformed, or a different separator
+    //   from the watermark) → candidate — the fast path never *skips* on a
+    //   value it cannot order (fail open);
+    // - **after the watermark** in strict keyset order → candidate — the
+    //   changed tail, read in ascending `(updated_at, session_id)` order
+    //   because the watermark is a durable resume position (D8a's rule);
+    // - otherwise → carried: the prior cursor rides forward unread. The skip
+    //   is justified by the sweep's coverage guarantee (§0), never by
+    //   `updated_at` itself.
+    let watermark_active = !prior.updated_at_high_water.is_empty();
+    let mut candidates = Vec::new();
+    for (session_id, updated_at) in &census {
+        let known = prior.sessions.contains_key(session_id);
+        let candidate = !known
+            || !watermark_active
+            || !nac_updated_at_comparable(updated_at, &prior.updated_at_high_water)
+            || nac_keyset_after(
+                updated_at,
+                session_id,
+                &prior.updated_at_high_water,
+                &prior.updated_at_high_water_session,
+            );
+        if candidate {
+            candidates.push((session_id.clone(), updated_at.clone(), known));
+        } else if let Some(cursor) = prior.sessions.get(session_id) {
+            next_state
+                .sessions
+                .insert(session_id.clone(), cursor.clone());
+        }
+    }
+    // Never-read sessions first, newest-first within that class (§2.3, D6:
+    // never-read-first is what makes a budget-degraded cold ingest converge,
+    // and a genuinely new session has no prior cursor so it is in this class
+    // already). The known tail follows in ascending keyset order so the
+    // watermark below resumes exactly where a bound poll stopped.
     candidates.sort_by(|a, b| {
-        let known_a = prior.sessions.contains_key(&a.0);
-        let known_b = prior.sessions.contains_key(&b.0);
-        known_a
-            .cmp(&known_b)
-            .then_with(|| b.1.cmp(&a.1))
-            .then_with(|| a.0.cmp(&b.0))
+        a.2.cmp(&b.2).then_with(|| {
+            if a.2 {
+                a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0))
+            } else {
+                b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0))
+            }
+        })
     });
     let mut point_read = connection.prepare_cached(&format!(
         "SELECT {projection} FROM sessions WHERE session_id = ?1"
     ))?;
+    let mut fast_path_bound = false;
     for idx in 0..candidates.len() {
         let over_budget = budget.is_exhausted_by(ledger.payload_rows, ledger.payload_bytes);
         let over_records = records.len() >= MAX_NAC_SYNTHETIC_RECORDS;
@@ -961,9 +1273,13 @@ fn scan_nac_rows(
             // Commit what was read (§2.1/§2.3): every skipped session keeps
             // its prior cursor — "unread this poll", never "deleted" — and a
             // skipped new session stays absent so a later poll detects it.
+            // The watermark did not advance past any skipped tail candidate
+            // (the tail is read in ascending keyset order), so the skip is
+            // held open by `pending_coverage` below.
             let remaining = &candidates[idx..];
             ledger.mark_degraded(remaining.len() as u64, 0);
-            for (session_id, _) in remaining {
+            fast_path_bound = true;
+            for (session_id, _, _) in remaining {
                 if let Some(cursor) = prior.sessions.get(session_id) {
                     next_state
                         .sessions
@@ -982,7 +1298,9 @@ fn scan_nac_rows(
             };
             match read_session_row(row, &schema.session_columns, ledger)? {
                 NacSessionRead::Row(session) => *session,
-                NacSessionRead::Oversized { estimated_bytes } => {
+                NacSessionRead::Oversized {
+                    estimated_bytes, ..
+                } => {
                     // An un-processable single row (§2.3): report it once,
                     // mark it in the cursor so the report does not repeat
                     // every poll, and keep scanning. A shrunk row hashes
@@ -1003,6 +1321,15 @@ fn scan_nac_rows(
                         });
                     }
                     next_state.sessions.insert(session_id.clone(), marker);
+                    // The row was fully processed for this poll's purposes, so
+                    // the tail watermark advances past it like any other item.
+                    if candidates[idx].2 {
+                        advance_updated_at_watermark(
+                            &mut next_state,
+                            &candidates[idx].1,
+                            &candidates[idx].0,
+                        );
+                    }
                     continue;
                 }
             }
@@ -1022,6 +1349,15 @@ fn scan_nac_rows(
             .sessions
             .insert(session.raw_session_id.clone(), cursor);
         contexts.insert(session.raw_session_id.clone(), session);
+        // Per-item resume advance, tail (known) candidates only: the tail is
+        // read in ascending keyset order, so committing the watermark at the
+        // last fully processed position is what lets a budget-bound poll
+        // resume instead of re-reading the same prefix forever. Never from
+        // the never-read class — it is processed out of keyset order, and an
+        // advance from there could leap past unread tail candidates.
+        if candidates[idx].2 {
+            advance_updated_at_watermark(&mut next_state, &candidates[idx].1, &candidates[idx].0);
+        }
     }
     drop(point_read);
 
@@ -1039,12 +1375,41 @@ fn scan_nac_rows(
         connection.query_row("SELECT coalesce(max(id), 0) FROM episodes", [], |row| {
             row.get(0)
         })?;
-    let scan_from = if max_episode_id < prior.episode_high_water {
-        next_state.worker_threads.clear();
-        0
-    } else {
-        prior.episode_high_water
-    };
+    if max_episode_id < prior.episode_high_water {
+        // §3.2: a vanished episode tail splits on the AUTOINCREMENT id
+        // ceiling, exactly as at the preflight (`nac_episodes_rewound`).
+        // While `sqlite_sequence` still covers the watermark, ids never
+        // recycle: the vanished coordinates can never be rewritten, so this
+        // is a **deletion** — archival, not a rewind. The watermark stands
+        // (new episodes are allocated above the ceiling, so `id > watermark`
+        // still admits every future insert), the loop below reads nothing
+        // behind it, and the archived rows stay untouched — deletion emits
+        // nothing (`a_session_deleted_from_the_store_emits_nothing_new`,
+        // e2e "nac deleted remote metadata remains archived"). It skips no
+        // live work: an insert after the deletion sits above the watermark
+        // and is read normally
+        // (`a_new_session_beside_a_deletion_still_emits`).
+        //
+        // A ceiling behind the watermark means those ids are re-allocatable
+        // — a true rewind (truncation of history) that must route through
+        // #602's generation replacement (G8c), which the preflight in
+        // `process_nac_sqlite_db` detects and starts. Reaching this arm with
+        // a rewound ceiling means the rewind landed *between* that preflight
+        // and this scan; failing the scan leaves the committed stat stale,
+        // so the next poll's preflight sees it and replaces properly. The
+        // old in-place `worker_threads.clear()` reset re-emitted worker
+        // history into the live generation with no barrier — exactly what
+        // #602 forbids — and never reset `sessions` at all.
+        if nac_episode_id_ceiling(connection)? < prior.episode_high_water {
+            return Err(NacScanError::Scan(anyhow::anyhow!(
+                "NAC episode history rewound mid-poll (max id {max_episode_id} and id ceiling \
+                 behind watermark {}); failing this scan so the next poll routes the rewind \
+                 through a generation replacement",
+                prior.episode_high_water
+            )));
+        }
+    }
+    let scan_from = prior.episode_high_water;
     let mut last_episode_id = scan_from;
     let mut episodes_processed = 0u64;
     let episode_bytes = "length(CAST(COALESCE(thread_name, '') AS BLOB)) + \
@@ -1052,19 +1417,14 @@ fn scan_nac_rows(
         length(CAST(COALESCE(action, '') AS BLOB)) + \
         length(CAST(COALESCE(content, '') AS BLOB)) + \
         length(CAST(COALESCE(created_at, '') AS BLOB))";
-    let guarded_episode = |name: &str| {
-        format!(
-            "CASE WHEN ({episode_bytes}) <= {SCAN_PAGE_MAX_BYTES} THEN {name} ELSE NULL END AS {name}"
-        )
-    };
+    // Plain columns plus one `estimated_bytes` expression — the same
+    // projection cleanup as `session_projection`: the loop below reads the
+    // size before taking any column, so an oversized row's payload is never
+    // handed to Rust.
     let episode_sql = format!(
-        "SELECT id, {}, {}, {}, {}, {}, ({episode_bytes}) AS estimated_bytes \
-         FROM episodes WHERE id > ?1 ORDER BY id LIMIT ?2",
-        guarded_episode("thread_name"),
-        guarded_episode("session_id"),
-        guarded_episode("action"),
-        guarded_episode("content"),
-        guarded_episode("created_at")
+        "SELECT id, thread_name, session_id, action, content, created_at, \
+         ({episode_bytes}) AS estimated_bytes \
+         FROM episodes WHERE id > ?1 ORDER BY id LIMIT ?2"
     );
     'episodes: loop {
         let mut stmt = connection.prepare_cached(&episode_sql)?;
@@ -1102,8 +1462,9 @@ fn scan_nac_rows(
             // decoded every column to evaluate `estimated_bytes`, so a skip
             // arm reporting zero rows would contradict the ledger's headline
             // guarantee. Bytes are still not charged from `estimated_bytes` —
-            // the guarded projection hands Rust NULL for an oversized row, and
-            // the ledger reports what was materialized.
+            // the size is read before any payload column is taken, so an
+            // oversized row hands Rust nothing beyond its id, and the ledger
+            // reports what was materialized.
             let id: i64 = row.get(0)?;
             ledger.charge_payload_row();
             page_rows += 1;
@@ -1218,21 +1579,205 @@ fn scan_nac_rows(
         }
     }
 
+    // Optional sweep slice (§2.2). Conditions 1 (reconcile trigger), 2
+    // (interval clock) and 4 (not replaying) were decided by the caller —
+    // `sweep` exists only when they held. Condition 3 is decided here, where
+    // the fast path's cost is known, with D7's waiver: a degraded poll is
+    // sweep-eligible despite its budget consumption, an emitting poll defers
+    // its slice to the next quiet reconcile tick. The slice runs inside the
+    // data_version bracket, so a mixed snapshot discards its advance with the
+    // rest of the scan. The slice is the mechanism behind G5c: it re-reads
+    // sessions in `session_id` order and re-emits any whose content disagrees
+    // with the carried cursor — the mutation `updated_at` never announced.
+    let mut swept = false;
+    if let Some(sweep_plan) = sweep {
+        let eligible = records.is_empty()
+            && (ledger.coverage_degraded
+                || !budget.is_half_consumed_by(ledger.payload_rows, ledger.payload_bytes));
+        if eligible {
+            let mut slice = ScanLedger::default();
+            let driven = drive_sweep_slice(
+                &prior.sweep,
+                &sweep_plan.budget,
+                sweep_plan.max_millis,
+                sweep_plan.now_unix_ms,
+                &mut slice,
+                |after, slice| {
+                    next_nac_sweep_item(
+                        connection,
+                        after,
+                        &namespace,
+                        &projection,
+                        &schema.session_columns,
+                        &mut next_state.sessions,
+                        &mut records,
+                        &mut row_errors,
+                        slice,
+                    )
+                },
+            );
+            // The slice's reads are paid whether or not it completed; fold
+            // them before inspecting the outcome so a failure arm still
+            // reports them.
+            ledger.absorb_sweep_slice(&slice);
+            let report = driven?;
+            next_state.sweep = report.state;
+            swept = true;
+        }
+    }
+
+    // Full fast-path coverage advances the watermark to the census maximum —
+    // over well-formed values sharing the maximum's separator only, so a
+    // mixed-format store keeps its minority-format rows as perpetual
+    // candidates rather than silently ordering across formats. A bound poll
+    // never jumps: its watermark stays at the last processed tail position.
+    if !fast_path_bound {
+        // The lexicographic maximum among well-formed values is by definition
+        // the maximum of its own comparability class (every same-separator
+        // value sorts at or below it), so it is the highest position the
+        // watermark can honestly claim.
+        let jump = census
+            .iter()
+            .filter(|(_, updated_at)| nac_timestamp_shape(updated_at).is_some())
+            .max_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+        if let Some((session_id, updated_at)) = jump {
+            next_state.updated_at_high_water = updated_at.clone();
+            next_state.updated_at_high_water_session = session_id.clone();
+        }
+    }
+
     // §2.3's persisted resume marker: a censused session absent from the
-    // carried cursor set has never been read in this generation, and an
-    // episode watermark short of `max(episodes.id)` is an unread episode
-    // tail. Either keeps the cheap stat short-circuit open (see the conjunct
-    // in `process_nac_sqlite_db`) until a scan covers everything.
+    // carried cursor set has never been read in this generation, a fast-path
+    // candidate was budget-skipped (`fast_path_bound` — the tail watermark
+    // stopped short), and an episode watermark short of `max(episodes.id)` is
+    // an unread episode tail. Any of the three keeps the cheap stat
+    // short-circuit open (see the conjunct in `process_nac_sqlite_db`) until
+    // a scan covers everything.
     next_state.pending_coverage = next_state.episode_high_water < max_episode_id
+        || fast_path_bound
         || census_ids
             .iter()
             .any(|id| !next_state.sessions.contains_key(id));
 
     ledger.rows_emitted = records.len() as u64;
     let relevant_rows = relevant_sessions.saturating_add(episodes_processed);
-    Ok((records, next_state, relevant_rows, row_errors))
+    Ok(NacRowsScan {
+        records,
+        state: next_state,
+        relevant_rows,
+        row_errors,
+        swept,
+    })
 }
 
+/// Advance the fast-path watermark to `(updated_at, session_id)` if that is a
+/// well-formed position strictly after (or seeding) the current one. Called
+/// only for fully processed tail candidates, in their ascending keyset order.
+fn advance_updated_at_watermark(state: &mut NacState, updated_at: &str, session_id: &str) {
+    if nac_timestamp_shape(updated_at).is_none() {
+        return;
+    }
+    if state.updated_at_high_water.is_empty() {
+        state.updated_at_high_water = updated_at.to_string();
+        state.updated_at_high_water_session = session_id.to_string();
+        return;
+    }
+    if nac_updated_at_comparable(updated_at, &state.updated_at_high_water)
+        && nac_keyset_after(
+            updated_at,
+            session_id,
+            &state.updated_at_high_water,
+            &state.updated_at_high_water_session,
+        )
+    {
+        state.updated_at_high_water = updated_at.to_string();
+        state.updated_at_high_water_session = session_id.to_string();
+    }
+}
+
+/// The NAC sweep reader (§2.2): the first session strictly after `after` in
+/// `session_id` order, read in full, re-synthesized against the carried
+/// cursor, and re-emitted where it disagrees — which is exactly how a
+/// mutation that never bumped `updated_at` is detected (G5c). Oversized rows
+/// take the same §2.3 marker path as the fast path.
+#[allow(clippy::too_many_arguments)]
+fn next_nac_sweep_item(
+    connection: &Connection,
+    after: &str,
+    namespace: &str,
+    projection: &str,
+    session_columns: &BTreeSet<String>,
+    sessions: &mut BTreeMap<String, NacSessionCursor>,
+    records: &mut Vec<SyntheticRecord>,
+    row_errors: &mut Vec<NacRowError>,
+    slice: &mut ScanLedger,
+) -> std::result::Result<Option<SweepItem>, NacScanError> {
+    let mut stmt = connection.prepare_cached(&format!(
+        "SELECT {projection} FROM sessions WHERE session_id > ?1 ORDER BY session_id LIMIT 1"
+    ))?;
+    let mut rows = stmt.query(params![after])?;
+    let Some(row) = rows.next()? else {
+        return Ok(None);
+    };
+    let bytes_before = slice.payload_bytes;
+    match read_session_row(row, session_columns, slice)? {
+        NacSessionRead::Row(session) => {
+            let position = session.raw_session_id.clone();
+            let normalized_session_id = format!("{namespace}:{position}");
+            let (mut session_records, cursor, parts_truncated) = synthesize_session(
+                &session,
+                &normalized_session_id,
+                sessions.get(&position),
+                MAX_NAC_SYNTHETIC_RECORDS.saturating_sub(records.len()),
+            )?;
+            if parts_truncated {
+                slice.mark_degraded(0, 0);
+            }
+            records.append(&mut session_records);
+            sessions.insert(position.clone(), cursor);
+            Ok(Some(SweepItem {
+                position,
+                payload_bytes: slice.payload_bytes.saturating_sub(bytes_before),
+            }))
+        }
+        NacSessionRead::Oversized {
+            session_id,
+            estimated_bytes,
+        } => {
+            let marker = NacSessionCursor {
+                metadata_hash: format!("{OVERSIZED_SESSION_MARKER}:{estimated_bytes}"),
+                created_at: String::new(),
+                part_hashes: BTreeMap::new(),
+            };
+            if sessions.get(&session_id) != Some(&marker) {
+                row_errors.push(NacRowError {
+                    source_line_no: 0,
+                    error_kind: ERROR_KIND_ROW_TOO_LARGE,
+                    error_text: format!(
+                        "NAC session {session_id} is {estimated_bytes} bytes, exceeding \
+                         the {SCAN_PAGE_MAX_BYTES} byte row ceiling; row skipped"
+                    ),
+                });
+            }
+            sessions.insert(session_id.clone(), marker);
+            Ok(Some(SweepItem {
+                position: session_id,
+                payload_bytes: slice.payload_bytes.saturating_sub(bytes_before),
+            }))
+        }
+    }
+}
+
+/// The session projection: plain columns plus **one** `estimated_bytes`
+/// expression. The previous shape wrapped every column in a
+/// `CASE WHEN (<14-term length expression>) <= … THEN col ELSE NULL END`
+/// guard, inlining the same expression 16 times per row — measured 1.65×
+/// slower than a plain select, scaling with blob size (§3.2's projection
+/// cleanup). The oversize guard did not move, it just changed language:
+/// `read_session_row` reads `estimated_bytes` and `session_id` *first* and
+/// returns without touching any payload column when the row is oversized, so
+/// SQLite never hands an oversized payload to Rust — `sqlite3_column` decodes
+/// lazily, per column requested.
 fn session_projection(columns: &BTreeSet<String>) -> String {
     let mut byte_columns = vec![
         "session_id",
@@ -1262,41 +1807,34 @@ fn session_projection(columns: &BTreeSet<String>) -> String {
         .map(|name| format!("length(CAST(COALESCE({name}, '') AS BLOB))"))
         .collect::<Vec<_>>()
         .join(" + ");
-    let guarded = |expression: &str, alias: &str| {
-        format!(
-            "CASE WHEN ({estimated_bytes}) <= {SCAN_PAGE_MAX_BYTES} THEN {expression} ELSE NULL END AS {alias}"
-        )
-    };
-    let guarded_optional = |name: &str, fallback: &str| {
+    let optional = |name: &str, fallback: &str| {
         if columns.contains(name) {
-            guarded(name, name)
+            name.to_string()
         } else {
             format!("{fallback} AS {name}")
         }
     };
     let remote = if columns.contains("host_id") {
-        guarded(
-            "CASE WHEN length(CAST(COALESCE(host_id, '') AS BLOB)) > 0 THEN 1 ELSE 0 END",
-            "is_remote",
-        )
+        "CASE WHEN length(CAST(COALESCE(host_id, '') AS BLOB)) > 0 THEN 1 ELSE 0 END AS is_remote"
+            .to_string()
     } else {
         "NULL AS is_remote".to_string()
     };
     [
-        guarded("session_id", "session_id"),
-        guarded("cwd", "cwd"),
-        guarded("model", "model"),
-        guarded("base_url", "base_url"),
-        guarded_optional("backend", "''"),
-        guarded_optional("reasoning_effort", "''"),
-        guarded_optional("sandbox_json", "NULL"),
-        guarded("messages_json", "messages_json"),
-        guarded_optional("last_response_duration_ms", "NULL"),
-        guarded_optional("previous_response_duration_ms", "NULL"),
-        guarded_optional("response_durations_json", "NULL"),
-        guarded_optional("token_usages_json", "NULL"),
-        guarded("created_at", "created_at"),
-        guarded("updated_at", "updated_at"),
+        "session_id".to_string(),
+        "cwd".to_string(),
+        "model".to_string(),
+        "base_url".to_string(),
+        optional("backend", "''"),
+        optional("reasoning_effort", "''"),
+        optional("sandbox_json", "NULL"),
+        "messages_json".to_string(),
+        optional("last_response_duration_ms", "NULL"),
+        optional("previous_response_duration_ms", "NULL"),
+        optional("response_durations_json", "NULL"),
+        optional("token_usages_json", "NULL"),
+        "created_at".to_string(),
+        "updated_at".to_string(),
         remote,
         format!("({estimated_bytes}) AS estimated_bytes"),
     ]
@@ -1306,8 +1844,15 @@ fn session_projection(columns: &BTreeSet<String>) -> String {
 /// Reads one session row. The projection includes `messages_json`, so every
 /// variable-length column it materializes is charged on the payload axis —
 /// deliberately *not* from the projection's own `estimated_bytes` expression,
-/// which SQLite computes over the pre-guard column values and which therefore
-/// reports bytes that were never handed to Rust for an oversized row.
+/// which SQLite computes internally and which therefore reports bytes that
+/// were never handed to Rust for an oversized row.
+///
+/// `estimated_bytes` and `session_id` are read **first**: an oversized row
+/// returns before any payload column is requested, so SQLite never decodes
+/// its large columns for Rust — the oversize guard the old per-column `CASE`
+/// projection implemented in SQL, now implemented at the read site. The id is
+/// taken (and charged) even for oversized rows because both the fast path's
+/// cursor marker and the sweep's resume position need it.
 fn read_session_row(
     row: &rusqlite::Row<'_>,
     columns: &BTreeSet<String>,
@@ -1315,17 +1860,17 @@ fn read_session_row(
 ) -> std::result::Result<NacSessionRead, NacScanError> {
     ledger.charge_payload_row();
     let estimated_bytes = checked_row_bytes(row.get(15)?, "NAC session row", 0)?;
-    if estimated_bytes > SCAN_PAGE_MAX_BYTES {
-        // The guarded projection already NULLed every column, so nothing was
-        // materialized beyond the row itself; the caller skips-and-reports
-        // per §2.3 instead of failing the scan.
-        return Ok(NacSessionRead::Oversized { estimated_bytes });
-    }
     // NOT NULL in the live `sessions` schema; a NULL is schema drift and must
     // fail the scan. `session_id` and `created_at`/`updated_at` below feed
     // logical-ID and timestamp derivation directly (§6), so absorbing a NULL
     // here would mint records keyed on the empty string.
     let raw_session_id = take_payload_required_string(ledger, row, 0)?;
+    if estimated_bytes > SCAN_PAGE_MAX_BYTES {
+        return Ok(NacSessionRead::Oversized {
+            session_id: raw_session_id,
+            estimated_bytes,
+        });
+    }
     let cwd = take_payload_required_string(ledger, row, 1)?;
     let model = take_payload_required_string(ledger, row, 2)?;
     let base_url = sanitize_base_url(&take_payload_required_string(ledger, row, 3)?);
@@ -1394,7 +1939,10 @@ fn read_session_row(
 /// footprint.
 enum NacSessionRead {
     Row(Box<NacSessionRow>),
-    Oversized { estimated_bytes: usize },
+    Oversized {
+        session_id: String,
+        estimated_bytes: usize,
+    },
 }
 
 fn checked_row_bytes(
@@ -1919,11 +2467,20 @@ fn link_tool_responses(records: &mut [SyntheticRecord], source_file: &str, gener
 }
 
 fn normalize_nac_timestamp(raw: &str, nanos: bool) -> std::result::Result<String, NacScanError> {
+    // Both separators normalize (§3.2's format guard, the reading half): the
+    // guard's fail-open rule *reads* a row whose `updated_at` separator
+    // differs from the watermark's instead of ordering against it, and a
+    // normalizer that only accepted the space form would turn that fail-open
+    // read into a latched scan failure — fail open would fail closed.
+    let trimmed = raw.trim();
     let parsed = if nanos {
-        NaiveDateTime::parse_from_str(raw.trim(), "%Y-%m-%d %H:%M:%S%.f")
+        NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%d %H:%M:%S%.f")
+            .or_else(|_| NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%dT%H:%M:%S%.f"))
     } else {
-        NaiveDateTime::parse_from_str(raw.trim(), "%Y-%m-%d %H:%M:%S")
-            .or_else(|_| NaiveDateTime::parse_from_str(raw.trim(), "%Y-%m-%d %H:%M:%S%.f"))
+        NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%d %H:%M:%S")
+            .or_else(|_| NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%d %H:%M:%S%.f"))
+            .or_else(|_| NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%dT%H:%M:%S"))
+            .or_else(|_| NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%dT%H:%M:%S%.f"))
     }
     .map_err(|exc| {
         NacScanError::Scan(anyhow::anyhow!(
@@ -2407,6 +2964,18 @@ mod tests {
             normalize_nac_timestamp("2026-07-18 12:16:58", false).unwrap(),
             "2026-07-18T12:16:58.000000Z"
         );
+        // Both separators must normalize, or the format guard's fail-open
+        // read of a `'T'`-separated row latches the scan instead
+        // (`a_mixed_updated_at_format_is_read_not_skipped` covers the scan
+        // half; this pins the normalizer half).
+        assert_eq!(
+            normalize_nac_timestamp("2026-07-18T12:15:51.775682000", true).unwrap(),
+            "2026-07-18T12:15:51.775682Z"
+        );
+        assert_eq!(
+            normalize_nac_timestamp("2026-07-18T12:16:58", false).unwrap(),
+            "2026-07-18T12:16:58.000000Z"
+        );
     }
 
     #[test]
@@ -2433,15 +3002,28 @@ mod tests {
         assert!(!projection.contains("api_key_env"));
         assert!(!projection.contains("extra_headers_json"));
         assert!(!projection.contains("store_path"));
-        assert!(projection
-            .contains("THEN CASE WHEN length(CAST(COALESCE(host_id, '') AS BLOB)) > 0 THEN 1"));
+        assert!(
+            projection.contains("CASE WHEN length(CAST(COALESCE(host_id, '') AS BLOB)) > 0 THEN 1")
+        );
         assert!(!projection.split(',').any(|field| field.trim() == "host_id"));
         assert!(projection.contains("messages_json"));
-        assert!(!projection.contains("THEN '[]'"));
+        assert!(!projection.contains("'[]' AS messages_json"));
         assert!(projection.contains("response_durations_json"));
         assert!(!projection.contains("response_durations_ms_json"));
         assert!(projection.contains("AS estimated_bytes"));
-        assert!(projection.contains("THEN messages_json ELSE NULL END AS messages_json"));
+        // §3.2's projection cleanup: exactly one `estimated_bytes` expression
+        // per row — the old shape inlined the same 14-term length sum inside a
+        // per-column CASE guard, 16 times per row. The oversize guard moved to
+        // `read_session_row` (size and id first, payload columns never taken
+        // for an oversized row); it did not disappear.
+        assert_eq!(
+            projection
+                .matches("COALESCE(messages_json, '') AS BLOB")
+                .count(),
+            1,
+            "the byte-sizing expression must appear exactly once, not once per \
+             guarded column"
+        );
         assert!(projection.contains("COALESCE(last_response_duration_ms, '') AS BLOB"));
         assert!(projection.contains("COALESCE(previous_response_duration_ms, '') AS BLOB"));
         assert!(projection.contains("COALESCE(host_id, '') AS BLOB"));
@@ -2579,6 +3161,7 @@ mod tests {
             stat,
             &NacState::default(),
             &default_nac_budget(),
+            None,
             MAX_NAC_CHECKPOINT_BYTES,
             &mut ledger,
         );
@@ -2654,6 +3237,7 @@ mod tests {
             stat,
             prior,
             &default_nac_budget(),
+            None,
             MAX_NAC_CHECKPOINT_BYTES,
             &mut ledger,
         ) {
@@ -2662,11 +3246,48 @@ mod tests {
                 state,
                 relevant_rows,
                 ..
-            } => (records, state, relevant_rows, ledger),
+            } => (records, *state, relevant_rows, ledger),
             NacScanOutcome::Failed {
                 error_kind,
                 error_text,
             } => panic!("fixture scan failed: {error_kind}: {error_text}"),
+        }
+    }
+
+    /// `scan_fixture_with_ledger`, with a sweep slice requested — what a
+    /// reconcile-triggered poll with an expired interval clock runs.
+    fn scan_fixture_with_sweep(
+        path: &Path,
+        prior: &NacState,
+        sweep: &SweepPlan,
+    ) -> (Vec<SyntheticRecord>, NacState, u64, ScanLedger) {
+        let stat = stat_fingerprint(path.to_str().expect("UTF-8 fixture path"))
+            .expect("fixture stat fingerprint");
+        let metadata = std::fs::metadata(path).expect("fixture metadata");
+        let inode = source_inode_for_file(path.to_str().expect("UTF-8 fixture path"), &metadata);
+        let mut ledger = ScanLedger::default();
+        match scan_nac_database(
+            path.to_str().expect("UTF-8 fixture path"),
+            "nac-fixture",
+            1,
+            inode,
+            stat,
+            prior,
+            &default_nac_budget(),
+            Some(sweep),
+            MAX_NAC_CHECKPOINT_BYTES,
+            &mut ledger,
+        ) {
+            NacScanOutcome::Scanned {
+                records,
+                state,
+                relevant_rows,
+                ..
+            } => (records, *state, relevant_rows, ledger),
+            NacScanOutcome::Failed {
+                error_kind,
+                error_text,
+            } => panic!("sweep fixture scan failed: {error_kind}: {error_text}"),
         }
     }
 
@@ -2736,6 +3357,7 @@ mod tests {
             stat,
             &NacState::default(),
             &default_nac_budget(),
+            None,
             MAX_NAC_CHECKPOINT_BYTES,
             &mut ledger,
         );
@@ -2801,6 +3423,7 @@ mod tests {
             stat,
             &NacState::default(),
             &default_nac_budget(),
+            None,
             MAX_NAC_CHECKPOINT_BYTES,
             &mut ledger,
         );
@@ -2923,6 +3546,9 @@ mod tests {
             schema_census.census_bytes + census_key_bytes as u64
         );
 
+        // The warm fast path reads **nothing** on an unchanged store — the
+        // §3.2 point: every session sits at or before the keyset watermark,
+        // so no payload row is materialized at all.
         let (second_records, second_state, _, second) = scan_fixture_with_ledger(&path, &state);
         assert!(
             second_records.is_empty(),
@@ -2930,24 +3556,35 @@ mod tests {
         );
         assert_eq!(second.rows_emitted, 0);
         assert_eq!(
-            second.payload_rows, sessions as u64,
-            "every session is still re-read on an unchanged store; only episodes \
-             are spared, by the existing append-only `episode_high_water`"
+            second.payload_rows, 0,
+            "the keyset fast path must not re-read unchanged sessions"
         );
-        assert!(
-            second.payload_bytes >= messages_bytes as u64,
-            "a scan that emits nothing still pays for every session it read"
-        );
+        assert_eq!(second.payload_bytes, 0);
 
-        let (third_records, _, _, third) = scan_fixture_with_ledger(&path, &second_state);
-        assert!(third_records.is_empty());
+        // A sweep slice is now the read-without-emitting case (the read-site
+        // charging this test exists for): the slice re-reads every session in
+        // `session_id` order, finds every hash unchanged, and emits nothing —
+        // an emit-site ledger would report zero where real bytes were paid,
+        // and a slice hidden from the payload axes would evade every budget.
+        let (third_records, _, _, third) = scan_fixture_with_sweep(
+            &path,
+            &second_state,
+            &SweepPlan::from_config(&AppConfig::default()),
+        );
+        assert!(third_records.is_empty(), "nothing changed, nothing emits");
         assert_eq!(third.rows_emitted, 0);
         assert_eq!(
-            third.payload_bytes, second.payload_bytes,
-            "two consecutive scans that emit nothing must charge identical, \
-             non-zero bytes — an emit-site ledger reports zero for both"
+            third.payload_rows, sessions as u64,
+            "the slice re-read every session; an emit-site ledger reports zero"
         );
-        assert_eq!(third.payload_rows, second.payload_rows);
+        assert_eq!(
+            third.sweep_rows, sessions as u64,
+            "and those reads are attributed to the sweep axes through the fold"
+        );
+        assert!(
+            third.payload_bytes >= messages_bytes as u64,
+            "a scan that emits nothing still pays for every session it read"
+        );
 
         std::fs::remove_file(&path).ok();
         std::fs::remove_file(format!("{}-wal", path.display())).ok();
@@ -3059,6 +3696,7 @@ mod tests {
             stat,
             prior,
             budget,
+            None,
             checkpoint_ceiling_bytes,
             &mut ledger,
         ) {
@@ -3067,7 +3705,7 @@ mod tests {
                 state,
                 row_errors,
                 ..
-            } => (records, state, row_errors, ledger),
+            } => (records, *state, row_errors, ledger),
             NacScanOutcome::Failed {
                 error_kind,
                 error_text,
@@ -3577,6 +4215,1465 @@ mod tests {
         cleanup_fixture(&path);
     }
 
+    /// §0's both-ways guard, deletion side — the unit twin of the e2e's
+    /// "nac deleted remote metadata remains archived": a session present in
+    /// the committed cursor but absent from the store — deleted, its episodes
+    /// with it, so `max(episodes.id)` regressed below the watermark — is
+    /// **archival**. The poll emits nothing, raises no replacement barrier,
+    /// and keeps its generation; only the cursor forgets the session.
+    /// Deletion is not disappearance-rewind: the AUTOINCREMENT id ceiling
+    /// still covers the watermark, so the vanished coordinates can never be
+    /// rewritten. And it is not new work: the surviving, unchanged session is
+    /// not re-read, let alone re-emitted.
+    ///
+    /// **[DIVERGENT FIXTURE]** the deletion leaves `sqlite_sequence`
+    /// untouched — the only shape deleting rows from a real NAC store can
+    /// produce. The pre-fix code routed every max-id regression through
+    /// generation replacement, re-emitting the surviving store into a fresh
+    /// namespace: one extra `session_meta` per surviving session, which is
+    /// exactly the e2e's remote-metadata count going 2 → 3.
+    ///
+    /// Fails for: dropping the id-ceiling conjunct from the preflight (the
+    /// deletion replays and re-emits), dropping it from the scan-side arm
+    /// (the scan errors and the cursor never records the deletion), or
+    /// re-emitting carried sessions on a deletion poll.
+    #[tokio::test]
+    async fn a_session_deleted_from_the_store_emits_nothing_new() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-deletion-archival".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let config = AppConfig::default();
+
+        drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        let generation_before = checkpoints
+            .read()
+            .await
+            .get(&cp_key)
+            .expect("cold checkpoint")
+            .source_generation;
+
+        // The deletion: the session row and its episode go together, exactly
+        // as the store's ON DELETE CASCADE would do it. max(episodes.id)
+        // regresses 3 → 2; sqlite_sequence stays at 3.
+        {
+            let connection = Connection::open(&path).expect("open fixture for deletion");
+            connection
+                .execute(
+                    "DELETE FROM episodes WHERE session_id = 'session-remote'",
+                    [],
+                )
+                .expect("delete remote episodes");
+            connection
+                .execute(
+                    "DELETE FROM sessions WHERE session_id = 'session-remote'",
+                    [],
+                )
+                .expect("delete remote session");
+        }
+
+        let (batches, transitions) =
+            drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        assert!(
+            transitions.is_empty(),
+            "a deletion must raise no replacement barrier; got {transitions:?}"
+        );
+        let raw_rows: usize = batches.iter().map(|batch| batch.raw_rows.len()).sum();
+        assert_eq!(
+            raw_rows, 0,
+            "a deletion emits nothing new — the archived canonical rows are \
+             the record of the deleted session"
+        );
+        let map = checkpoints.read().await;
+        let checkpoint = map.get(&cp_key).expect("post-deletion checkpoint");
+        assert_eq!(
+            checkpoint.source_generation, generation_before,
+            "deletion is archival, never a generation replacement"
+        );
+        let state = NacState::parse(&checkpoint.cursor_json);
+        assert!(
+            !state.sessions.contains_key("session-remote"),
+            "the cursor forgets the deleted session durably"
+        );
+        assert!(
+            state.sessions.contains_key("session-local"),
+            "the surviving session's cursor rides forward untouched"
+        );
+        assert_eq!(
+            state.episode_high_water, 3,
+            "the watermark stands: AUTOINCREMENT allocates every future \
+             episode above it, so nothing behind it is ever coverable again"
+        );
+        assert!(
+            !state
+                .worker_threads
+                .iter()
+                .any(|key| key.starts_with("session-remote\n")),
+            "the census prune drops the deleted session's worker identity"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// §0's both-ways guard, live side: the deletion skip must not widen into
+    /// skipping live work. In the same poll as a *visible* max-id regression
+    /// (the deleted episode was the store maximum), a genuinely-new session
+    /// still emits first-class — and on the next poll the stood watermark
+    /// still admits the next AUTOINCREMENT episode, which is allocated above
+    /// the deleted tail, never inside it.
+    ///
+    /// Fails for: a deletion arm that ends the scan early (skipping the
+    /// candidate read beside it), a preflight that turns a regression poll
+    /// into a wholesale no-op, or a watermark reset that makes the deleted
+    /// tail look like unread coverage debt.
+    #[tokio::test]
+    async fn a_new_session_beside_a_deletion_still_emits() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-deletion-live-side".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let config = AppConfig::default();
+
+        drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+
+        // One write burst: the remote session vanishes (max(id) 3 → 2, a
+        // visible regression) and a genuinely-new session lands.
+        {
+            let connection = Connection::open(&path).expect("open fixture for burst");
+            connection
+                .execute(
+                    "DELETE FROM episodes WHERE session_id = 'session-remote'",
+                    [],
+                )
+                .expect("delete remote episodes");
+            connection
+                .execute(
+                    "DELETE FROM sessions WHERE session_id = 'session-remote'",
+                    [],
+                )
+                .expect("delete remote session");
+            connection
+                .execute(
+                    "INSERT INTO sessions (session_id, cwd, model, base_url, messages_json, \
+                     created_at, updated_at) VALUES ('zz-fresh', '/workspace/fresh', 'model-f', \
+                     'https://api.example', \
+                     '[{\"role\":\"user\",\"content\":\"fresh question\"}]', \
+                     '2026-07-18 14:00:00', '2026-07-18 14:00:01')",
+                    [],
+                )
+                .expect("insert fresh session");
+        }
+
+        let (batches, transitions) =
+            drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        assert!(transitions.is_empty(), "no barrier: this is not a rewind");
+        let raw: Vec<String> = batches
+            .iter()
+            .flat_map(|batch| batch.raw_rows.iter())
+            .filter_map(|row| row.get("raw_json").and_then(Value::as_str))
+            .map(str::to_string)
+            .collect();
+        assert!(
+            raw.iter().any(|row| row.contains("fresh question")),
+            "the new session must emit first-class beside the deletion; got {raw:?}"
+        );
+        assert!(
+            !raw.iter().any(|row| row.contains("session-remote")),
+            "nothing may be emitted for the deleted session; got {raw:?}"
+        );
+        assert!(
+            !raw.iter().any(|row| row.contains("session-local")),
+            "the carried, unchanged session must not be re-emitted; got {raw:?}"
+        );
+
+        // The stood watermark still admits new episode work: AUTOINCREMENT
+        // allocates the next id above the deleted tail (4, not a reused 3).
+        append_worker_episode(&path, "fresh worker payload", "2026-07-18 14:00:02");
+        {
+            let connection = Connection::open(&path).expect("open fixture to re-home episode");
+            connection
+                .execute(
+                    "UPDATE episodes SET session_id = 'zz-fresh', thread_name = 'worker-fresh' \
+                     WHERE id = (SELECT max(id) FROM episodes)",
+                    [],
+                )
+                .expect("re-home appended episode");
+        }
+        let (batches, _) = drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        let raw: Vec<String> = batches
+            .iter()
+            .flat_map(|batch| batch.raw_rows.iter())
+            .filter_map(|row| row.get("raw_json").and_then(Value::as_str))
+            .map(str::to_string)
+            .collect();
+        assert!(
+            raw.iter().any(|row| row.contains("fresh worker payload")),
+            "an episode appended after the deletion must ingest; got {raw:?}"
+        );
+        let map = checkpoints.read().await;
+        let state = NacState::parse(&map.get(&cp_key).expect("checkpoint").cursor_json);
+        assert_eq!(
+            state.episode_high_water, 4,
+            "the new episode is allocated above the deleted tail"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// The e2e deletion scenario's exact shape: deleting a session's episodes
+    /// while the session row survives is a **silent noop** — no records, no
+    /// checkpoint write, no barrier — and the worker identity stays in the
+    /// cursor, so a thread that later resumes does not re-emit its archived
+    /// `session_meta` into the same generation.
+    ///
+    /// Fails for: routing the regression through generation replacement (the
+    /// pre-fix defect: the surviving remote session re-emits its metadata
+    /// under the new namespace — the e2e's 2 → 3), failing the scan on a
+    /// ceiling-covered regression (the noop becomes a durable error
+    /// checkpoint), or pruning `worker_threads` on episode disappearance
+    /// instead of the session census.
+    #[tokio::test]
+    async fn an_episode_deletion_with_a_live_session_is_a_silent_noop() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-episode-deletion-noop".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let config = AppConfig::default();
+
+        drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        let checkpoint_before = checkpoints
+            .read()
+            .await
+            .get(&cp_key)
+            .expect("cold checkpoint")
+            .clone();
+
+        {
+            let connection = Connection::open(&path).expect("open fixture for episode delete");
+            connection
+                .execute(
+                    "DELETE FROM episodes WHERE session_id = 'session-remote'",
+                    [],
+                )
+                .expect("delete remote episodes only");
+        }
+
+        let (batches, transitions) =
+            drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        assert!(
+            transitions.is_empty() && batches.is_empty(),
+            "an episode deletion under a live session changes nothing durable; \
+             got {} batches, {} transitions",
+            batches.len(),
+            transitions.len()
+        );
+        let map = checkpoints.read().await;
+        let checkpoint = map.get(&cp_key).expect("checkpoint");
+        assert_eq!(
+            checkpoint.cursor_json, checkpoint_before.cursor_json,
+            "the cursor is byte-identical: watermark stood, worker identity \
+             retained, session cursors carried"
+        );
+        let state = NacState::parse(&checkpoint.cursor_json);
+        assert!(
+            state
+                .worker_threads
+                .iter()
+                .any(|key| key.starts_with("session-remote\n")),
+            "the worker identity survives so a resumed thread does not \
+             re-emit its archived session_meta"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// The fail-closed floor of the deletion/rewind split: a store whose
+    /// `episodes` table has no AUTOINCREMENT never proves a deletion — ids
+    /// are reusable there, so a vanished tail is always a potential rewind
+    /// and must keep replacing. The ceiling helper must read 0 — not error —
+    /// when the `sqlite_sequence` row, or the whole `sqlite_sequence` table,
+    /// is absent.
+    ///
+    /// Fails for: querying `sqlite_sequence` without the existence guard
+    /// (every regression poll on a plain-rowid store errors), or defaulting
+    /// a missing sequence to the watermark instead of 0.
+    #[test]
+    fn the_episode_id_ceiling_is_zero_without_autoincrement() {
+        let plain = Connection::open_in_memory().expect("open plain store");
+        plain
+            .execute_batch(
+                "CREATE TABLE episodes (id INTEGER PRIMARY KEY, content TEXT); \
+                 INSERT INTO episodes (id, content) VALUES (7, 'reusable');",
+            )
+            .expect("seed plain store");
+        assert_eq!(
+            nac_episode_id_ceiling(&plain).expect("ceiling without sqlite_sequence"),
+            0,
+            "no sqlite_sequence table: ids are reusable, nothing is provable"
+        );
+
+        let foreign = Connection::open_in_memory().expect("open foreign-sequence store");
+        foreign
+            .execute_batch(
+                "CREATE TABLE episodes (id INTEGER PRIMARY KEY, content TEXT); \
+                 CREATE TABLE other (id INTEGER PRIMARY KEY AUTOINCREMENT); \
+                 INSERT INTO other DEFAULT VALUES;",
+            )
+            .expect("seed foreign-sequence store");
+        assert_eq!(
+            nac_episode_id_ceiling(&foreign).expect("ceiling without an episodes row"),
+            0,
+            "a sqlite_sequence row for another table proves nothing about episodes"
+        );
+
+        let path = fixture_db();
+        let fixture = Connection::open(&path).expect("open fixture");
+        assert_eq!(
+            nac_episode_id_ceiling(&fixture).expect("fixture ceiling"),
+            3,
+            "the AUTOINCREMENT fixture's ceiling covers every allocated id"
+        );
+        drop(fixture);
+        cleanup_fixture(&path);
+    }
+
+    /// Gate G5c (§8), the reason the NAC sweep exists: a session mutated
+    /// **without** touching `updated_at` is invisible to the keyset fast path
+    /// — no trigger maintains the column (§1.3), so nothing announces the
+    /// write — and only a sweep slice can find it, within the published
+    /// interval.
+    ///
+    /// **[DIVERGENT FIXTURE]** the mutation is written with
+    /// `UPDATE sessions SET messages_json = … ` and no `updated_at` change; a
+    /// fixture that bumps `updated_at` is caught by the fast path and the
+    /// guard cannot fail. The intermediate watcher poll proves the divergence
+    /// (the fast path really cannot see it) **and** noop-covers the stat, so
+    /// the reconcile poll also exercises the sweep's override of the
+    /// stat-covered volatile skip — without the override the mutation is
+    /// unreachable forever on a store that then goes quiet.
+    ///
+    /// Fails for: a fast path that silently re-reads everything (the
+    /// watcher-poll assertion), sweep eligibility keyed on anything that never
+    /// fires here, dropping the noop-cover override, or a slice that does not
+    /// re-verify content against the carried cursor.
+    #[tokio::test]
+    async fn nac_sweep_detects_a_session_whose_updated_at_did_not_move() {
+        let path = fixture_db();
+        {
+            // DELETE journal mode, so the watcher poll's noop really covers a
+            // frozen stat and the reconcile poll genuinely depends on the
+            // sweep's volatile-skip override — under WAL, `-shm` churn from
+            // the scan's own read-only open keeps the stat moving and the
+            // override arm is never reached (the mutation that drops it
+            // would survive).
+            let connection = Connection::open(&path).expect("open fixture for journal change");
+            connection
+                .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))
+                .expect("checkpoint fixture WAL");
+            connection
+                .query_row("PRAGMA journal_mode = DELETE", [], |_| Ok(()))
+                .expect("switch fixture to DELETE journal mode");
+        }
+        let source_file = path.to_string_lossy().to_string();
+        let watcher = WorkItem {
+            source_name: "nac-sweep-g5c".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let reconcile = WorkItem {
+            trigger: WorkTrigger::Reconcile,
+            ..watcher.clone()
+        };
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        let config = AppConfig::default();
+
+        let (cold, _) =
+            drive_nac_poll_with_metrics(&config, &watcher, &checkpoints, &poll_state, &metrics)
+                .await;
+        assert!(!cold.is_empty(), "the cold poll emits the fixture");
+
+        // The silent mutation: content changes, `updated_at` does not.
+        {
+            let connection = Connection::open(&path).expect("open fixture for silent mutation");
+            connection
+                .execute(
+                    "UPDATE sessions SET messages_json = ?1 WHERE session_id = 'session-remote'",
+                    params![
+                        "[{\"role\":\"user\",\"content\":\"remote question\"},\
+                         {\"role\":\"assistant\",\"content\":\"silently rewritten answer\"}]"
+                    ],
+                )
+                .expect("mutate messages without updated_at");
+        }
+
+        // The fast path cannot see it: the watcher poll scans (the stat
+        // moved) and emits nothing, noop-covering the stat.
+        let (blind, _) =
+            drive_nac_poll_with_metrics(&config, &watcher, &checkpoints, &poll_state, &metrics)
+                .await;
+        let blind_rows: usize = blind.iter().map(|batch| batch.raw_rows.len()).sum();
+        assert_eq!(
+            blind_rows, 0,
+            "an updated_at-silent mutation must be invisible to the fast path, \
+             or this fixture does not diverge"
+        );
+
+        // The reconcile poll's sweep slice finds it — through the noop cover.
+        let (swept, _) =
+            drive_nac_poll_with_metrics(&config, &reconcile, &checkpoints, &poll_state, &metrics)
+                .await;
+        let serialized: Vec<String> = swept
+            .iter()
+            .flat_map(|batch| batch.raw_rows.iter())
+            .filter_map(|row| row.get("raw_json").and_then(Value::as_str))
+            .map(str::to_string)
+            .collect();
+        assert!(
+            serialized
+                .iter()
+                .any(|raw| raw.contains("silently rewritten answer")),
+            "the sweep slice must detect and re-emit the silent mutation; got {serialized:?}"
+        );
+        assert!(
+            metrics
+                .sqlite_sweep_slices_total
+                .load(std::sync::atomic::Ordering::Relaxed)
+                > 0,
+            "and the detection must be attributable to a committed sweep slice"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// The upper bound of the sweep's volatile-skip override: a due slice may
+    /// ride over a *noop-covered stat*, never over a **failure backoff** — a
+    /// store whose scan is failing is not scanned harder because a sweep is
+    /// due. The G5c test above is the override's lower bound.
+    ///
+    /// Fails for: an override that reads the noop cover only (dropping the
+    /// `failure_retry_due` conjunct), or one that bypasses `should_skip_poll`
+    /// wholesale.
+    #[tokio::test]
+    async fn a_due_sweep_does_not_override_a_failure_backoff() {
+        let path = std::env::temp_dir().join(format!(
+            "moraine-nac-sweep-backoff-{}-{}.db",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ));
+        {
+            // `sessions` is missing: every scan fails schema validation.
+            let connection = Connection::open(&path).expect("create broken store");
+            connection
+                .execute_batch("CREATE TABLE episodes (id INTEGER PRIMARY KEY);")
+                .expect("create partial schema");
+        }
+        let source_file = path.to_string_lossy().to_string();
+        let reconcile = WorkItem {
+            source_name: "nac-sweep-backoff".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Reconcile,
+        };
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        let mut config = AppConfig::default();
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 0;
+
+        drive_nac_poll_with_metrics(&config, &reconcile, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            metrics
+                .sqlite_scan_failures_total
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "the first poll must reach the failing scan"
+        );
+
+        // Far inside the 15 s failure window, a due sweep must not force a
+        // second scan of the failing store.
+        drive_nac_poll_with_metrics(&config, &reconcile, &checkpoints, &poll_state, &metrics).await;
+        assert_eq!(
+            metrics
+                .sqlite_scan_failures_total
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "a due sweep must never override a failure backoff"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// The sweep's termination bound on a quiet store, both sides at once
+    /// (the mid-cycle short-circuit bypass in `process_nac_sqlite_db`):
+    ///
+    /// - **starvation side**: with a 1-row slice budget the cycle spans
+    ///   several polls, and a durably covered stat must not strand the
+    ///   in-progress cycle — every due reconcile poll advances it until the
+    ///   wrap;
+    /// - **runaway side**: once the cycle wraps and the store stays quiet,
+    ///   reconcile polls go fully idle — no scans, no slices, no checkpoint
+    ///   churn — even with the interval at zero.
+    ///
+    /// Fails for: dropping the mid-cycle bypass conjunct (the cycle stalls
+    /// mid-keyspace forever), or widening it past `cursor.is_empty()` (the
+    /// store sweeps forever and never idles).
+    #[tokio::test]
+    async fn a_quiet_nac_store_finishes_its_sweep_cycle_and_then_goes_idle() {
+        let path = fixture_db();
+        {
+            // DELETE journal mode, so "quiet" really means an unchanged stat
+            // (see `a_degraded_nac_cold_ingest_completes_without_new_writes`).
+            let connection = Connection::open(&path).expect("open fixture for journal change");
+            connection
+                .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))
+                .expect("checkpoint fixture WAL");
+            connection
+                .query_row("PRAGMA journal_mode = DELETE", [], |_| Ok(()))
+                .expect("switch fixture to DELETE journal mode");
+        }
+        let source_file = path.to_string_lossy().to_string();
+        let reconcile = WorkItem {
+            source_name: "nac-sweep-idle".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Reconcile,
+        };
+        let cp_key = checkpoint_key(&reconcile.source_name, &reconcile.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        let mut config = AppConfig::default();
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 0;
+        config.ingest.sqlite.sweep_slice_max_payload_rows = 1;
+
+        // Cold poll emits and, being reconcile-triggered and quiet-budgeted,
+        // may already start the cycle; drive until the cycle completes.
+        let mut polls = 0;
+        loop {
+            drive_nac_poll_with_metrics(&config, &reconcile, &checkpoints, &poll_state, &metrics)
+                .await;
+            polls += 1;
+            let map = checkpoints.read().await;
+            let state = NacState::parse(&map.get(&cp_key).expect("checkpoint").cursor_json);
+            if state.sweep.completed_cycles >= 1 && state.sweep.cursor.is_empty() {
+                break;
+            }
+            assert!(
+                polls <= 10,
+                "a 1-row slice against 2 sessions must complete its cycle; \
+                 still mid-cycle after {polls} polls"
+            );
+        }
+
+        // Idle: the cycle is complete, the stat is covered, the cursor is
+        // empty — further reconcile polls must not scan or sweep at all.
+        let slices_before = metrics
+            .sqlite_sweep_slices_total
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let rows_before = metrics
+            .sqlite_poll_payload_rows_total
+            .load(std::sync::atomic::Ordering::Relaxed);
+        for _ in 0..3 {
+            drive_nac_poll_with_metrics(&config, &reconcile, &checkpoints, &poll_state, &metrics)
+                .await;
+        }
+        assert_eq!(
+            metrics
+                .sqlite_sweep_slices_total
+                .load(std::sync::atomic::Ordering::Relaxed),
+            slices_before,
+            "a completed cycle over a quiet store must not restart"
+        );
+        assert_eq!(
+            metrics
+                .sqlite_poll_payload_rows_total
+                .load(std::sync::atomic::Ordering::Relaxed),
+            rows_before,
+            "idle means no reads at all"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// `sweep_baseline`'s cycle-start conjunct (§2.2/D14): only a slice that
+    /// *starts* a cycle stamps the baseline. A mid-cycle slice that
+    /// re-stamped it would advance the baseline past a silent write that
+    /// landed **behind** the sweep cursor during the cycle, erasing the owed
+    /// follow-up cycle — on a store that then goes quiet, the mutation is
+    /// never swept (D14's emitting-deferral scenario, a §0 coverage loss).
+    ///
+    /// The fixture: a 1-row slice budget spans the cycle across polls; after
+    /// the first slice commits (cursor at `session-local`), `session-local`
+    /// is silently rewritten — behind the cursor, `updated_at` untouched —
+    /// and the store goes quiet. The wrapping cycle must leave a follow-up
+    /// owed (the baseline, stamped at cycle start, trails the post-write
+    /// stat), and that follow-up cycle must re-emit the rewrite. The other
+    /// side of the bound — the baseline *does* catch up and the store then
+    /// idles — is `a_quiet_nac_store_finishes_its_sweep_cycle_and_then_goes_idle`.
+    ///
+    /// MUTATION (executed 2026-07-31): drop the
+    /// `prior.sweep.cursor.is_empty()` conjunct (`if swept && …` →
+    /// `if swept`) — this test fails: the mid-cycle slice re-stamps the
+    /// baseline to the post-write stat, the wrapped cycle closes the idle
+    /// conjunct, and the rewrite never re-emits.
+    #[tokio::test]
+    async fn a_silent_write_behind_the_sweep_cursor_owes_a_follow_up_cycle() {
+        let path = fixture_db();
+        {
+            // DELETE journal mode, so "quiet after the write" really means an
+            // unchanged stat (see the sibling sweep tests): under WAL, `-shm`
+            // churn keeps every poll scanning and the baseline conjunct is
+            // never what keeps the follow-up cycle alive.
+            let connection = Connection::open(&path).expect("open fixture for journal change");
+            connection
+                .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))
+                .expect("checkpoint fixture WAL");
+            connection
+                .query_row("PRAGMA journal_mode = DELETE", [], |_| Ok(()))
+                .expect("switch fixture to DELETE journal mode");
+        }
+        let source_file = path.to_string_lossy().to_string();
+        let reconcile = WorkItem {
+            source_name: "nac-sweep-baseline".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Reconcile,
+        };
+        let cp_key = checkpoint_key(&reconcile.source_name, &reconcile.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let metrics = Arc::new(Metrics::default());
+        let mut config = AppConfig::default();
+        config.ingest.sqlite.sweep_slice_min_interval_seconds = 0;
+        config.ingest.sqlite.sweep_slice_max_payload_rows = 1;
+
+        // Drive to the mid-cycle point: the first 1-row slice has committed
+        // and the cursor sits at the first session in `session_id` order.
+        let mut polls = 0;
+        loop {
+            drive_nac_poll_with_metrics(&config, &reconcile, &checkpoints, &poll_state, &metrics)
+                .await;
+            polls += 1;
+            let map = checkpoints.read().await;
+            let state = NacState::parse(&map.get(&cp_key).expect("checkpoint").cursor_json);
+            if state.sweep.cursor == "session-local" {
+                break;
+            }
+            assert!(
+                polls <= 5,
+                "the first 1-row slice must commit within a few polls; \
+                 cursor still elsewhere after {polls}"
+            );
+        }
+
+        // The silent write, behind the cursor: content changes, `updated_at`
+        // does not, and the in-progress cycle has already passed this key.
+        {
+            let connection = Connection::open(&path).expect("open fixture for silent mutation");
+            connection
+                .execute(
+                    "UPDATE sessions SET messages_json = ?1 WHERE session_id = 'session-local'",
+                    params![
+                        "[{\"role\":\"user\",\"content\":\"hello\"},\
+                         {\"role\":\"assistant\",\"content\":\"rewritten behind the sweep cursor\"}]"
+                    ],
+                )
+                .expect("mutate messages without updated_at");
+        }
+
+        // Quiet from here on. The wrapping cycle cannot see the write; the
+        // owed follow-up cycle must.
+        let mut polls = 0;
+        loop {
+            let (batches, _) = drive_nac_poll_with_metrics(
+                &config,
+                &reconcile,
+                &checkpoints,
+                &poll_state,
+                &metrics,
+            )
+            .await;
+            polls += 1;
+            let emitted = batches
+                .iter()
+                .flat_map(|batch| batch.raw_rows.iter())
+                .filter_map(|row| row.get("raw_json").and_then(Value::as_str))
+                .any(|raw| raw.contains("rewritten behind the sweep cursor"));
+            if emitted {
+                break;
+            }
+            assert!(
+                polls <= 10,
+                "a silent write behind the sweep cursor must be re-swept by \
+                 the owed follow-up cycle; still unseen after {polls} polls"
+            );
+        }
+
+        cleanup_fixture(&path);
+    }
+
+    /// Gate G1c (§8): tool request/result pairing under **delta emission**.
+    /// `link_tool_responses` recomputes request UIDs from the emitted record
+    /// set only (§6), so a delta scan where the request part is unchanged and
+    /// only the response re-emits must still link — through the
+    /// request-coordinate fields the response carries — and not silently fall
+    /// back to nothing.
+    ///
+    /// **[DIVERGENT FIXTURE]** only the tool *response* content changes (plus
+    /// the forward-dated `updated_at` that makes the session a candidate);
+    /// the request part's hash is unchanged, so it must **not** re-emit — the
+    /// linkage has to survive without the request in the batch.
+    ///
+    /// Fails for: dropping the `request_logical_id`/coordinate fallback from
+    /// `link_tool_responses`, or a delta scan that re-emits everything (the
+    /// request-absence assertion).
+    #[test]
+    fn nac_delta_scan_preserves_tool_request_result_pairing() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let (mut cold, cold_state, _) = scan_fixture(&path, &NacState::default());
+        link_tool_responses(&mut cold, &source_file, 1);
+        let cold_response_uid = cold
+            .iter()
+            .find(|record| record.record["type"] == "tool_response")
+            .and_then(|record| record.record.get("request_event_uid"))
+            .and_then(Value::as_str)
+            .expect("the cold scan links its tool response")
+            .to_string();
+
+        {
+            let connection = Connection::open(&path).expect("open fixture for response mutation");
+            connection
+                .execute(
+                    "UPDATE sessions SET messages_json = ?1, updated_at = ?2 \
+                     WHERE session_id = 'session-local'",
+                    params![
+                        // Identical to the fixture except the tool response
+                        // content, so only that part's hash moves.
+                        "[{\"role\":\"system\",\"content\":\"system prompt\"},\
+                          {\"role\":\"user\",\"content\":\"hello\"},\
+                          {\"role\":\"assistant\",\"content\":null,\"reasoning_text\":\"inspect first\",\"reasoning_details\":{\"kind\":\"analysis\"},\"tool_calls\":[{\"id\":\"call-1\",\"type\":\"function\",\"function\":{\"name\":\"mcp__moraine__search\",\"arguments\":\"{\\\"query\\\":\\\"nac\\\"}\"}}]},\
+                          {\"role\":\"tool\",\"tool_call_id\":\"call-1\",\"content\":\"{\\\"result\\\":\\\"changed\\\"}\"},\
+                          {\"role\":\"assistant\",\"content\":\"done\"}]",
+                        "2026-07-18 13:20:00.000000000"
+                    ],
+                )
+                .expect("mutate tool response only");
+        }
+
+        let (mut delta, _, _) = scan_fixture(&path, &cold_state);
+        link_tool_responses(&mut delta, &source_file, 1);
+        assert!(
+            !delta
+                .iter()
+                .any(|record| record.record["type"] == "tool_request"),
+            "[DIVERGENT FIXTURE] the unchanged request must not re-emit, or \
+             the fallback path is never exercised"
+        );
+        let response = delta
+            .iter()
+            .find(|record| record.record["type"] == "tool_response")
+            .expect("the changed response re-emits");
+        assert_eq!(
+            response
+                .record
+                .get("request_event_uid")
+                .and_then(Value::as_str),
+            Some(cold_response_uid.as_str()),
+            "the delta-emitted response must link to the same request UID the \
+             cold scan linked"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// §3.2's format guard, both sides, at the scan:
+    ///
+    /// - **fail open**: an `updated_at` whose separator differs from the
+    ///   watermark's sorts *below* it lexicographically (`'T'`-separated with
+    ///   an earlier date, here) — a naive keyset comparison silently skips
+    ///   it. The guard makes an incomparable value a candidate: the row is
+    ///   read and its change emits on the fast path.
+    /// - **the skip stands**: a *comparable* value at or before the watermark
+    ///   is genuinely skipped — that is the fast path's entire point, and the
+    ///   skip is what the sweep's coverage guarantee (§0) underwrites (G5c).
+    ///
+    /// Fails for: dropping `nac_updated_at_comparable` from the candidate
+    /// predicate (the incomparable row is skipped), or inverting it into
+    /// "read everything" (the comparable row's absence assertion).
+    #[test]
+    fn a_mixed_updated_at_format_is_read_not_skipped() {
+        let path = fixture_db();
+        let (_, cold_state, _) = scan_fixture(&path, &NacState::default());
+        assert!(
+            !cold_state.updated_at_high_water.is_empty(),
+            "the covering scan establishes the watermark"
+        );
+
+        {
+            let connection = Connection::open(&path).expect("open fixture for format drift");
+            // `'T'`-separated and a day earlier: sorts lexicographically below
+            // the space-separated watermark even though it is a fresh write.
+            connection
+                .execute(
+                    "UPDATE sessions SET messages_json = ?1, updated_at = ?2 \
+                     WHERE session_id = 'session-local'",
+                    params![
+                        "[{\"role\":\"user\",\"content\":\"format drifted write\"}]",
+                        "2026-07-17T00:00:00.000000000"
+                    ],
+                )
+                .expect("write format-drifted updated_at");
+            // A comparable value at the watermark boundary: content changes,
+            // but the fast path may honestly skip it (the sweep owns it).
+            connection
+                .execute(
+                    "UPDATE sessions SET messages_json = ?1 \
+                     WHERE session_id = 'session-remote'",
+                    params!["[{\"role\":\"user\",\"content\":\"comparable but stale stamp\"}]"],
+                )
+                .expect("write comparable below-watermark mutation");
+        }
+
+        let (records, _, _) = scan_fixture(&path, &cold_state);
+        let serialized: Vec<String> = records
+            .iter()
+            .map(|record| serde_json::to_string(&record.record).expect("serialize record"))
+            .collect();
+        assert!(
+            serialized
+                .iter()
+                .any(|raw| raw.contains("format drifted write")),
+            "an incomparable updated_at must be read, never ordered against \
+             the watermark; got {serialized:?}"
+        );
+        assert!(
+            !serialized
+                .iter()
+                .any(|raw| raw.contains("comparable but stale stamp")),
+            "[DIVERGENT FIXTURE] a comparable value at or before the watermark \
+             is the fast path's legitimate skip — if it emits here, the guard \
+             was widened into re-reading everything"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// §2.3's "continue next poll" for the **changed tail**: a 1-row budget
+    /// against two bumped sessions converges across resumed polls because the
+    /// keyset watermark is a durable resume position — ascending tail order,
+    /// watermark committed at the last fully processed position — and
+    /// `pending_coverage` keeps the quiet store scanning until covered.
+    ///
+    /// Fails for: a watermark that jumps to the census maximum on a *bound*
+    /// poll (the second session's change is skipped forever), a tail read in
+    /// descending order (the same newest session re-reads on every poll and
+    /// the older change starves), or `fast_path_bound` not reaching
+    /// `pending_coverage`.
+    #[test]
+    fn a_bound_nac_changed_tail_resumes_from_its_watermark() {
+        let path = fixture_db();
+        let (_, cold_state, _) = scan_fixture(&path, &NacState::default());
+
+        {
+            let connection = Connection::open(&path).expect("open fixture for tail bumps");
+            connection
+                .execute(
+                    "UPDATE sessions SET messages_json = ?1, updated_at = ?2 \
+                     WHERE session_id = 'session-local'",
+                    params![
+                        "[{\"role\":\"user\",\"content\":\"older tail change\"}]",
+                        "2026-07-18 13:10:00.000000000"
+                    ],
+                )
+                .expect("bump session-local");
+            connection
+                .execute(
+                    "UPDATE sessions SET messages_json = ?1, updated_at = ?2 \
+                     WHERE session_id = 'session-remote'",
+                    params![
+                        "[{\"role\":\"user\",\"content\":\"newer tail change\"}]",
+                        "2026-07-18 13:20:00.000000000"
+                    ],
+                )
+                .expect("bump session-remote");
+        }
+
+        let budget = ScanBudget {
+            max_payload_rows: 1,
+            max_payload_bytes: u64::MAX,
+        };
+        let (first_records, first_state, _, first_ledger) =
+            scan_fixture_with_budget(&path, &cold_state, &budget, MAX_NAC_CHECKPOINT_BYTES);
+        assert_eq!(first_ledger.payload_rows, 1, "one session per bound poll");
+        assert!(
+            serde_json::to_string(&first_records.iter().map(|r| &r.record).collect::<Vec<_>>())
+                .expect("serialize records")
+                .contains("older tail change"),
+            "the tail is read oldest-first — the resume order"
+        );
+        assert!(
+            first_state.pending_coverage,
+            "a bound tail is a durable coverage debt"
+        );
+        assert_eq!(
+            first_state.updated_at_high_water, "2026-07-18 13:10:00.000000000",
+            "the watermark commits at the last fully processed tail position, \
+             never the census maximum, on a bound poll"
+        );
+
+        let (second_records, second_state, _, second_ledger) =
+            scan_fixture_with_budget(&path, &first_state, &budget, MAX_NAC_CHECKPOINT_BYTES);
+        assert_eq!(second_ledger.payload_rows, 1);
+        assert!(
+            serde_json::to_string(&second_records.iter().map(|r| &r.record).collect::<Vec<_>>())
+                .expect("serialize records")
+                .contains("newer tail change"),
+            "the resumed poll picks up exactly where the watermark stopped"
+        );
+        assert!(
+            !second_state.pending_coverage,
+            "full coverage clears the debt"
+        );
+        assert_eq!(
+            second_state.updated_at_high_water, "2026-07-18 13:20:00.000000000",
+            "the covering poll's watermark reaches the census maximum"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// `nac_keyset_after`'s session-id tiebreak, at both of its consumers
+    /// (§3.2's same-millisecond race: second-precision stores make
+    /// same-timestamp write bursts ordinary, and a strict `updated_at >`
+    /// alone cannot split a timestamp class): three sessions are rewritten
+    /// at ONE shared timestamp, and a 2-row bound poll must (a) advance the
+    /// watermark through the tiebreak to the second-processed session — the
+    /// `advance_updated_at_watermark` consumer — and (b) let the resumed
+    /// poll classify the third session as strictly after `(T, second)` —
+    /// the candidate-classification consumer — reading exactly it and
+    /// nothing else (the at-watermark pair stays carried, which bounds the
+    /// tiebreak from the other side).
+    ///
+    /// MUTATION (executed 2026-07-31): drop the
+    /// `|| (updated_at == high_water && session_id > high_water_session)`
+    /// disjunct from `nac_keyset_after` — fails at the bound poll's
+    /// watermark (stuck at the first-processed session). Separately, inline
+    /// a strict `updated_at`-only comparison at the candidate-classification
+    /// call site alone — fails at the resumed poll's emission (the third
+    /// session is classified carried; its change never emits) while the
+    /// watermark assertions pass, so each consumer is pinned on its own.
+    #[test]
+    fn a_same_timestamp_nac_write_burst_resumes_through_the_session_id_tiebreak() {
+        let path = fixture_db();
+        {
+            // A third session that sorts below the fixture pair, so the
+            // shared-timestamp class spans three ids.
+            let connection = Connection::open(&path).expect("open fixture for third session");
+            connection
+                .execute(
+                    "INSERT INTO sessions (session_id, cwd, model, base_url, messages_json, \
+                     created_at, updated_at) VALUES ('aa-first', '/workspace/aa', 'model-a', \
+                     'https://api.example', '[{\"role\":\"user\",\"content\":\"aa cold\"}]', \
+                     '2026-07-18 11:00:00.000000000', '2026-07-18 11:00:01.000000000')",
+                    [],
+                )
+                .expect("insert third session");
+        }
+        let (_, cold_state, _) = scan_fixture(&path, &NacState::default());
+        assert_eq!(
+            cold_state.updated_at_high_water_session, "session-remote",
+            "the covering scan's watermark sits at the census maximum"
+        );
+
+        let stamp = "2026-07-18 14:00:00.000000000";
+        {
+            let connection = Connection::open(&path).expect("open fixture for write burst");
+            for (session_id, content) in [
+                ("aa-first", "same stamp change aa"),
+                ("session-local", "same stamp change local"),
+                ("session-remote", "same stamp change remote"),
+            ] {
+                connection
+                    .execute(
+                        "UPDATE sessions SET messages_json = ?1, updated_at = ?2 \
+                         WHERE session_id = ?3",
+                        params![
+                            format!("[{{\"role\":\"user\",\"content\":\"{content}\"}}]"),
+                            stamp,
+                            session_id
+                        ],
+                    )
+                    .expect("apply same-timestamp write");
+            }
+        }
+
+        let budget = ScanBudget {
+            max_payload_rows: 2,
+            max_payload_bytes: u64::MAX,
+        };
+        let (first_records, first_state, _, _) =
+            scan_fixture_with_budget(&path, &cold_state, &budget, MAX_NAC_CHECKPOINT_BYTES);
+        let serialized =
+            serde_json::to_string(&first_records.iter().map(|r| &r.record).collect::<Vec<_>>())
+                .expect("serialize records");
+        assert!(
+            serialized.contains("same stamp change aa")
+                && serialized.contains("same stamp change local")
+                && !serialized.contains("same stamp change remote"),
+            "ascending keyset order inside one timestamp is session_id order"
+        );
+        assert_eq!(first_state.updated_at_high_water, stamp);
+        assert_eq!(
+            first_state.updated_at_high_water_session, "session-local",
+            "the watermark must advance through the tiebreak to the second \
+             processed session of the shared timestamp — a strict `>` on \
+             `updated_at` alone strands it at the first"
+        );
+        assert!(first_state.pending_coverage);
+
+        let (second_records, second_state, _, second_ledger) =
+            scan_fixture_with_budget(&path, &first_state, &budget, MAX_NAC_CHECKPOINT_BYTES);
+        let serialized =
+            serde_json::to_string(&second_records.iter().map(|r| &r.record).collect::<Vec<_>>())
+                .expect("serialize records");
+        assert!(
+            serialized.contains("same stamp change remote"),
+            "the resumed poll must classify the third same-stamp session as \
+             after the watermark through the tiebreak; got {serialized}"
+        );
+        assert_eq!(
+            second_ledger.payload_rows, 1,
+            "and exactly it: the at-watermark pair stays carried — the \
+             tiebreak admits the strictly-after remainder, not the class"
+        );
+        assert!(
+            !second_state.pending_coverage,
+            "full coverage of the burst clears the debt"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// D6's "a genuinely new session is already in the first class", pinned
+    /// at the `!known` disjunct of the candidate predicate: a session
+    /// INSERTed with an `updated_at` at or below the watermark (clock skew,
+    /// an imported or restored store) has no prior cursor, so nothing else
+    /// admits it — the format guard finds it comparable and the keyset says
+    /// "before the watermark". Without the disjunct it is neither read nor
+    /// carried: every poll re-opens `pending_coverage` over it (standing
+    /// rescan churn) while its content waits on sweep latency.
+    ///
+    /// MUTATION (executed 2026-07-31): drop `!known ||` from the candidate
+    /// predicate — this test fails: the backdated session never emits, is
+    /// absent from the carried set, and `pending_coverage` latches.
+    #[test]
+    fn a_new_session_backdated_below_the_watermark_is_read_first_class() {
+        let path = fixture_db();
+        let (_, cold_state, _) = scan_fixture(&path, &NacState::default());
+        assert!(
+            !cold_state.updated_at_high_water.is_empty(),
+            "the covering scan establishes the watermark"
+        );
+
+        {
+            let connection = Connection::open(&path).expect("open fixture for backdated insert");
+            connection
+                .execute(
+                    "INSERT INTO sessions (session_id, cwd, model, base_url, messages_json, \
+                     created_at, updated_at) VALUES ('zz-backdated', '/workspace/zz', 'model-z', \
+                     'https://api.example', \
+                     '[{\"role\":\"user\",\"content\":\"backdated new session\"}]', \
+                     '2026-07-18 10:00:00.000000000', '2026-07-18 10:00:00.000000000')",
+                    [],
+                )
+                .expect("insert backdated session");
+        }
+
+        let (records, state, _, ledger) = scan_fixture_with_ledger(&path, &cold_state);
+        let serialized =
+            serde_json::to_string(&records.iter().map(|r| &r.record).collect::<Vec<_>>())
+                .expect("serialize records");
+        assert!(
+            serialized.contains("backdated new session"),
+            "a never-read session below the watermark is cold debt and must \
+             be read first-class, not deferred to sweep latency; got {serialized}"
+        );
+        assert_eq!(
+            ledger.payload_rows, 1,
+            "and it is the only read — the known pair stays carried, so the \
+             disjunct admits exactly the never-read class"
+        );
+        assert!(state.sessions.contains_key("zz-backdated"));
+        assert!(
+            !state.pending_coverage,
+            "a covered store owes nothing — the mutated predicate leaves \
+             this latched forever"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// Plan §7.2 F1, NAC's `schema_fingerprint == checkpoint.schema_fingerprint`
+    /// conjunct of `scan_is_noop`: a schema change with no row changes emits
+    /// nothing, and only the fingerprint comparison keeps its checkpoint from
+    /// being suppressed — leaving the drift re-discovered on every poll and
+    /// never durably recorded.
+    ///
+    /// Fails for: dropping the schema conjunct from NAC's `scan_is_noop`.
+    #[tokio::test]
+    async fn a_nac_schema_change_with_no_row_changes_still_persists_its_checkpoint() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-schema-conjunct".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let config = AppConfig::default();
+
+        drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        let fingerprint_before = checkpoints
+            .read()
+            .await
+            .get(&cp_key)
+            .expect("cold checkpoint")
+            .schema_fingerprint;
+
+        {
+            let connection = Connection::open(&path).expect("open fixture for schema change");
+            connection
+                .execute("ALTER TABLE episodes ADD COLUMN extra text", [])
+                .expect("add drifting column");
+        }
+        let (batches, _) = drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        let raw_rows: usize = batches.iter().map(|batch| batch.raw_rows.len()).sum();
+        assert_eq!(raw_rows, 0, "a schema change alone emits nothing");
+        let fingerprint_after = checkpoints
+            .read()
+            .await
+            .get(&cp_key)
+            .expect("post-drift checkpoint")
+            .schema_fingerprint;
+        assert_ne!(
+            fingerprint_before, fingerprint_after,
+            "the moved fingerprint must persist durably, not be suppressed as \
+             a noop and re-discovered on every later poll"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// Plan §7.2 F3, the `schema_fingerprint != 0` conjunct of NAC's cheap
+    /// short-circuit — the one of NAC's three extra conjuncts that is not an
+    /// equivalent mutant. (`!starts_replacement` and `!retry_blocked_replay`
+    /// are: a replay's `scan_state` is `NacState::default()`, whose default
+    /// stat fingerprint can never equal a real file's, so the stat conjunct
+    /// already fails — see the short-circuit's comment.) A cursor persisted
+    /// without a fingerprint must be rescanned once even though its stat
+    /// matches, or the fingerprint is never established and schema drift is
+    /// undetectable forever.
+    ///
+    /// Fails for: dropping `schema_fingerprint != 0` from the cheap
+    /// short-circuit.
+    #[tokio::test]
+    async fn a_legacy_cursor_without_a_schema_fingerprint_is_rescanned_once() {
+        let path = fixture_db();
+        {
+            // DELETE journal mode, so the covered-stat conjunct genuinely
+            // holds and the fingerprint conjunct is the one deciding — under
+            // WAL, sidecar churn re-runs the scan for the wrong reason and
+            // the dropped conjunct would survive its mutation.
+            let connection = Connection::open(&path).expect("open fixture for journal change");
+            connection
+                .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))
+                .expect("checkpoint fixture WAL");
+            connection
+                .query_row("PRAGMA journal_mode = DELETE", [], |_| Ok(()))
+                .expect("switch fixture to DELETE journal mode");
+        }
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-legacy-fingerprint".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let config = AppConfig::default();
+
+        drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        // A legacy cursor: covered stat, no fingerprint anywhere.
+        {
+            let mut map = checkpoints.write().await;
+            let checkpoint = map.get_mut(&cp_key).expect("committed checkpoint");
+            checkpoint.schema_fingerprint = 0;
+            let mut state = NacState::parse(&checkpoint.cursor_json);
+            state.schema_fingerprint = 0;
+            checkpoint.cursor_json = state.serialize().expect("serialize legacy cursor");
+        }
+
+        drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        let map = checkpoints.read().await;
+        let checkpoint = map.get(&cp_key).expect("post-rescan checkpoint");
+        assert_ne!(
+            checkpoint.schema_fingerprint, 0,
+            "the rescan must establish the fingerprint despite the covered \
+             stat, or schema drift is undetectable forever"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// Gate G8c (§8): an episode **rewind** — `max(episodes.id)` regressing
+    /// below the committed watermark *with the AUTOINCREMENT id ceiling
+    /// rewound too*, so the vanished coordinates are re-allocatable — is a
+    /// truncation of history and must route through #602's replacement path:
+    /// generation bump, `BeginReplay` barrier, `sessions` reset and
+    /// re-emitted. The pre-WI-07 code did an in-place
+    /// `worker_threads.clear()` inside the live generation, exposing
+    /// partially replayed worker history beside live data with no barrier,
+    /// and never reset `sessions` at all. **This gate fails against that
+    /// code** (confirmed: the plan requires the check before the fix).
+    ///
+    /// **[DIVERGENT FIXTURE]** the truncation resets `sqlite_sequence`
+    /// alongside the rows — the shape a recreated table leaves behind.
+    /// Deleting rows *without* touching the sequence is a deletion, which is
+    /// archival and emits nothing
+    /// (`a_session_deleted_from_the_store_emits_nothing_new`); a fixture
+    /// that only deletes cannot reach the replacement path at all. This test
+    /// is the upper bound of the deletion split: widening "deletion" to
+    /// every max-id regression (dropping the ceiling conjunct's rewind arm)
+    /// fails here.
+    ///
+    /// Fails for: restoring the in-place reset, a preflight that cannot see
+    /// the rewind, or a deletion split so wide no rewind replaces anymore.
+    #[tokio::test]
+    async fn nac_episode_rewind_routes_through_generation_replay() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-episode-rewind".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let config = AppConfig::default();
+
+        drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        let generation_before = checkpoints
+            .read()
+            .await
+            .get(&cp_key)
+            .expect("cold checkpoint")
+            .source_generation;
+
+        // Truncate episode history: max(id) regresses below the watermark
+        // AND the AUTOINCREMENT sequence rewinds with it, so ids 2 and 3 are
+        // re-allocatable — the recreated-table shape, a true rewind rather
+        // than a deletion.
+        {
+            let connection = Connection::open(&path).expect("open fixture for truncation");
+            connection
+                .execute("DELETE FROM episodes WHERE id >= 2", [])
+                .expect("truncate episodes");
+            connection
+                .execute(
+                    "UPDATE sqlite_sequence SET seq = 1 WHERE name = 'episodes'",
+                    [],
+                )
+                .expect("rewind the episode id sequence");
+        }
+
+        let (batches, transitions) =
+            drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        assert!(
+            transitions
+                .iter()
+                .any(|transition| transition.checkpoint.status == "replaying"),
+            "the rewind must raise a BeginReplay barrier, not reset in place"
+        );
+        let map = checkpoints.read().await;
+        let checkpoint = map.get(&cp_key).expect("replaced checkpoint");
+        assert_eq!(
+            checkpoint.source_generation,
+            generation_before + 1,
+            "the rewind must bump the generation exactly once"
+        );
+        assert_eq!(checkpoint.status, "active", "the replay finalizes");
+        let state = NacState::parse(&checkpoint.cursor_json);
+        assert_eq!(
+            state.sessions.len(),
+            2,
+            "`sessions` is reset and rebuilt in the new generation — the old \
+             in-place path never reset it"
+        );
+        assert_eq!(state.episode_high_water, 1, "the surviving episode");
+        let raw_rows: usize = batches.iter().map(|batch| batch.raw_rows.len()).sum();
+        assert!(
+            raw_rows > 0,
+            "the replacement generation re-emits the store"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// The NAC halves of the OpenCode blocked-replay throttle-bypass width
+    /// (§2.5): WI-07 moved NAC's throttle above the generation bump (the
+    /// episode preflight must not run for a throttled store), which makes the
+    /// two bypass conjuncts load-bearing exactly as at the OpenCode site — a
+    /// replaced database must never wait out a stale backoff.
+    ///
+    /// Fails for: dropping `!generation_changed` from the throttle gate.
+    #[tokio::test]
+    async fn a_replaced_nac_database_bypasses_the_blocked_replay_throttle() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-replaced-bypass".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let config = AppConfig::default();
+
+        drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+
+        // Durably block the source and arm its failure backoff.
+        {
+            let mut map = checkpoints.write().await;
+            let checkpoint = map.get_mut(&cp_key).expect("committed checkpoint");
+            checkpoint.status = "error".to_string();
+            checkpoint.block_reason = "blocked for the bypass test".to_string();
+        }
+        poll_state.record_blocked_replay(&cp_key, 1);
+
+        // Replace the database file wholesale: new inode, same path.
+        let replacement = fixture_db();
+        std::fs::rename(&replacement, &path).expect("replace database file");
+
+        let (_, transitions) = drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        assert!(
+            transitions
+                .iter()
+                .any(|transition| transition.checkpoint.status == "replaying"),
+            "a replaced database must bypass the blocked-replay throttle and \
+             start its replacement replay immediately"
+        );
+        let map = checkpoints.read().await;
+        assert_eq!(
+            map.get(&cp_key).expect("replacement checkpoint").status,
+            "active",
+            "the replacement finalizes despite the armed backoff"
+        );
+
+        cleanup_fixture(&path);
+    }
+
+    /// The exclusion half of the same width: see
+    /// `a_replaced_nac_database_bypasses_the_blocked_replay_throttle`.
+    ///
+    /// Fails for: dropping `!exclusions_changed` from the throttle gate.
+    #[tokio::test]
+    async fn an_exclusion_change_bypasses_the_nac_blocked_replay_throttle() {
+        let path = fixture_db();
+        let source_file = path.to_string_lossy().to_string();
+        let work = WorkItem {
+            source_name: "nac-exclusion-bypass".to_string(),
+            harness: "nac".to_string(),
+            format: moraine_config::SourceFormat::NacSqlite,
+            source_glob: source_file.clone(),
+            path: source_file.clone(),
+            trigger: WorkTrigger::Watcher,
+        };
+        let cp_key = checkpoint_key(&work.source_name, &work.path);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let poll_state = VolatilePollMap::new();
+        let config = AppConfig::default();
+
+        drive_nac_poll(&config, &work, &checkpoints, &poll_state).await;
+        {
+            let mut map = checkpoints.write().await;
+            let checkpoint = map.get_mut(&cp_key).expect("committed checkpoint");
+            checkpoint.status = "error".to_string();
+            checkpoint.block_reason = "blocked for the bypass test".to_string();
+        }
+        poll_state.record_blocked_replay(&cp_key, 1);
+
+        let mut changed = AppConfig::default();
+        changed.ingest.exclude_project_dirs = vec!["/nowhere/at/all/**".to_string()];
+        let (_, transitions) = drive_nac_poll(&changed, &work, &checkpoints, &poll_state).await;
+        assert!(
+            transitions
+                .iter()
+                .any(|transition| transition.checkpoint.status == "replaying"),
+            "an exclusion change must bypass the blocked-replay throttle"
+        );
+
+        cleanup_fixture(&path);
+    }
+
     #[test]
     fn tool_response_fallback_is_scoped_to_its_session() {
         let mut records = vec![
@@ -3679,6 +5776,7 @@ mod tests {
                 stat,
                 &NacState::default(),
                 &default_nac_budget(),
+                None,
                 MAX_NAC_CHECKPOINT_BYTES,
                 &mut ScanLedger::default(),
             ),
@@ -4105,7 +6203,11 @@ mod tests {
                     serde_json::to_string(messages).expect("serialize appended messages"),
                     "[1200,800]",
                     "[{\"input_tokens\":12,\"output_tokens\":4,\"cache_read_tokens\":2},{\"input_tokens\":8,\"output_tokens\":3}]",
-                    "2026-07-18 12:17:00.000000000"
+                    // Later than every fixture `updated_at`, matching the
+                    // writer's monotonic wall clock: the §3.2 fast path skips
+                    // values at or before the keyset watermark, so a backdated
+                    // bump is the *sweep's* case (G5c), not this test's.
+                    "2026-07-18 13:10:00.000000000"
                 ],
             )
             .expect("append session messages");

--- a/crates/moraine-ingest-core/src/sqlite_poll/opencode.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/opencode.rs
@@ -15,10 +15,10 @@ use tracing::{debug, warn};
 
 use super::{
     hash_str, open_read_only, record_scan_failure, record_scan_ledger, sqlite_data_version,
-    stat_fingerprint, take_payload_required_string, truncate_chars_local, ScanLedger,
+    stat_fingerprint, take_payload_required_string, truncate_chars_local, ScanBudget, ScanLedger,
     StatFingerprint, SyntheticRecord, VolatilePollMap, CURSOR_STATE_VERSION,
-    ERROR_KIND_MIXED_SNAPSHOT, ERROR_KIND_OPEN, ERROR_KIND_SCAN, ERROR_KIND_SCHEMA,
-    ERROR_KIND_TOO_LARGE, SCAN_PAGE_MAX_BYTES, SCAN_PAGE_SIZE,
+    ERROR_KIND_MIXED_SNAPSHOT, ERROR_KIND_OPEN, ERROR_KIND_ROW_TOO_LARGE, ERROR_KIND_SCAN,
+    ERROR_KIND_SCHEMA, SCAN_PAGE_MAX_BYTES, SCAN_PAGE_SIZE,
 };
 
 /// The paged event read, shared with the fixture-plan assertion in
@@ -29,12 +29,54 @@ const OPENCODE_EVENT_PAGE_SQL: &str = "SELECT id, aggregate_id, seq, type, data 
      WHERE aggregate_id = ?1 AND seq > ?2 AND seq <= ?3 \
      ORDER BY seq LIMIT ?4";
 
-const MAX_OPENCODE_RELEVANT_ROWS: u64 = 10_000;
-const MAX_OPENCODE_SCAN_BYTES: u64 = 128 * 1024 * 1024;
+/// Event types that feed the reconstruction context, split by which map they
+/// update. **Single source of truth** (issue #601 §3.1 Change 3):
+/// `update_opencode_context` dispatches on these slices and
+/// `opencode_context_rebuild_sql` derives its `IN` list from their
+/// concatenation, so a new context-bearing event type cannot be added to one
+/// and forgotten in the other.
+const OPENCODE_SESSION_CONTEXT_EVENT_TYPES: &[&str] = &["session.created.1", "session.updated.1"];
+const OPENCODE_MESSAGE_CONTEXT_EVENT_TYPES: &[&str] = &["message.updated.1"];
+
+/// Ceilings on the persisted reconstruction context (issue #601 §3.1
+/// Change 4). This is a **size budget, not an absence check**: WI-06 requires
+/// persisting the context (the old "cursor stays bounded" absence assertion
+/// directly contradicted it), and what stays bounded is the serialized
+/// footprint. Enforced by evicting whole aggregates — never by failing the
+/// scan — because eviction is cheap to recover from: the next delta poll of an
+/// evicted aggregate runs the type-scoped rebuild, measured at 95 rows / 47 KB
+/// / ~0.5 ms against the reference host's 639-event aggregate (§1.2).
+///
+/// Eviction order is ascending `aggregate_id`, and that is a *disclosed
+/// compromise*, not an oversight: OpenCode's `seq` is per-aggregate, so no
+/// cross-aggregate recency ordering exists in the store to be "least recently
+/// used" against. A deterministic order is mandatory (the maps ride
+/// `cursor_json`, hashed into the #602 transition digest — §2.6), and the
+/// rebuild cost above is what makes the ordering's quality nearly irrelevant.
+const MAX_OPENCODE_CONTEXT_ENTRIES: usize = 20_000;
+const MAX_OPENCODE_CONTEXT_BYTES: usize = 4 * 1024 * 1024;
+
 const OPENCODE_LONG_BINARY_STRING_CHARS: usize = 65_536;
 const OPENCODE_DUPLICATE_SESSION_MESSAGE_TYPES: &[&str] = &["user", "assistant"];
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+/// The §3.1 Change 3 bounded context rebuild: type-scoped (index-driven, never
+/// a full replay) and bounded at the resume watermark — events past it are
+/// walked by the page loop itself, so the rebuild reconstructs history only.
+fn opencode_context_rebuild_sql() -> String {
+    let types = OPENCODE_SESSION_CONTEXT_EVENT_TYPES
+        .iter()
+        .chain(OPENCODE_MESSAGE_CONTEXT_EVENT_TYPES)
+        .map(|event_type| format!("'{event_type}'"))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "SELECT id, aggregate_id, seq, type, data FROM event \
+         WHERE aggregate_id = ?1 AND seq <= ?2 AND type IN ({types}) \
+         ORDER BY seq"
+    )
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 struct OpenCodeSessionContext {
     #[serde(default)]
     directory: String,
@@ -42,7 +84,7 @@ struct OpenCodeSessionContext {
     model: Option<Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 struct OpenCodeMessageContext {
     #[serde(default)]
     role: String,
@@ -56,7 +98,10 @@ struct OpenCodeMessageContext {
     directory: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+/// `Eq` is deliberately absent: the persisted contexts carry `serde_json`
+/// values (`model`), which are `PartialEq` only. `scan_is_noop`'s structural
+/// comparison needs `PartialEq` alone.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 struct OpenCodeState {
     version: u32,
     format: String,
@@ -66,10 +111,32 @@ struct OpenCodeState {
     event_scan_complete: bool,
     #[serde(default)]
     aggregate_sequences: BTreeMap<String, i64>,
+    /// Persisted reconstruction context (issue #601 §3.1 Change 2): the exact
+    /// inputs `enrich_message_record` / `enrich_part_record` /
+    /// `enrich_session_message_record` and `push_opencode_record`'s
+    /// `project_dir` derivation consume, seeded from the prior poll and
+    /// updated in place by delta events — which is what lets the page loop
+    /// start at the watermark instead of replaying history for context.
+    /// Keyed by session id (OpenCode's aggregate id for session aggregates).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    session_contexts: BTreeMap<String, OpenCodeSessionContext>,
+    /// Message contexts, nested by session (aggregate) id then message id, so
+    /// the §3.1 Change 4 ceiling can evict whole aggregates and the Change 7
+    /// disappearance rule can drop them.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    message_contexts: BTreeMap<String, BTreeMap<String, OpenCodeMessageContext>>,
     #[serde(default)]
     project_exclusions_hash: u64,
     #[serde(default)]
     last_error: String,
+    /// True while a work budget deliberately left known events unread this
+    /// generation (issue #601 §2.3's persisted resume marker). The cheap stat
+    /// short-circuit must not fire while set, or a quiet store's remainder is
+    /// unreachable forever. A function of committed scan decisions — never a
+    /// timestamp — so it rides the #602 digest safely (§2.6), and omitted
+    /// while false so `cursor_json` stays byte-identical for covered stores.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pending_coverage: bool,
 }
 
 impl OpenCodeState {
@@ -98,6 +165,51 @@ impl OpenCodeState {
 
     fn serialize(&self) -> String {
         serde_json::to_string(self).unwrap_or_default()
+    }
+
+    /// Enforce the §3.1 Change 4 context ceilings by evicting whole aggregates
+    /// (session context plus that aggregate's message contexts together, so an
+    /// aggregate is either enrichable or cleanly rebuildable — never half of
+    /// each). Returns the number of context *entries* dropped. Removal is in
+    /// batches of one-eighth of the aggregate set per round so a pathological
+    /// many-small-entries payload does not re-serialize per entry. See the
+    /// ceiling constants for why the order is ascending `aggregate_id`.
+    fn evict_contexts_to_fit(&mut self, max_entries: usize, max_bytes: usize) -> u64 {
+        let mut evicted = 0u64;
+        loop {
+            let entries = self
+                .message_contexts
+                .values()
+                .map(BTreeMap::len)
+                .sum::<usize>()
+                + self.session_contexts.len();
+            let bytes = serde_json::to_string(&(&self.session_contexts, &self.message_contexts))
+                .map(|raw| raw.len())
+                .unwrap_or(0);
+            if entries <= max_entries && bytes <= max_bytes {
+                return evicted;
+            }
+            let aggregates: Vec<String> = self
+                .session_contexts
+                .keys()
+                .chain(self.message_contexts.keys())
+                .cloned()
+                .collect::<std::collections::BTreeSet<_>>()
+                .into_iter()
+                .collect();
+            if aggregates.is_empty() {
+                return evicted;
+            }
+            let batch = (aggregates.len().div_ceil(8)).max(1);
+            for id in aggregates.into_iter().take(batch) {
+                if self.session_contexts.remove(&id).is_some() {
+                    evicted += 1;
+                }
+                if let Some(messages) = self.message_contexts.remove(&id) {
+                    evicted += messages.len() as u64;
+                }
+            }
+        }
     }
 }
 
@@ -131,7 +243,6 @@ struct OpenCodeAccumulated {
 #[derive(Debug)]
 enum OpenCodeScanError {
     Scan(anyhow::Error),
-    TooLarge(String),
 }
 
 impl From<anyhow::Error> for OpenCodeScanError {
@@ -146,12 +257,24 @@ impl From<rusqlite::Error> for OpenCodeScanError {
     }
 }
 
+/// One skipped row, destined for a single `ingest_errors` row (§2.3): an
+/// un-processable single event — larger than `SCAN_PAGE_MAX_BYTES` — is
+/// reported once and advanced past, never allowed to fail the scan. The
+/// watermark advancing past it is what makes the report one-shot.
+#[derive(Debug, Clone)]
+struct OpenCodeRowError {
+    source_line_no: u64,
+    error_kind: &'static str,
+    error_text: String,
+}
+
 enum OpenCodeScanOutcome {
     Scanned {
         records: Vec<SyntheticRecord>,
-        new_state: OpenCodeState,
+        new_state: Box<OpenCodeState>,
         schema_fingerprint: u64,
         relevant_rows: u64,
+        row_errors: Vec<OpenCodeRowError>,
     },
     Failed {
         error_kind: &'static str,
@@ -313,7 +436,18 @@ pub(crate) async fn process_opencode_sqlite_db(
     // throttle for the sweep slice must read the fault ladder alone.
     // `an_ordinary_poll_of_a_contended_opencode_store_is_not_throttled` fails
     // if it is added. See `plans/601-delta-sqlite.md` §7 WI-10.
-    if state.stat == current_stat && state.event_scan_complete && state.last_error.is_empty() {
+    //
+    // The `!pending_coverage` conjunct is §2.3's "continue next poll": while a
+    // budget remainder exists an unchanged stat must not end the poll (a quiet
+    // store's stat never moves again). Terminates because each resumed poll
+    // retires at least one budget of the remainder and the flag clears with
+    // the covering scan's checkpoint
+    // (`a_degraded_opencode_cold_ingest_completes_without_new_writes`).
+    if state.stat == current_stat
+        && state.event_scan_complete
+        && state.last_error.is_empty()
+        && !state.pending_coverage
+    {
         return Ok(());
     }
 
@@ -336,9 +470,19 @@ pub(crate) async fn process_opencode_sqlite_db(
 
     let scan_db_path = source_file.clone();
     let scan_state = state.clone();
+    // The fast-path work budget (issue #601 §2.1), from `[ingest.sqlite]`.
+    // Exceeding it commits what was read and degrades coverage; it never fails
+    // the scan. A replacement replay is unbudgeted: its finalize publishes the
+    // generation whole, so degrading it would publish a hole through #602
+    // (`an_opencode_replacement_replay_reads_past_the_fast_path_budget`).
+    let budget = if replacement_replay {
+        ScanBudget::unbounded()
+    } else {
+        ScanBudget::fast_path(&config.ingest.sqlite)
+    };
     let (outcome, ledger) = tokio::task::spawn_blocking(move || {
         let mut ledger = ScanLedger::default();
-        let outcome = scan_opencode_database(&scan_db_path, &scan_state, &mut ledger);
+        let outcome = scan_opencode_database(&scan_db_path, &scan_state, &budget, &mut ledger);
         (outcome, ledger)
     })
     .await
@@ -351,6 +495,7 @@ pub(crate) async fn process_opencode_sqlite_db(
             mut new_state,
             schema_fingerprint,
             relevant_rows,
+            row_errors,
         } => {
             new_state.stat = current_stat;
             new_state.last_error = String::new();
@@ -372,7 +517,7 @@ pub(crate) async fn process_opencode_sqlite_db(
                 && !retry_blocked_replay
                 && records.is_empty()
                 && checkpoint.status == "active"
-                && new_state == prior_state_covered
+                && *new_state == prior_state_covered
                 && schema_fingerprint == checkpoint.schema_fingerprint;
             if scan_is_noop {
                 poll_state.record_noop_scan(&cp_key, checkpoint.source_generation, new_state.stat);
@@ -390,6 +535,22 @@ pub(crate) async fn process_opencode_sqlite_db(
             }
 
             let mut batch = RowBatch::default();
+            // Per-row skips (§2.3): one `ingest_errors` row each, one-shot
+            // because the aggregate watermark advanced past the skipped event.
+            for row_error in &row_errors {
+                batch.push_error_row(json!({
+                    "source_name": work.source_name,
+                    "harness": work.harness,
+                    "source_file": source_file,
+                    "source_inode": inode,
+                    "source_generation": checkpoint.source_generation,
+                    "source_line_no": row_error.source_line_no,
+                    "source_offset": 0u64,
+                    "error_kind": row_error.error_kind,
+                    "error_text": row_error.error_text,
+                    "raw_fragment": "",
+                }));
+            }
             let mut replay_block_reason = None::<String>;
             for synthetic in &records {
                 if crate::dispatch::record_project_dir_is_excluded(
@@ -463,7 +624,7 @@ pub(crate) async fn process_opencode_sqlite_db(
                 } else {
                     "active".to_string()
                 },
-                cursor_json: new_state.serialize(),
+                cursor_json: (*new_state).serialize(),
                 source_fingerprint: inode,
                 schema_fingerprint,
                 policy_fingerprint: policy_fingerprint.clone(),
@@ -606,9 +767,21 @@ pub(crate) async fn process_opencode_sqlite_db(
 
 /// The caller owns `ledger` so that every early return — including each
 /// failure arm — still reports the bytes this scan had already paid for.
+///
+/// **Ceiling degradation (issue #601 §2.3, G4 row 4).** This scan has no
+/// history-size failure mode: `MAX_OPENCODE_RELEVANT_ROWS` /
+/// `MAX_OPENCODE_SCAN_BYTES` and their `sqlite_cursor_too_large` arms are
+/// retired, along with the per-aggregate `sum(length(data))` preflight that
+/// fed them — which also removes the preflight's second full pass over `data`
+/// (the ~2× §1.1 finding 2 predicted) and one of the duplicate
+/// `event_sequence` reads (§3.1 Change 5): the scan now reads
+/// `event_sequence` exactly once, here, and threads it down. What bounds a
+/// poll is the per-poll work budget; exceeding it commits what was read and
+/// records `coverage_degraded`.
 fn scan_opencode_database(
     db_path: &str,
     prior: &OpenCodeState,
+    budget: &ScanBudget,
     ledger: &mut ScanLedger,
 ) -> OpenCodeScanOutcome {
     let connection = match open_read_only(db_path) {
@@ -643,44 +816,18 @@ fn scan_opencode_database(
         }
     };
 
-    match opencode_relevant_stats(&connection, prior, ledger) {
-        Ok(stats) if stats.rows > MAX_OPENCODE_RELEVANT_ROWS => {
-            return OpenCodeScanOutcome::Failed {
-                error_kind: ERROR_KIND_TOO_LARGE,
-                error_text: format!(
-                    "{} OpenCode events exceed the {MAX_OPENCODE_RELEVANT_ROWS} event scan ceiling",
-                    stats.rows
-                ),
-            };
-        }
-        Ok(stats) if stats.max_row_bytes > SCAN_PAGE_MAX_BYTES as u64 => {
-            return OpenCodeScanOutcome::Failed {
-                error_kind: ERROR_KIND_TOO_LARGE,
-                error_text: format!(
-                    "largest OpenCode row is {} bytes, exceeding the {} byte row ceiling",
-                    stats.max_row_bytes, SCAN_PAGE_MAX_BYTES
-                ),
-            };
-        }
-        Ok(stats) if stats.total_bytes > MAX_OPENCODE_SCAN_BYTES => {
-            return OpenCodeScanOutcome::Failed {
-                error_kind: ERROR_KIND_TOO_LARGE,
-                error_text: format!(
-                    "{} OpenCode source bytes exceed the {} byte scan ceiling",
-                    stats.total_bytes, MAX_OPENCODE_SCAN_BYTES
-                ),
-            };
-        }
-        Ok(_) => {}
+    // §3.1 Change 5: the single `event_sequence` read this scan performs.
+    let aggregates = match opencode_aggregate_sequences(&connection, ledger) {
+        Ok(aggregates) => aggregates,
         Err(exc) => {
             return OpenCodeScanOutcome::Failed {
                 error_kind: ERROR_KIND_SCAN,
                 error_text: format!("{exc:#}"),
-            };
+            }
         }
-    }
+    };
 
-    let result = scan_opencode_rows(&connection, prior, ledger);
+    let result = scan_opencode_rows(&connection, prior, &aggregates, budget, ledger);
     let data_version_after = match sqlite_data_version(&connection) {
         Ok(value) => value,
         Err(exc) => {
@@ -705,19 +852,16 @@ fn scan_opencode_database(
     }
 
     match result {
-        Ok((records, new_state, relevant_rows)) => OpenCodeScanOutcome::Scanned {
-            records,
-            new_state,
+        Ok(scan) => OpenCodeScanOutcome::Scanned {
+            records: scan.records,
+            new_state: scan.new_state,
             schema_fingerprint,
-            relevant_rows,
+            relevant_rows: scan.relevant_rows,
+            row_errors: scan.row_errors,
         },
         Err(OpenCodeScanError::Scan(exc)) => OpenCodeScanOutcome::Failed {
             error_kind: ERROR_KIND_SCAN,
             error_text: format!("{exc:#}"),
-        },
-        Err(OpenCodeScanError::TooLarge(error_text)) => OpenCodeScanOutcome::Failed {
-            error_kind: ERROR_KIND_TOO_LARGE,
-            error_text,
         },
     }
 }
@@ -752,90 +896,126 @@ fn validate_opencode_schema(
     Ok(hash_str(&schema_material))
 }
 
-#[derive(Default)]
-struct OpenCodeRelevantStats {
-    rows: u64,
-    total_bytes: u64,
-    max_row_bytes: u64,
+/// What one `scan_opencode_rows` call produced.
+struct OpenCodeRowsScan {
+    records: Vec<SyntheticRecord>,
+    new_state: Box<OpenCodeState>,
+    relevant_rows: u64,
+    row_errors: Vec<OpenCodeRowError>,
 }
 
-/// Preflight sizing, and an honest account of what it costs.
+/// The delta scan (issue #601 §3.1). Each changed aggregate's page loop starts
+/// at its persisted watermark (Change 1) — never `-1` — and the persisted
+/// contexts supply the history the replay used to rebuild (Change 2), with the
+/// type-scoped rebuild as the bounded fallback when an aggregate's context was
+/// evicted or predates persistence (Change 3).
 ///
-/// The per-aggregate statement below is a scalar aggregate, so it materializes
-/// no row — but `sum(length(coalesce(data, '')))` makes SQLite decode every
-/// byte of `data` in the range (§1.1 finding 2). Those bytes are charged on the
-/// payload axis, which is why a cold OpenCode scan's `payload_bytes` is roughly
-/// **twice** its `data` size: once here and once in the page loop. That is the
-/// truth, and it is what makes the duplication visible to a byte budget instead
-/// of leaving it "real and invisible".
+/// **Ordering under the budget.** Changed *known* aggregates first — their
+/// watermark is exact, so this is the §2.3 "newest-first" for OpenCode
+/// (`event_sequence.seq > persisted seq` is the one exact recency signal the
+/// store has) and what §4's active-session freshness claim rides on — then
+/// never-read aggregates (cold debt), ascending `aggregate_id` within each
+/// class (no cross-aggregate recency ordering exists; `seq` is per-aggregate).
+/// Convergence does not need Cursor/NAC's never-read-first rule here: the
+/// per-aggregate watermark is a durable resume position, so the delta class
+/// shrinks to nothing and cold debt then takes the whole budget — D8a's
+/// argument, per aggregate.
 ///
-/// Issue #601 §3.1 Change 5 folds this O(#aggregates) preflight into the single
-/// `event_sequence` read, at which point the doubling disappears;
-/// `opencode_ledger_charges_payload_bytes_at_the_read_site` pins the current
-/// number so that change cannot land silently.
-fn opencode_relevant_stats(
-    connection: &Connection,
-    prior: &OpenCodeState,
-    ledger: &mut ScanLedger,
-) -> Result<OpenCodeRelevantStats> {
-    let mut stats = OpenCodeRelevantStats::default();
-    for aggregate in opencode_aggregate_sequences(connection, ledger)? {
-        let prior_seq = opencode_scan_from_seq(prior, &aggregate);
-        let (rows, total_bytes, max_row_bytes): (i64, i64, i64) = connection
-            .query_row(
-                // `CAST(… AS BLOB)` on purpose: bare `length()` over a TEXT
-                // value counts *characters*, and both results are compared
-                // against byte ceilings and charged to a byte axis. The
-                // in-scan check (`build_event_row`) measures real bytes, so
-                // the character form also made the preflight and the loop
-                // disagree on any non-ASCII payload.
-                "SELECT count(*), coalesce(sum(length(CAST(coalesce(data, '') AS BLOB))), 0), \
-                 coalesce(max(length(CAST(coalesce(data, '') AS BLOB))), 0) \
-                 FROM event WHERE aggregate_id = ?1 AND seq > ?2 AND seq <= ?3",
-                rusqlite::params![&aggregate.aggregate_id, prior_seq, aggregate.seq],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-            )
-            .with_context(|| {
-                format!(
-                    "failed measuring OpenCode events for {}",
-                    aggregate.aggregate_id
-                )
-            })?;
-        stats.rows = stats.rows.saturating_add(rows.max(0) as u64);
-        stats.total_bytes = stats.total_bytes.saturating_add(total_bytes.max(0) as u64);
-        stats.max_row_bytes = stats.max_row_bytes.max(max_row_bytes.max(0) as u64);
-        // `sum(length(data))` is exactly the count of bytes SQLite decoded to
-        // answer this statement, so it is also exactly what the payload axis
-        // owes for it.
-        ledger.charge_aggregate_payload_bytes(total_bytes.max(0) as u64);
-    }
-    Ok(stats)
-}
-
+/// **Budget binding.** Between events, never before the first this poll (a
+/// poll always makes forward progress); the bound event was materialized by
+/// SQLite before the check could run, so it is charged one payload row with no
+/// bytes — the same honest-ledger rule as NAC's episode loop.
 fn scan_opencode_rows(
     connection: &Connection,
     prior: &OpenCodeState,
+    aggregates: &[OpenCodeAggregateSequence],
+    budget: &ScanBudget,
     ledger: &mut ScanLedger,
-) -> std::result::Result<(Vec<SyntheticRecord>, OpenCodeState, u64), OpenCodeScanError> {
+) -> std::result::Result<OpenCodeRowsScan, OpenCodeScanError> {
     let mut records = Vec::new();
     let mut accumulated = OpenCodeAccumulated::default();
     let mut aggregate_sequences = BTreeMap::new();
-    let mut session_contexts = BTreeMap::new();
-    let mut message_contexts = BTreeMap::new();
+    let mut row_errors = Vec::new();
     let mut relevant_events = 0u64;
-    let mut context_events = 0u64;
-    let mut context_bytes = 0u64;
+    let mut events_processed = 0u64;
+    let mut degraded = false;
 
-    for aggregate in opencode_aggregate_sequences(connection, ledger)? {
-        let scan_from_seq = opencode_scan_from_seq(prior, &aggregate);
+    // Change 7: a vanished aggregate drops its watermark (absent from the
+    // rebuild below) *and* its context entries (filtered here) — it is not a
+    // rewind and must never bump the generation (G8b).
+    let current_ids: std::collections::BTreeSet<&str> = aggregates
+        .iter()
+        .map(|aggregate| aggregate.aggregate_id.as_str())
+        .collect();
+    let mut session_contexts: BTreeMap<String, OpenCodeSessionContext> = prior
+        .session_contexts
+        .iter()
+        .filter(|(id, _)| current_ids.contains(id.as_str()))
+        .map(|(id, context)| (id.clone(), context.clone()))
+        .collect();
+    let mut message_contexts: BTreeMap<String, BTreeMap<String, OpenCodeMessageContext>> = prior
+        .message_contexts
+        .iter()
+        .filter(|(id, _)| current_ids.contains(id.as_str()))
+        .map(|(id, contexts)| (id.clone(), contexts.clone()))
+        .collect();
+
+    let mut changed: Vec<(&OpenCodeAggregateSequence, i64, bool)> = Vec::new();
+    for aggregate in aggregates {
+        let scan_from_seq = opencode_scan_from_seq(prior, aggregate);
         if aggregate.seq <= scan_from_seq {
             aggregate_sequences.insert(aggregate.aggregate_id.clone(), scan_from_seq);
             continue;
         }
+        let known = prior
+            .aggregate_sequences
+            .contains_key(&aggregate.aggregate_id);
+        changed.push((aggregate, scan_from_seq, known));
+    }
+    // Delta (known) class before cold (never-read) class; `aggregates` arrives
+    // in `aggregate_id` order, and the stable sort keeps it within each class.
+    changed.sort_by_key(|(_, _, known)| std::cmp::Reverse(*known));
 
-        let mut last_seq = -1;
+    for (idx, (aggregate, scan_from_seq, _)) in changed.iter().enumerate() {
+        if events_processed > 0 && budget.is_exhausted_by(ledger.payload_rows, ledger.payload_bytes)
+        {
+            // Commit what was read (§2.1/§2.3): skipped known aggregates keep
+            // their watermark ("unread this poll", never "rewound"), skipped
+            // never-read aggregates stay absent so a later poll re-detects
+            // them. The skip is exact on the rows axis — `seq` bounds it.
+            let mut skipped_events = 0u64;
+            for (aggregate, scan_from_seq, _) in &changed[idx..] {
+                if *scan_from_seq >= 0 {
+                    aggregate_sequences.insert(aggregate.aggregate_id.clone(), *scan_from_seq);
+                }
+                skipped_events = skipped_events
+                    .saturating_add(aggregate.seq.saturating_sub((*scan_from_seq).max(-1)) as u64);
+            }
+            ledger.mark_degraded(skipped_events, 0);
+            degraded = true;
+            break;
+        }
+
+        // Change 3: resuming an aggregate whose session context is missing
+        // (evicted, or the cursor predates context persistence) rebuilds it
+        // with the type-scoped read — 95 rows / 47 KB / ~0.5 ms on the
+        // reference aggregate versus 639 rows / 6.9 MB for the full replay.
+        if *scan_from_seq >= 0 && !session_contexts.contains_key(&aggregate.aggregate_id) {
+            rebuild_opencode_context(
+                connection,
+                &aggregate.aggregate_id,
+                *scan_from_seq,
+                &mut session_contexts,
+                &mut message_contexts,
+                ledger,
+            )?;
+        }
+
+        // Change 1: the page loop's lower bound is the persisted watermark.
+        let mut last_seq = *scan_from_seq;
         let mut observed_any = false;
-        loop {
+        let mut aggregate_bound = false;
+        'pages: loop {
             let mut page_rows = 0usize;
             let mut page_bytes = 0usize;
             let mut page_capped = false;
@@ -848,39 +1028,49 @@ fn scan_opencode_rows(
                     SCAN_PAGE_SIZE as i64
                 ])?;
                 while let Some(row) = rows.next()? {
+                    if events_processed > 0
+                        && budget.is_exhausted_by(ledger.payload_rows, ledger.payload_bytes)
+                    {
+                        // The row SQLite just handed over was materialized
+                        // before the budget could be consulted: one row on the
+                        // rows axis, no bytes (its columns are never taken).
+                        // It stays inside the skipped remainder — the
+                        // watermark did not advance past it.
+                        ledger.charge_payload_row();
+                        aggregate_bound = true;
+                        break 'pages;
+                    }
                     let event = build_event_row(row, ledger)?;
                     if event.data_bytes > SCAN_PAGE_MAX_BYTES {
-                        return Err(OpenCodeScanError::TooLarge(format!(
-                            "largest OpenCode event is {} bytes, exceeding the {} byte row ceiling",
-                            event.data_bytes, SCAN_PAGE_MAX_BYTES
-                        )));
+                        // Un-processable single row (§2.3): one error row,
+                        // skip it, advance the watermark past it — one-shot,
+                        // never a scan failure and never a stall.
+                        row_errors.push(OpenCodeRowError {
+                            source_line_no: event.seq.max(0) as u64,
+                            error_kind: ERROR_KIND_ROW_TOO_LARGE,
+                            error_text: format!(
+                                "OpenCode event {} (aggregate {}, seq {}) is {} bytes, \
+                                 exceeding the {} byte row ceiling; event skipped",
+                                event.id,
+                                event.aggregate_id,
+                                event.seq,
+                                event.data_bytes,
+                                SCAN_PAGE_MAX_BYTES
+                            ),
+                        });
+                        last_seq = event.seq;
+                        observed_any = true;
+                        events_processed += 1;
+                        relevant_events += 1;
+                        continue;
                     }
                     page_rows += 1;
                     page_bytes = page_bytes.saturating_add(event.data_bytes);
-                    context_events = context_events.saturating_add(1);
-                    context_bytes = context_bytes.saturating_add(event.data_bytes as u64);
-                    if context_events > MAX_OPENCODE_RELEVANT_ROWS {
-                        return Err(OpenCodeScanError::TooLarge(format!(
-                            "{context_events} OpenCode context events exceed the {MAX_OPENCODE_RELEVANT_ROWS} event scan ceiling"
-                        )));
-                    }
-                    if context_bytes > MAX_OPENCODE_SCAN_BYTES {
-                        return Err(OpenCodeScanError::TooLarge(format!(
-                            "{context_bytes} OpenCode context bytes exceed the {MAX_OPENCODE_SCAN_BYTES} byte scan ceiling"
-                        )));
-                    }
-
                     update_opencode_context(&event, &mut session_contexts, &mut message_contexts);
+                    apply_opencode_event(&event, &mut accumulated);
+                    relevant_events += 1;
+                    events_processed += 1;
                     observed_any = true;
-                    if event.seq > scan_from_seq {
-                        relevant_events += 1;
-                        if relevant_events > MAX_OPENCODE_RELEVANT_ROWS {
-                            return Err(OpenCodeScanError::TooLarge(format!(
-                                "{relevant_events} OpenCode events exceed the {MAX_OPENCODE_RELEVANT_ROWS} event scan ceiling"
-                            )));
-                        }
-                        apply_opencode_event(&event, &mut accumulated);
-                    }
                     last_seq = event.seq;
                     if page_bytes >= SCAN_PAGE_MAX_BYTES || page_rows >= SCAN_PAGE_SIZE {
                         page_capped = true;
@@ -893,10 +1083,25 @@ fn scan_opencode_rows(
                 break;
             }
         }
+        if aggregate_bound {
+            // Mid-aggregate bound: the watermark is the durable resume
+            // position (D8a's rule — oldest-first of the new tail, because an
+            // exact resume position exists), so the next poll continues from
+            // exactly here. Remaining aggregates are handled by the
+            // between-aggregate check above on the next iteration.
+            if observed_any {
+                aggregate_sequences.insert(aggregate.aggregate_id.clone(), last_seq);
+            } else if *scan_from_seq >= 0 {
+                aggregate_sequences.insert(aggregate.aggregate_id.clone(), *scan_from_seq);
+            }
+            ledger.mark_degraded(aggregate.seq.saturating_sub(last_seq.max(-1)) as u64, 0);
+            degraded = true;
+            continue;
+        }
         if observed_any {
             aggregate_sequences.insert(aggregate.aggregate_id.clone(), last_seq);
-        } else if scan_from_seq >= 0 {
-            aggregate_sequences.insert(aggregate.aggregate_id.clone(), scan_from_seq);
+        } else if *scan_from_seq >= 0 {
+            aggregate_sequences.insert(aggregate.aggregate_id.clone(), *scan_from_seq);
         }
     }
 
@@ -922,8 +1127,49 @@ fn scan_opencode_rows(
     new_state.project_exclusions_hash = prior.project_exclusions_hash;
     new_state.event_scan_complete = true;
     new_state.aggregate_sequences = aggregate_sequences;
+    new_state.session_contexts = session_contexts;
+    new_state.message_contexts = message_contexts;
+    // §2.3's persisted resume marker: set exactly when this scan deliberately
+    // left known events unread. Context eviction below is *not* coverage debt
+    // — events are immutable, watermarks are kept, and enrichment rebuilds on
+    // demand — so it marks the ledger but not this flag.
+    new_state.pending_coverage = degraded;
+    // Change 4: the context ceiling, enforced by eviction, never by failing.
+    let evicted =
+        new_state.evict_contexts_to_fit(MAX_OPENCODE_CONTEXT_ENTRIES, MAX_OPENCODE_CONTEXT_BYTES);
+    ledger.mark_evicted(evicted);
     ledger.rows_emitted = records.len() as u64;
-    Ok((records, new_state, relevant_events))
+    Ok(OpenCodeRowsScan {
+        records,
+        new_state: Box::new(new_state),
+        relevant_rows: relevant_events,
+        row_errors,
+    })
+}
+
+/// §3.1 Change 3: rebuild one aggregate's reconstruction context from its
+/// context-bearing events at or below the resume watermark. Type-scoped and
+/// index-driven — the whole point is that this is *not* a replay — and charged
+/// on the payload axis at the read site like every other `data` read.
+fn rebuild_opencode_context(
+    connection: &Connection,
+    aggregate_id: &str,
+    through_seq: i64,
+    session_contexts: &mut BTreeMap<String, OpenCodeSessionContext>,
+    message_contexts: &mut BTreeMap<String, BTreeMap<String, OpenCodeMessageContext>>,
+    ledger: &mut ScanLedger,
+) -> std::result::Result<(), OpenCodeScanError> {
+    let sql = opencode_context_rebuild_sql();
+    let mut stmt = connection.prepare_cached(&sql)?;
+    let mut rows = stmt.query(rusqlite::params![aggregate_id, through_seq])?;
+    while let Some(row) = rows.next()? {
+        let event = build_event_row(row, ledger)?;
+        if event.data_bytes > SCAN_PAGE_MAX_BYTES {
+            continue;
+        }
+        update_opencode_context(&event, session_contexts, message_contexts);
+    }
+    Ok(())
 }
 
 fn opencode_sequences_rewound(
@@ -941,13 +1187,20 @@ fn opencode_sequences_rewound(
         .into_iter()
         .map(|aggregate| (aggregate.aggregate_id, aggregate.seq))
         .collect::<BTreeMap<_, _>>();
+    // §3.1 Change 7: disappearance is not a rewind. An aggregate absent from
+    // `event_sequence` (one deleted old session) drops its watermark and
+    // context entries in the scan and must not force a whole-database
+    // generation bump and full re-ingest (G8b,
+    // `opencode_disappearing_aggregate_is_not_a_generation_bump`). Only a
+    // genuine `current < prior` regression routes through
+    // `begin_database_replay`.
     Ok(prior
         .aggregate_sequences
         .iter()
         .any(|(aggregate_id, prior_seq)| {
             current
                 .get(aggregate_id)
-                .is_none_or(|current_seq| current_seq < prior_seq)
+                .is_some_and(|current_seq| current_seq < prior_seq)
         }))
 }
 
@@ -1013,44 +1266,46 @@ fn build_event_row(row: &rusqlite::Row<'_>, ledger: &mut ScanLedger) -> Result<O
 fn update_opencode_context(
     event: &OpenCodeEventRow,
     session_contexts: &mut BTreeMap<String, OpenCodeSessionContext>,
-    message_contexts: &mut BTreeMap<String, OpenCodeMessageContext>,
+    message_contexts: &mut BTreeMap<String, BTreeMap<String, OpenCodeMessageContext>>,
 ) {
-    match event.event_type.as_str() {
-        "session.created.1" | "session.updated.1" => {
-            let info = event.data.get("info").unwrap_or(&event.data);
-            if let Some((id, record)) = build_session_event_record(info) {
-                let next = session_context_from_record(&record);
-                session_contexts
-                    .entry(id)
-                    .and_modify(|current| {
-                        if !std::path::Path::new(&current.directory).is_absolute()
-                            && std::path::Path::new(&next.directory).is_absolute()
-                        {
-                            current.directory.clone_from(&next.directory);
-                        }
-                        if next.model.is_some() {
-                            current.model.clone_from(&next.model);
-                        }
-                    })
-                    .or_insert(next);
-            }
+    // Dispatch on the same constants the rebuild SQL is derived from (§3.1
+    // Change 3's single source of truth).
+    let event_type = event.event_type.as_str();
+    if OPENCODE_SESSION_CONTEXT_EVENT_TYPES.contains(&event_type) {
+        let info = event.data.get("info").unwrap_or(&event.data);
+        if let Some((id, record)) = build_session_event_record(info) {
+            let next = session_context_from_record(&record);
+            session_contexts
+                .entry(id)
+                .and_modify(|current| {
+                    if !std::path::Path::new(&current.directory).is_absolute()
+                        && std::path::Path::new(&next.directory).is_absolute()
+                    {
+                        current.directory.clone_from(&next.directory);
+                    }
+                    if next.model.is_some() {
+                        current.model.clone_from(&next.model);
+                    }
+                })
+                .or_insert(next);
         }
-        "message.updated.1" => {
-            let info = event.data.get("info").unwrap_or(&event.data);
-            if let Some((id, record)) = build_message_event_record(info) {
-                let context = message_context_from_record(&record);
-                if let Some(session_id) = record.get("session_id").and_then(Value::as_str) {
-                    if std::path::Path::new(&context.directory).is_absolute() {
-                        let session = session_contexts.entry(session_id.to_string()).or_default();
-                        if !std::path::Path::new(&session.directory).is_absolute() {
-                            session.directory.clone_from(&context.directory);
-                        }
+    } else if OPENCODE_MESSAGE_CONTEXT_EVENT_TYPES.contains(&event_type) {
+        let info = event.data.get("info").unwrap_or(&event.data);
+        if let Some((id, record)) = build_message_event_record(info) {
+            let context = message_context_from_record(&record);
+            if let Some(session_id) = record.get("session_id").and_then(Value::as_str) {
+                if std::path::Path::new(&context.directory).is_absolute() {
+                    let session = session_contexts.entry(session_id.to_string()).or_default();
+                    if !std::path::Path::new(&session.directory).is_absolute() {
+                        session.directory.clone_from(&context.directory);
                     }
                 }
-                message_contexts.insert(id, context);
+                message_contexts
+                    .entry(session_id.to_string())
+                    .or_default()
+                    .insert(id, context);
             }
         }
-        _ => {}
     }
 }
 
@@ -1452,13 +1707,14 @@ fn enrich_message_record(
 fn enrich_part_record(
     record: &mut Map<String, Value>,
     session_contexts: &BTreeMap<String, OpenCodeSessionContext>,
-    message_contexts: &BTreeMap<String, OpenCodeMessageContext>,
+    message_contexts: &BTreeMap<String, BTreeMap<String, OpenCodeMessageContext>>,
 ) {
     let session_id = record
         .get("session_id")
         .and_then(Value::as_str)
-        .unwrap_or_default();
-    if let Some(context) = session_contexts.get(session_id) {
+        .unwrap_or_default()
+        .to_string();
+    if let Some(context) = session_contexts.get(&session_id) {
         if !record.contains_key("directory") && !context.directory.is_empty() {
             record.insert("directory".to_string(), json!(context.directory));
         }
@@ -1473,7 +1729,10 @@ fn enrich_part_record(
         .get("message_id")
         .and_then(Value::as_str)
         .unwrap_or_default();
-    if let Some(context) = message_contexts.get(message_id) {
+    if let Some(context) = message_contexts
+        .get(&session_id)
+        .and_then(|by_message| by_message.get(message_id))
+    {
         if !context.role.is_empty() {
             record.insert("message_role".to_string(), json!(context.role));
         }

--- a/crates/moraine-ingest-core/src/sqlite_poll/opencode/tests.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/opencode/tests.rs
@@ -494,6 +494,12 @@ fn seed_opencode_db(path: &PathBuf) -> Connection {
     connection
 }
 
+/// The shipped-default fast-path budget: what a production poll runs with
+/// when nothing in `[ingest.sqlite]` is overridden.
+fn default_opencode_budget() -> ScanBudget {
+    ScanBudget::fast_path(&moraine_config::SqliteIngestConfig::default())
+}
+
 fn opencode_sqlite_work(path: &Path) -> WorkItem {
     WorkItem {
         source_name: "opencode-sqlite-test".to_string(),
@@ -1101,9 +1107,17 @@ async fn opencode_sqlite_first_poll_emits_allowlisted_conversation_rows() {
             .is_some(),
         "OpenCode uses the append-only event sequence cursor"
     );
+    // §3.1 Change 4 restates the old "no context maps" absence check as a size
+    // budget: WI-06 *requires* persisting the reconstruction context (it is
+    // what lets the page loop start at the watermark), and what stays bounded
+    // is the serialized footprint, enforced by `evict_contexts_to_fit`.
     assert!(
-        cursor.get("session_contexts").is_none() && cursor.get("message_contexts").is_none(),
-        "OpenCode checkpoints stay bounded to aggregate sequence cursors"
+        cursor.pointer("/session_contexts/ses_demo").is_some(),
+        "the reconstruction context must persist in the cursor (§3.1 Change 2)"
+    );
+    assert!(
+        checkpoint.cursor_json.len() <= 4 * 1024 * 1024,
+        "the persisted cursor stays under the context byte ceiling"
     );
     let serialized = serde_json::to_string(&raw_rows).expect("serialize raw rows");
     assert!(
@@ -1315,6 +1329,7 @@ fn opencode_sqlite_scan_paginates_past_single_event_page() {
     let outcome = scan_opencode_database(
         path.to_str().expect("utf-8 path"),
         &OpenCodeState::fresh(),
+        &default_opencode_budget(),
         &mut ScanLedger::default(),
     );
     let (records, new_state, relevant_rows) = match outcome {
@@ -1385,6 +1400,7 @@ fn opencode_sqlite_project_dir_stays_on_first_absolute_session_directory() {
     let outcome = scan_opencode_database(
         path.to_str().expect("utf-8 path"),
         &OpenCodeState::fresh(),
+        &default_opencode_budget(),
         &mut ScanLedger::default(),
     );
     let records = match outcome {
@@ -1924,24 +1940,16 @@ fn opencode_fixture_uses_the_production_event_index() {
     cleanup(&path);
 }
 
-/// Issue #601 §2.0 / WI-01, OpenCode arm. Payload bytes are the exact lengths
-/// of what SQLite materialized *plus* what its aggregate preflight forced it to
-/// decode; the census axis carries schema validation and the narrow
-/// `event_sequence` read.
+/// Issue #601 §2.0 / WI-01, OpenCode arm, restated by WI-06 (§3.1 Change 5).
+/// Payload bytes are exactly the lengths of what SQLite materialized in the
+/// page loop — the per-aggregate `sum(length(data))` preflight that used to
+/// double a cold scan's byte cost is gone — and the census axis carries schema
+/// validation plus **one** `event_sequence` read, where WI-01's ledger showed
+/// two.
 ///
-/// Both totals record duplication the ledger exists to expose, so neither is an
-/// arbitrary constant:
-///
-/// - `opencode_aggregate_sequences` runs **twice** per scan (preflight + page
-///   loop), so the census is `2 ×` the `event_sequence` read;
-/// - `opencode_relevant_stats`'s `sum(length(data))` decodes every `data` byte
-///   in the range before the page loop reads the same rows again, so a cold
-///   scan's payload bytes are the row bytes **plus a second full pass over
-///   `data`** — the ~2× §1.1 finding 2 predicts, made visible instead of
-///   "real and invisible".
-///
-/// Issue #601 §3.1 Change 5 removes both duplications; these assertions are
-/// what force that to be restated rather than silently drifting.
+/// These equalities are what stop either duplication from silently returning:
+/// re-adding the preflight, or a second `opencode_aggregate_sequences` call,
+/// moves an exact number.
 #[test]
 fn opencode_ledger_charges_payload_bytes_at_the_read_site() {
     let path = unique_opencode_db_path("ledger-read-site");
@@ -1976,22 +1984,13 @@ fn opencode_ledger_charges_payload_bytes_at_the_read_site() {
     let aggregates: i64 = connection
         .query_row("SELECT count(*) FROM event_sequence", [], |row| row.get(0))
         .expect("count aggregates");
-    // What the preflight aggregate decodes: `data` only, over the same range.
-    let preflight_data_bytes: i64 = connection
-        .query_row(
-            "SELECT coalesce(sum(length(CAST(coalesce(e.data, '') AS BLOB))), 0) \
-             FROM event e JOIN event_sequence s ON s.aggregate_id = e.aggregate_id \
-             WHERE e.seq <= s.seq",
-            [],
-            |row| row.get(0),
-        )
-        .expect("sum preflight decoded bytes");
     drop(connection);
 
     let mut ledger = ScanLedger::default();
     let outcome = scan_opencode_database(
         path.to_str().expect("utf-8 path"),
         &OpenCodeState::fresh(),
+        &default_opencode_budget(),
         &mut ledger,
     );
     let records = match outcome {
@@ -2006,13 +2005,11 @@ fn opencode_ledger_charges_payload_bytes_at_the_read_site() {
         expected_rows > 0 && expected_bytes > 0,
         "fixture must have events"
     );
-    assert!(preflight_data_bytes > 0);
     assert_eq!(
-        ledger.payload_bytes,
-        (expected_bytes + preflight_data_bytes) as u64,
-        "payload bytes are the materialized column lengths plus the bytes the \
-         aggregate preflight forced SQLite to decode; charging only the former \
-         under-reports a cold scan by ~2×"
+        ledger.payload_bytes, expected_bytes as u64,
+        "payload bytes are exactly the materialized column lengths; more means \
+         a duplicate read path (the retired preflight) came back, fewer means \
+         a read bypassed the ledger"
     );
     assert_eq!(ledger.payload_rows, expected_rows as u64);
     assert_eq!(ledger.rows_emitted, records.len() as u64);
@@ -2021,10 +2018,6 @@ fn opencode_ledger_charges_payload_bytes_at_the_read_site() {
         "[DIVERGENT FIXTURE] events read and records emitted must differ, or the \
          two axes are interchangeable and neither is tested"
     );
-    // Census = schema validation + the `event_sequence` read, and the latter
-    // runs **twice** per scan today (preflight + page loop). Issue #601 §3.1
-    // Change 5 folds it to one; this assertion is what forces that number to
-    // be restated rather than silently drifting.
     let schema_census = {
         let connection = crate::sqlite_poll::open_read_only(path.to_str().expect("utf-8 path"))
             .expect("reopen for schema census");
@@ -2033,52 +2026,45 @@ fn opencode_ledger_charges_payload_bytes_at_the_read_site() {
     assert!(schema_census.census_rows > 0);
     assert_eq!(
         ledger.census_rows,
-        schema_census.census_rows + 2 * aggregates as u64,
+        schema_census.census_rows + aggregates as u64,
+        "one event_sequence read per scan (§3.1 Change 5), not two"
     );
     assert_eq!(
         ledger.census_bytes,
-        schema_census.census_bytes + 2 * aggregate_id_bytes as u64
+        schema_census.census_bytes + aggregate_id_bytes as u64
     );
 
     cleanup(&path);
 }
 
-/// Calibration baseline for gates G1b/G3 (issue #601 §3.1). Today
-/// `scan_opencode_rows` starts its page loop at `last_seq = -1`, so appending
-/// one event re-reads the aggregate's entire history — 639 events / 6.9 MB on
-/// the reference host to normalize one new event.
+/// The inversion of WI-01's calibration baseline (`opencode_incremental_scan_
+/// currently_re_reads_the_whole_aggregate`), exactly as that test demanded:
+/// with the page loop starting at the persisted watermark (§3.1 Change 1) and
+/// the reconstruction context persisted (Change 2), one appended event costs
+/// **exactly that event** — not the aggregate's history and not a context
+/// rebuild.
 ///
-/// This test *records* that, so that WI-06's fix has a measured "before" and
-/// so nobody can claim the fix without this assertion changing. When the
-/// watermark start lands, the incremental scan's payload bytes must collapse
-/// to the appended event and this assertion must be inverted.
+/// Fails for: restoring `let mut last_seq = -1;`, a context path that replays
+/// history on a warm scan, or any warm-scan read that bypasses the ledger.
 #[test]
-fn opencode_incremental_scan_currently_re_reads_the_whole_aggregate() {
-    let path = unique_opencode_db_path("incremental-baseline");
+fn opencode_fast_path_reads_only_the_appended_event() {
+    let path = unique_opencode_db_path("incremental-fast-path");
     let connection = seed_opencode_db(&path);
-
-    // The cold scan pays for `data` twice: once in the aggregate preflight and
-    // once in the page loop. Measure the preflight's share so the warm
-    // comparison below is denominated on the page loop alone.
-    let cold_preflight_data_bytes: i64 = connection
-        .query_row(
-            "SELECT coalesce(sum(length(CAST(coalesce(e.data, '') AS BLOB))), 0) \
-             FROM event e JOIN event_sequence s ON s.aggregate_id = e.aggregate_id \
-             WHERE e.seq <= s.seq",
-            [],
-            |row| row.get(0),
-        )
-        .expect("measure cold preflight bytes");
 
     let mut ledger = ScanLedger::default();
     let cold = scan_opencode_database(
         path.to_str().expect("utf-8 path"),
         &OpenCodeState::fresh(),
+        &default_opencode_budget(),
         &mut ledger,
     );
     let OpenCodeScanOutcome::Scanned { new_state, .. } = cold else {
         panic!("cold scan should succeed");
     };
+    assert!(
+        !new_state.session_contexts.is_empty(),
+        "the cold scan must persist the reconstruction context (§3.1 Change 2)"
+    );
 
     let next_seq: i64 = connection
         .query_row(
@@ -2120,42 +2106,24 @@ fn opencode_incremental_scan_currently_re_reads_the_whole_aggregate() {
             |row| row.get(0),
         )
         .expect("measure appended event");
-    // The preflight aggregate is denominated on `seq > prior_seq`, so on the
-    // warm scan it decodes only the appended event's `data` — while the page
-    // loop below still replays the whole aggregate. That asymmetry is §3.1
-    // Change 5's "the two axes must converge"; until they do, the warm total is
-    // the sum of both.
-    let appended_data_bytes: i64 = connection
-        .query_row(
-            "SELECT length(CAST(data AS BLOB)) FROM event WHERE id = 'evt_baseline_append'",
-            [],
-            |row| row.get(0),
-        )
-        .expect("measure appended data");
     drop(connection);
 
     let mut incremental = ScanLedger::default();
     let warm = scan_opencode_database(
         path.to_str().expect("utf-8 path"),
         &new_state,
+        &default_opencode_budget(),
         &mut incremental,
     );
     assert!(matches!(warm, OpenCodeScanOutcome::Scanned { .. }));
-
-    // Cold = preflight(all data) + page loop(all rows). Warm = preflight(the
-    // appended event's data only) + page loop(all rows + the appended row).
-    let cold_page_loop_bytes = ledger.payload_bytes - cold_preflight_data_bytes as u64;
     assert_eq!(
-        incremental.payload_bytes,
-        appended_data_bytes as u64 + cold_page_loop_bytes + appended_bytes as u64,
-        "BASELINE, NOT A TARGET: one appended event currently costs the whole \
-         aggregate's history because the page loop starts at seq = -1. Issue \
-         #601 WI-06 must make this collapse to the appended event alone (G1b/G3); \
-         when it does, invert this assertion rather than deleting it."
+        incremental.payload_rows, 1,
+        "one appended event is one payload row"
     );
-    assert!(
-        incremental.payload_bytes > 4 * appended_bytes as u64,
-        "the fixture must make the replay cost visibly dominate the append"
+    assert_eq!(
+        incremental.payload_bytes, appended_bytes as u64,
+        "one appended event costs exactly that event's bytes (WI-01's baseline \
+         measured the whole aggregate's history here)"
     );
 
     cleanup(&path);
@@ -2178,71 +2146,50 @@ fn poll_payload_rows(metrics: &Arc<Metrics>) -> u64 {
 /// `Scanned` and panicked otherwise, so the guarantee was unverified on every
 /// failure arm.
 ///
-/// The ceiling arm is reached through `opencode_relevant_stats`, whose
-/// `sum(length(data))` has already made SQLite decode the whole range — so
-/// "the bytes this scan had already paid for" is a real, non-zero number even
-/// though the page loop never ran.
+/// The failure driven is the headline scenario itself: a mixed-snapshot
+/// rejection *after* the page loop read everything — "a scan that reads and
+/// then loses the bracket is still charged". (WI-01's version reached a
+/// failure through the `MAX_OPENCODE_RELEVANT_ROWS` preflight ceiling; WI-06
+/// retired both the ceiling and the preflight.)
 ///
 /// Fails for: resetting or rebuilding the ledger on a `scan_opencode_database`
-/// failure arm, or dropping the aggregate byte charge from the preflight.
+/// failure arm.
 #[test]
 fn a_failed_opencode_scan_still_reports_the_bytes_it_had_already_read() {
     let path = unique_opencode_db_path("failure-arm-ledger");
     let connection = seed_opencode_db(&path);
-    let base_seq: i64 = connection
+    let expected_bytes: i64 = connection
         .query_row(
-            "SELECT seq FROM event_sequence WHERE aggregate_id = 'ses_demo'",
+            "SELECT coalesce(sum(length(CAST(e.id AS BLOB)) \
+             + length(CAST(e.aggregate_id AS BLOB)) \
+             + length(CAST(e.type AS BLOB)) \
+             + length(CAST(e.data AS BLOB))), 0) \
+             FROM event e JOIN event_sequence s ON s.aggregate_id = e.aggregate_id \
+             WHERE e.seq <= s.seq",
             [],
             |row| row.get(0),
         )
-        .expect("read base sequence");
-
-    // One event past `MAX_OPENCODE_RELEVANT_ROWS`, so the preflight ceiling
-    // fires before the page loop reads anything.
-    let overflow = 10_001i64;
-    connection
-        .execute_batch("BEGIN")
-        .expect("begin bulk insert");
-    {
-        let mut stmt = connection
-            .prepare(
-                "INSERT INTO event (id, aggregate_id, seq, type, data) VALUES (?1, ?2, ?3, ?4, ?5)",
-            )
-            .expect("prepare bulk insert");
-        for idx in 0..overflow {
-            stmt.execute(rusqlite::params![
-                format!("evt_ceiling_{idx:06}"),
-                "ses_demo",
-                base_seq + 1 + idx,
-                "message.part.updated.1",
-                r#"{"id":"prt_ceiling","messageID":"msg_demo","sessionID":"ses_demo"}"#,
-            ])
-            .expect("insert ceiling event");
-        }
-    }
-    connection
-        .execute(
-            "UPDATE event_sequence SET seq = ?1 WHERE aggregate_id = 'ses_demo'",
-            rusqlite::params![base_seq + overflow],
-        )
-        .expect("advance sequence");
-    connection.execute_batch("COMMIT").expect("commit");
+        .expect("sum event payload bytes");
     drop(connection);
+    let db_path = path.to_str().expect("utf-8 path");
 
+    crate::sqlite_poll::contention_injection::arm(db_path, 1);
     let mut ledger = ScanLedger::default();
     let outcome = scan_opencode_database(
-        path.to_str().expect("utf-8 path"),
+        db_path,
         &OpenCodeState::fresh(),
+        &default_opencode_budget(),
         &mut ledger,
     );
+    crate::sqlite_poll::contention_injection::disarm(db_path);
     let OpenCodeScanOutcome::Failed { error_kind, .. } = outcome else {
-        panic!("crossing the relevant-row ceiling must fail the scan");
+        panic!("the armed scan must lose the mixed-snapshot bracket");
     };
-    assert_eq!(error_kind, crate::sqlite_poll::ERROR_KIND_TOO_LARGE);
-    assert!(
-        ledger.payload_bytes > 0,
-        "the preflight had already decoded the whole range; a failure arm that \
-         reports zero bytes contradicts the ledger's headline guarantee"
+    assert_eq!(error_kind, crate::sqlite_poll::ERROR_KIND_MIXED_SNAPSHOT);
+    assert_eq!(
+        ledger.payload_bytes, expected_bytes as u64,
+        "the whole cold read had been paid before the bracket rejected it, and \
+         every byte of it must survive onto the failure arm"
     );
     assert!(
         ledger.census_rows > 0,
@@ -2768,6 +2715,1333 @@ async fn an_error_marker_without_a_block_reason_is_not_retried_as_a_blocked_open
         map.get(&cp_key).expect("checkpoint").status,
         "active",
         "the transient marker clears once a scan succeeds"
+    );
+
+    cleanup(&path);
+}
+
+/// Gate G1b (§8): the fast path must not replay part events. **[DIVERGENT
+/// FIXTURE]** 500 part events of ~16 KB each (~8 MB) against a dozen
+/// context-bearing events of ~1 KB — if part events were small, a full replay
+/// would pass the byte budget and the gate could not fail.
+///
+/// Two halves, one per §3.1 mechanism:
+///
+/// - **persisted context** (Change 2): with the cold cursor intact, one
+///   appended part event costs far under 128 KiB;
+/// - **bounded rebuild** (Change 3): with the contexts stripped (an evicted
+///   or pre-upgrade cursor), the type-scoped rebuild reads the context events
+///   only — still far under 128 KiB — and the emitted part is enriched from
+///   the rebuilt context, proving the rebuild is real and not just cheap.
+///
+/// Fails for: restoring `last_seq = -1`, or a context rebuild that drops the
+/// `type` filter (8 MB of part events crosses the 128 KiB line immediately).
+#[test]
+fn opencode_fast_path_does_not_replay_part_events() {
+    let path = unique_opencode_db_path("g1b-part-replay");
+    let connection = create_opencode_db(&path);
+    let part_padding = "p".repeat(16 * 1024);
+    let context_padding = "c".repeat(1024);
+    connection.execute_batch("BEGIN").expect("begin bulk seed");
+    connection
+        .execute(
+            "INSERT INTO event (id, aggregate_id, seq, type, data) \
+             VALUES ('evt_bulk_session', 'ses_bulk', 0, 'session.created.1', ?1)",
+            rusqlite::params![serde_json::to_string(&json!({
+                "sessionID": "ses_bulk",
+                "info": {
+                    "id": "ses_bulk",
+                    "directory": "/work/bulk",
+                    "title": "bulk session",
+                    "model": {"id": "glm-5.2", "providerID": "zai-coding-plan"},
+                    "time": {"created": 1780000000000_i64, "updated": 1780000000000_i64}
+                }
+            }))
+            .unwrap()],
+        )
+        .expect("insert bulk session event");
+    connection
+        .execute(
+            "INSERT INTO event (id, aggregate_id, seq, type, data) \
+             VALUES ('evt_bulk_message', 'ses_bulk', 1, 'message.updated.1', ?1)",
+            rusqlite::params![serde_json::to_string(&json!({
+                "sessionID": "ses_bulk",
+                "info": {
+                    "id": "msg_bulk",
+                    "sessionID": "ses_bulk",
+                    "role": "assistant",
+                    "modelID": "glm-5.2",
+                    "providerID": "zai-coding-plan",
+                    "note": context_padding,
+                    "time": {"created": 1780000000100_i64}
+                }
+            }))
+            .unwrap()],
+        )
+        .expect("insert bulk message event");
+    {
+        let mut stmt = connection
+            .prepare(
+                "INSERT INTO event (id, aggregate_id, seq, type, data) VALUES (?1, 'ses_bulk', ?2, ?3, ?4)",
+            )
+            .expect("prepare bulk insert");
+        for idx in 0..500i64 {
+            stmt.execute(rusqlite::params![
+                format!("evt_bulk_part_{idx:04}"),
+                2 + idx,
+                "message.part.updated.1",
+                serde_json::to_string(&json!({
+                    "sessionID": "ses_bulk",
+                    "part": {
+                        "id": format!("part_bulk_{idx:04}"),
+                        "messageID": "msg_bulk",
+                        "sessionID": "ses_bulk",
+                        "type": "text",
+                        "text": part_padding,
+                        "time": {"start": 1780000001000_i64 + idx}
+                    },
+                    "time": 1780000001000_i64 + idx
+                }))
+                .unwrap(),
+            ])
+            .expect("insert bulk part event");
+        }
+        // Ten more small context events, per the G1b fixture spec.
+        for idx in 0..10i64 {
+            stmt.execute(rusqlite::params![
+                format!("evt_bulk_ctx_{idx:02}"),
+                502 + idx,
+                "message.updated.1",
+                serde_json::to_string(&json!({
+                    "sessionID": "ses_bulk",
+                    "info": {
+                        "id": "msg_bulk",
+                        "sessionID": "ses_bulk",
+                        "role": "assistant",
+                        "modelID": "glm-5.2",
+                        "providerID": "zai-coding-plan",
+                        "note": context_padding,
+                        "time": {"created": 1780000002000_i64 + idx}
+                    }
+                }))
+                .unwrap(),
+            ])
+            .expect("insert bulk context event");
+        }
+    }
+    connection
+        .execute(
+            "INSERT INTO event_sequence (aggregate_id, seq, owner_id) VALUES ('ses_bulk', 511, NULL)",
+            [],
+        )
+        .expect("insert bulk sequence");
+    connection
+        .execute_batch("COMMIT")
+        .expect("commit bulk seed");
+
+    let mut cold_ledger = ScanLedger::default();
+    let cold = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &OpenCodeState::fresh(),
+        &default_opencode_budget(),
+        &mut cold_ledger,
+    );
+    let OpenCodeScanOutcome::Scanned { new_state, .. } = cold else {
+        panic!("cold scan should succeed");
+    };
+
+    connection
+        .execute(
+            "INSERT INTO event (id, aggregate_id, seq, type, data) \
+             VALUES ('evt_bulk_append', 'ses_bulk', 512, 'message.part.updated.1', ?1)",
+            rusqlite::params![serde_json::to_string(&json!({
+                "sessionID": "ses_bulk",
+                "part": {
+                    "id": "part_bulk_append",
+                    "messageID": "msg_bulk",
+                    "sessionID": "ses_bulk",
+                    "type": "text",
+                    "text": part_padding,
+                    "time": {"start": 1780000003000_i64}
+                },
+                "time": 1780000003000_i64
+            }))
+            .unwrap()],
+        )
+        .expect("append part event");
+    connection
+        .execute(
+            "UPDATE event_sequence SET seq = 512 WHERE aggregate_id = 'ses_bulk'",
+            [],
+        )
+        .expect("advance bulk sequence");
+    drop(connection);
+
+    // Half one: persisted context intact.
+    let mut warm_ledger = ScanLedger::default();
+    let warm = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &new_state,
+        &default_opencode_budget(),
+        &mut warm_ledger,
+    );
+    assert!(matches!(warm, OpenCodeScanOutcome::Scanned { .. }));
+    assert!(
+        warm_ledger.payload_bytes < 128 * 1024,
+        "one appended part event must not replay 8 MB of part history; read {} bytes",
+        warm_ledger.payload_bytes
+    );
+
+    // Half two: contexts stripped — the bounded rebuild path.
+    let mut stripped = (*new_state).clone();
+    stripped.session_contexts.clear();
+    stripped.message_contexts.clear();
+    let mut rebuild_ledger = ScanLedger::default();
+    let rebuilt = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &stripped,
+        &default_opencode_budget(),
+        &mut rebuild_ledger,
+    );
+    let OpenCodeScanOutcome::Scanned { records, .. } = rebuilt else {
+        panic!("rebuild scan should succeed");
+    };
+    assert!(
+        rebuild_ledger.payload_bytes < 128 * 1024,
+        "the type-scoped rebuild must read context events only; read {} bytes",
+        rebuild_ledger.payload_bytes
+    );
+    let part = records
+        .iter()
+        .find(|record| record.record.get("type").and_then(Value::as_str) == Some("opencode_part"))
+        .expect("the appended part re-emits");
+    assert_eq!(
+        part.record.get("message_role").and_then(Value::as_str),
+        Some("assistant"),
+        "the emitted part must be enriched from the rebuilt context — a rebuild \
+         that reads nothing would pass the byte bound and emit an unenriched part"
+    );
+    assert_eq!(
+        part.project_dir, "/work/bulk",
+        "project_dir derivation must survive the rebuild (it drives exclusion \
+         and backend routing — §3.1 calls this a correctness bug, not cosmetic)"
+    );
+
+    cleanup(&path);
+}
+
+/// Gate G3 (§8): an OpenCode session growing to N events has bounded per-poll
+/// incremental work. Parameterized over N ∈ {100, 1,000, 10,000} events in
+/// one aggregate, appending one identical event at each size: the appended
+/// event's cost at N = 10,000 must be within 2× of N = 100.
+///
+/// The fixture carries the production indexes (WI-01) — without them this
+/// measurement would be of a full table scan and miscalibrated in both
+/// directions (the §8 calibration mutation).
+///
+/// Fails for: reintroducing linear replay, or a context rebuild proportional
+/// to history.
+#[test]
+fn opencode_incremental_work_is_flat_in_aggregate_length() {
+    let path = unique_opencode_db_path("g3-flat");
+    let connection = create_opencode_db(&path);
+    connection
+        .execute(
+            "INSERT INTO event (id, aggregate_id, seq, type, data) \
+             VALUES ('evt_flat_session', 'ses_flat', 0, 'session.created.1', ?1)",
+            rusqlite::params![serde_json::to_string(&json!({
+                "sessionID": "ses_flat",
+                "info": {
+                    "id": "ses_flat",
+                    "directory": "/work/flat",
+                    "title": "flat session",
+                    "time": {"created": 1780000000000_i64, "updated": 1780000000000_i64}
+                }
+            }))
+            .unwrap()],
+        )
+        .expect("insert flat session event");
+    connection
+        .execute(
+            "INSERT INTO event_sequence (aggregate_id, seq, owner_id) VALUES ('ses_flat', 0, NULL)",
+            [],
+        )
+        .expect("insert flat sequence");
+
+    let mut filled = 0i64;
+    let mut fill_to = |target: i64| {
+        connection.execute_batch("BEGIN").expect("begin fill");
+        {
+            let mut stmt = connection
+                .prepare(
+                    "INSERT INTO event (id, aggregate_id, seq, type, data) VALUES (?1, 'ses_flat', ?2, 'message.part.updated.1', ?3)",
+                )
+                .expect("prepare fill");
+            while filled < target {
+                let seq = filled + 1;
+                stmt.execute(rusqlite::params![
+                    format!("evt_flat_{seq:06}"),
+                    seq,
+                    serde_json::to_string(&json!({
+                        "sessionID": "ses_flat",
+                        "part": {
+                            "id": format!("part_flat_{seq:06}"),
+                            "messageID": "msg_flat",
+                            "sessionID": "ses_flat",
+                            "type": "text",
+                            "text": format!("flat body {seq}"),
+                            "time": {"start": 1780000000000_i64 + seq}
+                        },
+                        "time": 1780000000000_i64 + seq
+                    }))
+                    .unwrap(),
+                ])
+                .expect("insert fill event");
+                filled += 1;
+            }
+        }
+        connection
+            .execute(
+                "UPDATE event_sequence SET seq = ?1 WHERE aggregate_id = 'ses_flat'",
+                rusqlite::params![target],
+            )
+            .expect("advance fill sequence");
+        connection.execute_batch("COMMIT").expect("commit fill");
+    };
+
+    let db_path = path.to_str().expect("utf-8 path").to_string();
+    let mut state = OpenCodeState::fresh();
+    let mut measured = Vec::new();
+    for target in [100i64, 1_000, 10_000] {
+        fill_to(target);
+        // Catch up to the new history so the *next* append is incremental.
+        // Looped: one poll's work budget legitimately bounds a single scan
+        // (2,000 rows at the shipped default), and production covers a large
+        // backlog across successive polls exactly like this.
+        loop {
+            let mut catch_up = ScanLedger::default();
+            let caught =
+                scan_opencode_database(&db_path, &state, &default_opencode_budget(), &mut catch_up);
+            let OpenCodeScanOutcome::Scanned { new_state, .. } = caught else {
+                panic!("catch-up scan should succeed at N = {target}");
+            };
+            state = *new_state;
+            if !state.pending_coverage {
+                break;
+            }
+        }
+
+        // The measured append: byte-identical at every N.
+        fill_to(target + 1);
+        let mut ledger = ScanLedger::default();
+        let scanned =
+            scan_opencode_database(&db_path, &state, &default_opencode_budget(), &mut ledger);
+        let OpenCodeScanOutcome::Scanned { new_state, .. } = scanned else {
+            panic!("incremental scan should succeed at N = {target}");
+        };
+        state = *new_state;
+        measured.push(ledger.payload_bytes);
+    }
+
+    let at_100 = measured[0];
+    let at_10_000 = measured[2];
+    assert!(at_100 > 0, "the appended event must cost something");
+    assert!(
+        at_10_000 <= 2 * at_100,
+        "per-poll incremental work must be flat in aggregate length: \
+         {at_100} bytes at N=100 vs {at_10_000} bytes at N=10,000"
+    );
+
+    cleanup(&path);
+}
+
+/// Gate G8b (§8) and §3.1 Change 7: an aggregate *disappearing* from
+/// `event_sequence` (one deleted old session) is not a rewind. It must drop
+/// its watermark and context entries durably — which is also §7.2 F1's
+/// `new_state == prior_state_covered` conjunct for OpenCode: the deletion
+/// emits nothing and moves only the structural state, so only that comparison
+/// keeps the checkpoint from being suppressed — and it must not bump the
+/// generation or re-ingest anything.
+///
+/// The genuine-regression side (a `seq` that moves backwards still routes
+/// through `begin_database_replay`) is pinned by
+/// `opencode_sqlite_sequence_regression_resets_aggregate_cursor`, which stays
+/// green beside this test — together they bound the `is_some_and` fix from
+/// both directions.
+///
+/// Fails for: the old `is_none_or` conflation (a bump and a full re-ingest),
+/// or dropping the state conjunct from `scan_is_noop` (the drop never
+/// persists).
+#[tokio::test(flavor = "multi_thread")]
+async fn opencode_disappearing_aggregate_is_not_a_generation_bump() {
+    let path = unique_opencode_db_path("g8b-disappearance");
+    let db = seed_opencode_db(&path);
+    db.execute(
+        "INSERT INTO event (id, aggregate_id, seq, type, data) \
+         VALUES ('evt_second_session', 'ses_second', 0, 'session.created.1', ?1)",
+        rusqlite::params![serde_json::to_string(&json!({
+            "sessionID": "ses_second",
+            "info": {
+                "id": "ses_second",
+                "directory": "/work/second",
+                "title": "second session",
+                "time": {"created": 1780000200000_i64, "updated": 1780000200000_i64}
+            }
+        }))
+        .unwrap()],
+    )
+    .expect("insert second aggregate event");
+    db.execute(
+        "INSERT INTO event_sequence (aggregate_id, seq, owner_id) VALUES ('ses_second', 0, NULL)",
+        [],
+    )
+    .expect("insert second sequence");
+
+    let work = opencode_sqlite_work(&path);
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let poll_state = VolatilePollMap::new();
+    let metrics = Arc::new(Metrics::default());
+    let config = moraine_config::AppConfig::default();
+
+    drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+    let generation_before = checkpoints
+        .read()
+        .await
+        .get(&cp_key)
+        .expect("cold checkpoint")
+        .source_generation;
+
+    // The old session is deleted wholesale: events and sequence row.
+    db.execute("DELETE FROM event WHERE aggregate_id = 'ses_second'", [])
+        .expect("delete second events");
+    db.execute(
+        "DELETE FROM event_sequence WHERE aggregate_id = 'ses_second'",
+        [],
+    )
+    .expect("delete second sequence");
+    drop(db);
+
+    let rows_before = poll_payload_rows(&metrics);
+    let batches =
+        drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+    let raw_rows: usize = batches.iter().map(|batch| batch.raw_rows.len()).sum();
+    assert_eq!(raw_rows, 0, "a disappearance emits nothing");
+    assert_eq!(
+        poll_payload_rows(&metrics),
+        rows_before,
+        "and re-ingests nothing — no payload row is read"
+    );
+    let map = checkpoints.read().await;
+    let checkpoint = map.get(&cp_key).expect("post-disappearance checkpoint");
+    assert_eq!(
+        checkpoint.source_generation, generation_before,
+        "a disappearance must not bump the generation"
+    );
+    let cursor: Value = serde_json::from_str(&checkpoint.cursor_json).expect("cursor parses");
+    assert!(
+        cursor.pointer("/aggregate_sequences/ses_second").is_none(),
+        "the vanished aggregate's watermark drops durably"
+    );
+    assert!(
+        cursor.pointer("/session_contexts/ses_second").is_none(),
+        "and its context entry drops with it (§3.1 Change 7)"
+    );
+    assert!(
+        cursor.pointer("/aggregate_sequences/ses_demo").is_some(),
+        "the surviving aggregate's watermark is untouched"
+    );
+
+    cleanup(&path);
+}
+
+/// Plan §7.2 F1, OpenCode's `schema_fingerprint == checkpoint.schema_fingerprint`
+/// conjunct of `scan_is_noop`: a schema change with no row changes emits
+/// nothing, and only the fingerprint comparison keeps its checkpoint from
+/// being suppressed and the drift re-discovered on every later poll.
+///
+/// Fails for: dropping the schema conjunct from OpenCode's `scan_is_noop`.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_opencode_schema_change_with_no_row_changes_still_persists_its_checkpoint() {
+    let path = unique_opencode_db_path("schema-conjunct");
+    let db = seed_opencode_db(&path);
+    let work = opencode_sqlite_work(&path);
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let poll_state = VolatilePollMap::new();
+    let config = moraine_config::AppConfig::default();
+
+    drive_opencode_poll(&config, &work, &checkpoints, &poll_state).await;
+    let fingerprint_before = checkpoints
+        .read()
+        .await
+        .get(&cp_key)
+        .expect("cold checkpoint")
+        .schema_fingerprint;
+
+    db.execute("ALTER TABLE event ADD COLUMN extra text", [])
+        .expect("add drifting column");
+    drop(db);
+
+    let batches = drive_opencode_poll(&config, &work, &checkpoints, &poll_state).await;
+    let raw_rows: usize = batches.iter().map(|batch| batch.raw_rows.len()).sum();
+    assert_eq!(raw_rows, 0, "a schema change alone emits nothing");
+    let fingerprint_after = checkpoints
+        .read()
+        .await
+        .get(&cp_key)
+        .expect("post-drift checkpoint")
+        .schema_fingerprint;
+    assert_ne!(
+        fingerprint_before, fingerprint_after,
+        "the moved fingerprint must persist durably, not be suppressed as a \
+         noop and re-discovered on every later poll"
+    );
+
+    cleanup(&path);
+}
+
+/// Gate G4, row 4 (§8) — the OpenCode ceiling retirement WI-06 owns (§7.1
+/// D9): a store past any former ceiling keeps ingesting recent work with
+/// `coverage_degraded`, and no `sqlite_cursor_too_large` row is ever minted.
+///
+/// **[DIVERGENT FIXTURE]** the newest work must not be what the old any-order
+/// scan reached first: the cold never-read aggregate sorts *first* by
+/// `aggregate_id` (`aaa_cold`), the actively written known aggregate sorts
+/// *last* (`zzz_active`) — so a budget that binds after the delta class only
+/// emits the new events if delta-before-cold ordering (§2.3's table row for
+/// OpenCode: `event_sequence.seq > persisted seq` is the exact recency
+/// signal) actually works.
+///
+/// Fails for: a budget that fails the scan instead of degrading (the old
+/// `TooLarge` latch), bounded progress that walks `aggregate_id` order
+/// blindly, or a degraded poll that loses the cold aggregate's debt.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_opencode_store_over_budget_still_ingests_the_newest_events_first() {
+    let path = unique_opencode_db_path("g4-budget-order");
+    let db = Connection::open(&path).expect("create db");
+    drop(db);
+    let db = seed_opencode_db(&path);
+
+    let work = opencode_sqlite_work(&path);
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let poll_state = VolatilePollMap::new();
+    let mut config = moraine_config::AppConfig::default();
+
+    // Cold-cover the demo aggregate first, unbudgeted.
+    drive_opencode_poll(&config, &work, &checkpoints, &poll_state).await;
+
+    // A big cold aggregate that sorts before everything...
+    db.execute_batch("BEGIN").expect("begin cold seed");
+    {
+        let mut stmt = db
+            .prepare(
+                "INSERT INTO event (id, aggregate_id, seq, type, data) VALUES (?1, 'aaa_cold', ?2, 'message.part.updated.1', ?3)",
+            )
+            .expect("prepare cold insert");
+        for seq in 0..40i64 {
+            stmt.execute(rusqlite::params![
+                format!("evt_cold_{seq:04}"),
+                seq,
+                serde_json::to_string(&json!({
+                    "sessionID": "aaa_cold",
+                    "part": {
+                        "id": format!("part_cold_{seq:04}"),
+                        "messageID": "msg_cold",
+                        "sessionID": "aaa_cold",
+                        "type": "text",
+                        "text": format!("cold body {seq}"),
+                        "time": {"start": 1780000100000_i64 + seq}
+                    },
+                    "time": 1780000100000_i64 + seq
+                }))
+                .unwrap(),
+            ])
+            .expect("insert cold event");
+        }
+    }
+    db.execute(
+        "INSERT INTO event_sequence (aggregate_id, seq, owner_id) VALUES ('aaa_cold', 39, NULL)",
+        [],
+    )
+    .expect("insert cold sequence");
+    db.execute_batch("COMMIT").expect("commit cold seed");
+    // ...and fresh delta work on the covered aggregate that sorts after it.
+    let next_seq: i64 = db
+        .query_row(
+            "SELECT seq + 1 FROM event_sequence WHERE aggregate_id = 'ses_demo'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read next demo sequence");
+    db.execute(
+        "INSERT INTO event (id, aggregate_id, seq, type, data) \
+         VALUES ('evt_recent_work', 'ses_demo', ?1, 'message.part.updated.1', ?2)",
+        rusqlite::params![
+            next_seq,
+            serde_json::to_string(&json!({
+                "sessionID": "ses_demo",
+                "part": {
+                    "id": "part_recent_work",
+                    "messageID": "msg_assistant",
+                    "sessionID": "ses_demo",
+                    "type": "text",
+                    "text": "the newest work in the store",
+                    "time": {"start": 1780000200000_i64}
+                },
+                "time": 1780000200000_i64
+            }))
+            .unwrap()
+        ],
+    )
+    .expect("append recent work");
+    db.execute(
+        "UPDATE event_sequence SET seq = ?1 WHERE aggregate_id = 'ses_demo'",
+        rusqlite::params![next_seq],
+    )
+    .expect("advance demo sequence");
+    drop(db);
+
+    // A budget the cold aggregate alone would exhaust many times over.
+    config.ingest.sqlite.fast_path_max_payload_rows = 2;
+    let batches = drive_opencode_poll(&config, &work, &checkpoints, &poll_state).await;
+    let event_rows = all_event_rows(&batches);
+    assert!(
+        event_rows
+            .iter()
+            .any(|row| row.get("text_content").and_then(Value::as_str)
+                == Some("the newest work in the store")),
+        "the delta class must be read before the cold debt — recent work keeps \
+         flowing while history is over budget"
+    );
+    let error_rows: usize = batches.iter().map(|batch| batch.error_rows.len()).sum();
+    assert_eq!(
+        error_rows, 0,
+        "history size is a degradation, never an error (no TooLarge rows)"
+    );
+    let map = checkpoints.read().await;
+    let checkpoint = map.get(&cp_key).expect("degraded checkpoint");
+    let cursor: Value = serde_json::from_str(&checkpoint.cursor_json).expect("cursor parses");
+    assert_eq!(
+        cursor.get("pending_coverage").and_then(Value::as_bool),
+        Some(true),
+        "the cold debt is a durable resume marker"
+    );
+    assert_eq!(
+        cursor
+            .pointer("/aggregate_sequences/ses_demo")
+            .and_then(Value::as_i64),
+        Some(next_seq),
+        "the delta aggregate's watermark reaches the new event"
+    );
+
+    cleanup(&path);
+}
+
+/// §2.3's "continue next poll" for OpenCode, end to end, with **no further
+/// writes**: a 1-row budget against two cold aggregates converges to full
+/// coverage across resumed polls — the persisted resume marker keeps the
+/// quiet store scanning — then clears the marker durably and quiesces, with
+/// `cursor_json` omitting the flag entirely once false (§2.6 byte-identity).
+///
+/// Fails for: dropping the `!pending_coverage` conjunct from the cheap
+/// short-circuit (the unchanged stat ends every later poll and the remainder
+/// is unreachable forever), or a budget break that loses the remainder.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_degraded_opencode_cold_ingest_completes_without_new_writes() {
+    let path = unique_opencode_db_path("d6-cold-converges");
+    let db = Connection::open(&path).expect("create db");
+    drop(db);
+    let connection = create_opencode_db(&path);
+    for (aggregate, base) in [("ses_a", 1780000100000_i64), ("ses_b", 1780000200000_i64)] {
+        connection
+            .execute(
+                "INSERT INTO event (id, aggregate_id, seq, type, data) VALUES (?1, ?2, 0, 'session.created.1', ?3)",
+                rusqlite::params![
+                    format!("evt_{aggregate}_session"),
+                    aggregate,
+                    serde_json::to_string(&json!({
+                        "sessionID": aggregate,
+                        "info": {
+                            "id": aggregate,
+                            "directory": format!("/work/{aggregate}"),
+                            "title": format!("session {aggregate}"),
+                            "time": {"created": base, "updated": base}
+                        }
+                    }))
+                    .unwrap(),
+                ],
+            )
+            .expect("insert session event");
+        for seq in 1..3i64 {
+            connection
+                .execute(
+                    "INSERT INTO event (id, aggregate_id, seq, type, data) VALUES (?1, ?2, ?3, 'message.part.updated.1', ?4)",
+                    rusqlite::params![
+                        format!("evt_{aggregate}_{seq}"),
+                        aggregate,
+                        seq,
+                        serde_json::to_string(&json!({
+                            "sessionID": aggregate,
+                            "part": {
+                                "id": format!("part_{aggregate}_{seq}"),
+                                "messageID": format!("msg_{aggregate}"),
+                                "sessionID": aggregate,
+                                "type": "text",
+                                "text": format!("{aggregate} body {seq}"),
+                                "time": {"start": base + seq}
+                            },
+                            "time": base + seq
+                        }))
+                        .unwrap(),
+                    ],
+                )
+                .expect("insert part event");
+        }
+        connection
+            .execute(
+                "INSERT INTO event_sequence (aggregate_id, seq, owner_id) VALUES (?1, 2, NULL)",
+                rusqlite::params![aggregate],
+            )
+            .expect("insert sequence");
+    }
+    drop(connection);
+
+    let work = opencode_sqlite_work(&path);
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let poll_state = VolatilePollMap::new();
+    let metrics = Arc::new(Metrics::default());
+    let mut config = moraine_config::AppConfig::default();
+    config.ingest.sqlite.fast_path_max_payload_rows = 1;
+
+    drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+    {
+        let map = checkpoints.read().await;
+        let checkpoint = map.get(&cp_key).expect("cold poll persists");
+        assert!(
+            checkpoint.cursor_json.contains("pending_coverage"),
+            "the resume marker must be durable"
+        );
+    }
+
+    // No touches: convergence must come from the marker alone.
+    let mut polls = 1;
+    loop {
+        drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+        polls += 1;
+        let map = checkpoints.read().await;
+        let checkpoint = map.get(&cp_key).expect("checkpoint");
+        let cursor: Value = serde_json::from_str(&checkpoint.cursor_json).expect("cursor parses");
+        if cursor.get("pending_coverage").is_none() {
+            assert_eq!(
+                cursor
+                    .pointer("/aggregate_sequences/ses_a")
+                    .and_then(Value::as_i64),
+                Some(2),
+                "every ses_a event covered"
+            );
+            assert_eq!(
+                cursor
+                    .pointer("/aggregate_sequences/ses_b")
+                    .and_then(Value::as_i64),
+                Some(2),
+                "every ses_b event covered"
+            );
+            break;
+        }
+        assert!(
+            polls <= 12,
+            "a 1-row budget against 6 events must converge; still pending \
+             after {polls} polls"
+        );
+    }
+
+    // Quiesce: coverage complete, stat unchanged — the next poll must not scan.
+    let rows_before = poll_payload_rows(&metrics);
+    drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+    assert_eq!(
+        poll_payload_rows(&metrics),
+        rows_before,
+        "a covered, unchanged store must short-circuit"
+    );
+
+    cleanup(&path);
+}
+
+/// The OpenCode twin of `a_replacement_replay_reads_past_the_fast_path_budget`
+/// (§7.1 D5): a replacement replay ignores the fast-path budget, because its
+/// finalize publishes the generation whole and a degraded replay would
+/// publish a hole through #602.
+///
+/// Fails for: passing the fast-path budget on OpenCode replays.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_opencode_replacement_replay_reads_past_the_fast_path_budget() {
+    let path = unique_opencode_db_path("d5-replay-unbudgeted");
+    let db = seed_opencode_db(&path);
+    let full_seq: i64 = db
+        .query_row(
+            "SELECT seq FROM event_sequence WHERE aggregate_id = 'ses_demo'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read full sequence");
+    drop(db);
+    let work = opencode_sqlite_work(&path);
+    let cp_key = checkpoint_key(&work.source_name, &work.path);
+    let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+    let poll_state = VolatilePollMap::new();
+    let metrics = Arc::new(Metrics::default());
+    let mut config = moraine_config::AppConfig::default();
+    config.ingest.sqlite.fast_path_max_payload_rows = 1;
+
+    drive_opencode_poll_with_metrics(&config, &work, &checkpoints, &poll_state, &metrics).await;
+
+    // A changed exclusion set starts a replacement replay under the same
+    // tight budget; the replay must ignore it.
+    let mut replaying = config.clone();
+    replaying.ingest.exclude_project_dirs = vec!["/no/such/dir/**".to_string()];
+    let rows_before = poll_payload_rows(&metrics);
+    drive_opencode_poll_with_metrics(&replaying, &work, &checkpoints, &poll_state, &metrics).await;
+    assert!(
+        poll_payload_rows(&metrics) - rows_before > 1,
+        "the replay must read past the 1-row budget"
+    );
+    let map = checkpoints.read().await;
+    let checkpoint = map.get(&cp_key).expect("finalized replay checkpoint");
+    assert_eq!(checkpoint.status, "active");
+    let cursor: Value = serde_json::from_str(&checkpoint.cursor_json).expect("cursor parses");
+    assert_eq!(
+        cursor
+            .pointer("/aggregate_sequences/ses_demo")
+            .and_then(Value::as_i64),
+        Some(full_seq),
+        "the replay must cover the whole aggregate, budget notwithstanding"
+    );
+    assert!(
+        cursor.get("pending_coverage").is_none(),
+        "a finalized replay owes nothing"
+    );
+
+    cleanup(&path);
+}
+
+/// §3.1 Change 4, the runaway side: contexts past either ceiling evict whole
+/// aggregates — session context and that aggregate's message contexts
+/// together, in the documented ascending-`aggregate_id` order — instead of
+/// failing anything. This pins the eviction *algorithm* at the method; the
+/// scan-path wiring (that a scan actually calls it before persisting) is
+/// `an_opencode_scan_evicts_contexts_over_the_ceiling_before_persisting`.
+///
+/// Fails for: an `evict_contexts_to_fit` that returns without evicting, one
+/// that evicts message contexts but strands the session context (or vice
+/// versa), or a descending order (the highest aggregate evicts first).
+#[test]
+fn an_opencode_context_over_its_ceiling_evicts_whole_aggregates_instead_of_failing() {
+    let mut state = OpenCodeState::fresh();
+    for aggregate in ["agg_a", "agg_b", "agg_c"] {
+        state.session_contexts.insert(
+            aggregate.to_string(),
+            OpenCodeSessionContext {
+                directory: format!("/work/{aggregate}"),
+                model: None,
+            },
+        );
+        let mut messages = BTreeMap::new();
+        for idx in 0..4 {
+            messages.insert(
+                format!("msg_{aggregate}_{idx}"),
+                OpenCodeMessageContext {
+                    role: "assistant".to_string(),
+                    ..OpenCodeMessageContext::default()
+                },
+            );
+        }
+        state
+            .message_contexts
+            .insert(aggregate.to_string(), messages);
+    }
+    // 15 entries (3 sessions + 12 messages); a 6-entry ceiling forces two
+    // whole aggregates out.
+    let evicted = state.evict_contexts_to_fit(6, usize::MAX);
+    assert_eq!(
+        evicted, 10,
+        "two whole aggregates — 2 sessions + 8 messages"
+    );
+    assert!(
+        !state.session_contexts.contains_key("agg_a")
+            && !state.message_contexts.contains_key("agg_a"),
+        "eviction is whole-aggregate and ascending: agg_a goes first"
+    );
+    assert!(
+        !state.session_contexts.contains_key("agg_b")
+            && !state.message_contexts.contains_key("agg_b"),
+        "agg_b goes second"
+    );
+    assert!(
+        state.session_contexts.contains_key("agg_c")
+            && state.message_contexts.contains_key("agg_c"),
+        "the highest aggregate survives whole"
+    );
+}
+
+/// §3.1 Change 4, the starvation side: contexts exactly at their ceiling
+/// evict nothing — the `<=` boundary — so the ceiling cannot chew through
+/// state it was meant to protect.
+///
+/// Fails for: `<` at either fit check.
+#[test]
+fn an_opencode_context_at_its_ceiling_evicts_nothing() {
+    let mut state = OpenCodeState::fresh();
+    state.session_contexts.insert(
+        "agg_a".to_string(),
+        OpenCodeSessionContext {
+            directory: "/work/agg_a".to_string(),
+            model: None,
+        },
+    );
+    let mut messages = BTreeMap::new();
+    messages.insert("msg_a_0".to_string(), OpenCodeMessageContext::default());
+    state.message_contexts.insert("agg_a".to_string(), messages);
+    let bytes = serde_json::to_string(&(&state.session_contexts, &state.message_contexts))
+        .expect("serialize contexts")
+        .len();
+
+    let before = state.clone();
+    let evicted = state.evict_contexts_to_fit(2, bytes);
+    assert_eq!(evicted, 0, "a payload exactly at its ceiling is kept");
+    assert_eq!(state, before, "and nothing was disturbed");
+}
+
+/// §2.3's un-processable single row, OpenCode arm (the rewrite of the old
+/// `TooLarge` row latch): one event larger than `SCAN_PAGE_MAX_BYTES` gets
+/// one error row, is skipped, and the watermark advances past it — so the
+/// report is one-shot and the aggregate keeps flowing.
+///
+/// Fails for: restoring the scan-failing `TooLarge` arm, a skip that stalls
+/// the watermark (the report repeats forever), or losing the neighbors.
+#[test]
+fn an_oversized_opencode_event_is_skipped_and_advanced_past() {
+    let path = unique_opencode_db_path("oversized-event");
+    let connection = create_opencode_db(&path);
+    let oversized = "x".repeat(SCAN_PAGE_MAX_BYTES + 1);
+    connection
+        .execute(
+            "INSERT INTO event (id, aggregate_id, seq, type, data) \
+             VALUES ('evt_before', 'ses_big', 0, 'session.created.1', ?1)",
+            rusqlite::params![serde_json::to_string(&json!({
+                "sessionID": "ses_big",
+                "info": {
+                    "id": "ses_big",
+                    "directory": "/work/big",
+                    "title": "session before the oversized row",
+                    "time": {"created": 1780000100000_i64, "updated": 1780000100000_i64}
+                }
+            }))
+            .unwrap()],
+        )
+        .expect("insert leading event");
+    connection
+        .execute(
+            "INSERT INTO event (id, aggregate_id, seq, type, data) \
+             VALUES ('evt_oversized', 'ses_big', 1, 'message.part.updated.1', ?1)",
+            rusqlite::params![format!("{{\"blob\":\"{oversized}\"}}")],
+        )
+        .expect("insert oversized event");
+    connection
+        .execute(
+            "INSERT INTO event (id, aggregate_id, seq, type, data) \
+             VALUES ('evt_after', 'ses_big', 2, 'message.part.updated.1', ?1)",
+            rusqlite::params![serde_json::to_string(&json!({
+                "sessionID": "ses_big",
+                "part": {
+                    "id": "part_after",
+                    "messageID": "msg_big",
+                    "sessionID": "ses_big",
+                    "type": "text",
+                    "text": "the neighbor after the oversized row",
+                    "time": {"start": 1780000100002_i64}
+                },
+                "time": 1780000100002_i64
+            }))
+            .unwrap()],
+        )
+        .expect("insert trailing event");
+    connection
+        .execute(
+            "INSERT INTO event_sequence (aggregate_id, seq, owner_id) VALUES ('ses_big', 2, NULL)",
+            [],
+        )
+        .expect("insert sequence");
+    drop(connection);
+
+    // Unbudgeted on purpose: the oversized row's bytes are honestly charged,
+    // so the default byte budget would bind right after it and defer the
+    // neighbor to the next poll — correct, but the budget tests' subject.
+    // This test isolates the §2.3 row-skip semantics.
+    let mut ledger = ScanLedger::default();
+    let outcome = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &OpenCodeState::fresh(),
+        &ScanBudget::unbounded(),
+        &mut ledger,
+    );
+    let OpenCodeScanOutcome::Scanned {
+        records,
+        new_state,
+        row_errors,
+        ..
+    } = outcome
+    else {
+        panic!("an oversized event degrades per §2.3; it must not fail the scan");
+    };
+    assert_eq!(row_errors.len(), 1, "one error row for the skipped event");
+    assert_eq!(
+        row_errors[0].error_kind,
+        crate::sqlite_poll::ERROR_KIND_ROW_TOO_LARGE
+    );
+    assert_eq!(
+        new_state.aggregate_sequences.get("ses_big").copied(),
+        Some(2),
+        "the watermark advances past the skipped event to the last observed row"
+    );
+    let serialized = serde_json::to_string(&records.iter().map(|r| &r.record).collect::<Vec<_>>())
+        .expect("serialize records");
+    assert!(
+        serialized.contains("the neighbor after the oversized row"),
+        "the events around the skipped row still flow"
+    );
+
+    // One-shot: the watermark is past the oversized row, so the warm scan
+    // neither re-reads nor re-reports it.
+    let mut warm_ledger = ScanLedger::default();
+    let warm = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &new_state,
+        &default_opencode_budget(),
+        &mut warm_ledger,
+    );
+    let OpenCodeScanOutcome::Scanned {
+        row_errors: warm_errors,
+        ..
+    } = warm
+    else {
+        panic!("warm scan should succeed");
+    };
+    assert!(warm_errors.is_empty(), "the report must be one-shot");
+    assert_eq!(
+        warm_ledger.payload_rows, 0,
+        "nothing is re-read behind the advanced watermark"
+    );
+
+    cleanup(&path);
+}
+
+/// The **byte** axis of the OpenCode work budget, at both of its call sites
+/// (WI-05's `a_nac_byte_budget_binds_at_both_call_sites` precedent): the
+/// rows-axis budget tests cannot see a call site that stops feeding the byte
+/// argument — `is_exhausted_by(ledger.payload_rows, 0)` at either site leaves
+/// them green — so each site gets its own divergent fixture: few large events
+/// under a byte-bounded, row-unbounded budget.
+///
+/// Scenario one pins the **between-aggregate** check: two cold aggregates of
+/// one event each. The second aggregate must never be materialized —
+/// `payload_rows` stays 1, because a site fed zero bytes falls through to the
+/// in-page check, which charges the second aggregate's first row before it
+/// can bind. Scenario two pins the **in-page** check: one aggregate of two
+/// events — the second event is charged one row and no bytes (the
+/// honest-ledger rule) and stays unread behind the committed watermark.
+///
+/// MUTATION (executed 2026-07-31): pass `0` for the byte argument at the
+/// between-aggregate call site — fails (scenario one charges 2 payload
+/// rows). Same at the in-page call site — fails (scenario one passes whole,
+/// then scenario two's watermark reaches seq 1). Each RED was confirmed in
+/// a filtered run, failing at its own scenario's named assertion — which is
+/// what makes the sites separately pinned.
+#[test]
+fn an_opencode_byte_budget_binds_at_both_call_sites() {
+    let byte_budget = ScanBudget {
+        max_payload_rows: u64::MAX,
+        max_payload_bytes: 1,
+    };
+
+    // Scenario one: the between-aggregate site.
+    let path = unique_opencode_db_path("byte-budget-between-aggregates");
+    let connection = create_opencode_db(&path);
+    for aggregate in ["agg_one", "agg_two"] {
+        connection
+            .execute(
+                "INSERT INTO event (id, aggregate_id, seq, type, data) \
+                 VALUES (?1, ?2, 0, 'session.created.1', ?3)",
+                rusqlite::params![
+                    format!("evt_{aggregate}"),
+                    aggregate,
+                    serde_json::to_string(&json!({
+                        "sessionID": aggregate,
+                        "info": {
+                            "id": aggregate,
+                            "directory": format!("/work/{aggregate}"),
+                            "title": format!("byte budget {aggregate}"),
+                            "time": {"created": 1780000100000_i64, "updated": 1780000100000_i64}
+                        }
+                    }))
+                    .unwrap(),
+                ],
+            )
+            .expect("insert session event");
+        connection
+            .execute(
+                "INSERT INTO event_sequence (aggregate_id, seq, owner_id) VALUES (?1, 0, NULL)",
+                rusqlite::params![aggregate],
+            )
+            .expect("insert sequence");
+    }
+    drop(connection);
+
+    let mut ledger = ScanLedger::default();
+    let outcome = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &OpenCodeState::fresh(),
+        &byte_budget,
+        &mut ledger,
+    );
+    let OpenCodeScanOutcome::Scanned {
+        records, new_state, ..
+    } = outcome
+    else {
+        panic!("a byte-bound scan degrades; it must not fail");
+    };
+    assert_eq!(
+        ledger.payload_rows, 1,
+        "the byte budget must bind at the between-aggregate site: the second \
+         aggregate is never materialized (a site fed 0 bytes falls through \
+         to the in-page check, which charges the second aggregate's first row)"
+    );
+    let serialized = serde_json::to_string(&records.iter().map(|r| &r.record).collect::<Vec<_>>())
+        .expect("serialize records");
+    assert!(serialized.contains("byte budget agg_one"));
+    assert!(
+        !serialized.contains("byte budget agg_two"),
+        "the byte-skipped aggregate must not emit"
+    );
+    assert!(ledger.coverage_degraded);
+    assert!(
+        new_state.pending_coverage,
+        "the byte-skipped aggregate is a durable coverage debt"
+    );
+    assert!(
+        !new_state.aggregate_sequences.contains_key("agg_two"),
+        "a skipped never-read aggregate stays absent so a later poll re-detects it"
+    );
+    cleanup(&path);
+
+    // Scenario two: the in-page site.
+    let path = unique_opencode_db_path("byte-budget-in-page");
+    let connection = create_opencode_db(&path);
+    connection
+        .execute(
+            "INSERT INTO event (id, aggregate_id, seq, type, data) \
+             VALUES ('evt_paged_session', 'ses_paged', 0, 'session.created.1', ?1)",
+            rusqlite::params![serde_json::to_string(&json!({
+                "sessionID": "ses_paged",
+                "info": {
+                    "id": "ses_paged",
+                    "directory": "/work/paged",
+                    "title": "the first event pays the byte budget",
+                    "time": {"created": 1780000100000_i64, "updated": 1780000100000_i64}
+                }
+            }))
+            .unwrap()],
+        )
+        .expect("insert first event");
+    connection
+        .execute(
+            "INSERT INTO event (id, aggregate_id, seq, type, data) \
+             VALUES ('evt_paged_part', 'ses_paged', 1, 'message.part.updated.1', ?1)",
+            rusqlite::params![serde_json::to_string(&json!({
+                "sessionID": "ses_paged",
+                "part": {
+                    "id": "part_paged",
+                    "messageID": "msg_paged",
+                    "sessionID": "ses_paged",
+                    "type": "text",
+                    "text": "the second event stays unread",
+                    "time": {"start": 1780000100001_i64}
+                },
+                "time": 1780000100001_i64
+            }))
+            .unwrap()],
+        )
+        .expect("insert second event");
+    connection
+        .execute(
+            "INSERT INTO event_sequence (aggregate_id, seq, owner_id) \
+             VALUES ('ses_paged', 1, NULL)",
+            [],
+        )
+        .expect("insert sequence");
+    let first_event_bytes: i64 = connection
+        .query_row(
+            "SELECT length(CAST(id AS BLOB)) + length(CAST(aggregate_id AS BLOB)) \
+             + length(CAST(type AS BLOB)) + length(CAST(data AS BLOB)) \
+             FROM event WHERE id = 'evt_paged_session'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("measure first event");
+    drop(connection);
+
+    let mut ledger = ScanLedger::default();
+    let outcome = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &OpenCodeState::fresh(),
+        &byte_budget,
+        &mut ledger,
+    );
+    let OpenCodeScanOutcome::Scanned {
+        records, new_state, ..
+    } = outcome
+    else {
+        panic!("a byte-bound scan degrades; it must not fail");
+    };
+    assert_eq!(
+        new_state.aggregate_sequences.get("ses_paged").copied(),
+        Some(0),
+        "the byte budget must bind at the in-page site: the watermark stops \
+         at the last processed event"
+    );
+    assert_eq!(
+        ledger.payload_rows, 2,
+        "the bound row was materialized before the budget could be consulted: \
+         one row on the rows axis"
+    );
+    assert_eq!(
+        ledger.payload_bytes, first_event_bytes as u64,
+        "and no bytes — the bound row's columns are never taken"
+    );
+    let serialized = serde_json::to_string(&records.iter().map(|r| &r.record).collect::<Vec<_>>())
+        .expect("serialize records");
+    assert!(
+        !serialized.contains("the second event stays unread"),
+        "the event behind the byte bound must not emit"
+    );
+    assert!(
+        new_state.pending_coverage,
+        "the unread tail is a durable coverage debt"
+    );
+    cleanup(&path);
+}
+
+/// §3.1 Change 4's **scan-path wiring**. The two method-level ceiling tests
+/// above pin the eviction *algorithm* (wholeness, order, boundary), not the
+/// production call inside `scan_opencode_rows` — delete that call and both
+/// stay green while nothing bounds the persisted contexts hashed into the
+/// #602 transition digest. This pin goes through `scan_opencode_database`
+/// with the production constants: a prior cursor carrying a context payload
+/// past `MAX_OPENCODE_CONTEXT_BYTES` must come out of the scan evicted and
+/// under the ceiling.
+///
+/// MUTATION (executed 2026-07-31): replace the `evict_contexts_to_fit` call
+/// in `scan_opencode_rows` with `let evicted = 0u64;` — this test fails
+/// (nothing evicts; the persisted payload stays over its ceiling) while both
+/// method-level ceiling tests stay green, which is the round-2 finding this
+/// pin closes.
+#[test]
+fn an_opencode_scan_evicts_contexts_over_the_ceiling_before_persisting() {
+    let path = unique_opencode_db_path("ceiling-scan-path");
+    let connection = create_opencode_db(&path);
+    for aggregate in ["agg_bloat", "ses_kept"] {
+        connection
+            .execute(
+                "INSERT INTO event (id, aggregate_id, seq, type, data) \
+                 VALUES (?1, ?2, 0, 'session.created.1', ?3)",
+                rusqlite::params![
+                    format!("evt_{aggregate}"),
+                    aggregate,
+                    serde_json::to_string(&json!({
+                        "sessionID": aggregate,
+                        "info": {
+                            "id": aggregate,
+                            "directory": format!("/work/{aggregate}"),
+                            "title": format!("ceiling {aggregate}"),
+                            "time": {"created": 1780000100000_i64, "updated": 1780000100000_i64}
+                        }
+                    }))
+                    .unwrap(),
+                ],
+            )
+            .expect("insert session event");
+        connection
+            .execute(
+                "INSERT INTO event_sequence (aggregate_id, seq, owner_id) VALUES (?1, 0, NULL)",
+                rusqlite::params![aggregate],
+            )
+            .expect("insert sequence");
+    }
+    drop(connection);
+
+    // A covered cursor (both watermarks current, so the scan reads nothing)
+    // whose carried context payload exceeds the production byte ceiling —
+    // only the scan's own eviction call can bring it back under.
+    let mut prior = OpenCodeState::fresh();
+    prior.event_scan_complete = true;
+    for aggregate in ["agg_bloat", "ses_kept"] {
+        prior.aggregate_sequences.insert(aggregate.to_string(), 0);
+    }
+    prior.session_contexts.insert(
+        "agg_bloat".to_string(),
+        OpenCodeSessionContext {
+            directory: "x".repeat(MAX_OPENCODE_CONTEXT_BYTES + 1024),
+            model: None,
+        },
+    );
+    prior.session_contexts.insert(
+        "ses_kept".to_string(),
+        OpenCodeSessionContext {
+            directory: "/work/ses_kept".to_string(),
+            model: None,
+        },
+    );
+
+    let mut ledger = ScanLedger::default();
+    let outcome = scan_opencode_database(
+        path.to_str().expect("utf-8 path"),
+        &prior,
+        &default_opencode_budget(),
+        &mut ledger,
+    );
+    let OpenCodeScanOutcome::Scanned { new_state, .. } = outcome else {
+        panic!("a ceiling crossing evicts per §2.3; it must not fail the scan");
+    };
+    assert_eq!(
+        ledger.evicted_entries, 1,
+        "the scan itself must evict the over-ceiling context before persisting"
+    );
+    assert!(
+        ledger.coverage_degraded,
+        "eviction reports itself as degraded coverage"
+    );
+    assert!(
+        !new_state.session_contexts.contains_key("agg_bloat"),
+        "whole-aggregate, ascending: the bloated aggregate goes"
+    );
+    assert!(
+        new_state.session_contexts.contains_key("ses_kept"),
+        "the aggregate above it survives whole"
+    );
+    let persisted =
+        serde_json::to_string(&(&new_state.session_contexts, &new_state.message_contexts))
+            .expect("serialize contexts")
+            .len();
+    assert!(
+        persisted <= MAX_OPENCODE_CONTEXT_BYTES,
+        "the persisted context payload must fit the production ceiling; got {persisted} bytes"
+    );
+    assert!(
+        !new_state.pending_coverage,
+        "context eviction is not coverage debt — events stay covered and \
+         enrichment rebuilds on demand"
     );
 
     cleanup(&path);

--- a/scripts/ci/e2e-stack.sh
+++ b/scripts/ci/e2e-stack.sh
@@ -2020,12 +2020,16 @@ PY
   assert_clickhouse_scalar "$clickhouse_url" "nac stat-only no-op writes no raw rows" "SELECT count() FROM ${clickhouse_database}.raw_events WHERE source_name = 'ci-nac'" "$nac_raw_rows_before_noop"
   assert_clickhouse_scalar "$clickhouse_url" "nac stat-only no-op writes no durable checkpoint" "SELECT toString(max(updated_at)) FROM ${clickhouse_database}.ingest_checkpoints WHERE source_name = 'ci-nac'" "$nac_checkpoint_updated_at_before_noop"
 
-  # Removing the highest episode forces a high-water reset. The source-side
-  # deletion is archival: previously indexed remote metadata and durable bodies
-  # remain retrievable.
+  # Removing the highest episode drops max(episodes.id) behind the committed
+  # watermark. With AUTOINCREMENT episode ids the vanished tail can never be
+  # rewritten, so this is a deletion, not a rewind: the poll emits nothing —
+  # no replacement barrier, no new canonical rows, no raw appends — while the
+  # previously indexed remote metadata and durable bodies remain retrievable.
   echo "[e2e] nac sqlite source deletion follows archival policy"
-  local nac_append_control_before_delete
-  nac_append_control_before_delete="$(clickhouse_scalar "$clickhouse_url" "SELECT toUInt64(control_revision) FROM ${clickhouse_database}.v_current_ingest_append_control WHERE host = ''")"
+  local nac_raw_rows_before_delete
+  local nac_heartbeat_before_delete
+  nac_raw_rows_before_delete="$(clickhouse_scalar "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.raw_events WHERE source_name = 'ci-nac'")"
+  nac_heartbeat_before_delete="$(clickhouse_scalar "$clickhouse_url" "SELECT toString(max(ts)) FROM ${clickhouse_database}.ingest_heartbeats")"
   "$python_bin" - "$nac_fixture_file" "$nac_remote_worker_id" <<'PY'
 import sqlite3
 import sys
@@ -2039,17 +2043,15 @@ connection.commit()
 connection.close()
 PY
   sleep 3
+  # A deletion commits no checkpoint and opens no append fence, so there is
+  # no publication event to wait for — an idle heartbeat with an empty queue
+  # after the mutation proves the watcher poll consumed it (the same
+  # quiescence pattern as the stat-only no-op above).
+  wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.ingest_heartbeats WHERE ts > parseDateTime64BestEffort('${nac_heartbeat_before_delete}') AND queue_depth = 0 AND files_active = 0" 120
   assert_clickhouse_count "$clickhouse_url" "nac deleted remote metadata remains archived" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-nac' AND event_kind = 'session_meta' AND JSONExtractString(payload_json, 'cwd_scope') = 'remote'" "2"
   assert_clickhouse_count "$clickhouse_url" "nac deleted remote body remains archived" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-nac' AND (position(text_content, '${nac_remote_keyword}') > 0 OR position(payload_json, '${nac_remote_keyword}') > 0)" "4"
-  # The archival rows can become visible before the ingest pass has committed
-  # its checkpoint/publication tail and before the MCP projector has consumed
-  # the resulting dirty revisions. Later cache assertions require a stable
-  # publication token, so wait for the mutation's own idle heartbeat, append
-  # fence, and projection catch-up rather than relying on a fixed sleep.
-  wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.v_current_ingest_append_control WHERE host = '' AND state = 'idle' AND control_revision > ${nac_append_control_before_delete}" 120
-  local nac_heartbeat_after_delete_commit
-  nac_heartbeat_after_delete_commit="$(clickhouse_scalar "$clickhouse_url" "SELECT toString(max(ts)) FROM ${clickhouse_database}.ingest_heartbeats")"
-  wait_for_clickhouse_count "$clickhouse_url" "SELECT count() FROM ${clickhouse_database}.ingest_heartbeats WHERE ts > parseDateTime64BestEffort('${nac_heartbeat_after_delete_commit}') AND queue_depth = 0 AND files_active = 0" 120
+  assert_clickhouse_count "$clickhouse_url" "nac deletion preserves canonical event count" "SELECT count() FROM ${clickhouse_database}.events FINAL WHERE source_name = 'ci-nac'" "19"
+  assert_clickhouse_scalar "$clickhouse_url" "nac deletion appends no raw history" "SELECT count() FROM ${clickhouse_database}.raw_events WHERE source_name = 'ci-nac'" "$nac_raw_rows_before_delete"
   wait_for_clickhouse_count "$clickhouse_url" "SELECT toUInt64(count() = 0) FROM (SELECT dirty.session_id FROM ${clickhouse_database}.mcp_open_dirty_sessions AS dirty FINAL ANY INNER JOIN (SELECT DISTINCT session_id FROM ${clickhouse_database}.v_live_events WHERE source_name = 'ci-nac') AS live USING (session_id) ANY LEFT JOIN (SELECT session_id, dirty_revision FROM ${clickhouse_database}.mcp_open_sessions FINAL) AS projected USING (session_id) WHERE dirty.dirty_revision > ifNull(projected.dirty_revision, toUInt64(0)))" 120
 
 


### PR DESCRIPTION
# #601 PR C — OpenCode watermark delta scans (WI-06), NAC keyset fast path + sweep (WI-07)

Third PR of the #601 delta-polling epic, on `epic/canonical-first-refactor` (head 489f0cc: PR A =
ScanLedger/backoff/trigger provenance; PR B = SweepState/ScanBudget/slice driver/ceiling
degradation). Plan: `plans/601-delta-sqlite.md` §3.1, §3.2 (local, git-ignored; §7.1 D11–D15 and
the §8 status/mutation updates were recorded there in this round and are restated below).

## What changed and why

**OpenCode (`crates/moraine-ingest-core/src/sqlite_poll/opencode.rs`) — §3.1, all seven changes:**

- **Watermark start (Change 1).** The page loop's lower bound is the persisted per-aggregate
  watermark, not `-1`. One appended event now costs exactly that event
  (`opencode_fast_path_reads_only_the_appended_event` asserts byte equality; WI-01's calibration
  baseline demanded its own inversion). On the re-measured reference aggregate that is 1 event vs
  639 events / 6.9 MB.
- **Persisted reconstruction context (Change 2).** `session_contexts` +
  `message_contexts` (nested by aggregate) ride `cursor_json`; they are the exact enrichment inputs
  (`enrich_*`, `project_dir` derivation — exclusion and backend routing, so correctness, not
  cosmetics).
- **Type-scoped bounded rebuild (Change 3).** Missing/evicted context rebuilds from
  `type IN (…)` at ≤ the resume watermark; the `IN` list and `update_opencode_context`'s dispatch
  share one constant pair, so a new context-bearing type cannot be added to one and forgotten in
  the other. Re-measured: 95 rows / 47,387 B / 0.10 ms vs 639 rows / 6.9 MB / 2.75 ms full replay.
- **Context ceilings (Change 4).** `MAX_OPENCODE_CONTEXT_ENTRIES` (20,000) /
  `MAX_OPENCODE_CONTEXT_BYTES` (4 MiB) enforced by whole-aggregate eviction, never failure; the old
  "cursor has no context maps" absence assertion is restated as a size budget, as the plan
  requires. Eviction order is ascending `aggregate_id`, disclosed: no cross-aggregate recency
  ordering exists in the store, and a ~0.5 ms rebuild makes the ordering's quality nearly
  irrelevant. Round 2 pinned the **scan-path wiring** the method-level tests could not see:
  deleting the production `evict_contexts_to_fit` call left every test green while nothing bounded
  the persisted contexts hashed into the #602 transition digest —
  `an_opencode_scan_evicts_contexts_over_the_ceiling_before_persisting` now fails that mutation
  through `scan_opencode_database` with the production constants (both method-level ceiling tests
  stay green under it, reproducing the finding).
- **Single `event_sequence` read + preflight retirement (Change 5).** The per-aggregate
  `sum(length(data))` preflight is gone (with it the ~2× cold-scan byte double-charge WI-01's
  ledger exposed), and the scan reads `event_sequence` exactly once
  (`opencode_ledger_charges_payload_bytes_at_the_read_site` pins both as equalities). The rewind
  preflight on stat change remains a separate read by design: the scan must re-read the table under
  its own mixed-snapshot bracket.
- **Dead test (Change 6).** Resolved in an earlier round (deleted, with the reasoning comment in
  `opencode/tests.rs`); no `MORAINE_OPENCODE_REAL_DB` read exists.
- **Disappearance ≠ rewind (Change 7).** `opencode_sequences_rewound` uses `is_some_and`; a
  vanished aggregate drops its watermark and context entries durably with no generation bump
  (G8b), while a genuine `seq` regression still routes through `begin_database_replay`
  (existing regression test stays green beside it).
- **Ceiling retirement (G4 row 4, deferred here by D9).** `MAX_OPENCODE_RELEVANT_ROWS` /
  `MAX_OPENCODE_SCAN_BYTES` and their `sqlite_cursor_too_large` arms are gone; ordinary polls run
  under the `[ingest.sqlite]` fast-path budget with `coverage_degraded`, a durable
  `pending_coverage` resume marker (D6 mirror), and D5's rule that replacement replays are
  unbudgeted. Oversized single events (> `SCAN_PAGE_MAX_BYTES`) are skipped one-shot behind the
  watermark with one `ingest_errors` row (`sqlite_row_too_large`), never a scan failure. Round 2
  pinned the budget's **byte axis at both call sites** (the WI-05 NAC precedent made this
  mandatory): `an_opencode_byte_budget_binds_at_both_call_sites` runs few large events under a
  byte-bounded, row-unbounded budget and fails the zero-byte-feed mutation at the
  between-aggregate check and the in-page check separately.

**NAC (`crates/moraine-ingest-core/src/sqlite_poll/nac.rs`) — §3.2:**

- **Keyset fast path.** `NacState` gains an `(updated_at, session_id)` watermark; census rows at or
  before it (comparable formats only) are carried unread. `updated_at` chooses *order*, never
  *coverage* (§0): the skip is underwritten by the sweep. The changed tail reads ascending —
  the watermark is a durable resume position (D8a's argument) — commits at the last processed
  position on a bound poll, and jumps to the census maximum on a covering poll. Never-read
  sessions keep D6's newest-first first-class priority. On an unchanged store the warm fast path
  now reads **zero** payload rows (was: every session, every poll). Round 2 pinned two values this
  bullet's claims rested on: the keyset's **session-id tiebreak** — the same-millisecond race
  §3.2's inclusive bound exists to remove — is now mutation-pinned at *both* consumers
  (`a_same_timestamp_nac_write_burst_resumes_through_the_session_id_tiebreak`: a whole-function
  drop fails at the watermark, a candidate-site-only strict comparison fails at the resumed
  poll's emission), and the candidate predicate's **`!known` disjunct** — what admits a new
  session inserted at or below the watermark (clock skew, an imported store) — is pinned by
  `a_new_session_backdated_below_the_watermark_is_read_first_class` (without it the insert is
  neither read nor carried: standing `pending_coverage` rescan churn plus sweep-latency
  freshness).
- **Format guard.** Lexicographic ordering only ever happens between well-formed, same-separator
  values; anything else is a *candidate* — read now, never ordered (fail open; strictly safer than
  the plan's whole-poll skip, D13). `normalize_nac_timestamp` accepts both separators so the
  fail-open read cannot latch.
- **Sweep (G5c).** PR B's `drive_sweep_slice` is consumed, not reimplemented: `next_nac_sweep_item`
  walks `session_id` order, re-synthesizes against the carried cursor, and re-emits disagreements —
  the mutation `updated_at` never announced. Commit ordering (slice clock armed after `clear`)
  mirrors the Cursor site. Episodes need no sweep (exact append-only id watermark).
- **Sweep-debt closures (D14, new invariants this PR had to add).** (a) A due sweep may override a
  *noop-covered* volatile skip — otherwise a silent mutation noop-covered by a watcher poll is
  unreachable forever on a store that goes quiet — but never a failure/contention backoff.
  (b) `sweep_baseline` (the stat at cycle start, persisted — same §2.6 class as the existing `stat`
  field) keeps due reconcile polls scanning until one full cycle covers content newer than the
  cycle's start; then the store goes fully idle. Both sides of both rules are mutation-pinned —
  including, from round 2, the stamp's **cycle-start conjunct** itself: a mid-cycle re-stamp
  advances the baseline past a silent write behind the sweep cursor and erases the owed follow-up
  cycle (D14's emitting-deferral scenario), which
  `a_silent_write_behind_the_sweep_cursor_owes_a_follow_up_cycle` now fails under (1-row slices,
  the write lands mid-cycle behind the cursor, the store goes quiet, and the follow-up cycle must
  re-emit it).
- **Episode rewind → #602 (G8c).** A preflight (throttle-gated, like OpenCode's) detects
  `max(episodes.id)` behind the watermark and routes through `checked_next_generation` +
  `BeginReplay` with `sessions` reset; the race window (rewind between preflight and scan) fails
  that one scan so the stale stat re-triggers the preflight. The old same-generation
  `worker_threads.clear()` reset is gone. **Confirmed RED against the pre-fix code** via the
  executed mutation that restores it.
- **Throttle move (D15).** The blocked-replay throttle sits above the generation bump so a blocked
  store never pays the preflight; its two bypass conjuncts became load-bearing and are pinned
  (mirroring the OpenCode round-8 pins).
- **Cleanups.** The 16×-inlined byte-sizing expression collapses to one per projection (oversize
  guard moved to the read site — `read_session_row` takes size + id first and never touches payload
  columns of an oversized row); normalization runs once per record (shared by the oversized
  pre-check and the emit loop) instead of twice; `worker_threads` census-prune and episode-orphan
  tolerance ship unchanged from PR B (D8b).

## Deviations recorded this round (plan §7.1)

- **D11** — OpenCode budget ordering is delta-before-cold (matches §2.3's own table row; D6's
  never-read-first is for orderings without a resume position).
- **D12** — the NAC keyset is an in-memory classification over the (mandatorily complete) census,
  not §3.2's literal SQL; same skip semantics, same payload cost.
- **D13** — the format guard fails open per row instead of skipping the fast path per poll;
  normalizer accepts `'T'`.
- **D14** — the §2.2 eligibility list meets the noop cover and the emitting deferral; two §0
  coverage holes only reachable once a real (non-exhaustive) fast path exists, closed with the
  override + `sweep_baseline`. Cursor keeps PR B's shape (still exhaustive); WI-08 inherits.
- **D15** — NAC's blocked-replay throttle moved above the generation bump.

## §2.6 / cursor_json disclosure (deliberate, with replay semantics)

`cursor_json` gains fields, all deterministic structural state, all `skip_serializing_if`-omitted
when absent so untouched stores stay byte-identical: OpenCode `session_contexts` /
`message_contexts` / `pending_coverage`; NAC `updated_at_high_water(_session)` / `sweep` /
`sweep_baseline` / (existing) `pending_coverage`. Consequences: (a) the first poll after upgrade
persists a migrated cursor once — for NAC that poll re-reads every known session once
(hash-suppressed, no re-emission) to establish the watermark; for OpenCode the cursor grows by the
context maps, bounded by the Change 4 ceilings; (b) a replacement replay resets all of it with the
rest of the state (fresh-state default), so #602's transition digest sees only committed structural
advances. No existing field changed meaning. One fixture-write change:
`fixture_snapshot_preserves_…`'s incremental mutation is now forward-dated (13:10, after the
store's max `updated_at`) — a backdated bump sorts below the keyset watermark by construction (the
plan's own SQL has the identical property) and is the *sweep's* case, which G5c covers; WI-10
should state the §4 NAC row as "when `updated_at` is bumped monotonically".

## Known-context compliance

- The shared `snapshot_is_mixed` bracket and all three call sites are untouched; the NAC sweep
  slice runs inside the bracket, so a mixed snapshot discards its advance.
- `retry_blocked_replay`'s narrowing (the `replaying` disjunct) is untouched at all three adapters.
- The D2 rule holds: no cheap short-circuit gained `|| !failure_retry_due`. The D14 override is the
  opposite polarity (it un-skips a poll; it can never return early on a contended store), and the
  three `an_ordinary_poll_of_a_contended_*` tests stay green.
- §7.2 F1 conjuncts touched here are closed: OpenCode state conjunct (G8b doubles as the F1
  deletion case), OpenCode + NAC schema conjuncts (new named tests). F3's NAC short-circuit:
  `schema_fingerprint != 0` pinned; `!starts_replacement` / `!retry_blocked_replay` documented as
  equivalent mutants at the site (a replay's default-state stat can never match a real file).
- The sweep driver is consumed, not reimplemented; NAC's condition-3 eligibility expression is
  token-identical to the pinned Cursor site and is exercised through G5c/idle tests — its emission
  and half-budget clauses are argued by construction at this site, not separately mutation-proven.

## Re-measured §1 baseline (2026-07-31, fresh read-only copies of the live stores)

- OpenCode `~/.local/share/opencode/opencode.db`: 2,621 events / 11,058,112 B / 9 aggregates —
  identical to the plan. Largest aggregate `ses_12271868affeJLcogzXRZBSCxS`: 639 events,
  6,900,965 B (blob-cast). Type-scoped context read: 95 rows / 47,387 B / best 0.101 ms vs full
  replay 2.75 ms (faster host than the plan's 32.8 ms; identical bytes → the 146× byte ratio
  stands). Both production indexes present; `EXPLAIN` uses `event_aggregate_seq_idx`.
- NAC `~/.config/nac/store.db`: 3 sessions / 82,256 payload B / 4 episodes (max id 4) — identical.
  Zero triggers; `idx_sessions_updated_at` present; every live `updated_at` space-separated,
  29 chars; schema drift vs the fixture confirmed unchanged (`response_durations_ms_json`,
  `episodes` FK → `threads`). Keyset probe uses the index (0.003 ms); point lookup 0.010 ms.
- Conclusion: the §2.2 budget arithmetic and every default shipped by PR B stand; no budget was
  changed by this PR.

## Validation

- `cargo fmt --all -- --check` — clean (re-run after round 2).
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean (re-run after round 2).
- `cargo test --workspace --locked` — **1662 passed, 0 failed** (moraine-ingest-core lib: 398;
  re-run after round 2, +5 tests over round 1's 1657).
- **38 executed mutations, every one RED against the shipped fixtures**, in an isolated content
  copy (pid+epoch scratch, no `.git`, per-mutation restore + `touch`, recompilation asserted,
  `diff -rq` clean afterwards, scratch deleted). The seven round-2 executions were additionally
  re-executed against the final tree in a second fresh isolated copy under the same protocol
  (73 Gi free after that pass). Full table in plan §8, including the seven round-2 rows that
  close the five free values the round-1 review found (OpenCode byte budget × 2 sites,
  context-ceiling scan-path wiring, `sweep_baseline` cycle-start conjunct, `nac_keyset_after`
  tiebreak × 2 consumers, candidate `!known` disjunct). Two first-run **survivors** are recorded
  there because they are findings: the G5c override and the NAC fingerprint conjunct were
  unpinnable under WAL fixtures (sidecar churn re-runs scans for the wrong reason); both fixtures
  now pin DELETE journal mode and both mutations are RED.
- Two ⊘ rows (deliberately not claimed): watermark-advance-from-cold-class (no discriminating
  fixture ships; hazard documented at the site; WI-08's shared machinery should inherit a pin) and
  the projection CASE re-wrap (behavior-neutral; the exactly-once sizing assertion pins the shape).
- `bash scripts/ci/e2e-stack.sh` not run here (needs the monitor frontend npm build, unprovisioned
  in this environment); CI runs it on every PR. No sandbox was booted (host deploy in progress).

## Unwritten gates, named

G1d (concurrent-reader mixed-snapshot), G1-oracle (`/proc/self/io` cross-check), G2
(`sqlite-delta-bench`), G7 (per-adapter visibility modes), G8d (`source-publication` vs SQLite) —
all WI-11 sandbox deliverables. G5d — WI-08 (Cursor's fast path is still exhaustive; its sweep-only
fixture cannot diverge yet). Nothing in this PR claims any of them.

## Operational impact

No config keys, no SQL migrations, no service-surface changes. `sqlite_cursor_too_large` is no
longer produced by any scan path (historical rows remain; the constant is test-only). New one-shot
`sqlite_row_too_large` rows for oversized OpenCode events, and one-shot `nac_orphan_episode` /
`sqlite_row_too_large` semantics unchanged from PR B. Checkpoint cadence: NAC sweep-cycle progress
persists one checkpoint per committed slice (min every `sweep_slice_min_interval_seconds`, default
300 s) until a cycle completes over quiet content, then stops — bounded, and only after real
content changes.
