### PR TITLE
fix: make migration 031 upgrade-safe

### DIFF
--- a/crates/moraine-clickhouse/src/lib.rs
+++ b/crates/moraine-clickhouse/src/lib.rs
@@ -1688,8 +1688,42 @@ mod tests {
         let exchange = position(
             "EXCHANGE TABLES other_db.tool_io\nAND other_db.tool_io_events_content_authority_031_frozen",
         );
-        let fold =
-            position("SELECT * FROM other_db.tool_io_events_content_authority_031_frozen FINAL");
+        let canonical_tool_projection = [
+            "event_uid",
+            "tool_call_id",
+            "parent_tool_call_id",
+            "tool_name",
+            "tool_phase",
+            "tool_error",
+            "input_json",
+            "output_json",
+            "output_text",
+            "input_bytes",
+            "output_bytes",
+            "input_preview",
+            "output_preview",
+            "io_hash",
+            "project_id",
+            "repo_rel_path",
+            "worktree_root",
+            "source_ref",
+            "event_version",
+        ]
+        .join(",\n      ");
+        let frozen_fold = format!(
+            "SELECT\n      {canonical_tool_projection}\n    \
+             FROM other_db.tool_io_events_content_authority_031_frozen FINAL"
+        );
+        let live_fold =
+            format!("SELECT\n      {canonical_tool_projection}\n    FROM other_db.tool_io FINAL");
+        let fold = position(&frozen_fold);
+        assert!(
+            sql.contains(&live_fold),
+            "both tool sources must use the same name-based projection"
+        );
+        assert!(!sql
+            .contains("SELECT * FROM other_db.tool_io_events_content_authority_031_frozen FINAL"));
+        assert!(!sql.contains("SELECT * FROM other_db.tool_io FINAL"));
         let drop_staging = position("DROP TABLE IF EXISTS other_db.tool_io");
         let truncate = position(
             "TRUNCATE TABLE IF EXISTS other_db.tool_io_events_content_authority_031_frozen",
@@ -1702,8 +1736,10 @@ mod tests {
                 && fold < drop_staging
                 && drop_staging < truncate
         );
-        assert!(sql.contains("UNION ALL\n    SELECT * FROM other_db.tool_io FINAL"));
+        assert!(sql.contains("UNION ALL\n    SELECT\n"));
         assert!(sql.contains("WHERE NOT JSONHas(e.payload_json, 'moraine_tool_io')"));
+        assert!(sql.contains(r#"concat('{"source_payload":', toJSONString(e.payload_json), '}')"#));
+        assert!(!sql.contains("toJSONString(tuple(e.payload_json AS source_payload))"));
         assert!(!sql.contains("RENAME TABLE IF EXISTS"));
         assert!(!sql
             .contains("DROP TABLE IF EXISTS other_db.tool_io_events_content_authority_031_frozen"));

--- a/sql/031_events_content_authority.sql
+++ b/sql/031_events_content_authority.sql
@@ -63,7 +63,7 @@ SELECT e.* REPLACE (
   JSONMergePatch(
     if(JSONType(e.payload_json) = 'Object',
        e.payload_json,
-       toJSONString(tuple(e.payload_json AS source_payload))),
+       concat('{"source_payload":', toJSONString(e.payload_json), '}')),
     concat('{"moraine_tool_io":', t.tool_json, '}')
   ) AS payload_json
 )
@@ -97,9 +97,49 @@ ALL INNER JOIN
     ) AS tool_json
   FROM
   (
-    SELECT * FROM moraine.tool_io_events_content_authority_031_frozen FINAL
+    SELECT
+      event_uid,
+      tool_call_id,
+      parent_tool_call_id,
+      tool_name,
+      tool_phase,
+      tool_error,
+      input_json,
+      output_json,
+      output_text,
+      input_bytes,
+      output_bytes,
+      input_preview,
+      output_preview,
+      io_hash,
+      project_id,
+      repo_rel_path,
+      worktree_root,
+      source_ref,
+      event_version
+    FROM moraine.tool_io_events_content_authority_031_frozen FINAL
     UNION ALL
-    SELECT * FROM moraine.tool_io FINAL
+    SELECT
+      event_uid,
+      tool_call_id,
+      parent_tool_call_id,
+      tool_name,
+      tool_phase,
+      tool_error,
+      input_json,
+      output_json,
+      output_text,
+      input_bytes,
+      output_bytes,
+      input_preview,
+      output_preview,
+      io_hash,
+      project_id,
+      repo_rel_path,
+      worktree_root,
+      source_ref,
+      event_version
+    FROM moraine.tool_io FINAL
   ) AS tool_source
   GROUP BY event_uid
 ) AS t ON t.event_uid = e.event_uid


### PR DESCRIPTION
## Description

**What.** Makes migration 031 independent of legacy `tool_io` column order and safely wraps non-object event payloads before merging tool detail.

**Why.** Existing databases upgraded to v0.7.2 can fail after migration 031 exchanges the legacy and replacement tables: positional `SELECT *` union arms align incompatible columns, and string-valued `payload_json` rows reach `JSONMergePatch` as arrays rather than objects.

Both union arms now use the same explicit name-based projection containing only fields consumed by the fold. Non-object payloads are preserved under an explicit `source_payload` JSON object before `moraine_tool_io` is merged. The bundled-migration test guards both invariants.

## Usage

Existing installations can rerun:

```bash
moraine up
```

Migration 031 handles either post-`EXCHANGE` retry state without requiring table reordering or database recreation. No configuration change is required.

## Changelog

- Preserves legacy `tool_io` detail when migration 031 encounters historical column order.
- Preserves string and other non-object event payloads while embedding canonical tool detail.

## Bug Evidence

On ClickHouse 25.12.5.44, the v0.7.2 migration failed against the reported legacy suffix order with Code 386 `NO_COMMON_TYPE`. After manually reordering only the empty side, string-valued payloads then failed with Code 36 `BAD_ARGUMENTS` because `toJSONString(tuple(...))` produced an array.

The fixed migration uses named columns for both union arms and constructs `{"source_payload": ...}` explicitly for non-object payloads.

## Validation

In an isolated dev sandbox, built a database through migration 030, seeded the reported legacy `tool_io` physical order plus a string-valued payload, and ran the released migration until it failed after `EXCHANGE` with `NO_COMMON_TYPE`. Rerunning the updated migration completed with exactly one canonical event at version 42 containing the preserved source payload and embedded tool fields. A second migration-031 run kept the same event/version/payload, and migrations 032–034 completed.

`cargo fmt --all -- --check` passed. `cargo test -p moraine-clickhouse --lib --locked` passed all 50 tests. `bash scripts/ci/e2e-stack.sh` completed successfully in the dev sandbox using the sandbox-built service binaries.

Closes #636