### PR TITLE
feat(ingest): expose durable progress and catch-up status

### DIFF
--- a/apps/moraine/src/commands/status.rs
+++ b/apps/moraine/src/commands/status.rs
@@ -14,11 +14,20 @@ use crate::service::Service;
 use anyhow::{bail, Context, Result};
 use moraine_clickhouse::DoctorReport;
 use moraine_config::AppConfig;
-use moraine_conversations::{ConversationRepository, IngestHeartbeatRead, StoreDiagnostics};
-use std::time::Duration;
+use moraine_conversations::{
+    ConversationRepository, IngestHeartbeatRead, IngestStatus, StoreDiagnostics,
+};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const STATUS_API_TIMEOUT: Duration = Duration::from_secs(2);
 const STATUS_API_MAX_RESPONSE_BYTES: usize = 256 * 1024;
+fn unix_now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| i64::try_from(duration.as_millis()).ok())
+        .unwrap_or(0)
+}
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(transparent)]
@@ -30,6 +39,8 @@ struct DaemonStatusResponse {
     clickhouse: DaemonClickhouseStatus,
     database: DaemonDatabaseStatus,
     ingestor: DaemonIngestorStatus,
+    #[serde(default)]
+    ingest_status: Option<IngestStatus>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -62,6 +73,7 @@ struct DaemonHeartbeat {
 struct StatusData {
     report: DoctorReport,
     heartbeat: HeartbeatSnapshot,
+    ingest_status: Option<IngestStatus>,
     source: StatusDataSource,
     fallback_note: Option<String>,
     clickhouse_health_url: String,
@@ -129,7 +141,7 @@ fn monitor_runtime_url(cfg: &AppConfig) -> String {
 }
 fn monitor_api_status_url(cfg: &AppConfig) -> String {
     format!(
-        "{}/api/v1/status",
+        "{}/api/v1/status?history=120",
         format_http_url(
             backend_http_connect_host(&cfg.monitor.host),
             cfg.monitor.port
@@ -181,6 +193,7 @@ fn daemon_status_data(payload: DaemonStatusResponse) -> Result<StatusData> {
     Ok(StatusData {
         report,
         heartbeat,
+        ingest_status: payload.ingest_status,
         source: StatusDataSource::DaemonApi,
         fallback_note: None,
         clickhouse_health_url: payload.clickhouse.url,
@@ -304,15 +317,21 @@ fn heartbeat_snapshot(read: IngestHeartbeatRead) -> HeartbeatSnapshot {
 
 async fn read_repository_status(
     repository: &dyn ConversationRepository,
-) -> Result<(DoctorReport, HeartbeatSnapshot)> {
+) -> Result<(DoctorReport, HeartbeatSnapshot, Option<IngestStatus>)> {
     let report = doctor_report(repository.read_store_diagnostics().await?);
-    let heartbeat = match repository.latest_ingest_heartbeat().await {
-        Ok(read) => heartbeat_snapshot(read),
-        Err(err) => HeartbeatSnapshot::Error {
-            message: err.to_string(),
-        },
+    let (heartbeat, ingest_status) = match repository.ingest_status(120).await {
+        Ok(read) => {
+            let heartbeat = heartbeat_snapshot(read.heartbeat.clone());
+            (heartbeat, Some(read.derive(unix_now_ms())))
+        }
+        Err(err) => (
+            HeartbeatSnapshot::Error {
+                message: err.to_string(),
+            },
+            None,
+        ),
     };
-    Ok((report, heartbeat))
+    Ok((report, heartbeat, ingest_status))
 }
 async fn read_preferred_status(
     cfg: &AppConfig,
@@ -324,10 +343,11 @@ async fn read_preferred_status(
         match read_daemon_status(cfg, timeout).await {
             Ok(status) => return Ok(status),
             Err(error) => {
-                let (report, heartbeat) = read_repository_status(repository).await?;
+                let (report, heartbeat, ingest_status) = read_repository_status(repository).await?;
                 return Ok(StatusData {
                     report,
                     heartbeat,
+                    ingest_status,
                     source: StatusDataSource::DirectDb,
                     fallback_note: Some(format!(
                         "daemon status API failed ({error:#}); using direct DB fallback"
@@ -338,10 +358,11 @@ async fn read_preferred_status(
         }
     }
 
-    let (report, heartbeat) = read_repository_status(repository).await?;
+    let (report, heartbeat, ingest_status) = read_repository_status(repository).await?;
     Ok(StatusData {
         report,
         heartbeat,
+        ingest_status,
         source: StatusDataSource::DirectDb,
         fallback_note: None,
         clickhouse_health_url: cfg.clickhouse.url.clone(),
@@ -374,6 +395,7 @@ pub(super) async fn cmd_status(
         report,
         heartbeat,
         source: data_source,
+        ingest_status,
         fallback_note,
         clickhouse_health_url,
     } = read_preferred_status(
@@ -414,6 +436,7 @@ pub(super) async fn cmd_status(
         clickhouse_health_url,
         status_notes,
         doctor: report,
+        ingest_status,
         heartbeat,
     })
 }
@@ -568,6 +591,7 @@ mod tests {
             watcher_reset_count: None,
             watcher_last_reset_unix_ms: None,
             backend_sinks: None,
+            progress: None,
         }
     }
 
@@ -602,9 +626,10 @@ mod tests {
         let calls = repository.calls();
         assert_eq!(calls.read_store_diagnostics, 0);
         assert_eq!(calls.latest_ingest_heartbeat, 0);
+        assert!(calls.ingest_status.is_empty());
         let request = worker.join().expect("daemon API worker");
         assert!(
-            request.starts_with("GET /api/v1/status HTTP/1.1"),
+            request.starts_with("GET /api/v1/status?history=120 HTTP/1.1"),
             "{request}"
         );
         assert!(request.contains("accept: application/json"), "{request}");
@@ -637,8 +662,9 @@ mod tests {
             let calls = repository.calls();
             assert_eq!(calls.read_store_diagnostics, 1);
             assert_eq!(calls.latest_ingest_heartbeat, 1);
+            assert_eq!(calls.ingest_status, vec![120]);
             let request = worker.join().expect("daemon API worker");
-            assert!(request.starts_with("GET /api/v1/status HTTP/1.1"));
+            assert!(request.starts_with("GET /api/v1/status?history=120 HTTP/1.1"));
         }
     }
     #[tokio::test]
@@ -669,6 +695,7 @@ mod tests {
             let calls = repository.calls();
             assert_eq!(calls.read_store_diagnostics, 1);
             assert_eq!(calls.latest_ingest_heartbeat, 1);
+            assert_eq!(calls.ingest_status, vec![120]);
             worker.join().expect("daemon API worker");
         }
     }
@@ -699,6 +726,7 @@ mod tests {
         let calls = repository.calls();
         assert_eq!(calls.read_store_diagnostics, 1);
         assert_eq!(calls.latest_ingest_heartbeat, 1);
+        assert_eq!(calls.ingest_status, vec![120]);
         worker.join().expect("daemon API worker");
     }
 
@@ -726,6 +754,7 @@ mod tests {
         let calls = repository.calls();
         assert_eq!(calls.read_store_diagnostics, 1);
         assert_eq!(calls.latest_ingest_heartbeat, 1);
+        assert_eq!(calls.ingest_status, vec![120]);
         worker.join().expect("daemon API worker");
     }
 
@@ -746,6 +775,7 @@ mod tests {
         let calls = repository.calls();
         assert_eq!(calls.read_store_diagnostics, 1);
         assert_eq!(calls.latest_ingest_heartbeat, 1);
+        assert_eq!(calls.ingest_status, vec![120]);
     }
 
     #[tokio::test]

--- a/apps/moraine/src/render.rs
+++ b/apps/moraine/src/render.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use moraine_clickhouse::DoctorReport;
+use moraine_conversations::{IngestAlertCode, IngestConditionState, IngestStatus};
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -102,6 +103,8 @@ pub(crate) struct StatusSnapshot {
     pub(crate) status_notes: Vec<String>,
     pub(crate) doctor: DoctorReport,
     pub(crate) heartbeat: HeartbeatSnapshot,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) ingest_status: Option<IngestStatus>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -387,6 +390,57 @@ fn format_start_pid(outcome: &StartOutcome) -> String {
     }
 }
 
+fn ingest_condition_summary(status: &IngestStatus) -> String {
+    status
+        .conditions
+        .iter()
+        .map(|condition| {
+            let state = match condition.state {
+                IngestConditionState::True => "ok",
+                IngestConditionState::False => "degraded",
+                IngestConditionState::Unknown => "unknown",
+            };
+            format!(
+                "{:?}={state} ({})",
+                condition.condition_type, condition.reason
+            )
+            .to_lowercase()
+        })
+        .collect::<Vec<_>>()
+        .join("  |  ")
+}
+
+fn ingest_progress_summaries(status: &IngestStatus) -> Option<Vec<String>> {
+    let progress = status.heartbeat.latest.as_ref()?.progress.as_ref()?;
+    let discovery_suffix = if progress.discovery_complete {
+        ""
+    } else {
+        " (discovering)"
+    };
+    let file_percent = (progress.files_total > 0)
+        .then(|| progress.files_completed as f64 * 100.0 / progress.files_total as f64);
+    let byte_percent = (progress.bytes_total > 0)
+        .then(|| progress.bytes_completed as f64 * 100.0 / progress.bytes_total as f64);
+    Some(vec![
+        format!(
+            "historical files: {}/{} ({}){discovery_suffix}",
+            progress.files_completed,
+            progress.files_total,
+            file_percent
+                .map(|percent| format!("{percent:.1}%"))
+                .unwrap_or_else(|| "n/a".to_string())
+        ),
+        format!(
+            "historical bytes: {}/{} ({}){discovery_suffix}",
+            progress.bytes_completed,
+            progress.bytes_total,
+            byte_percent
+                .map(|percent| format!("{percent:.1}%"))
+                .unwrap_or_else(|| "n/a".to_string())
+        ),
+    ])
+}
+
 pub(crate) fn render_status(output: &CliOutput, snapshot: &StatusSnapshot) -> Result<()> {
     if output.is_json() {
         println!("{}", serde_json::to_string_pretty(snapshot)?);
@@ -465,6 +519,9 @@ pub(crate) fn render_status(output: &CliOutput, snapshot: &StatusSnapshot) -> Re
     output.section("Database", &doctor_lines);
 
     // -- Ingest activity (only show when there is something to report) --
+    let mut ingest_lines = Vec::new();
+    let mut pressure = None;
+    let mut watcher = None;
     match &snapshot.heartbeat {
         HeartbeatSnapshot::Available {
             latest,
@@ -475,32 +532,104 @@ pub(crate) fn render_status(output: &CliOutput, snapshot: &StatusSnapshot) -> Re
             watcher_reset_count,
             watcher_last_reset_unix_ms,
         } => {
-            let mut lines = vec![
-                format!("last event: {latest}"),
-                format!("queue: {queue_depth}  |  active files: {files_active}"),
-            ];
-            if *watcher_error_count > 0 || *watcher_reset_count > 0 {
-                lines.push(format!(
-                    "watcher: {watcher_backend}  (errors: {watcher_error_count}, resets: {watcher_reset_count})"
-                ));
-            } else if output.verbose {
-                lines.push(format!("watcher: {watcher_backend}"));
-            }
-            if output.verbose {
-                lines.push(format!(
-                    "watcher last reset unix ms: {watcher_last_reset_unix_ms}"
-                ));
-            }
-            output.section("Ingest", &lines);
+            ingest_lines.push(format!("last event: {latest}"));
+            pressure = Some((*queue_depth, *files_active));
+            watcher = Some((
+                watcher_backend.as_str(),
+                *watcher_error_count,
+                *watcher_reset_count,
+                *watcher_last_reset_unix_ms,
+            ));
         }
         HeartbeatSnapshot::Unavailable => {
             if output.verbose {
-                output.section("Ingest", &["no heartbeat data".to_string()]);
+                ingest_lines.push("no heartbeat data".to_string());
             }
         }
         HeartbeatSnapshot::Error { message } => {
-            output.section("Ingest", &[format!("heartbeat error: {message}")]);
+            ingest_lines.push(format!("heartbeat error: {message}"));
         }
+    }
+
+    if let Some(status) = &snapshot.ingest_status {
+        ingest_lines.push(ingest_condition_summary(status));
+        if let Some(progress) = status
+            .heartbeat
+            .latest
+            .as_ref()
+            .and_then(|heartbeat| heartbeat.progress.as_ref())
+        {
+            if let Some((queue_depth, files_active)) = pressure {
+                ingest_lines.push(format!(
+                    "queue pressure: {queue_depth}/{}  |  active files: {files_active}",
+                    progress.queue_capacity
+                ));
+            }
+            if let Some(summaries) = ingest_progress_summaries(status) {
+                ingest_lines.extend(summaries);
+            }
+            ingest_lines.push(format!(
+                "sink pressure: {} rows  |  {} bytes  |  retry pressure: {}",
+                progress.sink_pending_rows,
+                progress.sink_pending_bytes,
+                if progress.sink_retrying {
+                    "active"
+                } else {
+                    "clear"
+                }
+            ));
+        } else if let Some((queue_depth, files_active)) = pressure {
+            ingest_lines.push(format!(
+                "queue pressure: {queue_depth}/unknown  |  active files: {files_active}"
+            ));
+        }
+        if let Some(rate) = &status.rate {
+            ingest_lines.push(format!(
+                "durable rate: {:.0} bytes/s over {}s",
+                rate.bytes_per_second, rate.sample_seconds
+            ));
+        }
+        if let Some(eta) = &status.eta {
+            ingest_lines.push(format!(
+                "ETA ({}): {}-{}s",
+                eta.scope, eta.low_seconds, eta.high_seconds
+            ));
+        }
+        if !status.alerts.is_empty() {
+            let codes = status
+                .alerts
+                .iter()
+                .map(|alert| match alert.code {
+                    IngestAlertCode::HeartbeatStale => "heartbeat_stale",
+                    IngestAlertCode::ProgressStalled => "progress_stalled",
+                    IngestAlertCode::QueueSaturated => "queue_saturated",
+                    IngestAlertCode::SinkRetrying => "sink_retrying",
+                    IngestAlertCode::CoverageDegraded => "coverage_degraded",
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            ingest_lines.push(format!("active alerts: {codes}"));
+        }
+    } else if let Some((queue_depth, files_active)) = pressure {
+        ingest_lines.push(format!(
+            "queue pressure: {queue_depth}/unknown  |  active files: {files_active}"
+        ));
+    }
+
+    if let Some((watcher_backend, watcher_error_count, watcher_reset_count, last_reset)) = watcher {
+        if watcher_error_count > 0 || watcher_reset_count > 0 {
+            ingest_lines.push(format!(
+                "watcher: {watcher_backend}  (errors: {watcher_error_count}, resets: {watcher_reset_count})"
+            ));
+        } else if output.verbose {
+            ingest_lines.push(format!("watcher: {watcher_backend}"));
+        }
+        if output.verbose {
+            ingest_lines.push(format!("watcher last reset unix ms: {last_reset}"));
+        }
+    }
+    if !ingest_lines.is_empty() {
+        output.section("Ingest", &ingest_lines);
     }
 
     // -- ClickHouse runtime details (verbose only) --

--- a/apps/moraine/tests/status_cli.rs
+++ b/apps/moraine/tests/status_cli.rs
@@ -266,7 +266,7 @@ fn status_prefers_canonical_daemon_api_and_preserves_json_schema() {
     assert_eq!(requests.len(), 2, "{requests:?}");
     assert!(requests[0].starts_with("GET / HTTP/1.1"), "{}", requests[0]);
     assert!(
-        requests[1].starts_with("GET /api/v1/status HTTP/1.1"),
+        requests[1].starts_with("GET /api/v1/status?history=120 HTTP/1.1"),
         "{}",
         requests[1]
     );
@@ -275,6 +275,116 @@ fn status_prefers_canonical_daemon_api_and_preserves_json_schema() {
             .iter()
             .all(|request| !request.contains("GET /api/status")),
         "{requests:?}"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn status_human_output_reports_truthful_progress_pressure_and_alerts() {
+    let progress = serde_json::json!({
+        "schema_version": 1,
+        "instance_id": "fixture-run",
+        "run_started_unix_ms": 1_700_000_000_000_i64,
+        "snapshot_unix_ms": 1_700_000_000_000_i64,
+        "discovery_complete": true,
+        "queue_capacity": 64,
+        "sink_pending_rows": 12,
+        "sink_pending_bytes": 4096,
+        "sink_retrying": true,
+        "oldest_pending_unix_ms": 1_700_000_050_000_i64,
+        "last_durable_progress_unix_ms": 1_700_000_100_000_i64,
+        "files_total": 8,
+        "files_completed": 8,
+        "bytes_total": 1000,
+        "bytes_completed": 750,
+        "sources": []
+    });
+    let heartbeat = serde_json::json!({
+        "ts": "2026-07-10 12:34:56.789",
+        "ts_unix_ms": 1_783_686_896_789_i64,
+        "host": "fixture",
+        "service_version": "0.6.4",
+        "queue_depth": 17,
+        "files_active": 2,
+        "files_watched": 8,
+        "rows_raw_written": 8,
+        "rows_events_written": 7,
+        "rows_errors_written": 1,
+        "flush_latency_ms": 4,
+        "append_to_visible_p50_ms": 5,
+        "append_to_visible_p95_ms": 6,
+        "last_error": "",
+        "progress": progress
+    });
+    let api_body = serde_json::json!({
+        "ok": true,
+        "clickhouse": {
+            "url": "http://127.0.0.1:8123",
+            "database": "api_db",
+            "healthy": true,
+            "version": "26.1.2.3",
+            "error": null
+        },
+        "database": {"exists": true},
+        "ingestor": {
+            "present": true,
+            "latest": {
+                "ts": "2026-07-10 12:34:56.789",
+                "queue_depth": 17,
+                "files_active": 2
+            }
+        },
+        "ingest_status": {
+            "observed_at_unix_ms": 1_783_686_899_789_i64,
+            "heartbeat": {"table_present": true, "latest": heartbeat},
+            "conditions": [
+                {"condition_type": "health", "state": "true", "reason": "heartbeat_recent", "observed_at_unix_ms": 1_783_686_899_789_i64},
+                {"condition_type": "coverage", "state": "false", "reason": "backfill_partial", "observed_at_unix_ms": 1_783_686_899_789_i64},
+                {"condition_type": "freshness", "state": "true", "reason": "progress_recent", "observed_at_unix_ms": 1_783_686_899_789_i64},
+                {"condition_type": "readiness", "state": "false", "reason": "retrieval_may_be_incomplete", "observed_at_unix_ms": 1_783_686_899_789_i64}
+            ],
+            "alerts": [
+                {"code": "sink_retrying", "observed_at_unix_ms": 1_783_686_899_789_i64},
+                {"code": "queue_saturated", "observed_at_unix_ms": 1_783_686_899_789_i64}
+            ]
+        }
+    })
+    .to_string();
+    let (monitor_port, worker) =
+        spawn_http_responses(vec![("200 OK", String::new()), ("200 OK", api_body)]);
+    let root = temp_dir();
+    let config = write_config(&root, monitor_port);
+
+    let output = run_plain_status(&config);
+    assert!(
+        output.status.success(),
+        "status failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let rendered = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "health=ok (heartbeat_recent)",
+        "coverage=degraded (backfill_partial)",
+        "freshness=ok (progress_recent)",
+        "readiness=degraded (retrieval_may_be_incomplete)",
+        "queue pressure: 17/64",
+        "historical files: 8/8 (100.0%)",
+        "historical bytes: 750/1000 (75.0%)",
+        "sink pressure: 12 rows  |  4096 bytes  |  retry pressure: active",
+        "active alerts: sink_retrying, queue_saturated",
+    ] {
+        assert!(
+            rendered.contains(expected),
+            "missing {expected:?} in {rendered}"
+        );
+    }
+
+    let requests = worker.join().expect("HTTP endpoint worker");
+    assert!(
+        requests[1].starts_with("GET /api/v1/status?history=120 HTTP/1.1"),
+        "{}",
+        requests[1]
     );
     let _ = fs::remove_dir_all(root);
 }

--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -955,6 +955,11 @@ pub fn bundled_migrations() -> Vec<Migration> {
             name: "033_replay_stable_events.sql",
             sql: include_str!("../../../sql/033_replay_stable_events.sql"),
         },
+        Migration {
+            version: "034",
+            name: "034_ingest_progress.sql",
+            sql: include_str!("../../../sql/034_ingest_progress.sql"),
+        },
     ]
 }
 
@@ -2553,11 +2558,11 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn migration_progress_applies_post_v071_storage_cutovers() {
+    async fn migration_progress_applies_post_v071_migrations() {
         let bundled = bundled_migrations();
         let pending = bundled
             .iter()
-            .filter(|migration| matches!(migration.version, "031" | "032" | "033"))
+            .filter(|migration| matches!(migration.version, "031" | "032" | "033" | "034"))
             .cloned()
             .collect::<Vec<_>>();
         assert_eq!(
@@ -2565,11 +2570,11 @@ mod tests {
                 .iter()
                 .map(|migration| migration.version)
                 .collect::<Vec<_>>(),
-            vec!["031", "032", "033"]
+            vec!["031", "032", "033", "034"]
         );
         let applied = bundled
             .iter()
-            .filter(|migration| !matches!(migration.version, "031" | "032" | "033"))
+            .filter(|migration| !matches!(migration.version, "031" | "032" | "033" | "034"))
             .map(|migration| migration.version.to_string())
             .collect::<Vec<_>>();
         assert_eq!(applied.last().map(String::as_str), Some("030"));
@@ -2586,9 +2591,9 @@ mod tests {
         let executed = client
             .run_migrations_with_progress(|event| events.push(event))
             .await
-            .expect("apply post-v0.7.1 storage migrations");
+            .expect("apply post-v0.7.1 migrations");
 
-        assert_eq!(executed, vec!["031", "032", "033"]);
+        assert_eq!(executed, vec!["031", "032", "033", "034"]);
         let mut expected_events = vec![MigrationProgress::Plan {
             applied: bundled.len() - pending.len(),
             pending: pending.len(),
@@ -2617,7 +2622,7 @@ mod tests {
                     .then_some(index)
             })
             .collect::<Vec<_>>();
-        assert_eq!(ledger_indices.len(), 3);
+        assert_eq!(ledger_indices.len(), pending.len());
         assert_eq!(ledger_indices.last().copied(), Some(queries.len() - 1));
     }
 

--- a/crates/moraine-conversations/src/clickhouse_repo/operations.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/operations.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::domain::{
-    IngestHeartbeat, IngestHeartbeatRead, StoreConnectionMetrics, StoreDiagnostics, StoreHealth,
-    StoreProbe, TableColumn, TablePreview, TablePreviewQuery, TableSummaries, TableSummary,
+    IngestHeartbeat, IngestHeartbeatRead, IngestProgressSnapshot, IngestStatusRead,
+    StoreConnectionMetrics, StoreDiagnostics, StoreHealth, StoreProbe, TableColumn, TablePreview,
+    TablePreviewQuery, TableSummaries, TableSummary,
 };
 
 #[derive(Deserialize)]
@@ -30,6 +31,41 @@ struct HeartbeatRow {
     watcher_reset_count: Option<u64>,
     watcher_last_reset_unix_ms: Option<u64>,
     backend_sinks: Option<String>,
+    progress_json: Option<String>,
+}
+fn heartbeat_from_row(row: HeartbeatRow) -> IngestHeartbeat {
+    IngestHeartbeat {
+        ts: row.ts,
+        ts_unix_ms: row.ts_unix_ms,
+        host: row.host,
+        service_version: row.service_version,
+        queue_depth: row.queue_depth,
+        files_active: row.files_active,
+        files_watched: row.files_watched,
+        rows_raw_written: row.rows_raw_written,
+        rows_events_written: row.rows_events_written,
+        rows_errors_written: row.rows_errors_written,
+        flush_latency_ms: row.flush_latency_ms,
+        append_to_visible_p50_ms: row.append_to_visible_p50_ms,
+        append_to_visible_p95_ms: row.append_to_visible_p95_ms,
+        last_error: row.last_error,
+        watcher_backend: row.watcher_backend,
+        watcher_error_count: row.watcher_error_count,
+        watcher_reset_count: row.watcher_reset_count,
+        watcher_last_reset_unix_ms: row.watcher_last_reset_unix_ms,
+        backend_sinks: decode_backend_sinks(row.backend_sinks),
+        progress: decode_ingest_progress(row.progress_json),
+    }
+}
+
+fn decode_ingest_progress(raw: Option<String>) -> Option<IngestProgressSnapshot> {
+    let raw = raw?;
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let progress = serde_json::from_str::<IngestProgressSnapshot>(raw).ok()?;
+    (progress.schema_version == 1).then_some(progress)
 }
 
 #[derive(Deserialize)]
@@ -101,6 +137,7 @@ impl ClickHouseConversationRepository {
         let watcher_last_reset_unix_ms =
             optional_projection("watcher_last_reset_unix_ms", "Nullable(UInt64)");
         let backend_sinks = optional_projection("backend_sinks", "Nullable(String)");
+        let progress_json = optional_projection("progress_json", "Nullable(String)");
         let heartbeats = self.table_ref("ingest_heartbeats");
         let heartbeat_query = format!(
             "SELECT\n\
@@ -122,7 +159,8 @@ impl ClickHouseConversationRepository {
                {watcher_error_count},\n\
                {watcher_reset_count},\n\
                {watcher_last_reset_unix_ms},\n\
-               {backend_sinks}\n\
+               {backend_sinks},\n\
+               {progress_json}\n\
              FROM {heartbeats}\n\
              ORDER BY `ts` DESC, `host` DESC\n\
              LIMIT 1\n\
@@ -130,32 +168,67 @@ impl ClickHouseConversationRepository {
         );
         let rows: Vec<HeartbeatRow> =
             self.map_backend(self.query_rows(&heartbeat_query, None).await)?;
-        let latest = rows.into_iter().next().map(|row| IngestHeartbeat {
-            ts: row.ts,
-            ts_unix_ms: row.ts_unix_ms,
-            host: row.host,
-            service_version: row.service_version,
-            queue_depth: row.queue_depth,
-            files_active: row.files_active,
-            files_watched: row.files_watched,
-            rows_raw_written: row.rows_raw_written,
-            rows_events_written: row.rows_events_written,
-            rows_errors_written: row.rows_errors_written,
-            flush_latency_ms: row.flush_latency_ms,
-            append_to_visible_p50_ms: row.append_to_visible_p50_ms,
-            append_to_visible_p95_ms: row.append_to_visible_p95_ms,
-            last_error: row.last_error,
-            watcher_backend: row.watcher_backend,
-            watcher_error_count: row.watcher_error_count,
-            watcher_reset_count: row.watcher_reset_count,
-            watcher_last_reset_unix_ms: row.watcher_last_reset_unix_ms,
-            backend_sinks: decode_backend_sinks(row.backend_sinks),
-        });
+        let latest = rows.into_iter().next().map(heartbeat_from_row);
 
         Ok(IngestHeartbeatRead {
             table_present: true,
             latest,
         })
+    }
+    pub(super) async fn ingest_status_impl(
+        &self,
+        history_limit: u16,
+    ) -> RepoResult<IngestStatusRead> {
+        let heartbeat = self.latest_ingest_heartbeat_impl().await?;
+        let Some(latest) = heartbeat.latest.as_ref() else {
+            return Ok(IngestStatusRead {
+                heartbeat,
+                history: Vec::new(),
+            });
+        };
+        let Some(progress) = latest.progress.as_ref() else {
+            return Ok(IngestStatusRead {
+                heartbeat,
+                history: Vec::new(),
+            });
+        };
+        let limit = history_limit.min(120);
+        if limit == 0 {
+            return Ok(IngestStatusRead {
+                heartbeat,
+                history: Vec::new(),
+            });
+        }
+
+        let heartbeats = self.table_ref("ingest_heartbeats");
+        let host = sql_quote(&latest.host);
+        let instance_id = sql_quote(&progress.instance_id);
+        let history_to_unix_ms = latest.ts_unix_ms;
+        let history_from_unix_ms = history_to_unix_ms.saturating_sub(300_000);
+        let query = format!(
+            "SELECT\n\
+               `ts`, toUnixTimestamp64Milli(`ts`) AS `ts_unix_ms`, `host`, `service_version`,\n\
+               `queue_depth`, `files_active`, `files_watched`, `rows_raw_written`,\n\
+               `rows_events_written`, `rows_errors_written`, `flush_latency_ms`,\n\
+               `append_to_visible_p50_ms`, `append_to_visible_p95_ms`, `last_error`,\n\
+               `watcher_backend`, `watcher_error_count`, `watcher_reset_count`,\n\
+               `watcher_last_reset_unix_ms`, `backend_sinks`, `progress_json`\n\
+             FROM {heartbeats}\n\
+             WHERE `host` = {host}\n\
+               AND `ts` >= fromUnixTimestamp64Milli({history_from_unix_ms})\n\
+               AND `ts` <= fromUnixTimestamp64Milli({history_to_unix_ms})\n\
+               AND JSONExtractString(`progress_json`, 'instance_id') = {instance_id}\n\
+             ORDER BY `ts` DESC, `progress_json` DESC, `queue_depth` DESC, `files_active` DESC\n\
+             LIMIT {limit}\n\
+             FORMAT JSONEachRow"
+        );
+        let mut history = self
+            .map_backend(self.query_rows::<HeartbeatRow>(&query, None).await)?
+            .into_iter()
+            .map(heartbeat_from_row)
+            .collect::<Vec<_>>();
+        history.reverse();
+        Ok(IngestStatusRead { heartbeat, history })
     }
 
     pub(super) async fn list_table_summaries_impl(&self) -> RepoResult<TableSummaries> {

--- a/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
+++ b/crates/moraine-conversations/src/clickhouse_repo/repo_impl.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::domain::{
-    AnalyticsRange, AnalyticsSnapshot, IngestHeartbeatRead, SessionAnalytics,
+    AnalyticsRange, AnalyticsSnapshot, IngestHeartbeatRead, IngestStatusRead, SessionAnalytics,
     SessionAnalyticsQuery, StoreDiagnostics, StoreHealth, TablePreview, TablePreviewQuery,
     TableSummaries, WebSearchEvent,
 };
@@ -31,6 +31,9 @@ impl ConversationRepository for ClickHouseConversationRepository {
 
     async fn latest_ingest_heartbeat(&self) -> RepoResult<IngestHeartbeatRead> {
         self.latest_ingest_heartbeat_impl().await
+    }
+    async fn ingest_status(&self, history_limit: u16) -> RepoResult<IngestStatusRead> {
+        self.ingest_status_impl(history_limit).await
     }
 
     async fn list_table_summaries(&self) -> RepoResult<TableSummaries> {

--- a/crates/moraine-conversations/src/domain.rs
+++ b/crates/moraine-conversations/src/domain.rs
@@ -1225,6 +1225,614 @@ pub struct IngestHeartbeat {
     pub watcher_last_reset_unix_ms: Option<u64>,
     #[serde(default)]
     pub backend_sinks: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub progress: Option<IngestProgressSnapshot>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct IngestProgressSnapshot {
+    pub schema_version: u16,
+    pub instance_id: String,
+    pub run_started_unix_ms: u64,
+    pub snapshot_unix_ms: u64,
+    pub discovery_complete: bool,
+    pub queue_capacity: u64,
+    pub sink_pending_rows: u64,
+    pub sink_pending_bytes: u64,
+    pub sink_retrying: bool,
+    pub oldest_pending_unix_ms: u64,
+    pub last_durable_progress_unix_ms: u64,
+    pub files_total: u64,
+    pub files_completed: u64,
+    pub bytes_total: u64,
+    pub bytes_completed: u64,
+    #[serde(default)]
+    pub sources: Vec<IngestSourceProgress>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IngestSourceProgress {
+    pub source_name: String,
+    pub format: String,
+    pub coverage_basis: IngestCoverageBasis,
+    pub files_total: u64,
+    pub files_completed: u64,
+    pub bytes_total: u64,
+    pub bytes_completed: u64,
+    pub coverage_degraded: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IngestCoverageBasis {
+    Bytes,
+    Files,
+    #[default]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IngestConditionType {
+    Health,
+    Coverage,
+    Freshness,
+    Readiness,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IngestConditionState {
+    True,
+    False,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IngestCondition {
+    pub condition_type: IngestConditionType,
+    pub state: IngestConditionState,
+    pub reason: String,
+    pub observed_at_unix_ms: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IngestAlertCode {
+    HeartbeatStale,
+    ProgressStalled,
+    QueueSaturated,
+    SinkRetrying,
+    CoverageDegraded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IngestAlert {
+    pub code: IngestAlertCode,
+    pub observed_at_unix_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IngestRate {
+    pub bytes_per_second: f64,
+    pub sample_seconds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IngestEta {
+    pub scope: String,
+    pub low_seconds: u64,
+    pub high_seconds: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct IngestStatusRead {
+    pub heartbeat: IngestHeartbeatRead,
+    pub history: Vec<IngestHeartbeat>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IngestHistoryPoint {
+    pub ts_unix_ms: i64,
+    pub queue_depth: u64,
+    pub files_active: u32,
+    pub queue_capacity: u64,
+    pub sink_pending_rows: u64,
+    pub sink_retrying: bool,
+    pub discovery_complete: bool,
+    pub files_total: u64,
+    pub files_completed: u64,
+    pub bytes_total: u64,
+    pub bytes_completed: u64,
+}
+
+impl IngestHistoryPoint {
+    fn from_heartbeat(heartbeat: &IngestHeartbeat) -> Self {
+        let (
+            queue_capacity,
+            sink_pending_rows,
+            sink_retrying,
+            discovery_complete,
+            files_total,
+            files_completed,
+            bytes_total,
+            bytes_completed,
+        ) = match heartbeat.progress.as_ref() {
+            Some(progress) => (
+                progress.queue_capacity,
+                progress.sink_pending_rows,
+                progress.sink_retrying,
+                progress.discovery_complete,
+                progress.files_total,
+                progress.files_completed,
+                progress.bytes_total,
+                progress.bytes_completed,
+            ),
+            None => (0, 0, false, false, 0, 0, 0, 0),
+        };
+        Self {
+            ts_unix_ms: heartbeat.ts_unix_ms,
+            queue_depth: heartbeat.queue_depth,
+            files_active: heartbeat.files_active,
+            queue_capacity,
+            sink_pending_rows,
+            sink_retrying,
+            discovery_complete,
+            files_total,
+            files_completed,
+            bytes_total,
+            bytes_completed,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IngestStatus {
+    pub observed_at_unix_ms: i64,
+    pub heartbeat: IngestHeartbeatRead,
+    pub conditions: Vec<IngestCondition>,
+    pub alerts: Vec<IngestAlert>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate: Option<IngestRate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eta: Option<IngestEta>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub history: Vec<IngestHistoryPoint>,
+}
+
+impl IngestStatusRead {
+    pub fn derive(self, now_unix_ms: i64) -> IngestStatus {
+        let IngestStatusRead { heartbeat, history } = self;
+        let latest = heartbeat.latest.as_ref();
+        let health = heartbeat_health_condition(latest, now_unix_ms);
+        let coverage = coverage_condition(latest, now_unix_ms);
+        let freshness = freshness_condition(latest, &health, now_unix_ms);
+        let readiness = readiness_condition(&health, &coverage, &freshness, now_unix_ms);
+        let (rate, eta) = ingest_rate_and_eta(latest, &history);
+        let alerts = ingest_alerts(
+            latest,
+            &history,
+            &health,
+            &coverage,
+            &freshness,
+            now_unix_ms,
+        );
+        let history_start_unix_ms =
+            latest.map(|heartbeat| heartbeat.ts_unix_ms.saturating_sub(300_000));
+        let history_end_unix_ms = latest.map(|heartbeat| heartbeat.ts_unix_ms);
+        let mut history = history
+            .iter()
+            .filter(|heartbeat| {
+                history_start_unix_ms
+                    .zip(history_end_unix_ms)
+                    .is_some_and(|(start, end)| (start..=end).contains(&heartbeat.ts_unix_ms))
+            })
+            .map(IngestHistoryPoint::from_heartbeat)
+            .collect::<Vec<_>>();
+        history.sort_by_key(|point| point.ts_unix_ms);
+        if history.len() > 120 {
+            let excess = history.len() - 120;
+            drop(history.drain(..excess));
+        }
+
+        IngestStatus {
+            observed_at_unix_ms: now_unix_ms,
+            heartbeat,
+            conditions: vec![health, coverage, freshness, readiness],
+            alerts,
+            rate,
+            eta,
+            history,
+        }
+    }
+}
+
+fn heartbeat_health_condition(
+    latest: Option<&IngestHeartbeat>,
+    now_unix_ms: i64,
+) -> IngestCondition {
+    let (state, reason) = match latest {
+        None => (IngestConditionState::Unknown, "heartbeat_missing"),
+        Some(latest) if latest.ts_unix_ms > now_unix_ms.saturating_add(5_000) => {
+            (IngestConditionState::Unknown, "heartbeat_clock_skew")
+        }
+        Some(latest) if now_unix_ms.saturating_sub(latest.ts_unix_ms) > 30_000 => {
+            (IngestConditionState::False, "heartbeat_stale")
+        }
+        Some(_) => (IngestConditionState::True, "heartbeat_recent"),
+    };
+    ingest_condition(IngestConditionType::Health, state, reason, now_unix_ms)
+}
+
+fn coverage_condition(latest: Option<&IngestHeartbeat>, now_unix_ms: i64) -> IngestCondition {
+    let Some(progress) = latest.and_then(|heartbeat| heartbeat.progress.as_ref()) else {
+        return ingest_condition(
+            IngestConditionType::Coverage,
+            IngestConditionState::Unknown,
+            "progress_unavailable",
+            now_unix_ms,
+        );
+    };
+    if progress
+        .sources
+        .iter()
+        .any(|source| source.coverage_degraded)
+    {
+        return ingest_condition(
+            IngestConditionType::Coverage,
+            IngestConditionState::False,
+            "coverage_degraded",
+            now_unix_ms,
+        );
+    }
+    if !progress.discovery_complete {
+        return ingest_condition(
+            IngestConditionType::Coverage,
+            IngestConditionState::False,
+            "discovery_incomplete",
+            now_unix_ms,
+        );
+    }
+    if progress.files_completed < progress.files_total
+        || progress.bytes_completed < progress.bytes_total
+    {
+        return ingest_condition(
+            IngestConditionType::Coverage,
+            IngestConditionState::False,
+            "backfill_partial",
+            now_unix_ms,
+        );
+    }
+    ingest_condition(
+        IngestConditionType::Coverage,
+        IngestConditionState::True,
+        "backfill_complete",
+        now_unix_ms,
+    )
+}
+
+fn freshness_condition(
+    latest: Option<&IngestHeartbeat>,
+    health: &IngestCondition,
+    now_unix_ms: i64,
+) -> IngestCondition {
+    if health.state != IngestConditionState::True {
+        return ingest_condition(
+            IngestConditionType::Freshness,
+            IngestConditionState::Unknown,
+            health.reason.as_str(),
+            now_unix_ms,
+        );
+    }
+    let Some(latest) = latest else {
+        unreachable!("healthy status requires a heartbeat")
+    };
+    let Some(progress) = latest.progress.as_ref() else {
+        return ingest_condition(
+            IngestConditionType::Freshness,
+            IngestConditionState::Unknown,
+            "progress_unavailable",
+            now_unix_ms,
+        );
+    };
+    let has_pressure = latest.queue_depth > 0
+        || latest.files_active > 0
+        || progress.sink_pending_rows > 0
+        || progress.sink_retrying;
+    let last_progress_unix_ms = progress
+        .last_durable_progress_unix_ms
+        .max(progress.run_started_unix_ms);
+    if snapshot_work_remaining(progress)
+        && has_pressure
+        && now_unix_ms.saturating_sub(last_progress_unix_ms as i64) >= 60_000
+    {
+        return ingest_condition(
+            IngestConditionType::Freshness,
+            IngestConditionState::False,
+            "progress_stalled",
+            now_unix_ms,
+        );
+    }
+    ingest_condition(
+        IngestConditionType::Freshness,
+        IngestConditionState::True,
+        if has_pressure {
+            "progress_recent"
+        } else {
+            "idle"
+        },
+        now_unix_ms,
+    )
+}
+
+fn snapshot_work_remaining(progress: &IngestProgressSnapshot) -> bool {
+    progress.files_completed < progress.files_total
+        || progress.bytes_completed < progress.bytes_total
+}
+
+fn readiness_condition(
+    health: &IngestCondition,
+    coverage: &IngestCondition,
+    freshness: &IngestCondition,
+    now_unix_ms: i64,
+) -> IngestCondition {
+    let conditions = [health, coverage, freshness];
+    if conditions
+        .iter()
+        .any(|condition| condition.state == IngestConditionState::False)
+    {
+        return ingest_condition(
+            IngestConditionType::Readiness,
+            IngestConditionState::False,
+            "retrieval_may_be_incomplete",
+            now_unix_ms,
+        );
+    }
+    if conditions
+        .iter()
+        .any(|condition| condition.state == IngestConditionState::Unknown)
+    {
+        return ingest_condition(
+            IngestConditionType::Readiness,
+            IngestConditionState::Unknown,
+            "readiness_unknown",
+            now_unix_ms,
+        );
+    }
+    ingest_condition(
+        IngestConditionType::Readiness,
+        IngestConditionState::True,
+        "ready",
+        now_unix_ms,
+    )
+}
+
+fn ingest_condition(
+    condition_type: IngestConditionType,
+    state: IngestConditionState,
+    reason: &str,
+    observed_at_unix_ms: i64,
+) -> IngestCondition {
+    IngestCondition {
+        condition_type,
+        state,
+        reason: reason.to_string(),
+        observed_at_unix_ms,
+    }
+}
+
+fn ingest_rate_and_eta(
+    latest: Option<&IngestHeartbeat>,
+    history: &[IngestHeartbeat],
+) -> (Option<IngestRate>, Option<IngestEta>) {
+    let Some(latest) = latest else {
+        return (None, None);
+    };
+    let Some(latest_progress) = latest.progress.as_ref() else {
+        return (None, None);
+    };
+    if !latest_progress.discovery_complete
+        || latest_progress.sink_retrying
+        || latest_progress.bytes_completed >= latest_progress.bytes_total
+    {
+        return (None, None);
+    }
+
+    let window_start = latest.ts_unix_ms.saturating_sub(300_000);
+    let mut samples = history
+        .iter()
+        .filter(|heartbeat| {
+            (window_start..=latest.ts_unix_ms).contains(&heartbeat.ts_unix_ms)
+                && heartbeat
+                    .progress
+                    .as_ref()
+                    .is_some_and(|progress| progress.instance_id == latest_progress.instance_id)
+        })
+        .collect::<Vec<_>>();
+    samples.sort_by_key(|heartbeat| heartbeat.ts_unix_ms);
+    if samples.len() < 6
+        || samples.last().map(|sample| sample.ts_unix_ms) != Some(latest.ts_unix_ms)
+        || samples.iter().any(|sample| {
+            let progress = sample.progress.as_ref().expect("filtered progress");
+            !progress.discovery_complete || progress.sink_retrying
+        })
+        || samples.iter().any(|sample| {
+            !same_snapshot_target(
+                sample.progress.as_ref().expect("filtered progress"),
+                latest_progress,
+            )
+        })
+        || samples.windows(2).any(|pair| {
+            !snapshot_progress_is_monotonic(
+                pair[0].progress.as_ref().expect("filtered progress"),
+                pair[1].progress.as_ref().expect("filtered progress"),
+            )
+        })
+    {
+        return (None, None);
+    }
+
+    let first = samples[0];
+    let latest_sample = *samples.last().expect("sample count checked");
+    if latest_sample.ts_unix_ms.saturating_sub(first.ts_unix_ms) < 30_000 {
+        return (None, None);
+    }
+    let short_start = latest_sample.ts_unix_ms.saturating_sub(60_000);
+    let short_first = samples
+        .iter()
+        .copied()
+        .find(|heartbeat| heartbeat.ts_unix_ms >= short_start)
+        .expect("latest sample is in short window");
+    let Some(long_rate) = sample_byte_rate(first, latest_sample) else {
+        return (None, None);
+    };
+    let Some(short_rate) = sample_byte_rate(short_first, latest_sample) else {
+        return (None, None);
+    };
+    let ratio = short_rate / long_rate;
+    if !(0.5..=2.0).contains(&ratio) {
+        return (None, None);
+    }
+    let sample_seconds = (latest_sample.ts_unix_ms.saturating_sub(first.ts_unix_ms) as u64) / 1_000;
+    let remaining = latest_progress
+        .bytes_total
+        .saturating_sub(latest_progress.bytes_completed) as f64;
+    let low_seconds = (remaining / short_rate.max(long_rate)).ceil() as u64;
+    let high_seconds = (remaining / short_rate.min(long_rate)).ceil() as u64;
+    (
+        Some(IngestRate {
+            bytes_per_second: long_rate,
+            sample_seconds,
+        }),
+        Some(IngestEta {
+            scope: "file_backfill".to_string(),
+            low_seconds,
+            high_seconds,
+        }),
+    )
+}
+
+fn same_snapshot_target(left: &IngestProgressSnapshot, right: &IngestProgressSnapshot) -> bool {
+    left.instance_id == right.instance_id
+        && left.snapshot_unix_ms == right.snapshot_unix_ms
+        && left.files_total == right.files_total
+        && left.bytes_total == right.bytes_total
+        && left.sources.len() == right.sources.len()
+        && left
+            .sources
+            .iter()
+            .zip(&right.sources)
+            .all(|(left, right)| {
+                left.source_name == right.source_name
+                    && left.format == right.format
+                    && left.coverage_basis == right.coverage_basis
+                    && left.files_total == right.files_total
+                    && left.bytes_total == right.bytes_total
+            })
+}
+
+fn snapshot_progress_is_monotonic(
+    previous: &IngestProgressSnapshot,
+    current: &IngestProgressSnapshot,
+) -> bool {
+    same_snapshot_target(previous, current)
+        && previous.files_completed <= current.files_completed
+        && previous.bytes_completed <= current.bytes_completed
+        && previous
+            .sources
+            .iter()
+            .zip(&current.sources)
+            .all(|(previous, current)| {
+                previous.files_completed <= current.files_completed
+                    && previous.bytes_completed <= current.bytes_completed
+            })
+}
+
+fn sample_byte_rate(first: &IngestHeartbeat, last: &IngestHeartbeat) -> Option<f64> {
+    let first_progress = first.progress.as_ref()?;
+    let last_progress = last.progress.as_ref()?;
+    let elapsed_ms = last.ts_unix_ms.checked_sub(first.ts_unix_ms)?;
+    let completed = last_progress
+        .bytes_completed
+        .checked_sub(first_progress.bytes_completed)?;
+    if elapsed_ms <= 0 || completed == 0 {
+        return None;
+    }
+    Some(completed as f64 / (elapsed_ms as f64 / 1_000.0))
+}
+
+fn ingest_alerts(
+    latest: Option<&IngestHeartbeat>,
+    history: &[IngestHeartbeat],
+    health: &IngestCondition,
+    coverage: &IngestCondition,
+    freshness: &IngestCondition,
+    now_unix_ms: i64,
+) -> Vec<IngestAlert> {
+    let mut alerts = Vec::new();
+    if health.state == IngestConditionState::False {
+        alerts.push(ingest_alert(IngestAlertCode::HeartbeatStale, now_unix_ms));
+    }
+    if freshness.reason == "progress_stalled" {
+        alerts.push(ingest_alert(IngestAlertCode::ProgressStalled, now_unix_ms));
+    }
+    if coverage.reason == "coverage_degraded" {
+        alerts.push(ingest_alert(IngestAlertCode::CoverageDegraded, now_unix_ms));
+    }
+    if health.state == IngestConditionState::True {
+        let Some(latest) = latest else {
+            unreachable!("healthy status requires a heartbeat")
+        };
+        let Some(instance_id) = latest
+            .progress
+            .as_ref()
+            .map(|progress| progress.instance_id.as_str())
+        else {
+            return alerts;
+        };
+        let window_start = latest.ts_unix_ms.saturating_sub(300_000);
+        let mut same_instance = history
+            .iter()
+            .filter(|heartbeat| {
+                (window_start..=latest.ts_unix_ms).contains(&heartbeat.ts_unix_ms)
+                    && heartbeat
+                        .progress
+                        .as_ref()
+                        .is_some_and(|progress| progress.instance_id == instance_id)
+            })
+            .collect::<Vec<_>>();
+        same_instance.sort_by_key(|heartbeat| heartbeat.ts_unix_ms);
+        if same_instance.last().map(|heartbeat| heartbeat.ts_unix_ms) != Some(latest.ts_unix_ms) {
+            return alerts;
+        }
+        if same_instance.len() >= 3
+            && same_instance.iter().rev().take(3).all(|heartbeat| {
+                heartbeat.progress.as_ref().is_some_and(|progress| {
+                    progress.queue_capacity > 0 && heartbeat.queue_depth >= progress.queue_capacity
+                })
+            })
+        {
+            alerts.push(ingest_alert(IngestAlertCode::QueueSaturated, now_unix_ms));
+        }
+        if same_instance.len() >= 2
+            && same_instance.iter().rev().take(2).all(|heartbeat| {
+                heartbeat
+                    .progress
+                    .as_ref()
+                    .is_some_and(|progress| progress.sink_retrying)
+            })
+        {
+            alerts.push(ingest_alert(IngestAlertCode::SinkRetrying, now_unix_ms));
+        }
+    }
+    alerts
+}
+
+fn ingest_alert(code: IngestAlertCode, observed_at_unix_ms: i64) -> IngestAlert {
+    IngestAlert {
+        code,
+        observed_at_unix_ms,
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -1381,7 +1989,9 @@ fn default_page_limit() -> u16 {
 #[cfg(test)]
 mod tests {
     use super::{
-        AnalyticsRange, SearchEventKind, SearchEventsQuery, SearchStrategyHint,
+        AnalyticsRange, IngestAlertCode, IngestConditionState, IngestCoverageBasis, IngestEta,
+        IngestHeartbeat, IngestHeartbeatRead, IngestProgressSnapshot, IngestSourceProgress,
+        IngestStatusRead, SearchEventKind, SearchEventsQuery, SearchStrategyHint,
         SessionAnalyticsQuery, SessionLookback, SessionOriginScope, SessionStep, TablePreviewQuery,
     };
 
@@ -1524,5 +2134,432 @@ mod tests {
                 "text": "hello",
             })
         );
+    }
+    fn heartbeat_with_progress(
+        ts_unix_ms: i64,
+        bytes_completed: u64,
+        bytes_total: u64,
+    ) -> IngestHeartbeat {
+        IngestHeartbeat {
+            ts: String::new(),
+            ts_unix_ms,
+            host: "host-a".to_string(),
+            service_version: "test".to_string(),
+            queue_depth: u64::from(bytes_completed < bytes_total),
+            files_active: u32::from(bytes_completed < bytes_total),
+            files_watched: 1,
+            rows_raw_written: 0,
+            rows_events_written: 0,
+            rows_errors_written: 0,
+            flush_latency_ms: 0,
+            append_to_visible_p50_ms: 0,
+            append_to_visible_p95_ms: 0,
+            last_error: String::new(),
+            watcher_backend: None,
+            watcher_error_count: None,
+            watcher_reset_count: None,
+            watcher_last_reset_unix_ms: None,
+            backend_sinks: None,
+            progress: Some(IngestProgressSnapshot {
+                schema_version: 1,
+                instance_id: "run-a".to_string(),
+                run_started_unix_ms: 1_000_000,
+                snapshot_unix_ms: 1_000_000,
+                discovery_complete: true,
+                queue_capacity: 1_024,
+                sink_pending_rows: 0,
+                sink_pending_bytes: 0,
+                sink_retrying: false,
+                oldest_pending_unix_ms: 0,
+                last_durable_progress_unix_ms: ts_unix_ms as u64,
+                files_total: 1,
+                files_completed: u64::from(bytes_completed >= bytes_total),
+                bytes_total,
+                bytes_completed,
+                sources: vec![IngestSourceProgress {
+                    source_name: "codex".to_string(),
+                    format: "jsonl".to_string(),
+                    coverage_basis: IngestCoverageBasis::Bytes,
+                    files_total: 1,
+                    files_completed: u64::from(bytes_completed >= bytes_total),
+                    bytes_total,
+                    bytes_completed,
+                    coverage_degraded: false,
+                }],
+            }),
+        }
+    }
+
+    #[test]
+    fn status_separates_health_from_partial_coverage() {
+        let latest = heartbeat_with_progress(1_060_000, 500, 1_000);
+        let status = IngestStatusRead {
+            heartbeat: IngestHeartbeatRead {
+                table_present: true,
+                latest: Some(latest.clone()),
+            },
+            history: vec![latest],
+        }
+        .derive(1_061_000);
+
+        assert_eq!(
+            status.conditions[0].state,
+            IngestConditionState::True,
+            "recent heartbeat remains healthy"
+        );
+        assert_eq!(status.conditions[1].reason, "backfill_partial");
+        assert_eq!(status.conditions[3].reason, "retrieval_may_be_incomplete");
+    }
+
+    #[test]
+    fn completed_file_based_coverage_is_ready_without_alert() {
+        let mut latest = heartbeat_with_progress(1_060_000, 0, 0);
+        let progress = latest.progress.as_mut().expect("progress snapshot");
+        let source = progress.sources.first_mut().expect("source progress");
+        source.source_name = "cursor-sqlite".to_string();
+        source.format = "cursor_sqlite".to_string();
+        source.coverage_basis = IngestCoverageBasis::Files;
+
+        let status = IngestStatusRead {
+            heartbeat: IngestHeartbeatRead {
+                table_present: true,
+                latest: Some(latest.clone()),
+            },
+            history: vec![latest],
+        }
+        .derive(1_061_000);
+
+        assert_eq!(status.conditions[1].state, IngestConditionState::True);
+        assert_eq!(status.conditions[1].reason, "backfill_complete");
+        assert_eq!(status.conditions[3].state, IngestConditionState::True);
+        assert_eq!(status.conditions[3].reason, "ready");
+        assert!(status.alerts.is_empty());
+    }
+
+    #[test]
+    fn stable_durable_history_produces_bounded_eta() {
+        let history = (0..=6)
+            .map(|sample| {
+                heartbeat_with_progress(
+                    1_000_000 + sample * 10_000,
+                    100 + sample as u64 * 100,
+                    1_000,
+                )
+            })
+            .collect::<Vec<_>>();
+        let latest = history.last().cloned().expect("latest sample");
+        let status = IngestStatusRead {
+            heartbeat: IngestHeartbeatRead {
+                table_present: true,
+                latest: Some(latest),
+            },
+            history,
+        }
+        .derive(1_061_000);
+
+        assert_eq!(
+            status.rate.as_ref().map(|rate| rate.bytes_per_second),
+            Some(10.0)
+        );
+        assert_eq!(
+            status.eta,
+            Some(IngestEta {
+                scope: "file_backfill".to_string(),
+                low_seconds: 30,
+                high_seconds: 30,
+            })
+        );
+    }
+
+    #[test]
+    fn eta_requires_six_samples_inside_the_five_minute_window() {
+        let history = [
+            (600_000, 100),
+            (620_000, 200),
+            (640_000, 300),
+            (680_000, 400),
+            (950_000, 500),
+            (1_000_000, 600),
+        ]
+        .into_iter()
+        .map(|(ts, completed)| heartbeat_with_progress(ts, completed, 1_000))
+        .collect::<Vec<_>>();
+        let latest = history.last().cloned().expect("latest sample");
+
+        let status = IngestStatusRead {
+            heartbeat: IngestHeartbeatRead {
+                table_present: true,
+                latest: Some(latest),
+            },
+            history,
+        }
+        .derive(1_001_000);
+
+        assert!(status.rate.is_none());
+        assert!(status.eta.is_none());
+        assert_eq!(status.history.len(), 2);
+    }
+
+    #[test]
+    fn eta_rejects_adjacent_completion_and_target_regressions() {
+        let mutations: [fn(&mut IngestHeartbeat); 2] = [
+            |sample: &mut IngestHeartbeat| {
+                let progress = sample.progress.as_mut().expect("progress");
+                progress.bytes_completed = 150;
+                progress.sources[0].bytes_completed = 150;
+            },
+            |sample: &mut IngestHeartbeat| {
+                let progress = sample.progress.as_mut().expect("progress");
+                progress.bytes_total = 900;
+                progress.sources[0].bytes_total = 900;
+            },
+        ];
+        for mutate in mutations {
+            let mut history = (0..=6)
+                .map(|sample| {
+                    heartbeat_with_progress(
+                        1_000_000 + sample * 10_000,
+                        100 + sample as u64 * 100,
+                        1_000,
+                    )
+                })
+                .collect::<Vec<_>>();
+            mutate(&mut history[3]);
+            let latest = history.last().cloned().expect("latest sample");
+
+            let status = IngestStatusRead {
+                heartbeat: IngestHeartbeatRead {
+                    table_present: true,
+                    latest: Some(latest),
+                },
+                history,
+            }
+            .derive(1_061_000);
+
+            assert!(status.rate.is_none());
+            assert!(status.eta.is_none());
+        }
+    }
+
+    #[test]
+    fn completed_snapshot_with_live_work_is_not_stalled() {
+        let mut latest = heartbeat_with_progress(1_060_000, 1_000, 1_000);
+        latest.queue_depth = 1;
+        latest.files_active = 1;
+        latest
+            .progress
+            .as_mut()
+            .expect("progress")
+            .last_durable_progress_unix_ms = 1_000_000;
+
+        let status = IngestStatusRead {
+            heartbeat: IngestHeartbeatRead {
+                table_present: true,
+                latest: Some(latest.clone()),
+            },
+            history: vec![latest],
+        }
+        .derive(1_061_000);
+
+        assert_eq!(status.conditions[2].reason, "progress_recent");
+        assert!(!status
+            .alerts
+            .iter()
+            .any(|alert| alert.code == IngestAlertCode::ProgressStalled));
+    }
+
+    #[test]
+    fn current_heartbeat_emits_sustained_live_pressure_alerts() {
+        let history = (0..3)
+            .map(|sample| {
+                let mut heartbeat =
+                    heartbeat_with_progress(1_000_000 + sample * 10_000, 100, 1_000);
+                heartbeat.queue_depth = 1_024;
+                heartbeat.progress.as_mut().expect("progress").sink_retrying = true;
+                heartbeat
+            })
+            .collect::<Vec<_>>();
+        let latest = history.last().cloned().expect("latest sample");
+
+        let status = IngestStatusRead {
+            heartbeat: IngestHeartbeatRead {
+                table_present: true,
+                latest: Some(latest),
+            },
+            history,
+        }
+        .derive(1_021_000);
+
+        assert!(status
+            .alerts
+            .iter()
+            .any(|alert| alert.code == IngestAlertCode::QueueSaturated));
+        assert!(status
+            .alerts
+            .iter()
+            .any(|alert| alert.code == IngestAlertCode::SinkRetrying));
+    }
+
+    #[test]
+    fn live_pressure_alerts_observe_hold_counts_and_recovery() {
+        let mut history = (0..2)
+            .map(|sample| {
+                let mut heartbeat =
+                    heartbeat_with_progress(1_000_000 + sample * 10_000, 100, 1_000);
+                heartbeat.queue_depth = 1_024;
+                heartbeat.progress.as_mut().expect("progress").sink_retrying = true;
+                heartbeat
+            })
+            .collect::<Vec<_>>();
+        let held_latest = history.last().cloned().expect("held latest");
+        let held = IngestStatusRead {
+            heartbeat: IngestHeartbeatRead {
+                table_present: true,
+                latest: Some(held_latest),
+            },
+            history: history.clone(),
+        }
+        .derive(1_011_000);
+        assert!(!held
+            .alerts
+            .iter()
+            .any(|alert| alert.code == IngestAlertCode::QueueSaturated));
+        assert!(held
+            .alerts
+            .iter()
+            .any(|alert| alert.code == IngestAlertCode::SinkRetrying));
+
+        let recovered = heartbeat_with_progress(1_020_000, 200, 1_000);
+        history.push(recovered.clone());
+        let recovered = IngestStatusRead {
+            heartbeat: IngestHeartbeatRead {
+                table_present: true,
+                latest: Some(recovered),
+            },
+            history,
+        }
+        .derive(1_021_000);
+        assert!(!recovered.alerts.iter().any(|alert| {
+            matches!(
+                alert.code,
+                IngestAlertCode::QueueSaturated | IngestAlertCode::SinkRetrying
+            )
+        }));
+    }
+    #[test]
+    fn stale_heartbeat_suppresses_live_pressure_alerts() {
+        let history = (0..3)
+            .map(|sample| {
+                let mut heartbeat =
+                    heartbeat_with_progress(1_000_000 + sample * 10_000, 100, 1_000);
+                heartbeat.queue_depth = 1_024;
+                heartbeat.progress.as_mut().expect("progress").sink_retrying = true;
+                heartbeat
+            })
+            .collect::<Vec<_>>();
+        let latest = history.last().cloned().expect("latest sample");
+
+        let status = IngestStatusRead {
+            heartbeat: IngestHeartbeatRead {
+                table_present: true,
+                latest: Some(latest),
+            },
+            history,
+        }
+        .derive(1_051_000);
+
+        assert!(status
+            .alerts
+            .iter()
+            .any(|alert| alert.code == IngestAlertCode::HeartbeatStale));
+        assert!(!status.alerts.iter().any(|alert| {
+            matches!(
+                alert.code,
+                IngestAlertCode::QueueSaturated | IngestAlertCode::SinkRetrying
+            )
+        }));
+    }
+
+    #[test]
+    fn derived_history_is_a_narrow_serializable_projection() {
+        let mut latest = heartbeat_with_progress(1_060_000, 500, 1_000);
+        latest.last_error = "/private/source/path".to_string();
+        latest.backend_sinks = Some(serde_json::json!({"credential": "secret"}));
+        let status = IngestStatusRead {
+            heartbeat: IngestHeartbeatRead {
+                table_present: true,
+                latest: Some(latest.clone()),
+            },
+            history: vec![latest],
+        }
+        .derive(1_061_000);
+
+        assert_eq!(
+            serde_json::to_value(&status.history[0]).expect("serialize history point"),
+            serde_json::json!({
+                "ts_unix_ms": 1_060_000,
+
+                "queue_depth": 1,
+                "files_active": 1,
+                "queue_capacity": 1_024,
+                "sink_pending_rows": 0,
+                "sink_retrying": false,
+                "discovery_complete": true,
+                "files_total": 1,
+                "files_completed": 0,
+                "bytes_total": 1_000,
+                "bytes_completed": 500,
+            })
+        );
+    }
+
+    #[test]
+    fn derived_history_preserves_missing_progress_as_a_gap() {
+        let mut gap = heartbeat_with_progress(1_050_000, 400, 1_000);
+        gap.queue_depth = 7;
+        gap.files_active = 2;
+        gap.progress = None;
+        let latest = heartbeat_with_progress(1_060_000, 500, 1_000);
+
+        let status = IngestStatusRead {
+            heartbeat: IngestHeartbeatRead {
+                table_present: true,
+                latest: Some(latest.clone()),
+            },
+            history: vec![gap, latest],
+        }
+        .derive(1_061_000);
+
+        assert_eq!(status.history.len(), 2);
+        let gap = &status.history[0];
+        assert_eq!(gap.ts_unix_ms, 1_050_000);
+        assert_eq!(gap.queue_depth, 7);
+        assert_eq!(gap.files_active, 2);
+        assert_eq!(gap.queue_capacity, 0);
+        assert!(!gap.discovery_complete);
+        assert_eq!(gap.files_total, 0);
+        assert_eq!(gap.bytes_total, 0);
+    }
+    #[test]
+    fn derived_history_retains_at_most_120_points() {
+        let history = (0..130)
+            .map(|sample| {
+                heartbeat_with_progress(1_000_000 + sample * 1_000, 100 + sample as u64, 1_000)
+            })
+            .collect::<Vec<_>>();
+        let latest = history.last().cloned().expect("latest sample");
+
+        let status = IngestStatusRead {
+            heartbeat: IngestHeartbeatRead {
+                table_present: true,
+                latest: Some(latest),
+            },
+            history,
+        }
+        .derive(1_130_000);
+
+        assert_eq!(status.history.len(), 120);
+        assert_eq!(status.history[0].ts_unix_ms, 1_010_000);
+        assert_eq!(status.history[119].ts_unix_ms, 1_129_000);
     }
 }

--- a/crates/moraine-conversations/src/in_memory_repo.rs
+++ b/crates/moraine-conversations/src/in_memory_repo.rs
@@ -3,9 +3,9 @@ use std::sync::{Mutex, MutexGuard};
 use async_trait::async_trait;
 
 use crate::domain::{
-    AnalyticsRange, AnalyticsSnapshot, AnalyticsWindow, IngestHeartbeatRead, SessionAnalytics,
-    SessionAnalyticsQuery, StoreDiagnostics, StoreHealth, TablePreview, TablePreviewQuery,
-    TableSummaries, WebSearchEvent,
+    AnalyticsRange, AnalyticsSnapshot, AnalyticsWindow, IngestHeartbeatRead, IngestStatusRead,
+    SessionAnalytics, SessionAnalyticsQuery, StoreDiagnostics, StoreHealth, TablePreview,
+    TablePreviewQuery, TableSummaries, WebSearchEvent,
 };
 use crate::domain::{
     Conversation, ConversationDetailOptions, ConversationListFilter, ConversationSearchQuery,
@@ -49,6 +49,7 @@ pub struct InMemoryConversationResponses {
     pub analytics_series: Option<RepoResult<AnalyticsSnapshot>>,
     pub list_web_searches: Option<RepoResult<Vec<WebSearchEvent>>>,
     pub latest_ingest_heartbeat: Option<RepoResult<IngestHeartbeatRead>>,
+    pub ingest_status: Option<RepoResult<IngestStatusRead>>,
     pub list_table_summaries: Option<RepoResult<TableSummaries>>,
     pub preview_table: Option<RepoResult<TablePreview>>,
     pub read_store_health: Option<RepoResult<StoreHealth>>,
@@ -80,6 +81,7 @@ pub struct InMemoryConversationCalls {
     pub analytics_series: Vec<AnalyticsRange>,
     pub list_web_searches: Vec<u16>,
     pub latest_ingest_heartbeat: usize,
+    pub ingest_status: Vec<u16>,
     pub list_table_summaries: usize,
     pub preview_table: Vec<TablePreviewQuery>,
     pub read_store_health: usize,
@@ -276,6 +278,23 @@ impl ConversationRepository for InMemoryConversationRepository {
             latest_ingest_heartbeat,
             IngestHeartbeatRead::default()
         )
+    }
+
+    async fn ingest_status(&self, history_limit: u16) -> RepoResult<IngestStatusRead> {
+        self.record(|calls| calls.ingest_status.push(history_limit));
+        match &self.responses.ingest_status {
+            Some(result) => {
+                let mut read = result.clone()?;
+                let limit = usize::from(history_limit.min(120));
+                let keep_from = read.history.len().saturating_sub(limit);
+                drop(read.history.drain(..keep_from));
+                Ok(read)
+            }
+            None => Ok(IngestStatusRead {
+                heartbeat: self.latest_ingest_heartbeat().await?,
+                history: Vec::new(),
+            }),
+        }
     }
 
     async fn list_table_summaries(&self) -> RepoResult<TableSummaries> {

--- a/crates/moraine-conversations/src/lib.rs
+++ b/crates/moraine-conversations/src/lib.rs
@@ -25,10 +25,13 @@ pub use domain::{
 };
 pub use domain::{
     AnalyticsConcurrencyPoint, AnalyticsRange, AnalyticsSnapshot, AnalyticsTokenPoint,
-    AnalyticsTurnPoint, AnalyticsWindow, IngestHeartbeat, IngestHeartbeatRead, SessionAnalytics,
-    SessionAnalyticsQuery, SessionLookback, SessionStep, SessionTurn, StoreConnectionMetrics,
-    StoreDiagnostics, StoreHealth, StoreProbe, TableColumn, TablePreview, TablePreviewQuery,
-    TableSummaries, TableSummary, ToolResult, WebSearchEvent,
+    AnalyticsTurnPoint, AnalyticsWindow, IngestAlert, IngestAlertCode, IngestCondition,
+    IngestConditionState, IngestConditionType, IngestCoverageBasis, IngestEta, IngestHeartbeat,
+    IngestHeartbeatRead, IngestHistoryPoint, IngestProgressSnapshot, IngestRate,
+    IngestSourceProgress, IngestStatus, IngestStatusRead, SessionAnalytics, SessionAnalyticsQuery,
+    SessionLookback, SessionStep, SessionTurn, StoreConnectionMetrics, StoreDiagnostics,
+    StoreHealth, StoreProbe, TableColumn, TablePreview, TablePreviewQuery, TableSummaries,
+    TableSummary, ToolResult, WebSearchEvent,
 };
 pub use error::{RepoError, RepoResult};
 pub use in_memory_repo::{

--- a/crates/moraine-conversations/src/repo.rs
+++ b/crates/moraine-conversations/src/repo.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 
 use crate::domain::{
-    AnalyticsRange, AnalyticsSnapshot, IngestHeartbeatRead, SessionAnalytics,
+    AnalyticsRange, AnalyticsSnapshot, IngestHeartbeatRead, IngestStatusRead, SessionAnalytics,
     SessionAnalyticsQuery, StoreDiagnostics, StoreHealth, TablePreview, TablePreviewQuery,
     TableSummaries, WebSearchEvent,
 };
@@ -31,6 +31,12 @@ pub trait ConversationRepository: Send + Sync {
     async fn list_web_searches(&self, limit: u16) -> RepoResult<Vec<WebSearchEvent>>;
 
     async fn latest_ingest_heartbeat(&self) -> RepoResult<IngestHeartbeatRead>;
+    async fn ingest_status(&self, _history_limit: u16) -> RepoResult<IngestStatusRead> {
+        Ok(IngestStatusRead {
+            heartbeat: self.latest_ingest_heartbeat().await?,
+            history: Vec::new(),
+        })
+    }
 
     async fn list_table_summaries(&self) -> RepoResult<TableSummaries>;
 

--- a/crates/moraine-conversations/tests/repository_integration/heartbeat.rs
+++ b/crates/moraine-conversations/tests/repository_integration/heartbeat.rs
@@ -236,3 +236,135 @@ async fn heartbeat_propagates_column_probe_and_latest_read_errors() {
         .contains("heartbeat latest read failed"));
     assert_script_consumed(&read_state, 2);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ingest_status_bounds_history_to_latest_five_minutes_and_hard_cap() {
+    let progress = json!({
+        "schema_version": 1,
+        "instance_id": "run-a",
+        "run_started_unix_ms": 1_780_307_700_000_u64,
+        "snapshot_unix_ms": 1_780_307_700_000_u64,
+        "discovery_complete": true,
+        "queue_capacity": 1_024_u64,
+        "sink_pending_rows": 0_u64,
+        "sink_pending_bytes": 0_u64,
+        "sink_retrying": false,
+        "oldest_pending_unix_ms": 0_u64,
+        "last_durable_progress_unix_ms": 1_780_308_000_000_u64,
+        "files_total": 1_u64,
+        "files_completed": 0_u64,
+        "bytes_total": 1_000_u64,
+        "bytes_completed": 500_u64,
+        "sources": [],
+    })
+    .to_string();
+    let mut latest = heartbeat_row();
+    latest["progress_json"] = json!(progress);
+    let mut older = latest.clone();
+    older["ts"] = json!("2026-06-01 09:55:00.000");
+    older["ts_unix_ms"] = json!(1_780_307_700_000_i64);
+    let responses = vec![
+        ScriptedResponse::rows(
+            &["FROM system.columns", "FORMAT JSONEachRow"],
+            heartbeat_columns(&[
+                "watcher_backend",
+                "watcher_error_count",
+                "watcher_reset_count",
+                "watcher_last_reset_unix_ms",
+                "backend_sinks",
+                "progress_json",
+            ]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "FROM `moraine`.`ingest_heartbeats`",
+                "ORDER BY `ts` DESC, `host` DESC",
+                "LIMIT 1",
+            ],
+            json!([latest.clone()]),
+        ),
+        ScriptedResponse::rows(
+            &[
+                "WHERE `host` = 'ingest-host'",
+                "AND `ts` >= fromUnixTimestamp64Milli(1780307700000)",
+                "AND `ts` <= fromUnixTimestamp64Milli(1780308000000)",
+                "AND JSONExtractString(`progress_json`, 'instance_id') = 'run-a'",
+                "ORDER BY `ts` DESC, `progress_json` DESC, `queue_depth` DESC, `files_active` DESC",
+                "LIMIT 120",
+            ],
+            json!([latest, older]),
+        ),
+    ];
+    let (repo, state) = build_scripted_repo(responses).await;
+
+    let status = repo
+        .ingest_status(u16::MAX)
+        .await
+        .expect("bounded ingest history");
+
+    assert_eq!(status.history.len(), 2);
+    assert_eq!(status.history[0].ts_unix_ms, 1_780_307_700_000);
+    assert_eq!(status.history[1].ts_unix_ms, 1_780_308_000_000);
+    assert_script_consumed(&state, 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ingest_status_does_not_borrow_older_progress_when_latest_is_unusable() {
+    let unknown_version = json!({
+        "schema_version": 2,
+        "instance_id": "run-a",
+        "run_started_unix_ms": 1_780_307_700_000_u64,
+        "snapshot_unix_ms": 1_780_307_700_000_u64,
+        "discovery_complete": true,
+        "queue_capacity": 1_024_u64,
+        "sink_pending_rows": 0_u64,
+        "sink_pending_bytes": 0_u64,
+        "sink_retrying": false,
+        "oldest_pending_unix_ms": 0_u64,
+        "last_durable_progress_unix_ms": 1_780_308_000_000_u64,
+        "files_total": 1_u64,
+        "files_completed": 0_u64,
+        "bytes_total": 1_000_u64,
+        "bytes_completed": 500_u64,
+        "sources": [],
+    })
+    .to_string();
+
+    for raw in [
+        None,
+        Some(""),
+        Some("{malformed"),
+        Some(unknown_version.as_str()),
+    ] {
+        let mut latest = heartbeat_row();
+        if let Some(raw) = raw {
+            latest["progress_json"] = json!(raw);
+        }
+        let optional_columns = raw.map(|_| vec!["progress_json"]).unwrap_or_default();
+        let responses = vec![
+            ScriptedResponse::rows(
+                &["FROM system.columns", "FORMAT JSONEachRow"],
+                heartbeat_columns(&optional_columns),
+            ),
+            ScriptedResponse::rows(
+                &[
+                    "FROM `moraine`.`ingest_heartbeats`",
+                    "ORDER BY `ts` DESC, `host` DESC",
+                    "LIMIT 1",
+                ],
+                json!([latest]),
+            ),
+        ];
+        let (repo, state) = build_scripted_repo(responses).await;
+
+        let status = repo
+            .ingest_status(120)
+            .await
+            .expect("unusable latest progress is tolerated");
+        let derived = status.derive(1_780_308_001_000);
+
+        assert!(derived.history.is_empty());
+        assert_eq!(derived.conditions[1].reason, "progress_unavailable");
+        assert_script_consumed(&state, 2);
+    }
+}

--- a/crates/moraine-ingest-core/src/dispatch.rs
+++ b/crates/moraine-ingest-core/src/dispatch.rs
@@ -1,13 +1,16 @@
 use crate::checkpoint::checkpoint_key;
 use crate::model::{Checkpoint, NormalizedRecord, RowBatch};
 use crate::normalize::{normalize_record, normalize_record_with_ts_hint};
+use crate::progress::unix_ms_now;
 use crate::sources::claude_code::cowork_session_path;
 use crate::sources::kiro_cli::{load_kiro_session_metadata, KiroSessionMetadata};
 use crate::sources::shared::{format_record_ts, infer_vendor_from_base_url, parse_record_ts};
 use crate::sqlite_poll::VolatilePollMap;
 use crate::{DispatchState, Metrics, SinkMessage, WorkItem};
 use anyhow::{Context, Result};
-use moraine_config::{is_workflow_journal_path, map_tracked_path, AppConfig, SourceFormat};
+use moraine_config::{
+    is_workflow_journal_path, map_tracked_path, AppConfig, IngestSource, SourceFormat,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use std::collections::HashMap;
@@ -64,12 +67,29 @@ fn encode_kiro_checkpoint_cursor(cursor: &KiroCheckpointCursor) -> String {
     serde_json::to_string(cursor).expect("Kiro checkpoint cursor is serializable")
 }
 
-/// A work item is processable only when its path is already the canonical
-/// tracked path for its format (sidecar paths are canonicalized at the
-/// watcher; anything else here is a stray event for an untracked file).
+/// A path is processable only when it is already the canonical tracked path
+/// for its format (sidecar paths are canonicalized at the watcher; anything
+/// else here is a stray event for an untracked file).
+fn path_is_canonical(format: SourceFormat, source_glob: &str, path: &str) -> bool {
+    map_tracked_path(format, source_glob, path).as_deref() == Some(path)
+}
+
+#[cfg(test)]
 fn work_path_is_canonical(work: &WorkItem) -> bool {
-    map_tracked_path(work.format, &work.source_glob, &work.path).as_deref()
-        == Some(work.path.as_str())
+    path_is_canonical(work.format, &work.source_glob, &work.path)
+}
+
+/// Borrowed form of the single ingestability gate used while discovering the
+/// frozen startup snapshot. It deliberately shares the same predicate as
+/// `work_item_is_ingestable` without constructing and cloning a `WorkItem`.
+pub(crate) fn source_path_is_ingestable(source: &IngestSource, path: &str) -> bool {
+    path_is_ingestable(
+        &source.name,
+        &source.harness,
+        source.format,
+        &source.glob,
+        path,
+    )
 }
 
 /// The single gate before a path becomes ingest work: every entry point
@@ -87,22 +107,38 @@ fn work_path_is_canonical(work: &WorkItem) -> bool {
 /// which never consult the glob. The exclusion is scoped to the `claude-code`
 /// harness so a same-named file under any other configured source is never
 /// silently dropped.
-fn work_item_is_ingestable(work: &WorkItem) -> bool {
-    if !work_path_is_canonical(work) {
+pub(crate) fn work_item_is_ingestable(work: &WorkItem) -> bool {
+    path_is_ingestable(
+        &work.source_name,
+        &work.harness,
+        work.format,
+        &work.source_glob,
+        &work.path,
+    )
+}
+
+fn path_is_ingestable(
+    source_name: &str,
+    harness: &str,
+    format: SourceFormat,
+    source_glob: &str,
+    path: &str,
+) -> bool {
+    if !path_is_canonical(format, source_glob, path) {
         debug!(
             "dropping non-canonical work item {} (format {})",
-            work.path, work.format
+            path, format
         );
         return false;
     }
-    if work.source_name == "claude-cowork" && cowork_session_path(&work.path).is_none() {
-        debug!("skipping non-transcript Claude Cowork path {}", work.path);
+    if source_name == "claude-cowork" && cowork_session_path(path).is_none() {
+        debug!("skipping non-transcript Claude Cowork path {}", path);
         return false;
     }
-    if work.harness == "claude-code" && is_workflow_journal_path(&work.path) {
+    if harness == "claude-code" && is_workflow_journal_path(path) {
         debug!(
             "skipping workflow orchestration journal {} (no sessionId; issue #386)",
-            work.path
+            path
         );
         return false;
     }
@@ -778,6 +814,29 @@ pub(crate) fn spawn_debounce_task(
     })
 }
 
+async fn send_queued_work(
+    work: WorkItem,
+    process_tx: &mpsc::Sender<WorkItem>,
+    metrics: &Metrics,
+) -> bool {
+    let Ok(permit) = process_tx.reserve().await else {
+        return false;
+    };
+    // The reserved slot prevents a receiver from observing this item until
+    // after its pressure accounting has been published.
+    metrics.queue_depth.fetch_add(1, Ordering::Relaxed);
+    permit.send(work);
+    true
+}
+
+pub(crate) fn note_work_received(metrics: &Metrics) {
+    let _ = metrics
+        .queue_depth
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |depth| {
+            Some(depth.saturating_sub(1))
+        });
+}
+
 pub(crate) async fn enqueue_work(
     work: WorkItem,
     process_tx: &mpsc::Sender<WorkItem>,
@@ -796,12 +855,17 @@ pub(crate) async fn enqueue_work(
         if state.inflight.contains(&key) {
             state.dirty.insert(key.clone());
         } else if state.pending.insert(key.clone()) {
+            state
+                .pending_since_unix_ms
+                .insert(key.clone(), unix_ms_now());
             should_send = true;
         }
     }
 
-    if should_send && process_tx.send(work).await.is_ok() {
-        metrics.queue_depth.fetch_add(1, Ordering::Relaxed);
+    if should_send && !send_queued_work(work, process_tx, metrics).await {
+        let mut state = dispatch.lock().expect("dispatch mutex poisoned");
+        state.pending.remove(&key);
+        state.pending_since_unix_ms.remove(&key);
     }
 }
 
@@ -811,6 +875,9 @@ pub(crate) fn complete_work(key: &str, dispatch: &Arc<Mutex<DispatchState>>) -> 
 
     if state.dirty.remove(key) {
         if state.pending.insert(key.to_string()) {
+            state
+                .pending_since_unix_ms
+                .insert(key.to_string(), unix_ms_now());
             return state.item_by_key.get(key).cloned();
         }
         return None;
@@ -857,9 +924,7 @@ pub(crate) async fn run_work_item(
     drop(permit);
 
     if let Some(item) = reschedule {
-        if process_tx.send(item).await.is_ok() {
-            metrics.queue_depth.fetch_add(1, Ordering::Relaxed);
-        }
+        let _ = send_queued_work(item, &process_tx, &metrics).await;
     }
 }
 
@@ -987,7 +1052,11 @@ pub(crate) async fn process_file(
     let sidecar_needs_processing =
         kiro_metadata.is_some() && (first_ingest || generation_changed || sidecar_changed);
 
-    if file_size == checkpoint.last_offset && !generation_changed && !sidecar_needs_processing {
+    if file_size == checkpoint.last_offset
+        && !first_ingest
+        && !generation_changed
+        && !sidecar_needs_processing
+    {
         return Ok(());
     }
     if !config.ingest.exclude_project_dirs.is_empty() {
@@ -1394,7 +1463,8 @@ pub(crate) async fn process_file(
         ..Default::default()
     };
 
-    if batch.row_count() > 0
+    if first_ingest
+        || batch.row_count() > 0
         || generation_changed
         || sidecar_needs_processing
         || offset != checkpoint.last_offset
@@ -1483,6 +1553,7 @@ async fn process_session_json_file(
 
     let cp_key = checkpoint_key(&work.source_name, source_file);
     let committed = { checkpoints.read().await.get(&cp_key).cloned() };
+    let first_ingest = committed.is_none();
 
     let mut checkpoint = committed.unwrap_or(Checkpoint {
         source_name: work.source_name.clone(),
@@ -1605,7 +1676,8 @@ async fn process_session_json_file(
         ..Default::default()
     };
 
-    if batch.row_count() > 0
+    if first_ingest
+        || batch.row_count() > 0
         || message_count != already_emitted
         || file_size != checkpoint.last_offset
     {
@@ -1801,10 +1873,11 @@ fn truncate(input: &str, max_chars: usize) -> String {
 mod tests {
     use super::{
         complete_work, compose_hermes_model, enqueue_work, enrich_claude_model_latency,
-        jsonl_source_line_byte_limit, process_file, process_session_json_file, run_work_item,
-        source_inode_for_file, work_item_is_ingestable, work_path_is_canonical, SessionCursor,
-        CLICKHOUSE_JSON_OBJECT_BYTE_LIMIT, ERROR_KIND_NORMALIZED_ROW_TOO_LARGE,
-        ERROR_KIND_SOURCE_LINE_TOO_LARGE, SESSION_JSON_GENERATION, SESSION_JSON_INODE,
+        jsonl_source_line_byte_limit, note_work_received, process_file, process_session_json_file,
+        run_work_item, send_queued_work, source_inode_for_file, work_item_is_ingestable,
+        work_path_is_canonical, SessionCursor, CLICKHOUSE_JSON_OBJECT_BYTE_LIMIT,
+        ERROR_KIND_NORMALIZED_ROW_TOO_LARGE, ERROR_KIND_SOURCE_LINE_TOO_LARGE,
+        SESSION_JSON_GENERATION, SESSION_JSON_INODE,
     };
     use crate::model::Checkpoint;
     use crate::sqlite_poll::VolatilePollMap;
@@ -2201,6 +2274,30 @@ mod tests {
             .expect("real session transcript must be forwarded");
         assert_eq!(forwarded.key(), session.key());
         assert_eq!(metrics.queue_depth.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn queue_depth_is_accounted_before_a_fast_receiver_observes_work() {
+        let metrics = Arc::new(Metrics::default());
+        let receiver_metrics = metrics.clone();
+        let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(1);
+        let receiver = tokio::spawn(async move {
+            process_rx.recv().await.expect("queued work");
+            let depth_at_receive = receiver_metrics.queue_depth.load(Ordering::Relaxed);
+            note_work_received(&receiver_metrics);
+            depth_at_receive
+        });
+
+        assert!(
+            send_queued_work(
+                sample_work("/tmp/queue-accounting.jsonl"),
+                &process_tx,
+                &metrics
+            )
+            .await
+        );
+        assert_eq!(receiver.await.expect("receiver task"), 1);
+        assert_eq!(metrics.queue_depth.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/crates/moraine-ingest-core/src/lib.rs
+++ b/crates/moraine-ingest-core/src/lib.rs
@@ -3,6 +3,7 @@ mod dispatch;
 mod heartbeat;
 pub mod model;
 pub mod normalize;
+mod progress;
 mod reconcile;
 mod redaction;
 mod sink;
@@ -12,11 +13,16 @@ mod tee;
 mod watch;
 
 use crate::checkpoint::checkpoint_key;
-use crate::dispatch::{enqueue_work, run_work_item, spawn_debounce_task};
+use crate::dispatch::{
+    enqueue_work, note_work_received, run_work_item, source_inode_for_file,
+    source_path_is_ingestable, spawn_debounce_task,
+};
 use crate::model::RowBatch;
+use crate::progress::{KiroTargetIdentity, ProgressState, TargetObservation};
 use crate::reconcile::spawn_reconcile_task;
 use crate::redaction::{RedactionAudit, SecretRedactor};
 use crate::sink::{spawn_sink_task, SinkAuthorConfig, SinkRole};
+use crate::sources::kiro_cli::load_kiro_session_metadata;
 use crate::tee::{
     spawn_tee_router, RedactionContext, RouteResolver, SharedRouteResolver, StatusRegistry,
 };
@@ -28,7 +34,7 @@ use moraine_config::{
 };
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, RwLock, Semaphore};
 use tracing::{info, warn};
@@ -59,9 +65,9 @@ pub(crate) struct DispatchState {
     pub(crate) inflight: HashSet<String>,
     pub(crate) dirty: HashSet<String>,
     pub(crate) item_by_key: HashMap<String, WorkItem>,
+    pub(crate) pending_since_unix_ms: HashMap<String, u64>,
 }
 
-#[derive(Default)]
 pub(crate) struct Metrics {
     pub(crate) raw_rows_written: AtomicU64,
     pub(crate) event_rows_written: AtomicU64,
@@ -77,6 +83,43 @@ pub(crate) struct Metrics {
     pub(crate) watcher_last_reset_unix_ms: AtomicU64,
     pub(crate) watcher_backend_state: AtomicU64,
     pub(crate) last_error: Mutex<String>,
+    pub(crate) sink_pending_rows: AtomicU64,
+    pub(crate) sink_pending_bytes: AtomicU64,
+    pub(crate) sink_retrying: AtomicBool,
+    pub(crate) progress: Mutex<ProgressState>,
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self {
+            raw_rows_written: AtomicU64::new(0),
+            event_rows_written: AtomicU64::new(0),
+            err_rows_written: AtomicU64::new(0),
+            last_flush_ms: AtomicU64::new(0),
+            append_to_visible_p50_ms: AtomicU64::new(0),
+            append_to_visible_p95_ms: AtomicU64::new(0),
+            flush_failures: AtomicU64::new(0),
+            queue_depth: AtomicU64::new(0),
+            watcher_registrations: AtomicU64::new(0),
+            watcher_error_count: AtomicU64::new(0),
+            watcher_reset_count: AtomicU64::new(0),
+            watcher_last_reset_unix_ms: AtomicU64::new(0),
+            watcher_backend_state: AtomicU64::new(0),
+            last_error: Mutex::new(String::new()),
+            sink_pending_rows: AtomicU64::new(0),
+            sink_pending_bytes: AtomicU64::new(0),
+            sink_retrying: AtomicBool::new(false),
+            progress: Mutex::new(ProgressState::new(1024)),
+        }
+    }
+}
+impl Metrics {
+    fn new(queue_capacity: usize) -> Self {
+        Self {
+            progress: Mutex::new(ProgressState::new(queue_capacity)),
+            ..Self::default()
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -178,10 +221,25 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
              `moraine db migrate` runs and this ingest service restarts"
         );
     }
+    let heartbeat_progress_column = heartbeat_column_available(&clickhouse, "progress_json")
+        .await
+        .context("failed to inspect ingest_heartbeats progress column")?;
+    if !heartbeat_progress_column {
+        warn!(
+            "ingest_heartbeats is missing the progress_json column (migration 034); \
+             finite ingest progress will not appear in heartbeats until \
+             `moraine db migrate` runs and this ingest service restarts"
+        );
+    }
 
+    let process_queue_capacity = config
+        .ingest
+        .max_inflight_batches
+        .saturating_mul(16)
+        .max(1024);
     let checkpoints = Arc::new(RwLock::new(checkpoint_map));
     let dispatch = Arc::new(Mutex::new(DispatchState::default()));
-    let metrics = Arc::new(Metrics::default());
+    let metrics = Arc::new(Metrics::new(process_queue_capacity));
     let redactor = Arc::new(
         SecretRedactor::new(&config.redaction).context("failed to initialize secret redaction")?,
     );
@@ -198,11 +256,6 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
         );
     }
 
-    let process_queue_capacity = config
-        .ingest
-        .max_inflight_batches
-        .saturating_mul(16)
-        .max(1024);
     let (process_tx, mut process_rx) = mpsc::channel::<WorkItem>(process_queue_capacity);
     let (sink_tx, sink_rx) =
         mpsc::channel::<SinkMessage>(config.ingest.max_inflight_batches.max(1));
@@ -236,6 +289,7 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
             backends: backend_statuses.clone(),
             backend_sinks_column: heartbeat_backend_column,
             redactions_column: heartbeat_redactions_column,
+            progress_column: heartbeat_progress_column,
             redactions: redaction_audit.clone(),
         },
     );
@@ -267,12 +321,13 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
 
         tokio::spawn(async move {
             while let Some(work) = process_rx.recv().await {
-                metrics_clone.queue_depth.fetch_sub(1, Ordering::Relaxed);
+                note_work_received(&metrics_clone);
                 let key = work.key();
 
                 {
                     let mut state = dispatch_clone.lock().expect("dispatch mutex poisoned");
                     state.pending.remove(&key);
+                    state.pending_since_unix_ms.remove(&key);
                     state.inflight.insert(key.clone());
                 }
 
@@ -304,6 +359,63 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
         metrics.clone(),
     );
 
+    let mut backfill_sources = Vec::new();
+    if config.ingest.backfill_on_start {
+        let checkpoint_snapshot = checkpoints.read().await.clone();
+        for source in &enabled_sources {
+            let files = enumerate_tracked_files(&source.glob, source.format)?
+                .into_iter()
+                .filter(|path| source_path_is_ingestable(source, path))
+                .collect::<Vec<_>>();
+            for path in &files {
+                let observation = match std::fs::metadata(path) {
+                    Ok(metadata) => {
+                        let kiro_identity =
+                            (source.format == SourceFormat::KiroSession).then(|| {
+                                let sidecar = load_kiro_session_metadata(path);
+                                KiroTargetIdentity::new(
+                                    sidecar.fingerprint(),
+                                    sidecar.transcript_fingerprint(),
+                                    sidecar.record().is_some(),
+                                    sidecar.error().is_none() || sidecar.fingerprint() != 0,
+                                )
+                            });
+                        TargetObservation::known(
+                            metadata.len(),
+                            source_inode_for_file(path, &metadata),
+                            kiro_identity,
+                        )
+                    }
+                    Err(exc) => {
+                        warn!(
+                            source = %source.name,
+                            source_file = %path,
+                            "startup snapshot metadata unavailable: {exc}"
+                        );
+                        TargetObservation::unknown()
+                    }
+                };
+                metrics
+                    .progress
+                    .lock()
+                    .expect("ingest progress mutex poisoned")
+                    .register_target(source, path, observation, &checkpoint_snapshot);
+            }
+            info!(
+                "startup backfill queueing {} files for source={} (format={})",
+                files.len(),
+                source.name,
+                source.format
+            );
+            backfill_sources.push((source.clone(), files.into_iter()));
+        }
+        metrics
+            .progress
+            .lock()
+            .expect("ingest progress mutex poisoned")
+            .finish_discovery();
+    }
+
     let reconcile_handle = spawn_reconcile_task(
         config.clone(),
         enabled_sources.clone(),
@@ -315,43 +427,29 @@ pub async fn run_ingestor(config: AppConfig) -> Result<()> {
     let watcher_threads =
         spawn_watcher_threads(enabled_sources.clone(), watch_path_tx, metrics.clone())?;
 
-    if config.ingest.backfill_on_start {
-        let mut backfill_sources = Vec::new();
-        for source in &enabled_sources {
-            let files = enumerate_tracked_files(&source.glob, source.format)?;
-            info!(
-                "startup backfill queueing {} files for source={} (format={})",
-                files.len(),
-                source.name,
-                source.format
-            );
-            backfill_sources.push((source.clone(), files.into_iter()));
+    loop {
+        let mut queued_any = false;
+        for (source, files) in &mut backfill_sources {
+            if let Some(path) = files.next() {
+                queued_any = true;
+                enqueue_work(
+                    WorkItem {
+                        source_name: source.name.clone(),
+                        harness: source.harness.clone(),
+                        format: source.format,
+                        source_glob: source.glob.clone(),
+                        path,
+                    },
+                    &process_tx,
+                    &dispatch,
+                    &metrics,
+                )
+                .await;
+            }
         }
 
-        loop {
-            let mut queued_any = false;
-            for (source, files) in &mut backfill_sources {
-                if let Some(path) = files.next() {
-                    queued_any = true;
-                    enqueue_work(
-                        WorkItem {
-                            source_name: source.name.clone(),
-                            harness: source.harness.clone(),
-                            format: source.format,
-                            source_glob: source.glob.clone(),
-                            path,
-                        },
-                        &process_tx,
-                        &dispatch,
-                        &metrics,
-                    )
-                    .await;
-                }
-            }
-
-            if !queued_any {
-                break;
-            }
+        if !queued_any {
+            break;
         }
     }
 

--- a/crates/moraine-ingest-core/src/progress.rs
+++ b/crates/moraine-ingest-core/src/progress.rs
@@ -1,0 +1,745 @@
+use crate::checkpoint::checkpoint_key;
+use crate::model::Checkpoint;
+use moraine_config::{IngestSource, SourceFormat};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug)]
+pub(crate) struct ProgressState {
+    instance_id: String,
+    run_started_unix_ms: u64,
+    snapshot_unix_ms: u64,
+    discovery_complete: bool,
+    queue_capacity: u64,
+    targets: HashMap<String, ProgressTarget>,
+    last_durable_progress_unix_ms: u64,
+}
+
+#[derive(Debug)]
+struct ProgressTarget {
+    source_name: String,
+    format: SourceFormat,
+    coverage_basis: CoverageBasis,
+    source_inode: Option<u64>,
+    source_generation: u32,
+    kiro_identity: Option<KiroTargetIdentity>,
+    target_bytes: Option<u64>,
+    completed_bytes: u64,
+    completed: bool,
+    degradation: TargetDegradation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetDegradation {
+    None,
+    UntilCompatibleCheckpoint,
+    Permanent,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TargetObservation {
+    file_size: Option<u64>,
+    source_inode: Option<u64>,
+    kiro_identity: Option<KiroTargetIdentity>,
+}
+
+impl TargetObservation {
+    pub(crate) fn known(
+        file_size: u64,
+        source_inode: u64,
+        kiro_identity: Option<KiroTargetIdentity>,
+    ) -> Self {
+        Self {
+            file_size: Some(file_size),
+            source_inode: Some(source_inode),
+            kiro_identity,
+        }
+    }
+
+    pub(crate) fn unknown() -> Self {
+        Self {
+            file_size: None,
+            source_inode: None,
+            kiro_identity: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct KiroTargetIdentity {
+    source_fingerprint: u64,
+    transcript_fingerprint: u64,
+    sidecar_valid: bool,
+    observable: bool,
+}
+
+impl KiroTargetIdentity {
+    pub(crate) fn new(
+        source_fingerprint: u64,
+        transcript_fingerprint: u64,
+        sidecar_valid: bool,
+        observable: bool,
+    ) -> Self {
+        Self {
+            source_fingerprint,
+            transcript_fingerprint,
+            sidecar_valid,
+            observable,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CoverageBasis {
+    Bytes,
+    Files,
+}
+
+#[derive(Serialize)]
+struct ProgressSnapshot {
+    schema_version: u16,
+    instance_id: String,
+    run_started_unix_ms: u64,
+    snapshot_unix_ms: u64,
+    discovery_complete: bool,
+    queue_capacity: u64,
+    sink_pending_rows: u64,
+    sink_pending_bytes: u64,
+    sink_retrying: bool,
+    oldest_pending_unix_ms: u64,
+    last_durable_progress_unix_ms: u64,
+    files_total: u64,
+    files_completed: u64,
+    bytes_total: u64,
+    bytes_completed: u64,
+    sources: Vec<SourceProgressSnapshot>,
+}
+
+#[derive(Default, Serialize)]
+struct SourceProgressSnapshot {
+    source_name: String,
+    format: String,
+    coverage_basis: Option<CoverageBasis>,
+    files_total: u64,
+    files_completed: u64,
+    bytes_total: u64,
+    bytes_completed: u64,
+    coverage_degraded: bool,
+}
+
+#[derive(Default, Deserialize)]
+struct KiroCheckpointIdentity {
+    #[serde(default)]
+    kiro_sidecar_valid: bool,
+    #[serde(default)]
+    transcript_fingerprint: u64,
+}
+
+#[derive(Deserialize)]
+struct SqliteCursorEvidence {
+    version: u32,
+    format: String,
+    #[serde(default)]
+    last_error: String,
+}
+
+impl ProgressState {
+    pub(crate) fn new(queue_capacity: usize) -> Self {
+        let now = unix_ms_now();
+        Self {
+            instance_id: format!("{now}-{}", std::process::id()),
+            run_started_unix_ms: now,
+            snapshot_unix_ms: 0,
+            discovery_complete: false,
+            queue_capacity: queue_capacity as u64,
+            targets: HashMap::new(),
+            last_durable_progress_unix_ms: 0,
+        }
+    }
+
+    pub(crate) fn register_target(
+        &mut self,
+        source: &IngestSource,
+        path: &str,
+        observation: TargetObservation,
+        checkpoints: &HashMap<String, Checkpoint>,
+    ) {
+        let coverage_basis = match source.format {
+            SourceFormat::Jsonl | SourceFormat::KiroSession | SourceFormat::SessionJson => {
+                CoverageBasis::Bytes
+            }
+            SourceFormat::CursorSqlite | SourceFormat::NacSqlite | SourceFormat::OpenCodeSqlite => {
+                CoverageBasis::Files
+            }
+            SourceFormat::Infer => return,
+        };
+        let key = checkpoint_key(&source.name, path);
+        let checkpoint = checkpoints.get(&key);
+        let source_inode = if source.format == SourceFormat::SessionJson {
+            observation.source_inode.map(|_| 0)
+        } else {
+            observation.source_inode
+        };
+        let target_bytes = if matches!(coverage_basis, CoverageBasis::Bytes) {
+            observation.file_size
+        } else {
+            None
+        };
+        let identity_observable = observation.file_size.is_some()
+            && source_inode.is_some()
+            && observation
+                .kiro_identity
+                .is_none_or(|identity| identity.observable);
+        let source_generation = expected_generation(
+            source.format,
+            source_inode,
+            observation.file_size,
+            checkpoint,
+        );
+        let mut target = ProgressTarget {
+            source_name: source.name.clone(),
+            format: source.format,
+            coverage_basis,
+            source_inode,
+            source_generation,
+            kiro_identity: observation.kiro_identity,
+            target_bytes,
+            completed_bytes: 0,
+            completed: false,
+            degradation: if identity_observable {
+                TargetDegradation::None
+            } else {
+                TargetDegradation::Permanent
+            },
+        };
+
+        if let Some(checkpoint) = checkpoint {
+            if checkpoint_is_compatible(&target, checkpoint) {
+                match target.coverage_basis {
+                    CoverageBasis::Bytes => {
+                        let target_bytes = target.target_bytes.unwrap_or(0);
+                        target.completed_bytes = checkpoint.last_offset;
+                        target.completed = checkpoint.last_offset >= target_bytes;
+                    }
+                    CoverageBasis::Files => target.completed = true,
+                }
+            } else if target.degradation != TargetDegradation::Permanent {
+                target.degradation = TargetDegradation::UntilCompatibleCheckpoint;
+            }
+        }
+
+        self.targets.insert(key, target);
+    }
+
+    pub(crate) fn finish_discovery(&mut self) {
+        self.discovery_complete = true;
+        self.snapshot_unix_ms = unix_ms_now();
+    }
+
+    pub(crate) fn acknowledge(
+        &mut self,
+        checkpoints: &HashMap<String, Checkpoint>,
+        sqlite_cursor_durable: bool,
+    ) {
+        let mut advanced = false;
+        for checkpoint in checkpoints.values() {
+            let key = checkpoint_key(&checkpoint.source_name, &checkpoint.source_file);
+            let Some(target) = self.targets.get_mut(&key) else {
+                continue;
+            };
+            if !checkpoint_identity_matches(target, checkpoint) {
+                invalidate_target(target, TargetDegradation::Permanent);
+                continue;
+            }
+            if !checkpoint_is_successful(target.format, checkpoint, sqlite_cursor_durable) {
+                let degradation = if target.degradation == TargetDegradation::Permanent {
+                    TargetDegradation::Permanent
+                } else {
+                    TargetDegradation::UntilCompatibleCheckpoint
+                };
+                invalidate_target(target, degradation);
+                continue;
+            }
+            if target.degradation == TargetDegradation::UntilCompatibleCheckpoint {
+                target.degradation = TargetDegradation::None;
+                advanced = true;
+            }
+            if target.degradation == TargetDegradation::Permanent {
+                continue;
+            }
+            match target.coverage_basis {
+                CoverageBasis::Bytes => {
+                    let Some(target_bytes) = target.target_bytes else {
+                        continue;
+                    };
+                    let completed = checkpoint.last_offset.min(target_bytes);
+                    if completed > target.completed_bytes {
+                        target.completed_bytes = completed;
+                        advanced = true;
+                    }
+                    if completed >= target_bytes && !target.completed {
+                        target.completed = true;
+                        advanced = true;
+                    }
+                }
+                CoverageBasis::Files => {
+                    if !target.completed {
+                        target.completed = true;
+                        advanced = true;
+                    }
+                }
+            }
+        }
+        if advanced {
+            self.last_durable_progress_unix_ms = unix_ms_now();
+        }
+    }
+
+    pub(crate) fn to_json(
+        &self,
+        oldest_pending_unix_ms: u64,
+        sink_pending_rows: u64,
+        sink_pending_bytes: u64,
+        sink_retrying: bool,
+    ) -> String {
+        let mut sources = BTreeMap::<String, SourceProgressSnapshot>::new();
+        let mut files_completed = 0_u64;
+        let mut bytes_total = 0_u64;
+        let mut bytes_completed = 0_u64;
+        for target in self.targets.values() {
+            let source = sources
+                .entry(target.source_name.clone())
+                .or_insert_with(|| SourceProgressSnapshot {
+                    source_name: target.source_name.clone(),
+                    format: target.format.as_str().to_string(),
+                    coverage_basis: Some(target.coverage_basis),
+                    ..SourceProgressSnapshot::default()
+                });
+            source.coverage_degraded |= target.degradation != TargetDegradation::None;
+            source.files_total = source.files_total.saturating_add(1);
+            if target.completed {
+                source.files_completed = source.files_completed.saturating_add(1);
+                files_completed = files_completed.saturating_add(1);
+            }
+            if let Some(target_bytes) = target.target_bytes {
+                source.bytes_total = source.bytes_total.saturating_add(target_bytes);
+                source.bytes_completed = source
+                    .bytes_completed
+                    .saturating_add(target.completed_bytes);
+                bytes_total = bytes_total.saturating_add(target_bytes);
+                bytes_completed = bytes_completed.saturating_add(target.completed_bytes);
+            }
+        }
+        serde_json::to_string(&ProgressSnapshot {
+            schema_version: 1,
+            instance_id: self.instance_id.clone(),
+            run_started_unix_ms: self.run_started_unix_ms,
+            snapshot_unix_ms: self.snapshot_unix_ms,
+            discovery_complete: self.discovery_complete,
+            queue_capacity: self.queue_capacity,
+            sink_pending_rows,
+            sink_pending_bytes,
+            sink_retrying,
+            oldest_pending_unix_ms,
+            last_durable_progress_unix_ms: self.last_durable_progress_unix_ms,
+            files_total: self.targets.len() as u64,
+            files_completed,
+            bytes_total,
+            bytes_completed,
+            sources: sources.into_values().collect(),
+        })
+        .unwrap_or_default()
+    }
+}
+
+fn expected_generation(
+    format: SourceFormat,
+    source_inode: Option<u64>,
+    file_size: Option<u64>,
+    checkpoint: Option<&Checkpoint>,
+) -> u32 {
+    if format == SourceFormat::SessionJson {
+        return 1;
+    }
+    let Some(checkpoint) = checkpoint else {
+        return 1;
+    };
+    if source_inode.is_some_and(|inode| checkpoint.source_inode != inode)
+        || file_size.is_some_and(|size| checkpoint.last_offset > size)
+    {
+        checkpoint.source_generation.saturating_add(1).max(1)
+    } else {
+        checkpoint.source_generation.max(1)
+    }
+}
+
+fn checkpoint_is_compatible(target: &ProgressTarget, checkpoint: &Checkpoint) -> bool {
+    checkpoint_identity_matches_initial(target, checkpoint)
+        && target
+            .target_bytes
+            .is_none_or(|target_bytes| checkpoint.last_offset <= target_bytes)
+        && checkpoint_is_successful(target.format, checkpoint, true)
+}
+
+fn checkpoint_identity_matches_initial(target: &ProgressTarget, checkpoint: &Checkpoint) -> bool {
+    if target.source_inode.is_none() {
+        return false;
+    }
+    let basic_identity_matches = if target.format == SourceFormat::SessionJson {
+        true
+    } else {
+        Some(checkpoint.source_inode) == target.source_inode
+            && checkpoint.source_generation.max(1) == target.source_generation
+    };
+    basic_identity_matches && kiro_identity_matches(target, checkpoint)
+}
+
+fn checkpoint_identity_matches(target: &ProgressTarget, checkpoint: &Checkpoint) -> bool {
+    Some(checkpoint.source_inode) == target.source_inode
+        && checkpoint.source_generation == target.source_generation
+        && kiro_identity_matches(target, checkpoint)
+}
+
+fn kiro_identity_matches(target: &ProgressTarget, checkpoint: &Checkpoint) -> bool {
+    let Some(expected) = target.kiro_identity else {
+        return true;
+    };
+    if !expected.observable || checkpoint.source_fingerprint != expected.source_fingerprint {
+        return false;
+    }
+    let cursor = if checkpoint.cursor_json.trim().is_empty() {
+        KiroCheckpointIdentity::default()
+    } else {
+        let Ok(cursor) = serde_json::from_str::<KiroCheckpointIdentity>(&checkpoint.cursor_json)
+        else {
+            return false;
+        };
+        cursor
+    };
+    cursor.kiro_sidecar_valid == expected.sidecar_valid
+        && cursor.transcript_fingerprint == expected.transcript_fingerprint
+}
+
+fn checkpoint_is_successful(
+    format: SourceFormat,
+    checkpoint: &Checkpoint,
+    sqlite_cursor_durable: bool,
+) -> bool {
+    if checkpoint.status != "active" {
+        return false;
+    }
+    if !matches!(
+        format,
+        SourceFormat::CursorSqlite | SourceFormat::NacSqlite | SourceFormat::OpenCodeSqlite
+    ) {
+        return true;
+    }
+    if !sqlite_cursor_durable {
+        return false;
+    }
+    let raw = checkpoint.cursor_json.trim();
+    if raw.is_empty() {
+        return false;
+    }
+    serde_json::from_str::<SqliteCursorEvidence>(raw).is_ok_and(|cursor| {
+        cursor.version > 0
+            && cursor.format == format.as_str()
+            && cursor.last_error.trim().is_empty()
+    })
+}
+
+fn invalidate_target(target: &mut ProgressTarget, degradation: TargetDegradation) {
+    target.completed_bytes = 0;
+    target.completed = false;
+    target.degradation = degradation;
+}
+
+pub(crate) fn unix_ms_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| u64::try_from(duration.as_millis()).ok())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+
+    fn source(format: SourceFormat) -> IngestSource {
+        IngestSource {
+            name: "test-source".to_string(),
+            harness: "test-harness".to_string(),
+            enabled: true,
+            glob: String::new(),
+            watch_root: String::new(),
+            format,
+        }
+    }
+
+    fn snapshot(progress: &ProgressState) -> Value {
+        serde_json::from_str(&progress.to_json(0, 0, 0, false)).expect("progress JSON")
+    }
+
+    fn checkpoint(
+        source: &IngestSource,
+        path: &str,
+        inode: u64,
+        generation: u32,
+        offset: u64,
+    ) -> Checkpoint {
+        Checkpoint {
+            source_name: source.name.clone(),
+            source_file: path.to_string(),
+            source_inode: inode,
+            source_generation: generation,
+            last_offset: offset,
+            status: "active".to_string(),
+            ..Checkpoint::default()
+        }
+    }
+
+    #[test]
+    fn later_files_do_not_move_frozen_snapshot() {
+        let mut progress = ProgressState::new(1024);
+        let source = source(SourceFormat::Jsonl);
+        progress.register_target(
+            &source,
+            "/missing/initial.jsonl",
+            TargetObservation::known(0, 1, None),
+            &HashMap::new(),
+        );
+        progress.finish_discovery();
+        assert_eq!(progress.targets.len(), 1);
+    }
+
+    #[test]
+    fn replaced_file_only_completes_after_matching_generation_commits() {
+        let mut progress = ProgressState::new(8);
+        let source = source(SourceFormat::Jsonl);
+        let path = "/sessions/replaced.jsonl";
+        let old_checkpoint = checkpoint(&source, path, 7, 1, 100);
+        let mut checkpoints = HashMap::from([(checkpoint_key(&source.name, path), old_checkpoint)]);
+        progress.register_target(
+            &source,
+            path,
+            TargetObservation::known(100, 8, None),
+            &checkpoints,
+        );
+        progress.finish_discovery();
+        let before = snapshot(&progress);
+        assert_eq!(before["bytes_completed"], 0);
+        assert_eq!(before["sources"][0]["coverage_degraded"], true);
+
+        checkpoints.insert(
+            checkpoint_key(&source.name, path),
+            checkpoint(&source, path, 8, 2, 100),
+        );
+        progress.acknowledge(&checkpoints, true);
+        let after = snapshot(&progress);
+        assert_eq!(after["bytes_completed"], 100);
+        assert_eq!(after["files_completed"], 1);
+        assert_eq!(after["sources"][0]["coverage_degraded"], false);
+    }
+
+    #[test]
+    fn same_inode_truncation_does_not_inherit_the_old_offset() {
+        let mut progress = ProgressState::new(8);
+        let source = source(SourceFormat::Jsonl);
+        let path = "/sessions/truncated.jsonl";
+        let mut checkpoints = HashMap::from([(
+            checkpoint_key(&source.name, path),
+            checkpoint(&source, path, 7, 1, 100),
+        )]);
+        progress.register_target(
+            &source,
+            path,
+            TargetObservation::known(40, 7, None),
+            &checkpoints,
+        );
+        let before = snapshot(&progress);
+        assert_eq!(before["bytes_completed"], 0);
+        assert_eq!(before["files_completed"], 0);
+        assert_eq!(before["sources"][0]["coverage_degraded"], true);
+
+        checkpoints.insert(
+            checkpoint_key(&source.name, path),
+            checkpoint(&source, path, 7, 2, 40),
+        );
+        progress.acknowledge(&checkpoints, true);
+        let after = snapshot(&progress);
+        assert_eq!(after["bytes_completed"], 40);
+        assert_eq!(after["files_completed"], 1);
+        assert_eq!(after["sources"][0]["coverage_degraded"], false);
+    }
+
+    #[test]
+    fn metadata_failure_is_unknown_instead_of_a_zero_byte_completion() {
+        let mut progress = ProgressState::new(8);
+        let source = source(SourceFormat::Jsonl);
+        progress.register_target(
+            &source,
+            "/sessions/unreadable.jsonl",
+            TargetObservation::unknown(),
+            &HashMap::new(),
+        );
+        let value = snapshot(&progress);
+        assert_eq!(value["files_total"], 1);
+        assert_eq!(value["files_completed"], 0);
+        assert_eq!(value["bytes_total"], 0);
+        assert_eq!(value["sources"][0]["coverage_degraded"], true);
+    }
+
+    #[test]
+    fn sqlite_file_completion_requires_a_successful_cursor() {
+        let mut progress = ProgressState::new(8);
+        let source = source(SourceFormat::CursorSqlite);
+        let path = "/sessions/cursor.db";
+        let mut malformed = checkpoint(&source, path, 7, 1, 0);
+        malformed.cursor_json = "{not-json".to_string();
+        let mut checkpoints = HashMap::from([(checkpoint_key(&source.name, path), malformed)]);
+        progress.register_target(
+            &source,
+            path,
+            TargetObservation::known(4096, 7, None),
+            &checkpoints,
+        );
+        assert_eq!(snapshot(&progress)["files_completed"], 0);
+
+        let mut failed = checkpoint(&source, path, 7, 1, 0);
+        failed.cursor_json = json!({
+            "version": 1,
+            "format": "cursor_sqlite",
+            "last_error": "database_locked"
+        })
+        .to_string();
+        checkpoints.insert(checkpoint_key(&source.name, path), failed);
+        progress.acknowledge(&checkpoints, true);
+        assert_eq!(snapshot(&progress)["files_completed"], 0);
+
+        let mut successful = checkpoint(&source, path, 7, 1, 0);
+        successful.cursor_json = json!({
+            "version": 1,
+            "format": "cursor_sqlite",
+            "last_error": ""
+        })
+        .to_string();
+        checkpoints.insert(checkpoint_key(&source.name, path), successful);
+        progress.acknowledge(&checkpoints, false);
+        assert_eq!(snapshot(&progress)["files_completed"], 0);
+        progress.acknowledge(&checkpoints, true);
+        let completed = snapshot(&progress);
+        assert_eq!(completed["files_completed"], 1);
+        assert_eq!(completed["sources"][0]["coverage_basis"], "files");
+        assert_eq!(completed["sources"][0]["coverage_degraded"], false);
+    }
+
+    #[test]
+    fn session_json_acknowledges_canonical_generation_one() {
+        let mut progress = ProgressState::new(8);
+        let source = source(SourceFormat::SessionJson);
+        let path = "/sessions/session.json";
+        let legacy = checkpoint(&source, path, 99, 8, 5);
+        let mut checkpoints = HashMap::from([(checkpoint_key(&source.name, path), legacy)]);
+        progress.register_target(
+            &source,
+            path,
+            TargetObservation::known(10, 101, None),
+            &checkpoints,
+        );
+        assert_eq!(
+            progress
+                .targets
+                .get(&checkpoint_key(&source.name, path))
+                .expect("session target")
+                .source_generation,
+            1
+        );
+        assert_eq!(snapshot(&progress)["bytes_completed"], 5);
+
+        checkpoints.insert(
+            checkpoint_key(&source.name, path),
+            checkpoint(&source, path, 0, 1, 10),
+        );
+        progress.acknowledge(&checkpoints, true);
+        let after = snapshot(&progress);
+        assert_eq!(after["bytes_completed"], 10);
+        assert_eq!(after["files_completed"], 1);
+    }
+
+    #[test]
+    fn post_snapshot_identity_mismatch_revokes_completion_and_degrades_coverage() {
+        let mut progress = ProgressState::new(8);
+        let source = source(SourceFormat::Jsonl);
+        let path = "/sessions/moved.jsonl";
+        let current = checkpoint(&source, path, 7, 1, 100);
+        let mut checkpoints = HashMap::from([(checkpoint_key(&source.name, path), current)]);
+        progress.register_target(
+            &source,
+            path,
+            TargetObservation::known(100, 7, None),
+            &checkpoints,
+        );
+        assert_eq!(snapshot(&progress)["files_completed"], 1);
+
+        checkpoints.insert(
+            checkpoint_key(&source.name, path),
+            checkpoint(&source, path, 8, 2, 100),
+        );
+        progress.acknowledge(&checkpoints, true);
+        let after = snapshot(&progress);
+        assert_eq!(after["files_completed"], 0);
+        assert_eq!(after["bytes_completed"], 0);
+        assert_eq!(after["sources"][0]["coverage_degraded"], true);
+
+        checkpoints.insert(
+            checkpoint_key(&source.name, path),
+            checkpoint(&source, path, 7, 1, 100),
+        );
+        progress.acknowledge(&checkpoints, true);
+        let still_degraded = snapshot(&progress);
+        assert_eq!(still_degraded["files_completed"], 0);
+        assert_eq!(still_degraded["sources"][0]["coverage_degraded"], true);
+    }
+
+    #[test]
+    fn kiro_sidecar_ambiguity_clears_only_after_matching_checkpoint() {
+        let mut progress = ProgressState::new(8);
+        let source = source(SourceFormat::KiroSession);
+        let path = "/sessions/kiro.jsonl";
+        let mut old = checkpoint(&source, path, 7, 1, 100);
+        old.source_fingerprint = 10;
+        old.cursor_json = json!({
+            "kiro_sidecar_valid": false,
+            "transcript_fingerprint": 0
+        })
+        .to_string();
+        let mut checkpoints = HashMap::from([(checkpoint_key(&source.name, path), old)]);
+        let identity = KiroTargetIdentity::new(20, 30, true, true);
+        progress.register_target(
+            &source,
+            path,
+            TargetObservation::known(100, 7, Some(identity)),
+            &checkpoints,
+        );
+        let before = snapshot(&progress);
+        assert_eq!(before["files_completed"], 0);
+        assert_eq!(before["sources"][0]["coverage_degraded"], true);
+
+        let mut matching = checkpoint(&source, path, 7, 1, 100);
+        matching.source_fingerprint = 20;
+        matching.cursor_json = json!({
+            "kiro_sidecar_valid": true,
+            "transcript_fingerprint": 30
+        })
+        .to_string();
+        checkpoints.insert(checkpoint_key(&source.name, path), matching);
+        progress.acknowledge(&checkpoints, true);
+        let after = snapshot(&progress);
+        assert_eq!(after["files_completed"], 1);
+        assert_eq!(after["sources"][0]["coverage_degraded"], false);
+    }
+}

--- a/crates/moraine-ingest-core/src/sink.rs
+++ b/crates/moraine-ingest-core/src/sink.rs
@@ -184,6 +184,8 @@ pub(crate) enum SinkRole {
         /// Whether `ingest_heartbeats` carries the `redactions_total` column
         /// (migration 022). Redaction still runs without this audit surface.
         redactions_column: bool,
+        /// Whether `ingest_heartbeats` carries migration 034 progress payloads.
+        progress_column: bool,
         redactions: Arc<RedactionAudit>,
     },
     /// A mirror sink for one named backend: filters intake down to the
@@ -492,6 +494,12 @@ pub(crate) fn spawn_sink_task(
 
                             let total_rows =
                                 raw_rows.len() + event_rows.len() + link_rows.len() + error_rows.len();
+                            metrics
+                                .sink_pending_rows
+                                .store(total_rows as u64, Ordering::Relaxed);
+                            metrics
+                                .sink_pending_bytes
+                                .store(pending_batch_bytes as u64, Ordering::Relaxed);
                             if total_rows >= config.ingest.batch_size
                                 || pending_batch_bytes >= config.ingest.max_batch_bytes.max(1)
                             {
@@ -880,25 +888,34 @@ fn clear_pending_sink_data(
 async fn commit_checkpoint_updates(
     clickhouse: &ClickHouseClient,
     checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
+    metrics: &Arc<Metrics>,
     checkpoint_rows: &[Value],
     checkpoint_updates: &HashMap<String, Checkpoint>,
+    sqlite_cursor_durable: bool,
 ) -> anyhow::Result<()> {
     if checkpoint_rows.is_empty() {
         return Ok(());
     }
 
     clickhouse
-        .insert_json_rows("ingest_checkpoints", checkpoint_rows)
+        .insert_json_rows_sync("ingest_checkpoints", checkpoint_rows)
         .await
         .context("failed to insert ingest checkpoint rows")?;
 
     // Offset-monotone merge, not a blind insert: a backend map has two
     // producers (live router batches and catch-up replay), so an out-of-order
     // flush must never regress what the map already committed.
-    let mut state = checkpoints.write().await;
-    for cp in checkpoint_updates.values() {
-        merge_checkpoint(&mut state, cp.clone());
+    {
+        let mut state = checkpoints.write().await;
+        for cp in checkpoint_updates.values() {
+            merge_checkpoint(&mut state, cp.clone());
+        }
     }
+    metrics
+        .progress
+        .lock()
+        .expect("ingest progress mutex poisoned")
+        .acknowledge(checkpoint_updates, sqlite_cursor_durable);
     Ok(())
 }
 
@@ -911,15 +928,24 @@ async fn emit_heartbeat(clickhouse: &ClickHouseClient, metrics: &Arc<Metrics>, r
         backends,
         backend_sinks_column,
         redactions_column,
+        progress_column,
         redactions,
     } = role
     else {
         return;
     };
 
-    let files_active = {
+    let (files_active, oldest_pending_unix_ms) = {
         let state = dispatch.lock().expect("dispatch mutex poisoned");
-        state.inflight.len() as u32
+        (
+            state.inflight.len() as u32,
+            state
+                .pending_since_unix_ms
+                .values()
+                .copied()
+                .min()
+                .unwrap_or(0),
+        )
     };
     let files_watched = metrics.watcher_registrations.load(Ordering::Relaxed) as u32;
     let last_error = {
@@ -968,6 +994,21 @@ async fn emit_heartbeat(clickhouse: &ClickHouseClient, metrics: &Arc<Metrics>, r
                 let counts_json = serde_json::to_string(&counts).unwrap_or_default();
                 obj.insert("redactions_total".to_string(), Value::String(counts_json));
             }
+        }
+    }
+    if *progress_column {
+        let progress_json = metrics
+            .progress
+            .lock()
+            .expect("ingest progress mutex poisoned")
+            .to_json(
+                oldest_pending_unix_ms,
+                metrics.sink_pending_rows.load(Ordering::Relaxed),
+                metrics.sink_pending_bytes.load(Ordering::Relaxed),
+                metrics.sink_retrying.load(Ordering::Relaxed),
+            );
+        if let Some(obj) = heartbeat.as_object_mut() {
+            obj.insert("progress_json".to_string(), Value::String(progress_json));
         }
     }
 
@@ -1028,6 +1069,10 @@ async fn flush_pending_with_ack(
     pending_ack: &mut PendingAckBatch,
 ) -> bool {
     let started = Instant::now();
+    metrics.sink_pending_rows.store(
+        (raw_rows.len() + event_rows.len() + link_rows.len() + error_rows.len()) as u64,
+        Ordering::Relaxed,
+    );
 
     let checkpoint_rows: Vec<Value> = checkpoint_updates
         .values()
@@ -1150,8 +1195,10 @@ async fn flush_pending_with_ack(
             commit_checkpoint_updates(
                 clickhouse,
                 checkpoints,
+                metrics,
                 &checkpoint_rows,
                 checkpoint_updates,
+                checkpoint_cursor_columns,
             )
             .await
             .map_err(|error| SinkFlushFailure::new(SinkStage::IngestCheckpoints, error))?;
@@ -1167,11 +1214,15 @@ async fn flush_pending_with_ack(
 
     match flush_result {
         Ok(()) => {
+            metrics.sink_pending_rows.store(0, Ordering::Relaxed);
+            metrics.sink_pending_bytes.store(0, Ordering::Relaxed);
+            metrics.sink_retrying.store(false, Ordering::Relaxed);
             ack_observer.observe(&pending_ack.event_identity_digests);
             pending_ack.clear();
             true
         }
         Err(failure) => {
+            metrics.sink_retrying.store(true, Ordering::Relaxed);
             metrics.flush_failures.fetch_add(1, Ordering::Relaxed);
             let error_text = failure.error.to_string();
             if is_oversized_json_each_row_insert_error(&failure.error) {
@@ -1221,8 +1272,10 @@ async fn flush_pending_with_ack(
                 if let Err(error) = commit_checkpoint_updates(
                     clickhouse,
                     checkpoints,
+                    metrics,
                     &checkpoint_rows,
                     checkpoint_updates,
+                    checkpoint_cursor_columns,
                 )
                 .await
                 {
@@ -1252,6 +1305,9 @@ async fn flush_pending_with_ack(
                     checkpoint_updates,
                 );
                 pending_ack.clear();
+                metrics.sink_pending_rows.store(0, Ordering::Relaxed);
+                metrics.sink_pending_bytes.store(0, Ordering::Relaxed);
+                metrics.sink_retrying.store(false, Ordering::Relaxed);
                 return true;
             }
 
@@ -1483,6 +1539,7 @@ mod tests {
             backends: Arc::new(Mutex::new(std::collections::BTreeMap::new())),
             backend_sinks_column: false,
             redactions_column: false,
+            progress_column: false,
             redactions: test_redaction_audit(),
         }
     }

--- a/crates/moraine-mcp-core/src/concurrency_tests.rs
+++ b/crates/moraine-mcp-core/src/concurrency_tests.rs
@@ -2,9 +2,9 @@ use super::*;
 use moraine_conversations::{
     AnalyticsRange, AnalyticsSnapshot, Conversation, ConversationDetailOptions,
     ConversationListFilter, ConversationSearchQuery, ConversationSearchResults, FileAttentionQuery,
-    FileAttentionTouch, InMemoryConversationRepository, IngestHeartbeatRead, McpEventOpen,
-    McpSessionListFilter, McpSessionListItem, McpSessionOpen, McpTurnOpen, OpenContext,
-    OpenEventRequest, Page, PageRequest, RepoConfig, RepoResult, SearchEventsQuery,
+    FileAttentionTouch, InMemoryConversationRepository, IngestHeartbeatRead, IngestStatusRead,
+    McpEventOpen, McpSessionListFilter, McpSessionListItem, McpSessionOpen, McpTurnOpen,
+    OpenContext, OpenEventRequest, Page, PageRequest, RepoConfig, RepoResult, SearchEventsQuery,
     SearchEventsResult, SearchMcpEventsQuery, SearchMcpEventsResult, SessionAnalytics,
     SessionAnalyticsQuery, SessionEventsQuery, SessionMetadata, SessionMetadataSearchQuery,
     SessionMetadataSearchResults, StoreDiagnostics, StoreHealth, TablePreview, TablePreviewQuery,
@@ -20,6 +20,7 @@ const DELAY_SEARCH: u8 = 3;
 const PANIC_SEARCH: u8 = 4;
 const BLOCK_LIST: u8 = 5;
 const BLOCK_OPEN: u8 = 6;
+const BLOCK_STATUS: u8 = 7;
 const TEST_MAX_PARALLEL_REQUESTS: usize = 2;
 
 struct BlockingRepository {
@@ -141,6 +142,13 @@ impl ConversationRepository for BlockingRepository {
 
     async fn latest_ingest_heartbeat(&self) -> RepoResult<IngestHeartbeatRead> {
         self.inner.latest_ingest_heartbeat().await
+    }
+
+    async fn ingest_status(&self, history_limit: u16) -> RepoResult<IngestStatusRead> {
+        if self.mode.load(Ordering::Acquire) == BLOCK_STATUS {
+            self.block_forever().await
+        }
+        self.inner.ingest_status(history_limit).await
     }
 
     async fn list_table_summaries(&self) -> RepoResult<TableSummaries> {
@@ -496,6 +504,104 @@ async fn full_queue_returns_structured_overload_within_one_hundred_milliseconds(
 }
 
 #[tokio::test]
+async fn ingest_status_obeys_shared_execution_and_queue_limits() {
+    let repository = Arc::new(BlockingRepository::new(BLOCK_STATUS));
+    let state = test_state_with_admission(repository.clone(), 1, 1);
+    let admission = state.request_admission.clone();
+    let (mut reader, mut writer, server) = start_connection_with_state(state);
+    let burst = ["status-1", "status-2", "status-3"]
+        .into_iter()
+        .map(|id| tool_request(id, "get_ingest_status", json!({})))
+        .collect::<String>();
+
+    writer
+        .write_all(burst.as_bytes())
+        .await
+        .expect("send status burst");
+    let overloaded = read_response(&mut reader).await;
+    assert_eq!(overloaded["id"], json!("status-3"));
+    assert_eq!(overloaded["result"]["isError"], json!(true));
+    assert_eq!(
+        overloaded["result"]["structuredContent"]["error"]["details"]["reason"],
+        json!("queue_full")
+    );
+    repository.wait_for_started(1).await;
+    assert_eq!(admission.execution.available_permits(), 0);
+    assert_eq!(admission.slots.available_permits(), 0);
+
+    for id in ["status-1", "status-2"] {
+        writer
+            .write_all(
+                format!(
+                    "{{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\",\"params\":{{\"requestId\":\"{id}\"}}}}\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .expect("cancel admitted status request");
+    }
+    writer.shutdown().await.expect("half-close request stream");
+    drop(writer);
+    tokio::time::timeout(std::time::Duration::from_secs(1), server)
+        .await
+        .expect("connection drained")
+        .expect("connection task joined")
+        .expect("connection succeeded");
+    repository.wait_for_cancelled(1).await;
+    assert_eq!(repository.started.load(Ordering::Acquire), 1);
+    assert_eq!(admission.execution.available_permits(), 1);
+    assert_eq!(admission.slots.available_permits(), 2);
+}
+
+#[tokio::test]
+async fn ingest_status_deadline_cancels_the_registered_backend_query() {
+    let repository = Arc::new(BlockingRepository::new(BLOCK_STATUS));
+    let state = test_state_with_admission(repository.clone(), 1, 1);
+    let (mut reader, mut writer, server) = start_connection_with_state(state);
+    let started_at = tokio::time::Instant::now();
+
+    writer
+        .write_all(tool_request("status", "get_ingest_status", json!({})).as_bytes())
+        .await
+        .expect("send blocked status request");
+    repository.wait_for_started(1).await;
+    let mut line = String::new();
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        reader.read_line(&mut line),
+    )
+    .await
+    .expect("status deadline response")
+    .expect("read status deadline response");
+    let response: Value = serde_json::from_str(line.trim()).expect("status response JSON");
+
+    assert_eq!(response["id"], json!("status"));
+    assert_eq!(response["result"]["isError"], json!(true));
+    assert_eq!(
+        response["result"]["structuredContent"]["error"]["code"],
+        json!("deadline_exceeded")
+    );
+    assert_eq!(
+        response["result"]["structuredContent"]["error"]["details"]["deadline_ms"],
+        json!(contract::GET_INGEST_STATUS_DEADLINE_MS)
+    );
+    assert!(
+        started_at.elapsed()
+            >= std::time::Duration::from_millis(contract::GET_INGEST_STATUS_DEADLINE_MS)
+    );
+    repository.wait_for_dropped(1).await;
+    repository.wait_for_cancelled(1).await;
+    assert!(repository.cancelled_queries.lock().await[0].starts_with("moraine-ingest-status-"));
+
+    writer.shutdown().await.expect("half-close request stream");
+    drop(writer);
+    tokio::time::timeout(std::time::Duration::from_secs(1), server)
+        .await
+        .expect("connection drained")
+        .expect("connection task joined")
+        .expect("connection succeeded");
+}
+#[tokio::test]
 async fn queued_success_reports_wall_time_from_frame_acceptance() {
     let repository = Arc::new(BlockingRepository::new(DELAY_SEARCH));
     let state = test_state_with_admission(repository.clone(), 1, 1);
@@ -831,6 +937,11 @@ async fn cancellation_is_registered_before_each_tool_first_repository_read() {
             "open",
             tool_request("open", "open", json!({ "id": session_id })),
         ),
+        (
+            BLOCK_STATUS,
+            "status",
+            tool_request("status", "get_ingest_status", json!({})),
+        ),
     ];
 
     for (index, (mode, id, request)) in requests.into_iter().enumerate() {
@@ -854,11 +965,12 @@ async fn cancellation_is_registered_before_each_tool_first_repository_read() {
     }
 
     let cancelled = repository.cancelled_queries.lock().await.clone();
-    assert_eq!(cancelled.len(), 3);
+    assert_eq!(cancelled.len(), 4);
     assert!(cancelled[0].starts_with("moraine-search-sessions-"));
-    assert!(cancelled[1..]
+    assert!(cancelled[1..3]
         .iter()
         .all(|query_id| query_id.starts_with("moraine-request-")));
+    assert!(cancelled[3].starts_with("moraine-ingest-status-"));
 
     writer.shutdown().await.expect("half-close request stream");
     drop(writer);

--- a/crates/moraine-mcp-core/src/contract.rs
+++ b/crates/moraine-mcp-core/src/contract.rs
@@ -14,6 +14,8 @@ const BASE64_URL_ALPHABET: &[u8; 64] =
 pub const SEARCH_SESSIONS_TOOL: &str = "search_sessions";
 pub const OPEN_TOOL: &str = "open";
 pub const LIST_SESSIONS_TOOL: &str = "list_sessions";
+pub const GET_INGEST_STATUS_TOOL: &str = "get_ingest_status";
+pub const GET_INGEST_STATUS_DEADLINE_MS: u64 = 3_000;
 pub const SEARCH_SESSIONS_SCHEMA_VERSION: &str = "moraine.mcp.search_sessions.v1";
 pub const OPEN_SCHEMA_VERSION: &str = "moraine.mcp.open.v1";
 pub const LIST_SESSIONS_SCHEMA_VERSION: &str = "moraine.mcp.list_sessions.v1";
@@ -37,6 +39,9 @@ pub const FILE_ATTENTION_DEADLINE_MS: u64 = 4_000;
 /// low-confidence warning. A bare basename (`mod.rs`, depth 1) warns;
 /// `src/lib.rs` (depth 2) does not.
 pub const FILE_ATTENTION_MIN_TAIL_SEGMENTS: usize = 2;
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetIngestStatusArgs {}
 
 pub type ContractResult<T> = Result<T, ContractError>;
 

--- a/crates/moraine-mcp-core/src/get_ingest_status_v1.rs
+++ b/crates/moraine-mcp-core/src/get_ingest_status_v1.rs
@@ -1,0 +1,646 @@
+use super::{
+    backend_query_id, cancel_query_with_deadline, handled_tool_error_result, request_performance,
+    tool_success_result, AppState, QueryCancellationGuard,
+};
+use crate::contract::{
+    ContractError, GetIngestStatusArgs, Performance, ToolEnvelope, ToolErrorCode,
+    ToolErrorEnvelope, GET_INGEST_STATUS_DEADLINE_MS, GET_INGEST_STATUS_TOOL,
+};
+use anyhow::{Context, Result};
+use moraine_conversations::{
+    IngestAlert, IngestCondition, IngestConditionState, IngestConditionType, IngestEta,
+    IngestHistoryPoint, IngestRate, IngestStatus, IngestStatusRead,
+};
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::time::{timeout, Duration, Instant};
+
+const INGEST_STATUS_HISTORY_LIMIT: u16 = 61;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IngestStatusReadError {
+    Deadline,
+    Unavailable,
+}
+
+#[derive(Debug, Serialize)]
+struct McpIngestStatus {
+    observed_at_unix_ms: i64,
+    current: Option<McpIngestCurrent>,
+    conditions: Vec<McpIngestCondition>,
+    alerts: Vec<McpIngestAlert>,
+    rate: Option<McpIngestRate>,
+    eta: Option<McpIngestEta>,
+    history: Vec<McpIngestHistoryPoint>,
+}
+
+#[derive(Debug, Serialize)]
+struct McpIngestCurrent {
+    heartbeat_observed_at_unix_ms: i64,
+    queue_depth: u64,
+    files_active: u32,
+    files_watched: u32,
+    progress: Option<McpIngestProgress>,
+}
+
+#[derive(Debug, Serialize)]
+struct McpIngestProgress {
+    discovery_complete: bool,
+    queue_capacity: u64,
+    sink_pending_rows: u64,
+    sink_pending_bytes: u64,
+    sink_retrying: bool,
+    oldest_pending_unix_ms: u64,
+    last_durable_progress_unix_ms: u64,
+    files_total: u64,
+    files_completed: u64,
+    bytes_total: u64,
+    bytes_completed: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct McpIngestCondition {
+    condition_type: IngestConditionType,
+    state: IngestConditionState,
+    reason: String,
+    observed_at_unix_ms: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct McpIngestAlert {
+    code: moraine_conversations::IngestAlertCode,
+    observed_at_unix_ms: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct McpIngestRate {
+    bytes_per_second: f64,
+    sample_seconds: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct McpIngestEta {
+    scope: String,
+    low_seconds: u64,
+    high_seconds: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct McpIngestHistoryPoint {
+    ts_unix_ms: i64,
+    queue_depth: u64,
+    files_active: u32,
+    queue_capacity: u64,
+    sink_pending_rows: u64,
+    sink_retrying: bool,
+    discovery_complete: bool,
+    files_total: u64,
+    files_completed: u64,
+    bytes_total: u64,
+    bytes_completed: u64,
+}
+
+impl AppState {
+    pub(crate) async fn get_ingest_status_v1(&self, arguments: Value) -> Result<Value> {
+        let perf = request_performance();
+        let request = json!({});
+        if serde_json::from_value::<GetIngestStatusArgs>(arguments).is_err() {
+            return encode_error(
+                request,
+                ContractError::new(
+                    ToolErrorCode::InvalidRequest,
+                    "get_ingest_status expects an empty JSON object",
+                ),
+                perf.finish(),
+            );
+        }
+
+        let read = match self
+            .read_ingest_status_bounded(INGEST_STATUS_HISTORY_LIMIT)
+            .await
+        {
+            Ok(read) => read,
+            Err(IngestStatusReadError::Deadline) => {
+                return encode_error(
+                    request,
+                    ContractError::new(
+                        ToolErrorCode::DeadlineExceeded,
+                        "get_ingest_status exceeded its response deadline",
+                    )
+                    .with_details(json!({ "deadline_ms": GET_INGEST_STATUS_DEADLINE_MS })),
+                    perf.finish(),
+                );
+            }
+            Err(IngestStatusReadError::Unavailable) => {
+                return encode_error(request, status_unavailable_error(), perf.finish());
+            }
+        };
+        let status = McpIngestStatus::from(read.derive(unix_now_ms()));
+        let data = serde_json::to_value(&status).context("failed to encode ingestion status")?;
+        let payload = serde_json::to_value(ToolEnvelope::success(
+            GET_INGEST_STATUS_TOOL,
+            request,
+            data,
+            perf.finish(),
+        ))
+        .context("failed to encode get_ingest_status response envelope")?;
+        Ok(tool_success_result(format_status_text(&status), payload))
+    }
+
+    pub(crate) async fn read_ingest_status_bounded(
+        &self,
+        history_limit: u16,
+    ) -> std::result::Result<IngestStatusRead, IngestStatusReadError> {
+        let query_id = backend_query_id("ingest-status");
+        let duration = Duration::from_millis(GET_INGEST_STATUS_DEADLINE_MS);
+        let deadline = Instant::now() + duration;
+        let mut cancellation = QueryCancellationGuard::new(query_id.clone());
+        let repo_result = timeout(
+            duration,
+            moraine_conversations::with_repository_query_deadline(
+                query_id.clone(),
+                deadline,
+                self.repo.ingest_status(history_limit),
+            ),
+        )
+        .await;
+
+        match repo_result {
+            Ok(Ok(read)) => {
+                cancellation.disarm();
+                Ok(read)
+            }
+            Ok(Err(_)) => {
+                cancellation.disarm();
+                Err(IngestStatusReadError::Unavailable)
+            }
+            Err(_) => {
+                cancel_query_with_deadline(self, &query_id).await;
+                cancellation.disarm();
+                Err(IngestStatusReadError::Deadline)
+            }
+        }
+    }
+}
+
+impl From<IngestStatus> for McpIngestStatus {
+    fn from(status: IngestStatus) -> Self {
+        Self {
+            observed_at_unix_ms: status.observed_at_unix_ms,
+            current: status.heartbeat.latest.as_ref().map(McpIngestCurrent::from),
+            conditions: status
+                .conditions
+                .into_iter()
+                .map(McpIngestCondition::from)
+                .collect(),
+            alerts: status
+                .alerts
+                .into_iter()
+                .map(McpIngestAlert::from)
+                .collect(),
+            rate: status.rate.map(McpIngestRate::from),
+            eta: status.eta.map(McpIngestEta::from),
+            history: status
+                .history
+                .into_iter()
+                .map(McpIngestHistoryPoint::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<&moraine_conversations::IngestHeartbeat> for McpIngestCurrent {
+    fn from(heartbeat: &moraine_conversations::IngestHeartbeat) -> Self {
+        Self {
+            heartbeat_observed_at_unix_ms: heartbeat.ts_unix_ms,
+            queue_depth: heartbeat.queue_depth,
+            files_active: heartbeat.files_active,
+            files_watched: heartbeat.files_watched,
+            progress: heartbeat.progress.as_ref().map(McpIngestProgress::from),
+        }
+    }
+}
+
+impl From<&moraine_conversations::IngestProgressSnapshot> for McpIngestProgress {
+    fn from(progress: &moraine_conversations::IngestProgressSnapshot) -> Self {
+        Self {
+            discovery_complete: progress.discovery_complete,
+            queue_capacity: progress.queue_capacity,
+            sink_pending_rows: progress.sink_pending_rows,
+            sink_pending_bytes: progress.sink_pending_bytes,
+            sink_retrying: progress.sink_retrying,
+            oldest_pending_unix_ms: progress.oldest_pending_unix_ms,
+            last_durable_progress_unix_ms: progress.last_durable_progress_unix_ms,
+            files_total: progress.files_total,
+            files_completed: progress.files_completed,
+            bytes_total: progress.bytes_total,
+            bytes_completed: progress.bytes_completed,
+        }
+    }
+}
+
+impl From<IngestCondition> for McpIngestCondition {
+    fn from(condition: IngestCondition) -> Self {
+        Self {
+            condition_type: condition.condition_type,
+            state: condition.state,
+            reason: condition.reason,
+            observed_at_unix_ms: condition.observed_at_unix_ms,
+        }
+    }
+}
+
+impl From<IngestAlert> for McpIngestAlert {
+    fn from(alert: IngestAlert) -> Self {
+        Self {
+            code: alert.code,
+            observed_at_unix_ms: alert.observed_at_unix_ms,
+        }
+    }
+}
+
+impl From<IngestRate> for McpIngestRate {
+    fn from(rate: IngestRate) -> Self {
+        Self {
+            bytes_per_second: rate.bytes_per_second,
+            sample_seconds: rate.sample_seconds,
+        }
+    }
+}
+
+impl From<IngestEta> for McpIngestEta {
+    fn from(eta: IngestEta) -> Self {
+        Self {
+            scope: eta.scope,
+            low_seconds: eta.low_seconds,
+            high_seconds: eta.high_seconds,
+        }
+    }
+}
+
+impl From<IngestHistoryPoint> for McpIngestHistoryPoint {
+    fn from(point: IngestHistoryPoint) -> Self {
+        Self {
+            ts_unix_ms: point.ts_unix_ms,
+            queue_depth: point.queue_depth,
+            files_active: point.files_active,
+            queue_capacity: point.queue_capacity,
+            sink_pending_rows: point.sink_pending_rows,
+            sink_retrying: point.sink_retrying,
+            discovery_complete: point.discovery_complete,
+            files_total: point.files_total,
+            files_completed: point.files_completed,
+            bytes_total: point.bytes_total,
+            bytes_completed: point.bytes_completed,
+        }
+    }
+}
+
+pub(crate) fn unix_now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| i64::try_from(duration.as_millis()).ok())
+        .unwrap_or(0)
+}
+
+fn condition_state(status: &McpIngestStatus, kind: IngestConditionType) -> (&'static str, &str) {
+    status
+        .conditions
+        .iter()
+        .find(|condition| condition.condition_type == kind)
+        .map(|condition| {
+            let state = match condition.state {
+                IngestConditionState::True => "ok",
+                IngestConditionState::False => "degraded",
+                IngestConditionState::Unknown => "unknown",
+            };
+            (state, condition.reason.as_str())
+        })
+        .unwrap_or(("unknown", "condition_missing"))
+}
+
+fn format_status_text(status: &McpIngestStatus) -> String {
+    let (health, health_reason) = condition_state(status, IngestConditionType::Health);
+    let (coverage, coverage_reason) = condition_state(status, IngestConditionType::Coverage);
+    let (freshness, freshness_reason) = condition_state(status, IngestConditionType::Freshness);
+    let (readiness, readiness_reason) = condition_state(status, IngestConditionType::Readiness);
+    let mut lines = vec![format!(
+        "Ingestion health={health} ({health_reason}); coverage={coverage} ({coverage_reason}); freshness={freshness} ({freshness_reason}); readiness={readiness} ({readiness_reason})."
+    )];
+
+    if let Some(progress) = status
+        .current
+        .as_ref()
+        .and_then(|current| current.progress.as_ref())
+    {
+        let percent = if progress.bytes_total > 0 {
+            progress.bytes_completed as f64 * 100.0 / progress.bytes_total as f64
+        } else if progress.files_total > 0 {
+            progress.files_completed as f64 * 100.0 / progress.files_total as f64
+        } else {
+            100.0
+        };
+        lines.push(format!(
+            "Historical startup snapshot: {}/{} files, {}/{} bytes ({percent:.1}%).",
+            progress.files_completed,
+            progress.files_total,
+            progress.bytes_completed,
+            progress.bytes_total
+        ));
+    }
+    if let Some(rate) = &status.rate {
+        lines.push(format!(
+            "Durable checkpoint rate: {:.0} bytes/s over {}s.",
+            rate.bytes_per_second, rate.sample_seconds
+        ));
+    }
+    if let Some(eta) = &status.eta {
+        lines.push(format!(
+            "Estimated {} completion: {}-{}s.",
+            eta.scope, eta.low_seconds, eta.high_seconds
+        ));
+    }
+    if !status.alerts.is_empty() {
+        lines.push(format!("Active alerts: {}.", status.alerts.len()));
+    }
+    lines.join("\n")
+}
+
+fn status_unavailable_error() -> ContractError {
+    ContractError::new(
+        ToolErrorCode::InternalError,
+        "ingestion status is unavailable",
+    )
+    .with_details(json!({ "reason": "status_unavailable" }))
+}
+
+fn encode_error(request: Value, error: ContractError, performance: Performance) -> Result<Value> {
+    let payload = serde_json::to_value(ToolErrorEnvelope::error(
+        GET_INGEST_STATUS_TOOL,
+        request,
+        error,
+        performance,
+    ))
+    .context("failed to encode get_ingest_status error envelope")?;
+    Ok(handled_tool_error_result(
+        "Unable to read ingestion status.".to_string(),
+        payload,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use moraine_config::AppConfig;
+    use moraine_conversations::{
+        InMemoryConversationRepository, InMemoryConversationResponses, IngestCoverageBasis,
+        IngestHeartbeat, IngestHeartbeatRead, IngestProgressSnapshot, IngestSourceProgress,
+        RepoConfig, RepoError,
+    };
+    use std::sync::Arc;
+
+    fn raw_heartbeat(ts_unix_ms: i64, marker: &str) -> IngestHeartbeat {
+        IngestHeartbeat {
+            ts: format!("{marker}:raw timestamp"),
+            ts_unix_ms,
+            host: format!("/Users/alice/private/{marker}.jsonl"),
+            service_version: format!("{marker}:service-version"),
+            queue_depth: 3,
+            files_active: 2,
+            files_watched: 4,
+            rows_raw_written: 10,
+            rows_events_written: 9,
+            rows_errors_written: 1,
+            flush_latency_ms: 5,
+            append_to_visible_p50_ms: 6,
+            append_to_visible_p95_ms: 7,
+            last_error: format!("{marker}:raw repository error password=hunter2"),
+            watcher_backend: Some(format!("{marker}:watcher diagnostics")),
+            watcher_error_count: Some(11),
+            watcher_reset_count: Some(12),
+            watcher_last_reset_unix_ms: Some(13),
+            backend_sinks: Some(json!({
+                "credential": format!("{marker}:SECRET_BACKEND_TOKEN"),
+                "source_path": format!("/private/{marker}.db"),
+            })),
+            progress: Some(IngestProgressSnapshot {
+                schema_version: 1,
+                instance_id: format!("{marker}:instance"),
+                run_started_unix_ms: 1,
+                snapshot_unix_ms: 2,
+                discovery_complete: true,
+                queue_capacity: 64,
+                sink_pending_rows: 8,
+                sink_pending_bytes: 1_024,
+                sink_retrying: false,
+                oldest_pending_unix_ms: 3,
+                last_durable_progress_unix_ms: 4,
+                files_total: 10,
+                files_completed: 8,
+                bytes_total: 10_000,
+                bytes_completed: 8_000,
+                sources: vec![IngestSourceProgress {
+                    source_name: format!("/Users/alice/private/{marker}.jsonl"),
+                    format: format!("{marker}:raw-format"),
+                    coverage_basis: IngestCoverageBasis::Bytes,
+                    files_total: 10,
+                    files_completed: 8,
+                    bytes_total: 10_000,
+                    bytes_completed: 8_000,
+                    coverage_degraded: false,
+                }],
+            }),
+        }
+    }
+
+    fn assert_no_markers(value: &Value, markers: &[&str]) {
+        match value {
+            Value::Array(values) => {
+                for value in values {
+                    assert_no_markers(value, markers);
+                }
+            }
+            Value::Object(values) => {
+                for (key, value) in values {
+                    for marker in markers {
+                        assert!(
+                            !key.contains(marker),
+                            "private marker {marker:?} leaked in key {key:?}"
+                        );
+                    }
+                    assert_no_markers(value, markers);
+                }
+            }
+            Value::String(text) => {
+                for marker in markers {
+                    assert!(
+                        !text.contains(marker),
+                        "private marker {marker:?} leaked in {text:?}"
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn assert_no_forbidden_status_keys(value: &Value) {
+        const FORBIDDEN: &[&str] = &[
+            "heartbeat",
+            "host",
+            "service_version",
+            "last_error",
+            "watcher_backend",
+            "watcher_error_count",
+            "watcher_reset_count",
+            "watcher_last_reset_unix_ms",
+            "backend_sinks",
+            "sources",
+            "source_name",
+            "instance_id",
+            "run_started_unix_ms",
+            "snapshot_unix_ms",
+        ];
+        match value {
+            Value::Array(values) => {
+                for value in values {
+                    assert_no_forbidden_status_keys(value);
+                }
+            }
+            Value::Object(values) => {
+                for (key, value) in values {
+                    assert!(
+                        !FORBIDDEN.contains(&key.as_str()),
+                        "forbidden status field {key:?} was serialized"
+                    );
+                    assert_no_forbidden_status_keys(value);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn explicit_status_projection_redacts_latest_and_raw_history_recursively() {
+        let latest_marker = "SECRET_LATEST_TOKEN";
+        let history_marker = "SECRET_HISTORY_TOKEN";
+        let latest = raw_heartbeat(120_000, latest_marker);
+        let mut history = raw_heartbeat(60_000, history_marker);
+        history
+            .progress
+            .as_mut()
+            .expect("history progress")
+            .bytes_completed = 4_000;
+        let status = IngestStatusRead {
+            heartbeat: IngestHeartbeatRead {
+                table_present: true,
+                latest: Some(latest),
+            },
+            history: vec![history],
+        }
+        .derive(120_001);
+        let safe_status = McpIngestStatus::from(status);
+        let data = serde_json::to_value(&safe_status).expect("safe status JSON");
+        let payload = serde_json::to_value(ToolEnvelope::success(
+            GET_INGEST_STATUS_TOOL,
+            json!({}),
+            data,
+            Performance::from_elapsed(Duration::ZERO),
+        ))
+        .expect("status envelope");
+        let response = tool_success_result(format_status_text(&safe_status), payload);
+
+        assert_no_markers(
+            &response,
+            &[
+                latest_marker,
+                history_marker,
+                "password=hunter2",
+                "SECRET_BACKEND_TOKEN",
+                "/Users/alice/private",
+                "/private/",
+                "raw repository error",
+                "watcher diagnostics",
+            ],
+        );
+        assert_no_forbidden_status_keys(&response["structuredContent"]["data"]);
+        assert_eq!(
+            response["structuredContent"]["data"]["history"][0],
+            json!({
+                "ts_unix_ms": 60_000,
+                "queue_depth": 3,
+                "files_active": 2,
+                "queue_capacity": 64,
+                "sink_pending_rows": 8,
+                "sink_retrying": false,
+                "discovery_complete": true,
+                "files_total": 10,
+                "files_completed": 8,
+                "bytes_total": 10_000,
+                "bytes_completed": 4_000,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_arguments_are_not_reflected_in_the_error_envelope() {
+        let state = AppState::embedded(
+            AppConfig::default(),
+            Arc::new(InMemoryConversationRepository::default()),
+        );
+        let response = state
+            .get_ingest_status_v1(json!({
+                "credential": "SECRET_INVALID_REQUEST",
+                "path": "/Users/alice/private/source.jsonl",
+            }))
+            .await
+            .expect("invalid request response");
+
+        assert_eq!(response["isError"], true);
+        assert_eq!(
+            response["structuredContent"]["error"]["code"],
+            "invalid_request"
+        );
+        assert_eq!(response["structuredContent"]["request"], json!({}));
+        assert_no_markers(
+            &response,
+            &["SECRET_INVALID_REQUEST", "/Users/alice/private"],
+        );
+    }
+
+    #[tokio::test]
+    async fn repository_failure_returns_only_the_stable_status_unavailable_error() {
+        let raw_error = "SECRET_REPOSITORY_ERROR /private/source.db password=hunter2";
+        let repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            InMemoryConversationResponses {
+                latest_ingest_heartbeat: Some(Err(RepoError::backend(raw_error))),
+                ..InMemoryConversationResponses::default()
+            },
+        ));
+        let state = AppState::embedded(AppConfig::default(), repository);
+        let response = state
+            .get_ingest_status_v1(json!({}))
+            .await
+            .expect("status unavailable response");
+
+        assert_eq!(response["isError"], true);
+        assert_eq!(
+            response["structuredContent"]["error"],
+            json!({
+                "code": "internal_error",
+                "message": "ingestion status is unavailable",
+                "details": { "reason": "status_unavailable" },
+            })
+        );
+        assert_no_markers(
+            &response,
+            &[
+                "SECRET_REPOSITORY_ERROR",
+                "/private/source.db",
+                "password=hunter2",
+            ],
+        );
+    }
+}

--- a/crates/moraine-mcp-core/src/lib.rs
+++ b/crates/moraine-mcp-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod contract;
 mod file_attention_v1;
+mod get_ingest_status_v1;
 mod list_sessions_v1;
 mod open_v1;
 mod private_proxy;
@@ -9,7 +10,9 @@ mod search_sessions_v1;
 
 use anyhow::{anyhow, Context, Result};
 use moraine_config::{AppConfig, KNOWN_INGEST_HARNESSES};
-use moraine_conversations::{BackendRepositoryRouter, RepoError};
+use moraine_conversations::{
+    BackendRepositoryRouter, IngestConditionState, IngestConditionType, RepoError,
+};
 pub use moraine_conversations::{ConversationRepository, SessionOriginScope};
 pub use private_proxy::private_route_deadline;
 #[cfg(unix)]
@@ -692,19 +695,285 @@ impl AppState {
                     "annotations": {
                         "readOnlyHint": true
                     }
+                },
+                {
+                    "name": contract::GET_INGEST_STATUS_TOOL,
+                    "description": "Report ingestion health, finite historical coverage, durable progress, freshness, alerts, and a conservative ETA when enough stable checkpoint history exists. Use this before concluding that a missing retrieval result never existed.",
+                    "inputSchema": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {}
+                    },
+                    "outputSchema": tool_output_schema(
+                        contract::GET_INGEST_STATUS_TOOL,
+                        json!({
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                                "observed_at_unix_ms",
+                                "current",
+                                "conditions",
+                                "alerts",
+                                "rate",
+                                "eta",
+                                "history"
+                            ],
+                            "properties": {
+                                "observed_at_unix_ms": { "type": "integer" },
+                                "current": {
+                                    "type": ["object", "null"],
+                                    "additionalProperties": false,
+                                    "required": [
+                                        "heartbeat_observed_at_unix_ms",
+                                        "queue_depth",
+                                        "files_active",
+                                        "files_watched",
+                                        "progress"
+                                    ],
+                                    "properties": {
+                                        "heartbeat_observed_at_unix_ms": { "type": "integer" },
+                                        "queue_depth": { "type": "integer", "minimum": 0 },
+                                        "files_active": { "type": "integer", "minimum": 0 },
+                                        "files_watched": { "type": "integer", "minimum": 0 },
+                                        "progress": {
+                                            "type": ["object", "null"],
+                                            "additionalProperties": false,
+                                            "required": [
+                                                "discovery_complete",
+                                                "queue_capacity",
+                                                "sink_pending_rows",
+                                                "sink_pending_bytes",
+                                                "sink_retrying",
+                                                "oldest_pending_unix_ms",
+                                                "last_durable_progress_unix_ms",
+                                                "files_total",
+                                                "files_completed",
+                                                "bytes_total",
+                                                "bytes_completed"
+                                            ],
+                                            "properties": {
+                                                "discovery_complete": { "type": "boolean" },
+                                                "queue_capacity": { "type": "integer", "minimum": 0 },
+                                                "sink_pending_rows": { "type": "integer", "minimum": 0 },
+                                                "sink_pending_bytes": { "type": "integer", "minimum": 0 },
+                                                "sink_retrying": { "type": "boolean" },
+                                                "oldest_pending_unix_ms": { "type": "integer", "minimum": 0 },
+                                                "last_durable_progress_unix_ms": { "type": "integer", "minimum": 0 },
+                                                "files_total": { "type": "integer", "minimum": 0 },
+                                                "files_completed": { "type": "integer", "minimum": 0 },
+                                                "bytes_total": { "type": "integer", "minimum": 0 },
+                                                "bytes_completed": { "type": "integer", "minimum": 0 }
+                                            }
+                                        }
+                                    }
+                                },
+                                "conditions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "required": [
+                                            "condition_type",
+                                            "state",
+                                            "reason",
+                                            "observed_at_unix_ms"
+                                        ],
+                                        "properties": {
+                                            "condition_type": {
+                                                "type": "string",
+                                                "enum": ["health", "coverage", "freshness", "readiness"]
+                                            },
+                                            "state": {
+                                                "type": "string",
+                                                "enum": ["true", "false", "unknown"]
+                                            },
+                                            "reason": { "type": "string" },
+                                            "observed_at_unix_ms": { "type": "integer" }
+                                        }
+                                    }
+                                },
+                                "alerts": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "required": ["code", "observed_at_unix_ms"],
+                                        "properties": {
+                                            "code": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "heartbeat_stale",
+                                                    "progress_stalled",
+                                                    "queue_saturated",
+                                                    "sink_retrying",
+                                                    "coverage_degraded"
+                                                ]
+                                            },
+                                            "observed_at_unix_ms": { "type": "integer" }
+                                        }
+                                    }
+                                },
+                                "rate": {
+                                    "type": ["object", "null"],
+                                    "additionalProperties": false,
+                                    "required": ["bytes_per_second", "sample_seconds"],
+                                    "properties": {
+                                        "bytes_per_second": { "type": "number", "minimum": 0 },
+                                        "sample_seconds": { "type": "integer", "minimum": 0 }
+                                    }
+                                },
+                                "eta": {
+                                    "type": ["object", "null"],
+                                    "additionalProperties": false,
+                                    "required": ["scope", "low_seconds", "high_seconds"],
+                                    "properties": {
+                                        "scope": { "type": "string" },
+                                        "low_seconds": { "type": "integer", "minimum": 0 },
+                                        "high_seconds": { "type": "integer", "minimum": 0 }
+                                    }
+                                },
+                                "history": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "required": [
+                                            "ts_unix_ms",
+                                            "queue_depth",
+                                            "files_active",
+                                            "queue_capacity",
+                                            "sink_pending_rows",
+                                            "sink_retrying",
+                                            "discovery_complete",
+                                            "files_total",
+                                            "files_completed",
+                                            "bytes_total",
+                                            "bytes_completed"
+                                        ],
+                                        "properties": {
+                                            "ts_unix_ms": { "type": "integer" },
+                                            "queue_depth": { "type": "integer", "minimum": 0 },
+                                            "files_active": { "type": "integer", "minimum": 0 },
+                                            "queue_capacity": { "type": "integer", "minimum": 0 },
+                                            "sink_pending_rows": { "type": "integer", "minimum": 0 },
+                                            "sink_retrying": { "type": "boolean" },
+                                            "discovery_complete": { "type": "boolean" },
+                                            "files_total": { "type": "integer", "minimum": 0 },
+                                            "files_completed": { "type": "integer", "minimum": 0 },
+                                            "bytes_total": { "type": "integer", "minimum": 0 },
+                                            "bytes_completed": { "type": "integer", "minimum": 0 }
+                                        }
+                                    }
+                                }
+                            }
+                        })
+                    ),
+                    "annotations": {
+                        "readOnlyHint": true
+                    }
                 }
             ]
         })
     }
 
     async fn call_tool(&self, params: ToolCallParams) -> Result<Value> {
-        match params.name.as_str() {
+        let tool = params.name;
+        let result = match tool.as_str() {
             contract::SEARCH_SESSIONS_TOOL => self.search_sessions_v1(params.arguments).await,
             contract::LIST_SESSIONS_TOOL => self.list_sessions_v1(params.arguments).await,
             contract::OPEN_TOOL => self.open_v1(params.arguments).await,
             contract::FILE_ATTENTION_TOOL => self.file_attention_v1(params.arguments).await,
+            contract::GET_INGEST_STATUS_TOOL => self.get_ingest_status_v1(params.arguments).await,
             other => Err(anyhow!("unknown tool: {other}")),
+        }?;
+        if matches!(
+            tool.as_str(),
+            contract::SEARCH_SESSIONS_TOOL
+                | contract::LIST_SESSIONS_TOOL
+                | contract::OPEN_TOOL
+                | contract::FILE_ATTENTION_TOOL
+        ) {
+            Ok(self.annotate_retrieval_coverage(result).await)
+        } else {
+            Ok(result)
         }
+    }
+
+    async fn annotate_retrieval_coverage(&self, mut result: Value) -> Value {
+        if result
+            .get("isError")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            return result;
+        }
+        let observed_at_unix_ms = get_ingest_status_v1::unix_now_ms();
+        let (state, reason, observed_at_unix_ms) = match self.read_ingest_status_bounded(1).await {
+            Ok(read) => read
+                .derive(observed_at_unix_ms)
+                .conditions
+                .into_iter()
+                .find(|condition| condition.condition_type == IngestConditionType::Coverage)
+                .map(|condition| {
+                    (
+                        condition.state,
+                        condition.reason,
+                        condition.observed_at_unix_ms,
+                    )
+                })
+                .unwrap_or((
+                    IngestConditionState::Unknown,
+                    "condition_missing".to_string(),
+                    observed_at_unix_ms,
+                )),
+            Err(_) => (
+                IngestConditionState::Unknown,
+                "status_unavailable".to_string(),
+                observed_at_unix_ms,
+            ),
+        };
+        if let Some(data) = result
+            .pointer_mut("/structuredContent/data")
+            .and_then(Value::as_object_mut)
+        {
+            data.insert(
+                "coverage".to_string(),
+                json!({
+                    "state": match state {
+                        IngestConditionState::True => "complete",
+                        IngestConditionState::False => "partial",
+                        IngestConditionState::Unknown => "unknown",
+                    },
+                    "reason": reason,
+                    "observed_at_unix_ms": observed_at_unix_ms,
+                }),
+            );
+        }
+        let warning = match state {
+            IngestConditionState::True => None,
+            IngestConditionState::False => Some(
+                "coverage_partial: historical ingestion is incomplete; retrieval results may be incomplete.",
+            ),
+            IngestConditionState::Unknown => Some(
+                "coverage_unknown: ingestion coverage is unavailable; retrieval results may be incomplete.",
+            ),
+        };
+        if let Some(warning) = warning {
+            if let Some(warnings) = result
+                .pointer_mut("/structuredContent/warnings")
+                .and_then(Value::as_array_mut)
+            {
+                warnings.push(Value::String(warning.to_string()));
+            }
+            if let Some(text) = result
+                .pointer_mut("/content/0/text")
+                .and_then(|value| value.as_str())
+                .map(ToOwned::to_owned)
+            {
+                result["content"][0]["text"] = Value::String(format!("{text}\nWarning: {warning}"));
+            }
+        }
+        result
     }
 }
 
@@ -1301,6 +1570,10 @@ fn admitted_tool_call(req: &RpcRequest, max_results: u16) -> Option<AdmittedTool
             serde_json::from_value::<contract::FileAttentionArgs>(params.arguments.clone())
                 .is_ok_and(|args| args.validate(max_results).is_ok())
         }
+        contract::GET_INGEST_STATUS_TOOL => params
+            .arguments
+            .as_object()
+            .is_some_and(serde_json::Map::is_empty),
         _ => false,
     };
     valid.then_some(AdmittedToolCall {
@@ -1992,6 +2265,143 @@ mod tests {
         assert_eq!(state.request_admission.slots.available_permits(), 24);
     }
 
+    #[test]
+    fn ingest_status_admission_accepts_only_an_empty_object() {
+        let request = |arguments| RpcRequest {
+            id: Some(json!(1)),
+            method: "tools/call".to_string(),
+            params: json!({
+                "name": contract::GET_INGEST_STATUS_TOOL,
+                "arguments": arguments,
+            }),
+        };
+
+        assert!(admitted_tool_call(&request(json!({})), 50).is_some());
+        for invalid in [
+            Value::Null,
+            json!([]),
+            json!(true),
+            json!(0),
+            json!(""),
+            json!({ "unexpected": true }),
+        ] {
+            assert!(
+                admitted_tool_call(&request(invalid), 50).is_none(),
+                "invalid status arguments must bypass repository admission"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn every_retrieval_coverage_annotation_preserves_payload_and_is_three_fields() {
+        let state = test_state();
+        for tool in [
+            contract::SEARCH_SESSIONS_TOOL,
+            contract::LIST_SESSIONS_TOOL,
+            contract::OPEN_TOOL,
+            contract::FILE_ATTENTION_TOOL,
+        ] {
+            let payload = serde_json::to_value(
+                contract::ToolEnvelope::success(
+                    tool,
+                    json!({ "request_sentinel": tool }),
+                    json!({ "result_sentinel": tool }),
+                    contract::Performance::from_elapsed(std::time::Duration::ZERO),
+                )
+                .with_warnings(vec![format!("existing_warning:{tool}")]),
+            )
+            .expect("retrieval envelope");
+            let original = tool_success_result(format!("existing text:{tool}"), payload);
+            let annotated = state.annotate_retrieval_coverage(original).await;
+            let data = &annotated["structuredContent"]["data"];
+            let coverage = data["coverage"].as_object().expect("coverage object");
+
+            assert_eq!(data["result_sentinel"], json!(tool));
+            assert_eq!(
+                annotated["structuredContent"]["request"]["request_sentinel"],
+                json!(tool)
+            );
+            assert_eq!(coverage.len(), 3);
+            assert!(coverage.contains_key("state"));
+            assert!(coverage.contains_key("reason"));
+            assert!(coverage.contains_key("observed_at_unix_ms"));
+            assert!(!coverage.contains_key("complete"));
+            assert_eq!(
+                annotated["structuredContent"]["warnings"][0],
+                json!(format!("existing_warning:{tool}"))
+            );
+            assert_eq!(
+                annotated["structuredContent"]["warnings"][1],
+                json!("coverage_unknown: ingestion coverage is unavailable; retrieval results may be incomplete.")
+            );
+            assert!(annotated["content"][0]["text"]
+                .as_str()
+                .expect("text result")
+                .starts_with(&format!("existing text:{tool}\nWarning: ")));
+        }
+    }
+
+    #[tokio::test]
+    async fn retrieval_coverage_failure_is_generic_and_does_not_leak_repository_error() {
+        let raw_error = "SECRET_COVERAGE_ERROR /private/source.db password=hunter2";
+        let repository = Arc::new(InMemoryConversationRepository::with_responses(
+            RepoConfig::default(),
+            InMemoryConversationResponses {
+                latest_ingest_heartbeat: Some(Err(RepoError::backend(raw_error))),
+                ..InMemoryConversationResponses::default()
+            },
+        ));
+        let state = AppState::embedded(AppConfig::default(), repository);
+        let payload = serde_json::to_value(contract::ToolEnvelope::success(
+            contract::SEARCH_SESSIONS_TOOL,
+            json!({}),
+            json!({ "result_count": 0 }),
+            contract::Performance::from_elapsed(std::time::Duration::ZERO),
+        ))
+        .expect("retrieval envelope");
+        let annotated = state
+            .annotate_retrieval_coverage(tool_success_result("No results.".to_string(), payload))
+            .await;
+        let coverage = &annotated["structuredContent"]["data"]["coverage"];
+        let serialized = serde_json::to_string(&annotated).expect("annotated response JSON");
+
+        assert_eq!(
+            coverage,
+            &json!({
+                "state": "unknown",
+                "reason": "status_unavailable",
+                "observed_at_unix_ms": coverage["observed_at_unix_ms"],
+            })
+        );
+        assert!(!serialized.contains("SECRET_COVERAGE_ERROR"));
+        assert!(!serialized.contains("/private/source.db"));
+        assert!(!serialized.contains("password=hunter2"));
+    }
+
+    #[tokio::test]
+    async fn ingest_status_success_uses_the_published_safe_output_shape() {
+        let state = test_state();
+        let response = call_tool_rpc(&state, 7, contract::GET_INGEST_STATUS_TOOL, json!({})).await;
+        let data = &response["result"]["structuredContent"]["data"];
+
+        assert_eq!(response["result"]["isError"], json!(false));
+        assert_eq!(data["current"], Value::Null);
+        let fields = data.as_object().expect("status data object");
+        assert_eq!(fields.len(), 7);
+        for field in [
+            "alerts",
+            "conditions",
+            "current",
+            "eta",
+            "history",
+            "observed_at_unix_ms",
+            "rate",
+        ] {
+            assert!(fields.contains_key(field), "missing status field {field}");
+        }
+        assert_published_output_schema_matches(&response, contract::GET_INGEST_STATUS_TOOL);
+    }
+
     fn successful_test_state() -> Arc<AppState> {
         let session = McpSessionOpen {
             metadata: SessionMetadata {
@@ -2094,13 +2504,15 @@ mod tests {
             }
         }
 
-        if let Some(required) = schema.get("required").and_then(Value::as_array) {
-            if required.iter().any(|field| {
-                field
-                    .as_str()
-                    .is_none_or(|field| instance.get(field).is_none())
-            }) {
-                return false;
+        if instance.is_object() {
+            if let Some(required) = schema.get("required").and_then(Value::as_array) {
+                if required.iter().any(|field| {
+                    field
+                        .as_str()
+                        .is_none_or(|field| instance.get(field).is_none())
+                }) {
+                    return false;
+                }
             }
         }
 
@@ -2243,10 +2655,22 @@ mod tests {
 
         assert_eq!(
             names,
-            ["search_sessions", "open", "list_sessions", "file_attention"]
+            [
+                "search_sessions",
+                "open",
+                "list_sessions",
+                "file_attention",
+                "get_ingest_status"
+            ]
         );
 
-        for tool_name in ["search_sessions", "open", "list_sessions", "file_attention"] {
+        for tool_name in [
+            "search_sessions",
+            "open",
+            "list_sessions",
+            "file_attention",
+            "get_ingest_status",
+        ] {
             let tool = tools
                 .iter()
                 .find(|tool| tool["name"].as_str() == Some(tool_name))
@@ -2257,6 +2681,29 @@ mod tests {
             );
             assert_eq!(tool["annotations"]["readOnlyHint"], json!(true));
         }
+
+        let status = tools
+            .iter()
+            .find(|tool| tool["name"].as_str() == Some("get_ingest_status"))
+            .expect("get_ingest_status exists");
+        assert_eq!(status["inputSchema"]["additionalProperties"], json!(false));
+        let status_data = &status["outputSchema"]["properties"]["data"];
+        assert_eq!(status_data["additionalProperties"], json!(false));
+        assert_eq!(
+            status_data["required"],
+            json!([
+                "observed_at_unix_ms",
+                "current",
+                "conditions",
+                "alerts",
+                "rate",
+                "eta",
+                "history",
+            ])
+        );
+        assert!(status_data["properties"].get("heartbeat").is_none());
+        assert!(status_data["properties"].get("current").is_some());
+        assert!(status_data["properties"].get("history").is_some());
 
         let open = tools
             .iter()

--- a/crates/moraine-monitor-core/src/lib.rs
+++ b/crates/moraine-monitor-core/src/lib.rs
@@ -37,6 +37,10 @@ struct LimitQuery {
     limit: Option<u32>,
 }
 
+#[derive(Default, Deserialize)]
+struct StatusQuery {
+    history: Option<u64>,
+}
 #[derive(Deserialize)]
 struct AnalyticsQuery {
     range: Option<String>,
@@ -427,7 +431,10 @@ fn health_failure_response(
     )
 }
 
-async fn api_status(Extension(backend): Extension<Arc<BackendRepository>>) -> Response {
+async fn api_status(
+    Query(query): Query<StatusQuery>,
+    Extension(backend): Extension<Arc<BackendRepository>>,
+) -> Response {
     let health = backend
         .repository()
         .read_store_health()
@@ -435,10 +442,11 @@ async fn api_status(Extension(backend): Extension<Arc<BackendRepository>>) -> Re
         .unwrap_or_else(|error| unavailable_store_health(error.to_string()));
     let database_exists = probe_bool(&health.database_exists).unwrap_or(false);
 
-    let (tables, heartbeat) = if database_exists {
-        let (tables, heartbeat) = tokio::join!(
+    let history_limit = query.history.unwrap_or(0).min(120) as u16;
+    let (tables, heartbeat, ingest_status) = if database_exists {
+        let (tables, status) = tokio::join!(
             backend.repository().list_table_summaries(),
-            backend.repository().latest_ingest_heartbeat()
+            backend.repository().ingest_status(history_limit)
         );
         let tables = match tables {
             Ok(tables) => monitor_table_summaries(tables),
@@ -449,10 +457,14 @@ async fn api_status(Extension(backend): Extension<Arc<BackendRepository>>) -> Re
                 );
             }
         };
-        let heartbeat = heartbeat.map(monitor_heartbeat_status).unwrap_or_default();
-        (tables, heartbeat)
+        let status = status.map(|read| read.derive(unix_now_ms()));
+        let heartbeat = status
+            .as_ref()
+            .map(|status| monitor_heartbeat_status(status.heartbeat.clone()))
+            .unwrap_or_default();
+        (tables, heartbeat, status.ok())
     } else {
-        (Vec::new(), MonitorHeartbeatStatus::default())
+        (Vec::new(), MonitorHeartbeatStatus::default(), None)
     };
 
     let estimated_total_rows = tables.iter().map(|table| table.rows).sum::<u64>();
@@ -469,6 +481,7 @@ async fn api_status(Extension(backend): Extension<Arc<BackendRepository>>) -> Re
                 "tables": tables,
             },
             "ingestor": heartbeat_payload(&heartbeat),
+            "ingest_status": ingest_status,
         }),
         StatusCode::OK,
     )
@@ -1137,9 +1150,9 @@ mod tests {
     use moraine_conversations::{
         AnalyticsConcurrencyPoint, AnalyticsSnapshot, AnalyticsTokenPoint, AnalyticsTurnPoint,
         AnalyticsWindow, ConversationMode, ConversationRepository, ConversationSummary,
-        InMemoryConversationRepository, InMemoryConversationResponses, IngestHeartbeat, RepoConfig,
-        SessionStep, StoreDiagnostics, TableColumn, TablePreview, TableSummary, ToolResult,
-        TurnSummary, WebSearchEvent,
+        InMemoryConversationRepository, InMemoryConversationResponses, IngestHeartbeat,
+        IngestStatusRead, RepoConfig, SessionStep, StoreDiagnostics, TableColumn, TablePreview,
+        TableSummary, ToolResult, TurnSummary, WebSearchEvent,
     };
     use std::collections::BTreeMap;
     use std::fs;
@@ -1293,6 +1306,26 @@ mod tests {
         (status, response_json(response).await)
     }
 
+    fn normalize_status_observation_times(payload: &mut Value) {
+        let Some(status) = payload
+            .get_mut("ingest_status")
+            .and_then(Value::as_object_mut)
+        else {
+            return;
+        };
+        status.insert("observed_at_unix_ms".to_string(), json!(0));
+        for field in ["conditions", "alerts"] {
+            let Some(entries) = status.get_mut(field).and_then(Value::as_array_mut) else {
+                continue;
+            };
+            for entry in entries {
+                if let Some(entry) = entry.as_object_mut() {
+                    entry.insert("observed_at_unix_ms".to_string(), json!(0));
+                }
+            }
+        }
+    }
+
     fn sample_health() -> StoreHealth {
         StoreHealth {
             ping: StoreProbe::Available(3.5),
@@ -1332,6 +1365,7 @@ mod tests {
                 watcher_reset_count: Some(0),
                 watcher_last_reset_unix_ms: None,
                 backend_sinks: Some(json!({"team-ch": "healthy"})),
+                progress: None,
             }),
         }
     }
@@ -1563,6 +1597,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn status_history_query_defaults_to_zero_clamps_and_rejects_malformed_values() {
+        let heartbeat = sample_heartbeat();
+        let mut template = heartbeat.latest.clone().expect("sample heartbeat");
+        template.progress = Some(Default::default());
+        let history = (0_i64..121)
+            .map(|offset| {
+                let mut sample = template.clone();
+                sample.ts_unix_ms = template
+                    .ts_unix_ms
+                    .saturating_sub((120_i64.saturating_sub(offset)).saturating_mul(1_000));
+                sample
+            })
+            .collect();
+        let mut responses = successful_responses();
+        responses.ingest_status = Some(Ok(IngestStatusRead { heartbeat, history }));
+        let (state, repository) = fake_state(responses);
+        let app = monitor_router(state);
+
+        for path in ["/api/v1/status", "/api/status?history=0"] {
+            let (status, payload) = router_json(&app, path).await;
+            assert_eq!(status, StatusCode::OK, "{path}");
+            assert!(
+                payload["ingest_status"].get("history").is_none(),
+                "{path} must not return history"
+            );
+        }
+
+        for path in ["/api/v1/status?history=999", "/api/status?history=999"] {
+            let (status, payload) = router_json(&app, path).await;
+            assert_eq!(status, StatusCode::OK, "{path}");
+            let history = payload["ingest_status"]["history"]
+                .as_array()
+                .expect("bounded history");
+            assert_eq!(history.len(), 120, "{path}");
+            let point = history[0].as_object().expect("narrow history point");
+            for excluded in ["host", "last_error", "progress", "backend_sinks", "sources"] {
+                assert!(
+                    !point.contains_key(excluded),
+                    "history must not include {excluded}"
+                );
+            }
+        }
+
+        for path in [
+            "/api/v1/status?history=not-a-number",
+            "/api/status?history=-1",
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(path)
+                        .body(Body::empty())
+                        .expect("malformed history request"),
+                )
+                .await
+                .expect("malformed history response");
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{path}");
+        }
+
+        assert_eq!(repository.calls().ingest_status, vec![0, 0, 120, 120]);
+    }
+
+    #[tokio::test]
     async fn handlers_delegate_to_shared_repository_and_preserve_json_contracts() {
         let (backend, repository) = fake_backend(successful_responses()).await;
 
@@ -1577,7 +1675,7 @@ mod tests {
             json!({"backend_sinks": {"team-ch": "healthy"}})
         );
 
-        let response = api_status(Extension(backend.clone())).await;
+        let response = api_status(Query(StatusQuery::default()), Extension(backend.clone())).await;
         assert_eq!(response.status(), StatusCode::OK);
         let status = response_json(response).await;
         assert_eq!(status["database"]["exists"], json!(true));
@@ -1659,6 +1757,7 @@ mod tests {
         assert_eq!(calls.read_store_health, 2);
         assert_eq!(calls.read_store_diagnostics, 0);
         assert_eq!(calls.latest_ingest_heartbeat, 2);
+        assert_eq!(calls.ingest_status, vec![0]);
         assert_eq!(calls.list_table_summaries, 2);
         assert_eq!(calls.list_web_searches, vec![1_000]);
         assert_eq!(calls.analytics_series, vec![AnalyticsRange::SevenDays]);
@@ -1812,7 +1911,9 @@ mod tests {
         let health = response_json(api_health(Extension(backend.clone())).await).await;
         assert_eq!(health["ingestor"]["latest"]["backend_sinks"], json!({}));
 
-        let status = response_json(api_status(Extension(backend)).await).await;
+        let status =
+            response_json(api_status(Query(StatusQuery::default()), Extension(backend)).await)
+                .await;
         let latest = status["ingestor"]["latest"].as_object().expect("latest");
         assert!(!latest.contains_key("backend_sinks"));
         assert!(!latest.contains_key("watcher_backend"));
@@ -1884,13 +1985,21 @@ mod tests {
             ),
         ];
         for (canonical_path, legacy_path) in route_matrix {
-            let canonical = router_json(&app, canonical_path).await;
-            let legacy = router_json(&app, legacy_path).await;
+            let (canonical_status, mut canonical_payload) = router_json(&app, canonical_path).await;
+            if canonical_path == "/api/v1/status" {
+                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            }
+            let (legacy_status, mut legacy_payload) = router_json(&app, legacy_path).await;
+            if canonical_path == "/api/v1/status" {
+                normalize_status_observation_times(&mut canonical_payload);
+                normalize_status_observation_times(&mut legacy_payload);
+            }
             assert_eq!(
-                canonical, legacy,
+                (canonical_status, canonical_payload),
+                (legacy_status, legacy_payload),
                 "{legacy_path} must directly alias {canonical_path}"
             );
-            assert_eq!(canonical.0, StatusCode::OK);
+            assert_eq!(canonical_status, StatusCode::OK);
         }
 
         let (status, capabilities) = router_json(&app, "/api/v1/capabilities").await;
@@ -1917,6 +2026,7 @@ mod tests {
         assert_eq!(calls.read_store_health, 4);
         assert_eq!(calls.read_store_diagnostics, 1);
         assert_eq!(calls.latest_ingest_heartbeat, 4);
+        assert_eq!(calls.ingest_status, vec![0, 0]);
         assert_eq!(calls.list_table_summaries, 4);
         assert_eq!(calls.list_web_searches, vec![1_000, 1_000]);
         assert_eq!(

--- a/docs/agent-mcp-search/interface.md
+++ b/docs/agent-mcp-search/interface.md
@@ -13,7 +13,7 @@ plain text `content` and machine-readable `structuredContent`. See the
 [MCP tools specification](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)
 for the protocol-level model.
 
-Moraine advertises one read-only server, `moraine-mcp`, with four tools:
+Moraine advertises one read-only server, `moraine-mcp`, with five tools:
 
 | Tool | Use it for |
 | --- | --- |
@@ -21,10 +21,33 @@ Moraine advertises one read-only server, `moraine-mcp`, with four tools:
 | `open` | Expanding an event, turn, or session ID into structured context. |
 | `list_sessions` | Time-window browsing over sessions and active work. |
 | `file_attention` | Every session that touched a file, across every worktree. |
+| `get_ingest_status` | Ingestion health, historical coverage, durable progress, freshness, alerts, and conservative ETA. |
 
-All four tools return a short text summary for clients that display text, and
+All five tools return a short text summary for clients that display text, and
 the same result as JSON in `structuredContent` for clients that can inspect
 structured tool output.
+
+`search_sessions`, `list_sessions`, `open`, and `file_attention` also attach a
+compact `data.coverage` object. When historical coverage is partial or unknown,
+they add a stable `coverage_partial` or `coverage_unknown` warning so an agent
+does not interpret a missing result as proof that an event never existed.
+
+## `get_ingest_status`
+
+Call `get_ingest_status` with an empty object:
+
+```json
+{}
+```
+
+The response keeps process health separate from finite historical coverage and
+live freshness. `conditions` contains `health`, `coverage`, `freshness`, and
+`readiness` entries with three-state values and stable reason codes. The latest
+heartbeat may include the frozen startup denominator, durable file/byte
+completion, queue capacity, sink pressure, and per-source progress. `rate` and
+`eta` remain absent until a stable same-instance checkpoint history supports a
+bounded estimate. Source names are included; source file paths and raw ingest
+errors are not.
 
 ## Record Model
 

--- a/docs/monitor-http-api.md
+++ b/docs/monitor-http-api.md
@@ -15,7 +15,7 @@ All canonical routes are `GET` routes and successful responses use JSON.
 | --- | --- | --- |
 | `/api/v1/capabilities` | none | Describe this server build, its observed schema migration level, and available HTTP feature groups. |
 | `/api/v1/health` | none | Probe ClickHouse health and report a compact ingest heartbeat summary. |
-| `/api/v1/status` | none | Return the diagnostic ClickHouse, database, table, connection, and ingestor snapshot used by the status dashboard. |
+| `/api/v1/status` | `history` | Return ClickHouse/database diagnostics plus typed ingestion health, finite historical coverage, optional durable progress history, conservative ETA, and active alerts. |
 | `/api/v1/analytics` | `range` | Return token, turn, and concurrent-session time series for a supported window. |
 | `/api/v1/tables` | none | List tables with engine, temporary-table marker, and estimated row count. |
 | `/api/v1/tables/:table` | `limit` | Return the named table's schema and a bounded row preview. `:table` is a path parameter. |
@@ -82,6 +82,7 @@ unsigned integer is a malformed query and returns HTTP `400`.
 
 | Route | Parameter | Default | Accepted or effective values |
 | --- | --- | --- | --- |
+| `/api/v1/status` | `history` | `0` | clamped to `0..=120`; omitted or `0` performs no history read |
 | `/api/v1/analytics` | `range` | `24h` | `15m`, `1h`, `6h`, `24h`, `7d`, or `30d` |
 | `/api/v1/sessions` | `since` | `30d` | `1h`, `6h`, `24h`, `7d`, `30d`, `90d`, or `all` |
 | `/api/v1/sessions` | `limit` | `50` | clamped to `1..=200` |
@@ -92,6 +93,11 @@ An unknown `range` does not produce an error; it resolves to `24h`. An unknown
 `since` similarly resolves to `30d`. Responses report or embody the resolved
 window, so clients should treat the supported values above as the request
 contract rather than relying on fallback behavior.
+
+Status history is the exception to positive collection limits: zero is meaningful
+and preserves the cheap latest-only status poll. When requested, history contains
+at most 120 oldest-to-newest narrow checkpoint points for the selected ingestor
+run; it does not repeat host data, source paths, errors, or backend sink payloads.
 
 The table path parameter must match the strict ASCII identifier pattern
 `[A-Za-z_][A-Za-z0-9_]*`. A rejected identifier returns HTTP `400`. A
@@ -119,6 +125,22 @@ rows. They do not use `null` to mean an empty collection.
 - When no ingest heartbeat is available, `ingestor.present` and
   `ingestor.alive` are `false`, while `ingestor.latest` and
   `ingestor.age_seconds` are `null`.
+- `ingest_status` is `null` when the status repository read fails. When present,
+  its independent `health`, `coverage`, `freshness`, and `readiness` conditions
+  use `true`, `false`, or `unknown` states with stable reason codes.
+- `ingest_status.heartbeat.latest.progress` is absent on pre-034 heartbeat rows.
+  A present progress snapshot freezes the startup file/byte denominator for one
+  ingestor instance and advances only after checkpoint rows are durably
+  committed. SQLite sources without a byte watermark report completed-file
+  coverage; `coverage_basis: "files"` identifies that measurement without
+  degrading an otherwise complete, healthy ingest run.
+- `ingest_status.history` is omitted when `history` is omitted or zero. Requested
+  history points contain timestamp, queue/active pressure, queue capacity, sink
+  row/retry pressure, discovery state, and durable file/byte completion counters.
+- `ingest_status.rate` and `ingest_status.eta` are `null` until at least six
+  same-instance observations cover 30 seconds with stable throughput. ETA is
+  also suppressed during discovery, sink retries, zero progress, and excessive
+  short/long-window variance.
 
 Clients must distinguish a diagnostic value inside an HTTP `200` response from
 an endpoint failure represented by a non-2xx status.

--- a/scripts/bench/tests/test_native_central_burst.py
+++ b/scripts/bench/tests/test_native_central_burst.py
@@ -130,7 +130,9 @@ class FakeLifecycle:
         self.concurrency = concurrency
         self.started = False
         self.closed = False
-        self.tool_surfaces = [("search_sessions", "open", "list_sessions", "file_attention")]
+        self.tool_surfaces = [
+            ("search_sessions", "open", "list_sessions", "file_attention", "get_ingest_status")
+        ]
 
     def start(self) -> None:
         self.started = True

--- a/scripts/ci/mcp_smoke.py
+++ b/scripts/ci/mcp_smoke.py
@@ -169,6 +169,26 @@ def assert_structured_content(result: Dict[str, Any], tool_name: str) -> Dict[st
         raise AssertionError(f"{tool_name} returned error envelope: {payload['error']}")
     if not isinstance(payload.get("data"), dict):
         raise AssertionError(f"{tool_name} structuredContent missing data object")
+    if tool_name in {"search_sessions", "list_sessions", "open", "file_attention"}:
+        coverage = payload["data"].get("coverage")
+        if not isinstance(coverage, dict) or set(coverage) != {
+            "state",
+            "reason",
+            "observed_at_unix_ms",
+        }:
+            raise AssertionError(
+                f"{tool_name} must return only compact three-field coverage: {coverage}"
+            )
+        if coverage.get("state") not in {"complete", "partial", "unknown"}:
+            raise AssertionError(
+                f"{tool_name} returned invalid coverage state: {coverage}"
+            )
+        if not isinstance(coverage.get("reason"), str) or not isinstance(
+            coverage.get("observed_at_unix_ms"), int
+        ):
+            raise AssertionError(
+                f"{tool_name} returned invalid compact coverage values: {coverage}"
+            )
     return payload
 
 
@@ -207,6 +227,19 @@ def collect_strings(value: Any) -> list[str]:
         return strings
     return []
 
+def collect_keys(value: Any) -> list[str]:
+    if isinstance(value, dict):
+        keys = list(value)
+        for child in value.values():
+            keys.extend(collect_keys(child))
+        return keys
+    if isinstance(value, list):
+        keys: list[str] = []
+        for child in value:
+            keys.extend(collect_keys(child))
+        return keys
+    return []
+
 
 def contains_text(value: Any, needle: str) -> bool:
     return any(needle in text for text in collect_strings(value))
@@ -218,6 +251,7 @@ def assert_tools_surface(tool_names_ordered: list[str]) -> None:
         "open",
         "list_sessions",
         "file_attention",
+        "get_ingest_status",
     ]:
         raise AssertionError(
             "tools/list must publish the MCP search surface exactly: "
@@ -717,6 +751,183 @@ def run_smoke(
             write_tools_snapshot(tools_snapshot, tools_result)
 
         next_id = 3
+        ingest_status_result = call_tool(
+            proc,
+            next_id,
+            "get_ingest_status",
+            {},
+        )
+        next_id += 1
+        ingest_status_payload = assert_structured_content(
+            ingest_status_result,
+            "get_ingest_status",
+        )
+        status_data = ingest_status_payload.get("data", {})
+        expected_status_fields = {
+            "observed_at_unix_ms",
+            "current",
+            "conditions",
+            "alerts",
+            "rate",
+            "eta",
+            "history",
+        }
+        if set(status_data) != expected_status_fields:
+            raise AssertionError(
+                f"get_ingest_status must return the explicit safe allowlist: {status_data}"
+            )
+        if not isinstance(status_data.get("conditions"), list):
+            raise AssertionError("get_ingest_status missing typed conditions")
+        if not isinstance(status_data.get("alerts"), list):
+            raise AssertionError("get_ingest_status missing typed alerts")
+        if not isinstance(status_data.get("history"), list):
+            raise AssertionError("get_ingest_status missing narrow history")
+
+        expected_condition_fields = {
+            "condition_type",
+            "state",
+            "reason",
+            "observed_at_unix_ms",
+        }
+        for condition in status_data["conditions"]:
+            if not isinstance(condition, dict) or set(condition) != expected_condition_fields:
+                raise AssertionError(
+                    f"get_ingest_status returned an invalid condition: {condition}"
+                )
+            if condition.get("condition_type") not in {
+                "health",
+                "coverage",
+                "freshness",
+                "readiness",
+            } or condition.get("state") not in {"true", "false", "unknown"}:
+                raise AssertionError(
+                    f"get_ingest_status returned an untyped condition: {condition}"
+                )
+
+        for alert in status_data["alerts"]:
+            if (
+                not isinstance(alert, dict)
+                or set(alert) != {"code", "observed_at_unix_ms"}
+                or alert.get("code")
+                not in {
+                    "heartbeat_stale",
+                    "progress_stalled",
+                    "queue_saturated",
+                    "sink_retrying",
+                    "coverage_degraded",
+                }
+            ):
+                raise AssertionError(
+                    f"get_ingest_status returned an invalid alert: {alert}"
+                )
+
+        rate = status_data.get("rate")
+        if rate is not None and (
+            not isinstance(rate, dict)
+            or set(rate) != {"bytes_per_second", "sample_seconds"}
+        ):
+            raise AssertionError(f"get_ingest_status returned invalid rate data: {rate}")
+        eta = status_data.get("eta")
+        if eta is not None and (
+            not isinstance(eta, dict)
+            or set(eta) != {"scope", "low_seconds", "high_seconds"}
+        ):
+            raise AssertionError(f"get_ingest_status returned invalid ETA data: {eta}")
+
+        expected_history_fields = {
+            "ts_unix_ms",
+            "queue_depth",
+            "files_active",
+            "queue_capacity",
+            "sink_pending_rows",
+            "sink_retrying",
+            "discovery_complete",
+            "files_total",
+            "files_completed",
+            "bytes_total",
+            "bytes_completed",
+        }
+        for point in status_data["history"]:
+            if not isinstance(point, dict) or set(point) != expected_history_fields:
+                raise AssertionError(
+                    f"get_ingest_status returned non-allowlisted history: {point}"
+                )
+
+        current = status_data.get("current")
+        if current is not None:
+            expected_current_fields = {
+                "heartbeat_observed_at_unix_ms",
+                "queue_depth",
+                "files_active",
+                "files_watched",
+                "progress",
+            }
+            if not isinstance(current, dict) or set(current) != expected_current_fields:
+                raise AssertionError(
+                    f"get_ingest_status returned non-allowlisted current data: {current}"
+                )
+            progress = current.get("progress")
+            if progress is not None and (
+                not isinstance(progress, dict)
+                or set(progress)
+                != {
+                    "discovery_complete",
+                    "queue_capacity",
+                    "sink_pending_rows",
+                    "sink_pending_bytes",
+                    "sink_retrying",
+                    "oldest_pending_unix_ms",
+                    "last_durable_progress_unix_ms",
+                    "files_total",
+                    "files_completed",
+                    "bytes_total",
+                    "bytes_completed",
+                }
+            ):
+                raise AssertionError(
+                    f"get_ingest_status returned non-allowlisted progress: {progress}"
+                )
+
+        forbidden_status_fields = {
+            "heartbeat",
+            "host",
+            "service_version",
+            "last_error",
+            "watcher_backend",
+            "watcher_error_count",
+            "watcher_reset_count",
+            "watcher_last_reset_unix_ms",
+            "backend_sinks",
+            "sources",
+            "source_name",
+            "instance_id",
+            "run_started_unix_ms",
+            "snapshot_unix_ms",
+            "source_path",
+            "credentials",
+            "password",
+        }
+        leaked_fields = forbidden_status_fields.intersection(collect_keys(status_data))
+        if leaked_fields:
+            raise AssertionError(
+                f"get_ingest_status leaked private fields: {sorted(leaked_fields)}"
+            )
+
+        invalid_status_payload = call_tool_expect_handled_error(
+            proc,
+            next_id,
+            "get_ingest_status",
+            {"unexpected": "SECRET_INVALID_STATUS_ARGUMENT"},
+            "invalid_request",
+        )
+        next_id += 1
+        if invalid_status_payload.get("request") != {} or contains_text(
+            invalid_status_payload, "SECRET_INVALID_STATUS_ARGUMENT"
+        ):
+            raise AssertionError(
+                "get_ingest_status invalid arguments must be rejected without reflection"
+            )
+
         search_arguments: Dict[str, Any] = {
             "query": query,
             "n_hits": 20,

--- a/sql/034_ingest_progress.sql
+++ b/sql/034_ingest_progress.sql
@@ -1,0 +1,2 @@
+ALTER TABLE moraine.ingest_heartbeats
+  ADD COLUMN IF NOT EXISTS progress_json String DEFAULT '';

--- a/web/monitor/e2e/monitor.live.spec.ts
+++ b/web/monitor/e2e/monitor.live.spec.ts
@@ -167,7 +167,7 @@ test('live monitor UI reflects ingested fixture data', async ({ page }) => {
   const expectedModelText = `${expectedModelCount} model${expectedModelCount === 1 ? '' : 's'}`;
 
   const runtimeTraffic = trackRuntimeTraffic(page);
-  const navigationResponse = await page.goto('/');
+  const navigationResponse = await page.goto('/', { waitUntil: 'domcontentloaded' });
   expect(navigationResponse).not.toBeNull();
   const pageOrigin = new URL(navigationResponse!.url()).origin;
 

--- a/web/monitor/e2e/monitor.smoke.spec.ts
+++ b/web/monitor/e2e/monitor.smoke.spec.ts
@@ -130,7 +130,44 @@ async function setupMockMonitorApi(page: Page): Promise<void> {
     });
   });
 
-  await page.route('**/api/v1/status', async (route) => {
+  await page.route('**/api/v1/status?history=120', async (route) => {
+    expect(new URL(route.request().url()).searchParams.get('history')).toBe('120');
+    const progress = {
+      schema_version: 1,
+      instance_id: 'fixture-run',
+      run_started_unix_ms: 1_700_000_000_000,
+      snapshot_unix_ms: 1_700_000_000_000,
+      discovery_complete: true,
+      queue_capacity: 1_024,
+      sink_pending_rows: 12,
+      sink_pending_bytes: 4_096,
+      sink_retrying: true,
+      oldest_pending_unix_ms: 1_700_000_050_000,
+      last_durable_progress_unix_ms: 1_700_000_100_000,
+      files_total: 8,
+      files_completed: 8,
+      bytes_total: 1_000,
+      bytes_completed: 750,
+      sources: [
+        {
+          source_name: 'codex',
+          format: 'jsonl',
+          coverage_basis: 'bytes',
+          files_total: 8,
+          files_completed: 8,
+          bytes_total: 1_000,
+          bytes_completed: 750,
+          coverage_degraded: false,
+        },
+      ],
+    };
+    const heartbeat = {
+      ts_unix_ms: 1_700_000_100_000,
+      queue_depth: 1,
+      files_active: 2,
+      files_watched: 8,
+      progress,
+    };
     await route.fulfill({
       json: {
         ok: true,
@@ -138,11 +175,48 @@ async function setupMockMonitorApi(page: Page): Promise<void> {
           present: true,
           alive: true,
           age_seconds: 3,
-          latest: {
-            queue_depth: 1,
-            files_active: 2,
-            files_watched: 8,
-          },
+          latest: heartbeat,
+        },
+        ingest_status: {
+          observed_at_unix_ms: 1_700_000_103_000,
+          heartbeat: { table_present: true, latest: heartbeat },
+          conditions: [
+            { condition_type: 'health', state: 'true', reason: 'heartbeat_recent', observed_at_unix_ms: 1_700_000_103_000 },
+            { condition_type: 'coverage', state: 'false', reason: 'backfill_partial', observed_at_unix_ms: 1_700_000_103_000 },
+            { condition_type: 'freshness', state: 'true', reason: 'progress_recent', observed_at_unix_ms: 1_700_000_103_000 },
+            { condition_type: 'readiness', state: 'false', reason: 'retrieval_may_be_incomplete', observed_at_unix_ms: 1_700_000_103_000 },
+          ],
+          alerts: [{ code: 'sink_retrying', observed_at_unix_ms: 1_700_000_103_000 }],
+          rate: { bytes_per_second: 25, sample_seconds: 60 },
+          eta: { scope: 'file_backfill', low_seconds: 8, high_seconds: 12 },
+          history: [
+            {
+              ts_unix_ms: 1_700_000_040_000,
+              queue_depth: 2,
+              files_active: 2,
+              queue_capacity: 1_024,
+              sink_pending_rows: 24,
+              sink_retrying: false,
+              discovery_complete: true,
+              files_total: 8,
+              files_completed: 8,
+              bytes_total: 1_000,
+              bytes_completed: 500,
+            },
+            {
+              ts_unix_ms: 1_700_000_100_000,
+              queue_depth: 1,
+              files_active: 2,
+              queue_capacity: 1_024,
+              sink_pending_rows: 12,
+              sink_retrying: true,
+              discovery_complete: true,
+              files_total: 8,
+              files_completed: 8,
+              bytes_total: 1_000,
+              bytes_completed: 750,
+            },
+          ],
         },
       },
     });
@@ -228,7 +302,7 @@ test.beforeEach(async ({ page }) => {
 
 test('loads dashboard and handles core interactions', async ({ page }) => {
   const runtimeTraffic = trackRuntimeTraffic(page);
-  const navigationResponse = await page.goto('/');
+  const navigationResponse = await page.goto('/', { waitUntil: 'domcontentloaded' });
   expect(navigationResponse).not.toBeNull();
   const pageOrigin = new URL(navigationResponse!.url()).origin;
 
@@ -238,6 +312,19 @@ test('loads dashboard and handles core interactions', async ({ page }) => {
   await expect(page.locator('#healthGroup')).toContainText('127.0.0.1:8123');
   await expect(page.locator('#healthGroup')).toContainText('moraine');
   await expect(page.locator('#ingestorGroup')).toContainText('healthy');
+  await expect(page.getByRole('heading', { name: 'Ingestion Progress' })).toBeVisible();
+  await expect(page.locator('#ingestorGroup')).toContainText('queue pressure');
+  await expect(page.locator('#ingestorGroup')).toContainText('1 / 1024');
+  const fileCoverageChip = page.locator('.ss-chip', { hasText: 'file coverage' });
+  await expect(fileCoverageChip).toContainText('8 / 8 · 100.0%');
+  await expect(fileCoverageChip).toHaveClass(/ss-warn/);
+  await expect(page.locator('.source-grid')).toContainText('files · 8/8');
+  await expect(page.locator('.source-grid')).toContainText('bytes · 750/1000');
+  await expect(page.locator('.source-grid article')).toHaveClass(/coverage-partial/);
+  await expect(page.getByText('sink retrying')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Durable Snapshot Completion' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Durable Checkpoint Throughput' })).toBeVisible();
+  await expect(page.locator('.ingest-chart-grid canvas')).toHaveCount(2);
 
   await page.locator('#analyticsRanges').getByRole('button', { name: '7d' }).click();
   await expect(page.locator('#analyticsMeta')).toContainText('Last 7d');
@@ -287,7 +374,7 @@ test('loads dashboard and handles core interactions', async ({ page }) => {
 
 test('keeps dashboard and detail views inside the mobile viewport', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
-  await page.goto('/');
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
 
   await expect(page.getByRole('heading', { name: 'Moraine Monitor' })).toBeVisible();
   await expect(page.locator('#sessionsPanel')).toBeVisible();

--- a/web/monitor/src/App.svelte
+++ b/web/monitor/src/App.svelte
@@ -2,6 +2,7 @@
   import { get } from 'svelte/store';
   import { onMount } from 'svelte';
   import AnalyticsPanel from './lib/components/AnalyticsPanel.svelte';
+  import IngestProgressPanel from './lib/components/IngestProgressPanel.svelte';
   import StatusStrip from './lib/components/StatusStrip.svelte';
   import SessionsPanel from './lib/components/sessions/SessionsPanel.svelte';
   import TopBar from './lib/components/TopBar.svelte';
@@ -160,6 +161,7 @@
 
   <main class="layout">
     <StatusStrip health={healthData} {healthError} status={statusData} {statusError} />
+    <IngestProgressPanel status={statusData} theme={$themeStore} />
 
     <AnalyticsPanel
       payload={analyticsPayload}

--- a/web/monitor/src/lib/api/client.test.ts
+++ b/web/monitor/src/lib/api/client.test.ts
@@ -16,7 +16,7 @@ describe('versioned monitor requests', () => {
     {
       label: 'status',
       request: () => fetchStatus(),
-      expectedPath: '/api/v1/status',
+      expectedPath: '/api/v1/status?history=120',
     },
     {
       label: 'analytics',

--- a/web/monitor/src/lib/api/client.ts
+++ b/web/monitor/src/lib/api/client.ts
@@ -35,7 +35,7 @@ export function fetchHealth(): Promise<HealthResponse> {
 }
 
 export function fetchStatus(): Promise<StatusResponse> {
-  return requestJson<StatusResponse>('/api/v1/status');
+  return requestJson<StatusResponse>('/api/v1/status?history=120');
 }
 
 export function fetchAnalytics(range: AnalyticsRangeKey): Promise<AnalyticsResponse> {

--- a/web/monitor/src/lib/charts/chart.ts
+++ b/web/monitor/src/lib/charts/chart.ts
@@ -13,7 +13,7 @@ export function createOrUpdateChart(
   canvas: HTMLCanvasElement,
   type: ChartType,
   labels: string[],
-  datasets: ChartDataset<ChartType, number[]>[],
+  datasets: ChartDataset<ChartType, Array<number | null>>[],
   yTitle: string,
   options: ChartUpdateOptions = {},
 ): ChartInstance<ChartType> {
@@ -68,7 +68,7 @@ export function createOrUpdateChart(
 
   (currentChart.config as { type: ChartType }).type = type;
   currentChart.data.labels = labels;
-  currentChart.data.datasets = datasets as ChartDataset<ChartType, number[]>[];
+  currentChart.data.datasets = datasets as ChartDataset<ChartType, Array<number | null>>[];
 
   const scaleOptions = currentChart.options?.scales as
     | Record<string, { stacked?: boolean; ticks?: Record<string, unknown>; grid?: Record<string, unknown>; title?: Record<string, unknown> }>

--- a/web/monitor/src/lib/charts/ingest.test.ts
+++ b/web/monitor/src/lib/charts/ingest.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import type { IngestHistoryPoint, IngestStatus } from '../types/api';
+import { buildIngestChartView } from './ingest';
+
+function statusWithHistory(history: IngestHistoryPoint[]): IngestStatus {
+  return {
+    observed_at_unix_ms: 9_000,
+    heartbeat: { table_present: true, latest: null },
+    conditions: [],
+    alerts: [],
+    history,
+  };
+}
+
+function point(overrides: Partial<IngestHistoryPoint> = {}): IngestHistoryPoint {
+  return {
+    ts_unix_ms: 1_000,
+    queue_depth: 0,
+    files_active: 0,
+    queue_capacity: 16,
+    sink_pending_rows: 0,
+    sink_retrying: false,
+    discovery_complete: true,
+    files_total: 10,
+    files_completed: 2,
+    bytes_total: 100,
+    bytes_completed: 20,
+    ...overrides,
+  };
+}
+
+describe('ingest history charts', () => {
+  it('preserves every timestamp and leaves truthful nullable throughput gaps', () => {
+    const history = [
+      point(),
+      point({ ts_unix_ms: 2_000, files_completed: 4, bytes_completed: 40 }),
+      point({ ts_unix_ms: 3_000, files_completed: 6, bytes_total: 0, bytes_completed: 0 }),
+      point({ ts_unix_ms: 4_000, files_completed: 8, bytes_completed: 10 }),
+      point({ ts_unix_ms: 5_000, files_completed: 9, bytes_completed: 5 }),
+      point({ ts_unix_ms: 5_000, files_completed: 10, bytes_completed: 6 }),
+      point({ ts_unix_ms: 7_000, files_completed: 10, bytes_total: 200, bytes_completed: 20 }),
+      point({ ts_unix_ms: 8_000, files_completed: 10, bytes_completed: undefined as unknown as number }),
+    ];
+
+    const view = buildIngestChartView(statusWithHistory(history));
+
+    expect(view?.labels).toHaveLength(history.length);
+    expect(view?.completionDatasets[0].data).toEqual([20, 40, null, 10, 5, 6, 10, null]);
+    expect(view?.completionDatasets[1].data).toEqual([20, 40, 60, 80, 90, 100, 100, 100]);
+    expect(view?.throughputDatasets[0].data).toEqual([
+      null,
+      20,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ]);
+    expect(view?.throughputDatasets[0].spanGaps).toBe(false);
+  });
+
+  it('keeps unsupported completion dimensions null instead of claiming completion', () => {
+    const view = buildIngestChartView(
+      statusWithHistory([
+        point({ files_total: 0, files_completed: 0, bytes_total: 100, bytes_completed: 100 }),
+      ]),
+    );
+
+    expect(view?.completionDatasets[0].data).toEqual([100]);
+    expect(view?.completionDatasets[1].data).toEqual([null]);
+  });
+
+  it('leaves completion dimensions gapped until discovery freezes the denominator', () => {
+    const view = buildIngestChartView(
+      statusWithHistory([point({ discovery_complete: false, bytes_completed: 100 })]),
+    );
+
+    expect(view?.completionDatasets[0].data).toEqual([null]);
+    expect(view?.completionDatasets[1].data).toEqual([null]);
+  });
+
+  it('caps client chart samples at the newest 120 points', () => {
+    const history = Array.from({ length: 121 }, (_, index) =>
+      point({ ts_unix_ms: (index + 1) * 1_000, bytes_total: 200, bytes_completed: index }),
+    );
+
+    const view = buildIngestChartView(statusWithHistory(history));
+
+    expect(view?.labels).toHaveLength(120);
+    expect(view?.completionDatasets[0].data).toHaveLength(120);
+    expect(view?.completionDatasets[0].data[0]).toBe(0.5);
+  });
+});

--- a/web/monitor/src/lib/charts/ingest.ts
+++ b/web/monitor/src/lib/charts/ingest.ts
@@ -1,0 +1,117 @@
+import type { ChartDataset } from 'chart.js';
+import type { IngestHistoryPoint, IngestStatus } from '../types/api';
+import { chartTheme } from './theme';
+
+export interface IngestChartView {
+  labels: string[];
+  completionDatasets: ChartDataset<'line', Array<number | null>>[];
+  throughputDatasets: ChartDataset<'line', Array<number | null>>[];
+}
+
+function labelFor(point: IngestHistoryPoint): string {
+  const timestamp = Number(point.ts_unix_ms);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return 'unknown';
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function completionPercent(completed: number, total: number): number | null {
+  if (
+    !Number.isFinite(completed) ||
+    !Number.isFinite(total) ||
+    total <= 0 ||
+    completed < 0 ||
+    completed > total
+  ) {
+    return null;
+  }
+  return Math.min(100, (completed / total) * 100);
+}
+
+function durableByteThroughput(
+  previous: IngestHistoryPoint | undefined,
+  current: IngestHistoryPoint,
+): number | null {
+  if (!previous) return null;
+
+  const previousTimestamp = Number(previous.ts_unix_ms);
+  const currentTimestamp = Number(current.ts_unix_ms);
+  const previousTotal = Number(previous.bytes_total);
+  const currentTotal = Number(current.bytes_total);
+  const previousCompleted = Number(previous.bytes_completed);
+  const currentCompleted = Number(current.bytes_completed);
+  if (
+    !Number.isFinite(previousTimestamp) ||
+    !Number.isFinite(currentTimestamp) ||
+    !Number.isFinite(previousTotal) ||
+    !Number.isFinite(currentTotal) ||
+    !Number.isFinite(previousCompleted) ||
+    !Number.isFinite(currentCompleted) ||
+    currentTimestamp <= previousTimestamp ||
+    previousTotal <= 0 ||
+    currentTotal <= 0 ||
+    currentTotal !== previousTotal ||
+    previousCompleted < 0 ||
+    currentCompleted < previousCompleted ||
+    currentCompleted > currentTotal
+  ) {
+    return null;
+  }
+
+  return (currentCompleted - previousCompleted) / ((currentTimestamp - previousTimestamp) / 1_000);
+}
+
+export function buildIngestChartView(status: IngestStatus): IngestChartView | null {
+  const samples = (status.history ?? []).slice(-120);
+  if (samples.length === 0) return null;
+
+  const palette = chartTheme();
+  return {
+    labels: samples.map(labelFor),
+    completionDatasets: [
+      {
+        label: 'Durable byte coverage',
+        data: samples.map((point) =>
+          point.discovery_complete
+            ? completionPercent(Number(point.bytes_completed), Number(point.bytes_total))
+            : null,
+        ),
+        borderColor: palette.good,
+        backgroundColor: palette.good,
+        borderWidth: 2,
+        pointRadius: 0,
+        tension: 0.16,
+        spanGaps: false,
+      },
+      {
+        label: 'Durable file coverage',
+        data: samples.map((point) =>
+          point.discovery_complete
+            ? completionPercent(Number(point.files_completed), Number(point.files_total))
+            : null,
+        ),
+        borderColor: palette.primary,
+        backgroundColor: palette.primary,
+        borderWidth: 2,
+        pointRadius: 0,
+        tension: 0.16,
+        spanGaps: false,
+      },
+    ],
+    throughputDatasets: [
+      {
+        label: 'Durable checkpoint bytes/s',
+        data: samples.map((point, index) => durableByteThroughput(samples[index - 1], point)),
+        borderColor: palette.warn,
+        backgroundColor: palette.warn,
+        borderWidth: 2,
+        pointRadius: 0,
+        tension: 0.12,
+        spanGaps: false,
+      },
+    ],
+  };
+}

--- a/web/monitor/src/lib/charts/theme.ts
+++ b/web/monitor/src/lib/charts/theme.ts
@@ -1,6 +1,9 @@
 export interface ChartPalette {
   text: string;
   grid: string;
+  good: string;
+  primary: string;
+  warn: string;
 }
 
 function readCssVar(name: string, fallback: string): string {
@@ -12,5 +15,8 @@ export function chartTheme(): ChartPalette {
   return {
     text: readCssVar('--chart-text', '#435568'),
     grid: readCssVar('--chart-grid', '#e8eff4'),
+    good: readCssVar('--good', '#0f766e'),
+    primary: readCssVar('--primary', '#155e75'),
+    warn: readCssVar('--warn', '#b45309'),
   };
 }

--- a/web/monitor/src/lib/components/IngestProgressPanel.svelte
+++ b/web/monitor/src/lib/components/IngestProgressPanel.svelte
@@ -1,0 +1,250 @@
+<script lang="ts">
+  import type { Chart, ChartType } from 'chart.js';
+  import { buildIngestChartView, type IngestChartView } from '../charts/ingest';
+  import { createOrUpdateChart, destroyChart } from '../charts/chart';
+  import type { IngestCondition, StatusResponse } from '../types/api';
+  import type { ThemeMode } from '../types/ui';
+
+  export let status: StatusResponse | null = null;
+  export let theme: ThemeMode = 'light';
+
+  let chartView: IngestChartView | null = null;
+
+  $: ingestStatus = status?.ingest_status ?? null;
+  $: latestProgress = ingestStatus?.heartbeat.latest?.progress ?? null;
+  $: coverageCondition =
+    ingestStatus?.conditions.find((condition) => condition.condition_type === 'coverage') ?? null;
+  $: {
+    theme;
+    chartView = ingestStatus ? buildIngestChartView(ingestStatus) : null;
+  }
+
+  function stateLabel(condition: IngestCondition): string {
+    if (condition.state === 'unknown') return 'unknown';
+    if (condition.state === 'false') {
+      if (condition.condition_type === 'health') return 'unhealthy';
+      if (condition.condition_type === 'coverage') return 'partial';
+      if (condition.condition_type === 'freshness') return 'stale';
+      return 'not ready';
+    }
+    if (condition.condition_type === 'health') return 'healthy';
+    if (condition.condition_type === 'coverage') return 'complete';
+    if (condition.condition_type === 'freshness') return 'fresh';
+    return 'ready';
+  }
+
+  function progressPercent(completed: number, total: number): string | null {
+    if (
+      !Number.isFinite(completed) ||
+      !Number.isFinite(total) ||
+      total <= 0 ||
+      completed < 0 ||
+      completed > total
+    ) {
+      return null;
+    }
+    return `${((completed / total) * 100).toFixed(1)}%`;
+  }
+
+  type IngestChartKind = 'completion' | 'throughput';
+
+  interface IngestChartBinding {
+    kind: IngestChartKind;
+    theme: ThemeMode;
+    view: IngestChartView | null;
+  }
+
+  function renderChart(canvas: HTMLCanvasElement, initial: IngestChartBinding) {
+    let chart: Chart<ChartType> | null = null;
+
+    function update(binding: IngestChartBinding): void {
+      void binding.theme;
+      if (!binding.view) {
+        destroyChart(chart);
+        chart = null;
+        return;
+      }
+      const completion = binding.kind === 'completion';
+      chart = createOrUpdateChart(
+        chart,
+        canvas,
+        'line',
+        binding.view.labels,
+        completion ? binding.view.completionDatasets : binding.view.throughputDatasets,
+        completion ? 'Coverage' : 'Bytes/s',
+        completion
+          ? { maxTicks: 8, yTickFormatter: (value) => `${value}%` }
+          : { maxTicks: 8 },
+      );
+    }
+
+    update(initial);
+    return {
+      update,
+      destroy(): void {
+        destroyChart(chart);
+      },
+    };
+  }
+</script>
+
+{#if ingestStatus}
+  <section class="panel ingest-progress" aria-labelledby="ingestProgressTitle">
+    <div class="ingest-head">
+      <div>
+        <p class="eyebrow">Durable checkpoint telemetry</p>
+        <h2 id="ingestProgressTitle">Ingestion Progress</h2>
+      </div>
+      <div class="eta-block">
+        <span>ETA RANGE</span>
+        {#if ingestStatus.eta}
+          <strong>{ingestStatus.eta.low_seconds}–{ingestStatus.eta.high_seconds}s</strong>
+          <small>{ingestStatus.eta.scope.replaceAll('_', ' ')} · stable file-byte rate</small>
+        {:else}
+          <strong>Unavailable</strong>
+          <small>Requires stable durable file-byte throughput</small>
+        {/if}
+      </div>
+    </div>
+
+    <div class="condition-rail" aria-label="Independent ingestion conditions">
+      {#each ingestStatus.conditions as condition (condition.condition_type)}
+        <article
+          class:condition-bad={condition.state === 'false' && condition.condition_type === 'health'}
+          class:condition-warn={condition.state === 'false' && condition.condition_type !== 'health'}
+          class:condition-unknown={condition.state === 'unknown'}
+        >
+          <span>{condition.condition_type}</span>
+          <strong>{stateLabel(condition)}</strong>
+          <code>{condition.reason}</code>
+        </article>
+      {/each}
+    </div>
+
+    {#if ingestStatus.alerts.length > 0}
+      <div class="alert-ribbon" role="status">
+        <strong>{ingestStatus.alerts.length} active ingestion alert{ingestStatus.alerts.length === 1 ? '' : 's'}</strong>
+        <span>{ingestStatus.alerts.map((alert) => alert.code.replaceAll('_', ' ')).join(' · ')}</span>
+      </div>
+    {/if}
+
+    <div class="chart-grid ingest-chart-grid">
+      <article class="chart-card">
+        <h3>Durable Snapshot Completion</h3>
+        {#if chartView}
+          <div class="chart-wrap">
+            <canvas
+              use:renderChart={{ kind: 'completion', theme, view: chartView }}
+              aria-label="File and byte completion history"
+            ></canvas>
+          </div>
+        {:else}
+          <p class="chart-empty">No durable completion history requested or recorded yet.</p>
+        {/if}
+      </article>
+      <article class="chart-card">
+        <h3>Durable Checkpoint Throughput</h3>
+        {#if chartView}
+          <div class="chart-wrap">
+            <canvas
+              use:renderChart={{ kind: 'throughput', theme, view: chartView }}
+              aria-label="Durable checkpoint byte throughput history"
+            ></canvas>
+          </div>
+        {:else}
+          <p class="chart-empty">No consecutive durable byte samples are available yet.</p>
+        {/if}
+        {#if ingestStatus.rate}
+          <p class="chart-note">
+            Stable window: {Math.round(ingestStatus.rate.bytes_per_second).toLocaleString()} bytes/s
+            over {ingestStatus.rate.sample_seconds}s
+          </p>
+        {/if}
+      </article>
+    </div>
+
+    {#if latestProgress && latestProgress.sources.length > 0}
+      <div class="source-grid" aria-label="Progress by ingest source">
+        {#each latestProgress.sources as source (source.source_name)}
+          <article
+            class:coverage-complete={coverageCondition?.state === 'true'}
+            class:coverage-partial={coverageCondition?.state === 'false'}
+            class:coverage-unknown={coverageCondition?.state === 'unknown' || !coverageCondition}
+          >
+            <div class="source-head">
+              <strong>{source.source_name}</strong>
+              <span>{source.format}</span>
+            </div>
+            <div class="coverage-row">
+              <div class="source-foot">
+                <span>files · {source.files_completed}/{source.files_total}</span>
+                <strong>{source.coverage_basis === 'unknown'
+                  ? 'n/a'
+                  : (progressPercent(source.files_completed, source.files_total) ?? 'n/a')}</strong>
+              </div>
+              <div class="meter" aria-hidden="true">
+                <i style={`width: ${source.coverage_basis === 'unknown'
+                  ? '0%'
+                  : (progressPercent(source.files_completed, source.files_total) ?? '0%')}`}></i>
+              </div>
+            </div>
+            <div class="coverage-row">
+              <div class="source-foot">
+                <span>bytes · {source.bytes_completed}/{source.bytes_total}</span>
+                <strong>{source.coverage_basis === 'bytes'
+                  ? (progressPercent(source.bytes_completed, source.bytes_total) ?? 'n/a')
+                  : 'n/a'}</strong>
+              </div>
+              <div class="meter" aria-hidden="true">
+                <i style={`width: ${source.coverage_basis === 'bytes'
+                  ? (progressPercent(source.bytes_completed, source.bytes_total) ?? '0%')
+                  : '0%'}`}></i>
+              </div>
+            </div>
+            {#if source.coverage_degraded}<small>Approximate mutation coverage</small>{/if}
+          </article>
+        {/each}
+      </div>
+    {/if}
+  </section>
+{/if}
+
+<style>
+  .ingest-progress { overflow: hidden; }
+  .ingest-head { display: flex; align-items: end; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+  .ingest-head h2 { margin: 0; }
+  .eyebrow { margin: 0 0 0.2rem; color: var(--subtle); font: 600 0.67rem/1.2 'IBM Plex Mono', monospace; letter-spacing: 0.12em; text-transform: uppercase; }
+  .eta-block { display: grid; justify-items: end; max-width: 22rem; text-align: right; }
+  .eta-block span { color: var(--subtle); font: 600 0.65rem 'IBM Plex Mono', monospace; letter-spacing: 0.1em; }
+  .eta-block strong { color: var(--primary); font: 700 1.15rem 'IBM Plex Mono', monospace; }
+  .eta-block small { color: var(--subtle); font: 0.67rem 'IBM Plex Mono', monospace; }
+  .condition-rail { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 0.55rem; margin-bottom: 0.75rem; }
+  .condition-rail article { display: grid; gap: 0.12rem; padding: 0.65rem 0.75rem; border: 1px solid color-mix(in srgb, var(--good) 42%, var(--line)); border-left: 3px solid var(--good); border-radius: 0.55rem; background: var(--panel-alt); }
+  .condition-rail article.condition-bad { border-left-color: var(--bad); }
+  .condition-rail article.condition-warn,
+  .condition-rail article.condition-unknown { border-left-color: var(--warn); }
+  .condition-rail span { color: var(--subtle); font: 600 0.66rem 'IBM Plex Mono', monospace; text-transform: uppercase; }
+  .condition-rail strong { font-size: 0.88rem; text-transform: capitalize; }
+  .condition-rail code { color: var(--subtle); font-size: 0.68rem; overflow-wrap: anywhere; }
+  .alert-ribbon { display: flex; justify-content: space-between; gap: 1rem; margin-bottom: 0.75rem; padding: 0.55rem 0.75rem; border: 1px solid color-mix(in srgb, var(--bad) 50%, var(--line)); border-radius: 0.5rem; background: color-mix(in srgb, var(--bad) 8%, var(--panel)); color: var(--text); font-size: 0.78rem; }
+  .alert-ribbon span { color: var(--subtle); text-transform: capitalize; }
+  .ingest-chart-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .chart-empty { display: grid; min-height: 12rem; margin: 0; place-items: center; color: var(--subtle); font: 0.75rem 'IBM Plex Mono', monospace; text-align: center; }
+  .chart-note { margin: 0.4rem 0 0; color: var(--subtle); font: 0.67rem 'IBM Plex Mono', monospace; }
+  .source-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(175px, 1fr)); gap: 0.55rem; margin-top: 0.75rem; }
+  .source-grid article { --coverage-tone: var(--warn); padding: 0.65rem; border: 1px solid var(--line); border-left: 3px solid var(--coverage-tone); border-radius: 0.55rem; background: var(--surface); }
+  .source-grid article.coverage-complete { --coverage-tone: var(--good); }
+  .source-grid article.coverage-unknown { --coverage-tone: var(--line-strong); }
+  .source-head, .source-foot { display: flex; align-items: baseline; justify-content: space-between; gap: 0.5rem; }
+  .source-head span, .source-foot, .source-grid small { color: var(--subtle); font: 0.67rem 'IBM Plex Mono', monospace; }
+  .coverage-row { margin-top: 0.65rem; }
+  .meter { height: 4px; margin-top: 0.3rem; overflow: hidden; border-radius: 999px; background: var(--line); }
+  .meter i { display: block; height: 100%; border-radius: inherit; background: var(--coverage-tone); }
+  .source-grid small { display: block; margin-top: 0.35rem; color: var(--warn); }
+  @media (max-width: 760px) {
+    .ingest-head { align-items: start; flex-direction: column; }
+    .eta-block { justify-items: start; text-align: left; }
+    .condition-rail, .ingest-chart-grid { grid-template-columns: 1fr; }
+    .alert-ribbon { flex-direction: column; gap: 0.2rem; }
+  }
+</style>

--- a/web/monitor/src/lib/components/IngestProgressPanel.test.ts
+++ b/web/monitor/src/lib/components/IngestProgressPanel.test.ts
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import type { IngestAlert, IngestCondition, StatusResponse } from '../types/api';
+import IngestProgressPanel from './IngestProgressPanel.svelte';
+
+const observedAt = 1_700_000_103_000;
+const unknownConditions: IngestCondition[] = [
+  {
+    condition_type: 'health',
+    state: 'unknown',
+    reason: 'heartbeat_clock_skew',
+    observed_at_unix_ms: observedAt,
+  },
+  {
+    condition_type: 'coverage',
+    state: 'unknown',
+    reason: 'progress_unavailable',
+    observed_at_unix_ms: observedAt,
+  },
+  {
+    condition_type: 'freshness',
+    state: 'unknown',
+    reason: 'progress_unavailable',
+    observed_at_unix_ms: observedAt,
+  },
+  {
+    condition_type: 'readiness',
+    state: 'unknown',
+    reason: 'conditions_unknown',
+    observed_at_unix_ms: observedAt,
+  },
+];
+
+function panelStatus(alerts: IngestAlert[]): StatusResponse {
+  const latest = {
+    ts_unix_ms: observedAt + 10_000,
+    queue_depth: 0,
+    files_active: 0,
+    files_watched: 0,
+    progress: null,
+  };
+  return {
+    ok: true,
+    ingestor: { present: true, alive: false, latest, age_seconds: 0 },
+    ingest_status: {
+      observed_at_unix_ms: observedAt,
+      heartbeat: { table_present: true, latest },
+      conditions: unknownConditions,
+      alerts,
+    },
+  };
+}
+
+describe('IngestProgressPanel', () => {
+  it('keeps every independent condition visible when progress cannot be decoded', () => {
+    render(IngestProgressPanel, { props: { status: panelStatus([]) } });
+
+    expect(screen.getByRole('heading', { name: 'Ingestion Progress' })).toBeVisible();
+    for (const label of ['health', 'coverage', 'freshness', 'readiness']) {
+      expect(screen.getByText(label)).toBeVisible();
+    }
+    expect(screen.getByText('Unavailable')).toBeVisible();
+    expect(screen.getByText('No durable completion history requested or recorded yet.')).toBeVisible();
+    expect(screen.getByText('No consecutive durable byte samples are available yet.')).toBeVisible();
+  });
+
+  it('removes recovered alerts on the next status response', async () => {
+    const alert: IngestAlert = {
+      code: 'progress_stalled',
+      observed_at_unix_ms: observedAt,
+    };
+    const view = render(IngestProgressPanel, { props: { status: panelStatus([alert]) } });
+    expect(screen.getByText('progress stalled')).toBeVisible();
+
+    await view.rerender({ status: panelStatus([]) });
+
+    expect(screen.queryByText('progress stalled')).not.toBeInTheDocument();
+  });
+});

--- a/web/monitor/src/lib/components/StatusStrip.svelte
+++ b/web/monitor/src/lib/components/StatusStrip.svelte
@@ -25,6 +25,19 @@
     return `${Math.round(seconds / 3600)}h ago`;
   }
 
+  function formatCoverage(completed: number, total: number): string {
+    if (
+      !Number.isFinite(completed) ||
+      !Number.isFinite(total) ||
+      total <= 0 ||
+      completed < 0 ||
+      completed > total
+    ) {
+      return 'n/a';
+    }
+    return `${((completed / total) * 100).toFixed(1)}%`;
+  }
+
   function buildHealthChips(data: HealthResponse | null, error: string | null): Chip[] {
     if (error || !data?.ok) {
       return [
@@ -58,44 +71,123 @@
     }
 
     const ingestor = data?.ingestor;
-    if (!ingestor) {
+    const ingestStatus = data?.ingest_status;
+    if (!ingestor && !ingestStatus) {
       return [{ key: 'status', value: 'unknown', ok: false, tone: 'warn' }];
     }
 
-    let statusLabel = 'unknown';
-    let statusOk = false;
-    let tone: Chip['tone'];
+    const chips: Chip[] = [];
+    for (const conditionType of ['health', 'coverage', 'freshness', 'readiness'] as const) {
+      const condition = ingestStatus?.conditions.find(
+        (candidate) => candidate.condition_type === conditionType,
+      );
+      if (!condition) continue;
 
-    if (!ingestor.present) {
-      statusLabel = 'missing';
-      tone = 'warn';
-    } else if (!ingestor.latest) {
-      statusLabel = 'waiting';
-      tone = 'warn';
-    } else if (ingestor.alive) {
-      statusLabel = 'healthy';
-      statusOk = true;
-    } else {
-      statusLabel = 'stale';
-      tone = 'warn';
+      const stateLabel =
+        condition.state === 'unknown'
+          ? 'unknown'
+          : condition.state === 'true'
+            ? {
+                health: 'healthy',
+                coverage: 'complete',
+                freshness: 'fresh',
+                readiness: 'ready',
+              }[conditionType]
+            : {
+                health: 'unhealthy',
+                coverage: 'partial',
+                freshness: 'stale',
+                readiness: 'not ready',
+              }[conditionType];
+      chips.push({
+        key: conditionType,
+        value: `${stateLabel} · ${condition.reason.replaceAll('_', ' ')}`,
+        ok: condition.state === 'true',
+        tone:
+          condition.state === 'unknown'
+            ? 'warn'
+            : condition.state === 'false'
+              ? conditionType === 'health'
+                ? 'bad'
+                : 'warn'
+              : undefined,
+      });
     }
 
-    const chips: Chip[] = [{ key: 'status', value: statusLabel, ok: statusOk, tone }];
+    if (chips.length === 0 && ingestor) {
+      if (!ingestor.present) {
+        chips.push({ key: 'status', value: 'missing', ok: false, tone: 'warn' });
+      } else if (!ingestor.latest) {
+        chips.push({ key: 'status', value: 'waiting', ok: false, tone: 'warn' });
+      } else if (ingestor.alive) {
+        chips.push({ key: 'status', value: 'healthy', ok: true });
+      } else {
+        chips.push({ key: 'status', value: 'stale', ok: false, tone: 'warn' });
+      }
+    }
 
-    if (ingestor.age_seconds !== null && ingestor.age_seconds !== undefined) {
+    if (ingestor?.age_seconds !== null && ingestor?.age_seconds !== undefined) {
       chips.push({ key: 'heartbeat', value: formatAge(ingestor.age_seconds), ok: false });
     }
 
-    if (ingestor.latest) {
+    if (ingestor?.latest) {
       const queue = ingestor.latest.queue_depth;
+      const capacity = ingestStatus?.heartbeat.latest?.progress?.queue_capacity;
       chips.push({
-        key: 'queue',
-        value: queue === null || queue === undefined ? 'n/a' : String(queue),
+        key: 'queue pressure',
+        value:
+          queue === null || queue === undefined
+            ? 'n/a'
+            : `${queue} / ${capacity === null || capacity === undefined ? '?' : capacity}`,
         ok: false,
       });
       const active = ingestor.latest.files_active ?? '?';
       const watched = ingestor.latest.files_watched ?? '?';
-      chips.push({ key: 'files', value: `${active} / ${watched}`, ok: false });
+      chips.push({ key: 'files active', value: `${active} / ${watched}`, ok: false });
+    }
+
+    const progress = ingestStatus?.heartbeat.latest?.progress;
+    const coverageCondition = ingestStatus?.conditions.find(
+      (condition) => condition.condition_type === 'coverage',
+    );
+    if (progress) {
+      const coverageTone: Chip['tone'] =
+        coverageCondition?.state === 'false'
+          ? 'warn'
+          : coverageCondition?.state === 'unknown'
+            ? 'warn'
+            : undefined;
+      const coverageOk = coverageCondition?.state === 'true';
+      const filePercent = formatCoverage(progress.files_completed, progress.files_total);
+      const bytePercent = formatCoverage(progress.bytes_completed, progress.bytes_total);
+      chips.push({
+        key: 'file coverage',
+        value: `${progress.files_completed} / ${progress.files_total} · ${filePercent}`,
+        ok: coverageOk && progress.files_total > 0,
+        tone: coverageTone,
+      });
+      chips.push({
+        key: 'byte coverage',
+        value: `${progress.bytes_completed} / ${progress.bytes_total} · ${bytePercent}`,
+        ok: coverageOk && progress.bytes_total > 0,
+        tone: coverageTone,
+      });
+    }
+
+    if (ingestStatus?.eta) {
+      chips.push({
+        key: 'ETA',
+        value: `${formatAge(ingestStatus.eta.low_seconds).replace(' ago', '')}–${formatAge(ingestStatus.eta.high_seconds).replace(' ago', '')}`,
+        ok: false,
+      });
+    }
+    if ((ingestStatus?.alerts.length ?? 0) > 0) {
+      chips.push({
+        key: 'alerts',
+        value: String(ingestStatus?.alerts.length),
+        ok: false,
+        tone: 'bad',
+      });
     }
 
     return chips;

--- a/web/monitor/src/lib/components/StatusStrip.test.ts
+++ b/web/monitor/src/lib/components/StatusStrip.test.ts
@@ -1,0 +1,110 @@
+import { render, screen, within } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import type { IngestCondition, IngestProgressSnapshot, StatusResponse } from '../types/api';
+import StatusStrip from './StatusStrip.svelte';
+
+const observedAt = 1_700_000_103_000;
+
+function condition(
+  conditionType: IngestCondition['condition_type'],
+  state: IngestCondition['state'],
+  reason: string,
+): IngestCondition {
+  return {
+    condition_type: conditionType,
+    state,
+    reason,
+    observed_at_unix_ms: observedAt,
+  };
+}
+
+function statusResponse(
+  conditions: IngestCondition[],
+  progress: IngestProgressSnapshot | null,
+): StatusResponse {
+  const latest = {
+    ts_unix_ms: observedAt - 3_000,
+    queue_depth: 0,
+    files_active: 0,
+    files_watched: 8,
+    progress,
+  };
+  return {
+    ok: true,
+    ingestor: { present: true, alive: true, latest, age_seconds: 3 },
+    ingest_status: {
+      observed_at_unix_ms: observedAt,
+      heartbeat: { table_present: true, latest },
+      conditions,
+      alerts: [],
+    },
+  };
+}
+
+describe('StatusStrip ingestion conditions', () => {
+  it('renders all independent unknown conditions without decoded progress', () => {
+    render(StatusStrip, {
+      props: {
+        status: statusResponse(
+          [
+            condition('health', 'unknown', 'heartbeat_clock_skew'),
+            condition('coverage', 'unknown', 'progress_unavailable'),
+            condition('freshness', 'unknown', 'progress_unavailable'),
+            condition('readiness', 'unknown', 'conditions_unknown'),
+          ],
+          null,
+        ),
+      },
+    });
+
+    const ingestor = screen.getByText('Ingestor').parentElement!;
+    for (const label of ['health', 'coverage', 'freshness', 'readiness']) {
+      const chip = within(ingestor).getByText(label).closest('.ss-chip');
+      expect(chip).toHaveClass('ss-warn');
+      expect(chip).toHaveTextContent('unknown');
+    }
+  });
+
+  it('shows file and byte completion separately with tone from the shared coverage condition', () => {
+    const progress: IngestProgressSnapshot = {
+      schema_version: 1,
+      instance_id: 'run-a',
+      run_started_unix_ms: observedAt - 60_000,
+      snapshot_unix_ms: observedAt - 60_000,
+      discovery_complete: true,
+      queue_capacity: 16,
+      sink_pending_rows: 0,
+      sink_pending_bytes: 0,
+      sink_retrying: false,
+      oldest_pending_unix_ms: 0,
+      last_durable_progress_unix_ms: observedAt,
+      files_total: 8,
+      files_completed: 8,
+      bytes_total: 1_000,
+      bytes_completed: 750,
+      sources: [],
+    };
+    render(StatusStrip, {
+      props: {
+        status: statusResponse(
+          [
+            condition('health', 'true', 'heartbeat_recent'),
+            condition('coverage', 'false', 'backfill_partial'),
+            condition('freshness', 'true', 'progress_recent'),
+            condition('readiness', 'false', 'retrieval_may_be_incomplete'),
+          ],
+          progress,
+        ),
+      },
+    });
+
+    const fileCoverage = screen.getByText('file coverage').closest('.ss-chip');
+    const byteCoverage = screen.getByText('byte coverage').closest('.ss-chip');
+    expect(fileCoverage).toHaveTextContent('8 / 8 · 100.0%');
+    expect(fileCoverage).toHaveClass('ss-warn');
+    expect(fileCoverage).not.toHaveClass('ss-ok');
+    expect(byteCoverage).toHaveTextContent('750 / 1000 · 75.0%');
+    expect(byteCoverage).toHaveClass('ss-warn');
+    expect(screen.queryByText('backfill')).not.toBeInTheDocument();
+  });
+});

--- a/web/monitor/src/lib/types/api.ts
+++ b/web/monitor/src/lib/types/api.ts
@@ -24,6 +24,8 @@ export interface IngestorLatest {
   queue_depth?: number | null;
   files_active?: number | null;
   files_watched?: number | null;
+  ts_unix_ms?: number;
+  progress?: IngestProgressSnapshot | null;
   [key: string]: unknown;
 }
 
@@ -33,10 +35,85 @@ export interface IngestorStatus {
   latest: IngestorLatest | null;
   age_seconds: number | null;
 }
+export interface IngestProgressSnapshot {
+  schema_version: number;
+  instance_id: string;
+  run_started_unix_ms: number;
+  snapshot_unix_ms: number;
+  discovery_complete: boolean;
+  queue_capacity: number;
+  sink_pending_rows: number;
+  sink_pending_bytes: number;
+  sink_retrying: boolean;
+  oldest_pending_unix_ms: number;
+  last_durable_progress_unix_ms: number;
+  files_total: number;
+  files_completed: number;
+  bytes_total: number;
+  bytes_completed: number;
+  sources: IngestSourceProgress[];
+}
+
+export interface IngestSourceProgress {
+  source_name: string;
+  format: string;
+  coverage_basis: 'bytes' | 'files' | 'unknown';
+  files_total: number;
+  files_completed: number;
+  bytes_total: number;
+  bytes_completed: number;
+  coverage_degraded: boolean;
+}
+
+export interface IngestCondition {
+  condition_type: 'health' | 'coverage' | 'freshness' | 'readiness';
+  state: 'true' | 'false' | 'unknown';
+  reason: string;
+  observed_at_unix_ms: number;
+}
+
+export interface IngestAlert {
+  code:
+    | 'heartbeat_stale'
+    | 'progress_stalled'
+    | 'queue_saturated'
+    | 'sink_retrying'
+    | 'coverage_degraded';
+  observed_at_unix_ms: number;
+}
+
+export interface IngestHistoryPoint {
+  ts_unix_ms: number;
+  queue_depth: number;
+  files_active: number;
+  queue_capacity: number;
+  sink_pending_rows: number;
+  sink_retrying: boolean;
+  discovery_complete: boolean;
+  files_total: number;
+  files_completed: number;
+  bytes_total: number;
+  bytes_completed: number;
+}
+
+export interface IngestStatus {
+  observed_at_unix_ms: number;
+  heartbeat: {
+    table_present: boolean;
+    latest: IngestorLatest | null;
+  };
+  conditions: IngestCondition[];
+  alerts: IngestAlert[];
+  rate?: { bytes_per_second: number; sample_seconds: number } | null;
+  eta?: { scope: string; low_seconds: number; high_seconds: number } | null;
+  history?: IngestHistoryPoint[];
+}
+
 
 export interface StatusResponse {
   ok: boolean;
   ingestor?: IngestorStatus;
+  ingest_status?: IngestStatus | null;
   error?: string;
 }
 


### PR DESCRIPTION
## Description

**What.** Adds durable, finite ingestion progress telemetry and exposes it consistently through CLI status, monitor HTTP/UI, and a new `get_ingest_status` MCP tool.

**Why.** Queue depth and heartbeat liveness alone cannot tell users or retrieval agents whether historical backfill is complete, advancing, stalled, or safe to query.

- Freezes per-run file and byte targets during startup discovery, then advances completion only after matching checkpoints are durably committed.
- Persists the versioned progress snapshot in `ingest_heartbeats.progress_json` via additive migration 034, after main's replay-stable events migration 033.
- Derives independent health, coverage, freshness, and readiness conditions with stable reason codes, bounded alerts, sustained-rate windows, and conservative ETA suppression rules.
- Treats completed-file coverage for SQLite sources as a measurement basis rather than an active degradation; alerts remain reserved for real metadata, identity, or checkpoint-confidence failures.
- Adds bounded same-instance progress history to `/api/v1/status?history=N`, while keeping default status polls latest-only.
- Adds `get_ingest_status` to the MCP surface with an aggregate, path-free response suitable for retrieval agents.
- Adds an Ingestion Progress monitor panel with durable completion and throughput charts, per-source coverage, pressure indicators, and alerts.
- Extends `moraine status` human and JSON output with the same typed ingestion model.

## Usage

Inspect status from the CLI:

```bash
moraine status
moraine --output json status | jq '.ingest_status'
```

Request bounded history from the monitor API:

```bash
curl 'http://127.0.0.1:8123/api/v1/status?history=120'
```

Agents can call `get_ingest_status` with an empty object:

```json
{}
```

The monitor dashboard loads 120 history points for the Ingestion Progress panel. Default `/api/v1/status` requests remain latest-only.

## Operational Impact

- Applies additive ClickHouse migration `034_ingest_progress.sql`, adding `progress_json String DEFAULT ''` to `ingest_heartbeats`.
- No configuration changes.
- Old heartbeat rows remain readable; missing progress is reported as unknown rather than complete.
- ETA remains absent until six valid same-instance samples span at least 30 seconds with stable throughput, and is suppressed during discovery, retries, zero progress, or unstable rates.

## Changelog

- Adds durable historical-ingestion completion, throughput, ETA, and alert telemetry.
- Adds `get_ingest_status` for retrieval agents.
- Adds ingestion progress reporting to CLI status and the monitor dashboard.

## Validation

- `cargo fmt --all -- --check` — passed.
- `cargo test --workspace --locked` — 1,023 tests passed with 5 expected ignores, including all 24 `moraine-monitor-core` tests after making the status-route alias check ignore only request-time observation timestamps.
- `bun run typecheck` in `web/monitor` — passed.
- `bun run test` in `web/monitor` — 25 tests passed.
- `bun run test:e2e:mocked` in `web/monitor` — 2 mocked browser cases passed before the final review-only test hardening; final UI was also exercised manually at 1440x1200 with the Ingestion Progress panel and both canvases rendered.
- `make docs-build` — passed with no issues.
- `scripts/ci/e2e-stack.sh` in sandbox `sb-3e577a` — passed after the coverage-basis separation. The stack applied `033_replay_stable_events.sql` followed by `034_ingest_progress.sql`, then passed SQLite updates and replacements, monitor APIs, daemon and embedded MCP routes, status fallback, and shutdown.
- Full seven-persona code review completed; all accepted correctness, boundary, privacy, and status-surface findings were resolved before the final focused test runs.
