### PR TITLE
chore(release): cut v0.7.2

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.7.1)"
+        description: "Tag to release (for example v0.7.2)"
         required: true
         type: string
       target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "moraine"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "glob",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1311,11 +1311,11 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor"
-version = "0.7.1"
+version = "0.7.2"
 
 [[package]]
 name = "moraine-monitor-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/moraine-ingest/Cargo.toml
+++ b/apps/moraine-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Moraine ingest service binary"
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Moraine MCP stdio entry and unified backend daemon"
 

--- a/apps/moraine-monitor/Cargo.toml
+++ b/apps/moraine-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Deprecated alias for the unified Moraine backend"
 

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Unified runtime control plane for Moraine services"
 

--- a/bindings/python/moraine_conversations/Cargo.lock
+++ b/bindings/python/moraine_conversations/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "flate2",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "glob",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-clickhouse"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Shared Moraine ClickHouse client and query helpers"
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-config"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Shared Moraine configuration schema and loaders"
 

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-conversations"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "High-level read/query APIs for Moraine conversations"
 

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest-core"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Core ingestion pipeline internals for Moraine"
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp-core"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "MCP protocol and tool routing core for Moraine"
 

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor-core"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "Analytics and query logic for Moraine monitor service"
 

--- a/plugins/hermes-moraine/plugin.yaml
+++ b/plugins/hermes-moraine/plugin.yaml
@@ -1,6 +1,6 @@
 manifest_version: 1
 name: moraine
-version: "0.7.1"
+version: "0.7.2"
 description: "Hermes integration for Moraine MCP session search, realtime agent awareness, sanitized bug reports, and setup diagnostics."
 author: "Moraine maintainers"
 provides_tools:

--- a/plugins/moraine/.claude-plugin/plugin.json
+++ b/plugins/moraine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "displayName": "Moraine",
   "description": "Claude Code plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {

--- a/plugins/moraine/.codex-plugin/plugin.json
+++ b/plugins/moraine/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Codex plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {
     "name": "Moraine maintainers",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ install directory precedence:
 
 examples:
   scripts/install.sh
-  MORAINE_INSTALL_VERSION=v0.7.1 scripts/install.sh
+  MORAINE_INSTALL_VERSION=v0.7.2 scripts/install.sh
   MORAINE_INSTALL_ASSET_BASE_URL=http://127.0.0.1:8080 \
     MORAINE_INSTALL_VERSION=ci-e2e scripts/install.sh
   MORAINE_INSTALL_DIR="$HOME/bin" MORAINE_INSTALL_SKIP_CLICKHOUSE=1 scripts/install.sh


### PR DESCRIPTION
## Description

**What.** Bumps Moraine's release-managed packages, runtime plugin manifests, installer example, and release workflow example from `0.7.1` to `0.7.2`.

**Why.** `v0.7.2` publishes the user-visible changes merged since `v0.7.1` as one consistent set of CLI, service, plugin, bundle, and Python-package artifacts.

This release adds durable ingestion progress across CLI, monitor, HTTP, and MCP; first-class Qwen Code, Kiro CLI, and NAC ingestion/setup; environment-backed ClickHouse values; replay-stable canonical event identity; and a single-copy content storage model. It also makes the unified backend start with every `moraine up` and refreshes existing Claude plugin installations during setup.

## Usage

No runtime behavior changes are introduced by this version-only commit. After merge, pushing annotated tag `v0.7.2` will build and publish the release artifacts.

## Changelog

- Bumps all release-managed Rust packages to `0.7.2` while leaving the internal `moraine-conversations-py` extension package version unchanged.
- Updates the Python binding lockfile's path dependencies and the Claude, Codex, and Hermes runtime plugin versions.
- Updates the release workflow and installer examples to `v0.7.2`.

## Validation

`git diff --check` and `cargo fmt --all -- --check` passed. `cargo test --workspace --locked` passed 1,023 tests across 27 suites with 5 expected ignores.

Sandbox `sb-50d646` passed `bash scripts/ci/e2e-stack.sh`; `/api/v1/health` returned `ok: true`. The agent-driven MCP smoke passed on Claude Opus 4.7, Sonnet 4.6, and Haiku 4.5. The sandbox and all its volumes were removed afterward.

## Operational Impact

Merging this PR does not publish artifacts. Pushing annotated tag `v0.7.2` at the merged commit will trigger `release-moraine`, build four platform bundles and checksums, create the GitHub release, and publish four wheels plus the stub source distribution as `moraine-cli==0.7.2` on PyPI.
