### PR TITLE
fix(ingest): make mirror catch-up checkpoint-safe

### DIFF
--- a/crates/moraine-ingest-core/src/lib.rs
+++ b/crates/moraine-ingest-core/src/lib.rs
@@ -123,8 +123,22 @@ impl Metrics {
 }
 
 #[derive(Debug)]
+// Keep the hot-path RowBatch inline; boxing every ingest batch to optimize the
+// rare backend-only barrier would add an allocation to the default path.
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum SinkMessage {
     Batch(RowBatch),
+    /// Live traffic admitted to a named backend. The admission epoch lets the
+    /// sink withhold a checkpoint if an earlier queued batch invalidates the
+    /// backend after this message was accepted.
+    BackendBatch {
+        batch: RowBatch,
+        epoch: u64,
+        persist_checkpoint: bool,
+    },
+    /// Ordered durability fence used by backend replay. The sink acknowledges
+    /// only after every earlier batch (including its checkpoint) is durable.
+    FlushBarrier(tokio::sync::oneshot::Sender<()>),
 }
 
 fn build_ingest_clickhouse_client(config: ClickHouseConfig) -> Result<ClickHouseClient> {

--- a/crates/moraine-ingest-core/src/sink.rs
+++ b/crates/moraine-ingest-core/src/sink.rs
@@ -5,8 +5,8 @@ use crate::normalize::finalize_batch_event_identities;
 use crate::redaction::{RedactionAudit, SecretRedactor};
 use crate::sources::shared::truncate_chars;
 use crate::tee::{
-    backend_sinks_json, filter_batch_for_backend, BackendSinkCell, ReplayFloor,
-    SharedRouteResolver, StatusRegistry,
+    backend_sinks_json, filter_batch_for_backend, BackendSinkCell, SharedRouteResolver,
+    StatusRegistry,
 };
 use crate::{
     DispatchState, Metrics, SinkMessage, WATCHER_BACKEND_MIXED, WATCHER_BACKEND_NATIVE,
@@ -18,7 +18,7 @@ use moraine_clickhouse::{is_oversized_json_each_row_insert_error, ClickHouseClie
 use serde::Serialize;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -28,6 +28,18 @@ struct IdentityScope {
     source_name: String,
     source_file: String,
     source_generation: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum IdentityLane {
+    Durable,
+    BackendLive,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct IdentityMapKey {
+    scope: IdentityScope,
+    lane: IdentityLane,
 }
 
 fn batch_identity_scope(batch: &RowBatch) -> Option<IdentityScope> {
@@ -193,13 +205,9 @@ pub(crate) enum SinkRole {
     Backend {
         cell: Arc<BackendSinkCell>,
         resolver: SharedRouteResolver,
-        /// Signalled on the lagging/unreachable -> ok transition so the
+        /// Signalled on the lagging/unreachable -> catching-up transition so the
         /// backend's supervisor schedules a catch-up replay pass.
         replay_notify: Arc<Notify>,
-        /// Checkpoint floor handed to that pass, captured at the same
-        /// transition (see `note_flush_outcome` for why it must be taken
-        /// here, inside the sink task, and not when the supervisor wakes).
-        replay_floor: ReplayFloor,
         redactor: Arc<SecretRedactor>,
         redactions: Arc<RedactionAudit>,
     },
@@ -233,16 +241,10 @@ impl SinkAuthorConfig {
 /// Backend-role health bookkeeping after a flush attempt; no-op for the
 /// default sink. Recovery requires a drained queue so one successful flush
 /// mid-backlog does not trigger a replay storm.
-async fn note_flush_outcome(
-    role: &SinkRole,
-    checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
-    flush_ok: bool,
-    queue_drained: bool,
-) {
+fn note_flush_outcome(role: &SinkRole, flush_ok: bool, queue_drained: bool) {
     let SinkRole::Backend {
         cell,
         replay_notify,
-        replay_floor,
         ..
     } = role
     else {
@@ -261,14 +263,6 @@ async fn note_flush_outcome(
     }
 
     if queue_drained && cell.mark_recovered() {
-        // Capture the replay floor BEFORE signalling the supervisor. This
-        // sink task is the checkpoint map's only writer and has not yet
-        // accepted any post-recovery batch, so the snapshot cannot contain
-        // a live-forwarded checkpoint that jumps past the outage's dropped
-        // span — the gap the scheduled pass exists to close. Snapshotting
-        // when the supervisor wakes instead would race the next live flush.
-        let floor = checkpoints.read().await.clone();
-        *replay_floor.lock().expect("replay floor mutex poisoned") = Some(floor);
         info!(
             backend = cell.name(),
             dropped_batches = cell.dropped_batches(),
@@ -360,7 +354,9 @@ pub(crate) fn spawn_sink_task(
             config.ingest.ack_observation && matches!(&role, SinkRole::Default { .. }),
         );
         let mut pending_ack = PendingAckBatch::default();
-        let mut identity_maps = HashMap::<IdentityScope, HashMap<String, String>>::new();
+        let mut pending_flush_barrier: Option<tokio::sync::oneshot::Sender<()>> = None;
+        let mut identity_maps = HashMap::<IdentityMapKey, HashMap<String, String>>::new();
+        let mut rejected_scopes = HashSet::<IdentityMapKey>::new();
 
         // Mirror sinks share one ingest_checkpoints table per team backend,
         // so their rows are scoped per host (migration 018; guaranteed
@@ -417,10 +413,14 @@ pub(crate) fn spawn_sink_task(
                     &mut pending_ack,
                 )
                 .await;
-                note_flush_outcome(&role, &checkpoints, flush_ok, rx.is_empty()).await;
+                let barrier_waiting = pending_flush_barrier.is_some();
+                note_flush_outcome(&role, flush_ok, barrier_waiting || rx.is_empty());
                 if flush_ok {
                     pending_batch_bytes = 0;
                     throttling_flush_retries = false;
+                    if let Some(barrier) = pending_flush_barrier.take() {
+                        let _ = barrier.send(());
+                    }
                     info!("flush retry succeeded; resuming sink intake");
                 } else {
                     tokio::select! {
@@ -436,7 +436,32 @@ pub(crate) fn spawn_sink_task(
             tokio::select! {
                 maybe_msg = rx.recv() => {
                     match maybe_msg {
-                        Some(SinkMessage::Batch(batch)) => {
+                        Some(message @ (SinkMessage::Batch(_) | SinkMessage::BackendBatch { .. })) => {
+                            let (batch, persist_checkpoint, backend_epoch, identity_lane) = match message {
+                                SinkMessage::Batch(batch) => {
+                                    (batch, true, None, IdentityLane::Durable)
+                                }
+                                SinkMessage::BackendBatch {
+                                    batch,
+                                    epoch,
+                                    persist_checkpoint,
+                                } => {
+                                    let SinkRole::Backend { cell, .. } = &role else {
+                                        tracing::error!(
+                                            "default sink received a backend-only batch"
+                                        );
+                                        continue;
+                                    };
+                                    (
+                                        batch,
+                                        persist_checkpoint
+                                            && cell.can_persist_backend_checkpoint(epoch),
+                                        Some(epoch),
+                                        IdentityLane::BackendLive,
+                                    )
+                                }
+                                SinkMessage::FlushBarrier(_) => unreachable!(),
+                            };
                             // Mirror sinks only buffer the sessions routed to
                             // them; the default sink takes batches whole.
                             let mut batch = match &role {
@@ -459,11 +484,29 @@ pub(crate) fn spawn_sink_task(
                             };
                             author.apply_to_batch(&mut batch);
                             let identity_scope = batch_identity_scope(&batch);
+                            let identity_key = identity_scope.clone().map(|scope| IdentityMapKey {
+                                scope,
+                                lane: identity_lane,
+                            });
+                            let backend_role = matches!(&role, SinkRole::Backend { .. });
                             let scan_complete = batch.checkpoint.is_some();
-                            let finalization = if let Some(scope) = identity_scope.as_ref() {
+                            if backend_role
+                                && identity_key
+                                    .as_ref()
+                                    .is_some_and(|key| rejected_scopes.contains(key))
+                            {
+                                if scan_complete {
+                                    if let Some(key) = identity_key.as_ref() {
+                                        rejected_scopes.remove(key);
+                                        identity_maps.remove(key);
+                                    }
+                                }
+                                continue;
+                            }
+                            let finalization = if let Some(key) = identity_key.as_ref() {
                                 finalize_batch_event_identities(
                                     &mut batch,
-                                    identity_maps.entry(scope.clone()).or_default(),
+                                    identity_maps.entry(key.clone()).or_default(),
                                 )
                             } else {
                                 finalize_batch_event_identities(
@@ -471,16 +514,33 @@ pub(crate) fn spawn_sink_task(
                                     &mut HashMap::new(),
                                 )
                             };
-                            if scan_complete {
-                                if let Some(scope) = identity_scope.as_ref() {
-                                    identity_maps.remove(scope);
-                                }
-                            }
                             if let Err(error) = finalization {
+                                if let SinkRole::Backend {
+                                    cell,
+                                    replay_notify,
+                                    ..
+                                } = &role
+                                {
+                                    if cell.invalidate_checkpoint_authority(backend_epoch) {
+                                        replay_notify.notify_one();
+                                    }
+                                }
+                                if let Some(key) = identity_key.as_ref() {
+                                    identity_maps.remove(key);
+                                    if backend_role && !scan_complete {
+                                        rejected_scopes.insert(key.clone());
+                                    }
+                                }
                                 warn!(
                                     "rejecting malformed normalized batch before insert: {error:#}"
                                 );
                                 continue;
+                            }
+                            if scan_complete {
+                                if let Some(key) = identity_key.as_ref() {
+                                    identity_maps.remove(key);
+                                    rejected_scopes.remove(key);
+                                }
                             }
                             pending_batch_bytes =
                                 pending_batch_bytes.saturating_add(batch.approx_bytes());
@@ -488,8 +548,10 @@ pub(crate) fn spawn_sink_task(
                             event_rows.extend(batch.event_rows);
                             link_rows.extend(batch.link_rows);
                             error_rows.extend(batch.error_rows);
-                            if let Some(cp) = batch.checkpoint {
-                                merge_checkpoint(&mut checkpoint_updates, cp);
+                            if persist_checkpoint {
+                                if let Some(cp) = batch.checkpoint {
+                                    merge_checkpoint(&mut checkpoint_updates, cp);
+                                }
                             }
 
                             let total_rows =
@@ -517,7 +579,7 @@ pub(crate) fn spawn_sink_task(
                     &ack_observer,
                     &mut pending_ack,
                                 ).await;
-                                note_flush_outcome(&role, &checkpoints, flush_ok, rx.is_empty()).await;
+                                note_flush_outcome(&role, flush_ok, rx.is_empty());
                                 if !flush_ok {
                                     if !throttling_flush_retries {
                                         warn!(
@@ -529,6 +591,47 @@ pub(crate) fn spawn_sink_task(
                                 } else {
                                     pending_batch_bytes = 0;
                                 }
+                            }
+                        }
+                        Some(SinkMessage::FlushBarrier(barrier)) => {
+                            if has_pending_data(
+                                &raw_rows,
+                                &event_rows,
+                                &link_rows,
+                                &error_rows,
+                                &checkpoint_updates,
+                            ) {
+                                let flush_ok = flush_pending_with_ack(
+                                    &clickhouse,
+                                    &checkpoints,
+                                    &metrics,
+                                    &mut raw_rows,
+                                    &mut event_rows,
+                                    &mut link_rows,
+                                    &mut error_rows,
+                                    &mut checkpoint_updates,
+                                    checkpoint_cursor_columns,
+                                    &checkpoint_host,
+                                    &ack_observer,
+                                    &mut pending_ack,
+                                )
+                                .await;
+                                // The barrier is the ordered drain point for
+                                // every earlier message, even if later live
+                                // deltas are already queued behind it.
+                                note_flush_outcome(&role, flush_ok, true);
+                                if flush_ok {
+                                    pending_batch_bytes = 0;
+                                    let _ = barrier.send(());
+                                } else {
+                                    pending_flush_barrier = Some(barrier);
+                                    throttling_flush_retries = true;
+                                }
+                            } else {
+                                // FIFO delivery means all preceding batches
+                                // have already crossed the durable flush path.
+                                note_flush_outcome(&role, true, true);
+                                let _ = barrier.send(());
                             }
                         }
                         None => break,
@@ -550,7 +653,7 @@ pub(crate) fn spawn_sink_task(
                     &ack_observer,
                     &mut pending_ack,
                         ).await;
-                        note_flush_outcome(&role, &checkpoints, flush_ok, rx.is_empty()).await;
+                        note_flush_outcome(&role, flush_ok, rx.is_empty());
                         if !flush_ok {
                             if !throttling_flush_retries {
                                 warn!(
@@ -592,7 +695,12 @@ pub(crate) fn spawn_sink_task(
                 &mut pending_ack,
             )
             .await;
-            note_flush_outcome(&role, &checkpoints, flush_ok, true).await;
+            note_flush_outcome(&role, flush_ok, true);
+            if flush_ok {
+                if let Some(barrier) = pending_flush_barrier.take() {
+                    let _ = barrier.send(());
+                }
+            }
         }
     })
 }
@@ -1544,6 +1652,45 @@ mod tests {
         }
     }
 
+    fn backend_role(cell: Arc<BackendSinkCell>, replay_notify: Arc<Notify>) -> SinkRole {
+        let mut config = moraine_config::AppConfig::default();
+        config.backends.insert(
+            "team-ch".to_string(),
+            moraine_config::ClickHouseConfig::default(),
+        );
+        config.routes.push(moraine_config::RouteConfig {
+            dir: "/work/team/**".to_string(),
+            backend: "team-ch".to_string(),
+            mode: moraine_config::ROUTE_MODE_MIRROR.to_string(),
+        });
+        SinkRole::Backend {
+            cell,
+            resolver: Arc::new(Mutex::new(crate::tee::RouteResolver::new(Arc::new(config)))),
+            replay_notify,
+            redactor: test_redactor(),
+            redactions: test_redaction_audit(),
+        }
+    }
+
+    fn routed_batch(id: u64, checkpoint: Checkpoint) -> RowBatch {
+        let mut batch = RowBatch::default();
+        batch.raw_rows.push(json!({
+            "id": id,
+            "session_id": "team-session",
+            "cwd": "/work/team/project",
+        }));
+        batch.checkpoint = Some(checkpoint);
+        batch
+    }
+
+    fn backend_batch(batch: RowBatch, epoch: u64, persist_checkpoint: bool) -> SinkMessage {
+        SinkMessage::BackendBatch {
+            batch,
+            epoch,
+            persist_checkpoint,
+        }
+    }
+
     fn fixed_monotonic_timestamp() -> Option<u64> {
         Some(42_000_000)
     }
@@ -1783,6 +1930,713 @@ mod tests {
         );
 
         handle.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_barrier_waits_for_subthreshold_checkpoint_durability() {
+        let (clickhouse, mock_state) = spawn_mock_clickhouse("").await;
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.batch_size = usize::MAX;
+        config.ingest.flush_interval_seconds = 60.0;
+        config.ingest.heartbeat_interval_seconds = 60.0;
+
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let metrics = Arc::new(Metrics::default());
+        let (tx, rx) = mpsc::channel(4);
+        let handle = spawn_sink_task(
+            config,
+            clickhouse,
+            checkpoints.clone(),
+            metrics,
+            rx,
+            true,
+            SinkAuthorConfig::fully_supported(String::new()),
+            default_role(),
+        );
+
+        let checkpoint = sample_checkpoint();
+        let key = checkpoint_key(&checkpoint.source_name, &checkpoint.source_file);
+        let mut batch = RowBatch::default();
+        batch.checkpoint = Some(checkpoint.clone());
+        tx.send(SinkMessage::Batch(batch))
+            .await
+            .expect("queue checkpoint-only replay batch");
+        let (barrier_tx, barrier_rx) = tokio::sync::oneshot::channel();
+        tx.send(SinkMessage::FlushBarrier(barrier_tx))
+            .await
+            .expect("queue replay barrier");
+
+        timeout(Duration::from_secs(2), barrier_rx)
+            .await
+            .expect("barrier acknowledgement timeout")
+            .expect("sink closed before barrier acknowledgement");
+
+        assert_eq!(
+            checkpoints.read().await.get(&key).map(|cp| cp.last_offset),
+            Some(checkpoint.last_offset),
+            "barrier ACK requires the in-memory durable checkpoint map to advance"
+        );
+        assert_eq!(
+            mock_state.rows("ingest_checkpoints").len(),
+            1,
+            "barrier must force a subthreshold checkpoint insert"
+        );
+
+        drop(tx);
+        timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("sink exits after channel close")
+            .expect("sink task does not panic");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_barrier_ack_survives_retry_and_never_precedes_checkpoint() {
+        let state = MockClickHouseState::with_permanent_failure(
+            "ingest_checkpoints",
+            "intentional checkpoint outage",
+        );
+        let (clickhouse, mock_state) = spawn_mock_clickhouse_with_state(state).await;
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.batch_size = usize::MAX;
+        config.ingest.flush_interval_seconds = 0.05;
+        config.ingest.heartbeat_interval_seconds = 60.0;
+
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let metrics = Arc::new(Metrics::default());
+        let (tx, rx) = mpsc::channel(4);
+        let handle = spawn_sink_task(
+            config,
+            clickhouse,
+            checkpoints.clone(),
+            metrics,
+            rx,
+            true,
+            SinkAuthorConfig::fully_supported(String::new()),
+            default_role(),
+        );
+
+        let checkpoint = sample_checkpoint();
+        let key = checkpoint_key(&checkpoint.source_name, &checkpoint.source_file);
+        let mut batch = RowBatch::default();
+        batch.checkpoint = Some(checkpoint);
+        tx.send(SinkMessage::Batch(batch))
+            .await
+            .expect("queue replay");
+        let (barrier_tx, mut barrier_rx) = tokio::sync::oneshot::channel();
+        tx.send(SinkMessage::FlushBarrier(barrier_tx))
+            .await
+            .expect("queue barrier");
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while mock_state.call_count("ingest_checkpoints") == 0 && Instant::now() < deadline {
+            tokio::task::yield_now().await;
+        }
+        assert!(mock_state.call_count("ingest_checkpoints") > 0);
+        assert!(
+            timeout(Duration::from_millis(50), &mut barrier_rx)
+                .await
+                .is_err(),
+            "failed checkpoint insert must not acknowledge the barrier"
+        );
+        mock_state
+            .fail_always_by_table
+            .lock()
+            .expect("mock fail_always mutex poisoned")
+            .remove("ingest_checkpoints");
+        timeout(Duration::from_secs(2), barrier_rx)
+            .await
+            .expect("barrier retry timeout")
+            .expect("barrier sender dropped");
+        assert_eq!(
+            checkpoints.read().await.get(&key).map(|cp| cp.last_offset),
+            Some(100)
+        );
+        assert_eq!(mock_state.rows("ingest_checkpoints").len(), 1);
+
+        drop(tx);
+        timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("sink exits")
+            .expect("sink task does not panic");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_barrier_reports_rejected_batch_and_withholds_its_checkpoint() {
+        let (clickhouse, mock_state) = spawn_mock_clickhouse("").await;
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.batch_size = usize::MAX;
+        config.ingest.flush_interval_seconds = 60.0;
+        config.ingest.heartbeat_interval_seconds = 60.0;
+
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let metrics = Arc::new(Metrics::default());
+        let (tx, rx) = mpsc::channel(4);
+        let handle = spawn_sink_task(
+            config,
+            clickhouse,
+            checkpoints.clone(),
+            metrics,
+            rx,
+            true,
+            SinkAuthorConfig::fully_supported(String::new()),
+            default_role(),
+        );
+
+        let checkpoint = sample_checkpoint();
+        let key = checkpoint_key(&checkpoint.source_name, &checkpoint.source_file);
+        let mut malformed = RowBatch::default();
+        malformed
+            .event_rows
+            .push(json!({"session_id": "missing-event-uid"}));
+        malformed.checkpoint = Some(checkpoint);
+        tx.send(SinkMessage::Batch(malformed))
+            .await
+            .expect("queue malformed replay batch");
+        let (barrier_tx, barrier_rx) = tokio::sync::oneshot::channel();
+        tx.send(SinkMessage::FlushBarrier(barrier_tx))
+            .await
+            .expect("queue barrier");
+
+        timeout(Duration::from_secs(2), barrier_rx)
+            .await
+            .expect("barrier timeout")
+            .expect("barrier sender dropped");
+        assert!(checkpoints.read().await.get(&key).is_none());
+        assert!(mock_state.rows("ingest_checkpoints").is_empty());
+
+        drop(tx);
+        timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("sink exits")
+            .expect("sink task does not panic");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn default_sink_does_not_quarantine_the_rest_of_a_rejected_scan() {
+        let (clickhouse, _) = spawn_mock_clickhouse("").await;
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.batch_size = usize::MAX;
+        config.ingest.flush_interval_seconds = 60.0;
+        config.ingest.heartbeat_interval_seconds = 60.0;
+
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let (tx, rx) = mpsc::channel(4);
+        let handle = spawn_sink_task(
+            config,
+            clickhouse,
+            checkpoints.clone(),
+            Arc::new(Metrics::default()),
+            rx,
+            true,
+            SinkAuthorConfig::fully_supported(String::new()),
+            default_role(),
+        );
+
+        let checkpoint = sample_checkpoint();
+        let key = checkpoint_key(&checkpoint.source_name, &checkpoint.source_file);
+        let mut malformed_non_final = RowBatch::default();
+        malformed_non_final.event_rows.push(json!({
+            "session_id": "default-session",
+            "source_name": checkpoint.source_name,
+            "source_file": checkpoint.source_file,
+            "source_generation": checkpoint.source_generation,
+        }));
+        tx.send(SinkMessage::Batch(malformed_non_final))
+            .await
+            .expect("queue malformed default chunk");
+
+        let mut final_boundary = RowBatch::default();
+        final_boundary.checkpoint = Some(checkpoint.clone());
+        tx.send(SinkMessage::Batch(final_boundary))
+            .await
+            .expect("queue default scan boundary");
+        let (barrier_tx, barrier_rx) = tokio::sync::oneshot::channel();
+        tx.send(SinkMessage::FlushBarrier(barrier_tx))
+            .await
+            .expect("queue default barrier");
+        timeout(Duration::from_secs(2), barrier_rx)
+            .await
+            .expect("default barrier timeout")
+            .expect("default barrier sender dropped");
+
+        assert_eq!(
+            checkpoints.read().await.get(&key).map(|cp| cp.last_offset),
+            Some(checkpoint.last_offset),
+            "mirror recovery bookkeeping must not change default-sink scan behavior"
+        );
+
+        drop(tx);
+        timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("sink exits")
+            .expect("sink task does not panic");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn backend_delta_preserves_scan_boundary_without_persisting_checkpoint() {
+        let (clickhouse, mock_state) = spawn_mock_clickhouse("").await;
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.batch_size = usize::MAX;
+        config.ingest.flush_interval_seconds = 60.0;
+        config.ingest.heartbeat_interval_seconds = 60.0;
+
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let metrics = Arc::new(Metrics::default());
+        let cell = Arc::new(BackendSinkCell::new("team-ch"));
+        cell.set_status_for_test(crate::tee::BackendSinkStatus::CatchingUp);
+        let (tx, rx) = mpsc::channel(8);
+        let handle = spawn_sink_task(
+            config,
+            clickhouse,
+            checkpoints.clone(),
+            metrics,
+            rx,
+            true,
+            SinkAuthorConfig::fully_supported(String::new()),
+            backend_role(cell, Arc::new(Notify::new())),
+        );
+
+        let checkpoint = sample_checkpoint();
+        let key = checkpoint_key(&checkpoint.source_name, &checkpoint.source_file);
+        let mut malformed_non_final = RowBatch::default();
+        malformed_non_final.event_rows.push(json!({
+            "session_id": "team-session",
+            "source_name": checkpoint.source_name,
+            "source_file": checkpoint.source_file,
+            "source_generation": checkpoint.source_generation,
+            "cwd": "/work/team/project",
+        }));
+        tx.send(backend_batch(malformed_non_final, 0, false))
+            .await
+            .expect("queue rejected non-final delta");
+
+        let mut final_boundary = RowBatch::default();
+        final_boundary.checkpoint = Some(checkpoint.clone());
+        tx.send(backend_batch(final_boundary, 0, false))
+            .await
+            .expect("queue final delta boundary");
+        let (barrier_tx, barrier_rx) = tokio::sync::oneshot::channel();
+        tx.send(SinkMessage::FlushBarrier(barrier_tx))
+            .await
+            .expect("queue first barrier");
+        timeout(Duration::from_secs(2), barrier_rx)
+            .await
+            .expect("first barrier timeout")
+            .expect("first barrier sender dropped");
+        assert!(checkpoints.read().await.get(&key).is_none());
+        assert!(mock_state.rows("ingest_checkpoints").is_empty());
+
+        let mut next_scan = RowBatch::default();
+        next_scan.event_rows.push(json!({
+            "event_uid": "next-scan-event",
+            "session_id": "team-session",
+            "source_name": checkpoint.source_name,
+            "source_file": checkpoint.source_file,
+            "source_generation": checkpoint.source_generation,
+            "harness": "test",
+            "event_kind": "message",
+            "actor_kind": "user",
+            "payload_type": "text",
+            "text_content": "recovered",
+            "cwd": "/work/team/project",
+        }));
+        next_scan.checkpoint = Some(checkpoint);
+        tx.send(backend_batch(next_scan, 1, false))
+            .await
+            .expect("queue next scan delta");
+        let (barrier_tx, barrier_rx) = tokio::sync::oneshot::channel();
+        tx.send(SinkMessage::FlushBarrier(barrier_tx))
+            .await
+            .expect("queue second barrier");
+        timeout(Duration::from_secs(2), barrier_rx)
+            .await
+            .expect("second barrier timeout")
+            .expect("second barrier sender dropped");
+        assert!(checkpoints.read().await.get(&key).is_none());
+        assert!(mock_state.rows("ingest_checkpoints").is_empty());
+        assert_eq!(mock_state.rows("events").len(), 1);
+
+        drop(tx);
+        timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("sink exits")
+            .expect("sink task does not panic");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn replay_and_live_identity_maps_are_isolated() {
+        let (clickhouse, mock_state) = spawn_mock_clickhouse("").await;
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.batch_size = usize::MAX;
+        config.ingest.flush_interval_seconds = 60.0;
+        config.ingest.heartbeat_interval_seconds = 60.0;
+
+        let cell = Arc::new(BackendSinkCell::new("team-ch"));
+        cell.set_status_for_test(crate::tee::BackendSinkStatus::CatchingUp);
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let (tx, rx) = mpsc::channel(8);
+        let handle = spawn_sink_task(
+            config,
+            clickhouse,
+            checkpoints,
+            Arc::new(Metrics::default()),
+            rx,
+            true,
+            SinkAuthorConfig::fully_supported(String::new()),
+            backend_role(cell, Arc::new(Notify::new())),
+        );
+
+        let checkpoint = sample_checkpoint();
+        let source_fields = json!({
+            "source_name": checkpoint.source_name,
+            "source_file": checkpoint.source_file,
+            "source_generation": checkpoint.source_generation,
+        });
+        let mut replay_request = RowBatch::default();
+        replay_request.event_rows.push(json!({
+            "event_uid": "request-provisional",
+            "harness": "nac",
+            "session_id": "team-session",
+            "event_kind": "tool_call",
+            "actor_kind": "assistant",
+            "payload_type": "tool_use",
+            "tool_call_id": "call-1",
+            "tool_name": "Read",
+            "tool_phase": "request",
+            "text_content": "request",
+            "payload_json": "{}",
+            "cwd": "/work/team/project",
+            "source_name": source_fields["source_name"],
+            "source_file": source_fields["source_file"],
+            "source_generation": source_fields["source_generation"],
+        }));
+        tx.send(SinkMessage::Batch(replay_request))
+            .await
+            .expect("queue non-final replay request");
+
+        let mut live_boundary = RowBatch::default();
+        live_boundary.checkpoint = Some(checkpoint.clone());
+        tx.send(backend_batch(live_boundary, 0, false))
+            .await
+            .expect("queue interleaved live scan boundary");
+
+        let mut replay_response = RowBatch::default();
+        replay_response.event_rows.push(json!({
+            "event_uid": "response-provisional",
+            "origin_event_id": "request-provisional",
+            "harness": "nac",
+            "session_id": "team-session",
+            "event_kind": "tool_result",
+            "actor_kind": "tool",
+            "payload_type": "tool_result",
+            "tool_call_id": "call-1",
+            "tool_name": "Read",
+            "tool_phase": "response",
+            "text_content": "response",
+            "payload_json": "{\"request_event_uid\":\"request-provisional\"}",
+            "cwd": "/work/team/project",
+            "source_name": source_fields["source_name"],
+            "source_file": source_fields["source_file"],
+            "source_generation": source_fields["source_generation"],
+        }));
+        replay_response.checkpoint = Some(checkpoint);
+        tx.send(SinkMessage::Batch(replay_response))
+            .await
+            .expect("queue final replay response");
+        let (barrier_tx, barrier_rx) = tokio::sync::oneshot::channel();
+        tx.send(SinkMessage::FlushBarrier(barrier_tx))
+            .await
+            .expect("queue identity barrier");
+        timeout(Duration::from_secs(2), barrier_rx)
+            .await
+            .expect("identity barrier timeout")
+            .expect("identity barrier sender dropped");
+
+        let events = mock_state.rows("events");
+        let request_uid = events
+            .iter()
+            .find(|event| event["event_kind"] == "tool_call")
+            .and_then(|event| event["event_uid"].as_str())
+            .expect("persisted request UID");
+        let response = events
+            .iter()
+            .find(|event| event["event_kind"] == "tool_result")
+            .expect("persisted response");
+        assert_eq!(response["origin_event_id"], request_uid);
+        assert_ne!(response["origin_event_id"], "request-provisional");
+
+        drop(tx);
+        timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("sink exits")
+            .expect("sink task does not panic");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn backend_delta_cannot_advance_checkpoint_across_restart_gap() {
+        let (clickhouse, mock_state) = spawn_mock_clickhouse("").await;
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.batch_size = usize::MAX;
+        config.ingest.flush_interval_seconds = 60.0;
+        config.ingest.heartbeat_interval_seconds = 60.0;
+
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let metrics = Arc::new(Metrics::default());
+        let cell = Arc::new(BackendSinkCell::new("team-ch"));
+        cell.set_status_for_test(crate::tee::BackendSinkStatus::CatchingUp);
+        let (tx, rx) = mpsc::channel(8);
+        let handle = spawn_sink_task(
+            config.clone(),
+            clickhouse.clone(),
+            checkpoints.clone(),
+            metrics,
+            rx,
+            true,
+            SinkAuthorConfig::fully_supported(String::new()),
+            backend_role(cell, Arc::new(Notify::new())),
+        );
+
+        let mut replay_checkpoint = sample_checkpoint();
+        replay_checkpoint.last_offset = 50;
+        let key = checkpoint_key(
+            &replay_checkpoint.source_name,
+            &replay_checkpoint.source_file,
+        );
+        tx.send(SinkMessage::Batch(routed_batch(
+            1,
+            replay_checkpoint.clone(),
+        )))
+        .await
+        .expect("queue replay gap");
+        let mut live_checkpoint = replay_checkpoint.clone();
+        live_checkpoint.last_offset = 100;
+        tx.send(backend_batch(
+            routed_batch(2, live_checkpoint.clone()),
+            0,
+            false,
+        ))
+        .await
+        .expect("queue live delta");
+        let (barrier_tx, barrier_rx) = tokio::sync::oneshot::channel();
+        tx.send(SinkMessage::FlushBarrier(barrier_tx))
+            .await
+            .expect("queue first barrier");
+        timeout(Duration::from_secs(2), barrier_rx)
+            .await
+            .expect("first barrier timeout")
+            .expect("first barrier sender dropped");
+        assert_eq!(
+            checkpoints.read().await.get(&key).map(|cp| cp.last_offset),
+            Some(50),
+            "a live delta must not over-assert coverage beyond the replayed gap"
+        );
+
+        drop(tx);
+        timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("first sink exits")
+            .expect("first sink does not panic");
+
+        let reloaded = Arc::new(RwLock::new(checkpoints.read().await.clone()));
+        let restarted_cell = Arc::new(BackendSinkCell::new("team-ch"));
+        restarted_cell.set_status_for_test(crate::tee::BackendSinkStatus::CatchingUp);
+        let (tx, rx) = mpsc::channel(4);
+        let restarted = spawn_sink_task(
+            config,
+            clickhouse,
+            reloaded.clone(),
+            Arc::new(Metrics::default()),
+            rx,
+            true,
+            SinkAuthorConfig::fully_supported(String::new()),
+            backend_role(restarted_cell, Arc::new(Notify::new())),
+        );
+        tx.send(SinkMessage::Batch(routed_batch(2, live_checkpoint)))
+            .await
+            .expect("replay missing delta after restart");
+        let (barrier_tx, barrier_rx) = tokio::sync::oneshot::channel();
+        tx.send(SinkMessage::FlushBarrier(barrier_tx))
+            .await
+            .expect("queue restart barrier");
+        timeout(Duration::from_secs(2), barrier_rx)
+            .await
+            .expect("restart barrier timeout")
+            .expect("restart barrier sender dropped");
+        assert_eq!(
+            reloaded.read().await.get(&key).map(|cp| cp.last_offset),
+            Some(100),
+            "restart replay must close the gap before advancing its checkpoint"
+        );
+        assert_eq!(mock_state.rows("raw_events").len(), 3);
+
+        drop(tx);
+        timeout(Duration::from_secs(2), restarted)
+            .await
+            .expect("restarted sink exits")
+            .expect("restarted sink does not panic");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rejected_backend_batch_revokes_queued_checkpoint_authority() {
+        let (clickhouse, mock_state) = spawn_mock_clickhouse("").await;
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.batch_size = usize::MAX;
+        config.ingest.flush_interval_seconds = 60.0;
+        config.ingest.heartbeat_interval_seconds = 60.0;
+
+        let cell = Arc::new(BackendSinkCell::new("team-ch"));
+        cell.set_status_for_test(crate::tee::BackendSinkStatus::Ok);
+        let replay_notify = Arc::new(Notify::new());
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let (tx, rx) = mpsc::channel(4);
+        let handle = spawn_sink_task(
+            config,
+            clickhouse,
+            checkpoints.clone(),
+            Arc::new(Metrics::default()),
+            rx,
+            true,
+            SinkAuthorConfig::fully_supported(String::new()),
+            backend_role(cell.clone(), replay_notify.clone()),
+        );
+
+        let mut malformed_delta = RowBatch::default();
+        malformed_delta.event_rows.push(json!({
+            "session_id": "team-session",
+            "cwd": "/work/team/project",
+        }));
+        tx.send(backend_batch(malformed_delta, 0, false))
+            .await
+            .expect("queue stale catch-up delta");
+
+        let mut live_checkpoint = sample_checkpoint();
+        live_checkpoint.last_offset = 200;
+        let key = checkpoint_key(&live_checkpoint.source_name, &live_checkpoint.source_file);
+        tx.send(backend_batch(
+            routed_batch(2, live_checkpoint.clone()),
+            0,
+            true,
+        ))
+        .await
+        .expect("queue post-promotion live batch");
+        let (barrier_tx, barrier_rx) = tokio::sync::oneshot::channel();
+        tx.send(SinkMessage::FlushBarrier(barrier_tx))
+            .await
+            .expect("queue invalidation barrier");
+
+        timeout(Duration::from_secs(2), barrier_rx)
+            .await
+            .expect("invalidation barrier timeout")
+            .expect("invalidation barrier sender dropped");
+        assert_eq!(
+            cell.status(),
+            crate::tee::BackendSinkStatus::CatchingUp,
+            "a rejected stale delta must revoke the prior promotion"
+        );
+        assert!(checkpoints.read().await.get(&key).is_none());
+        assert!(mock_state.rows("ingest_checkpoints").is_empty());
+        assert!(
+            timeout(Duration::from_millis(200), replay_notify.notified())
+                .await
+                .is_ok(),
+            "rejection after promotion must wake replay"
+        );
+
+        tx.send(SinkMessage::Batch(routed_batch(2, live_checkpoint)))
+            .await
+            .expect("queue recovery replay");
+        let (barrier_tx, barrier_rx) = tokio::sync::oneshot::channel();
+        tx.send(SinkMessage::FlushBarrier(barrier_tx))
+            .await
+            .expect("queue recovery barrier");
+        timeout(Duration::from_secs(2), barrier_rx)
+            .await
+            .expect("recovery barrier timeout")
+            .expect("recovery barrier sender dropped");
+        assert_eq!(
+            checkpoints.read().await.get(&key).map(|cp| cp.last_offset),
+            Some(200)
+        );
+
+        drop(tx);
+        timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("sink exits")
+            .expect("sink task does not panic");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_barrier_recovers_after_retry_drains_with_barrier_queued() {
+        let state =
+            MockClickHouseState::with_permanent_failure("raw_events", "intentional backend outage");
+        let (clickhouse, mock_state) = spawn_mock_clickhouse_with_state(state).await;
+        let mut config = moraine_config::AppConfig::default();
+        config.ingest.batch_size = 1;
+        config.ingest.flush_interval_seconds = 0.05;
+        config.ingest.heartbeat_interval_seconds = 60.0;
+
+        let cell = Arc::new(BackendSinkCell::new("team-ch"));
+        cell.set_status_for_test(crate::tee::BackendSinkStatus::Ok);
+        let replay_notify = Arc::new(Notify::new());
+        let checkpoints = Arc::new(RwLock::new(HashMap::new()));
+        let (tx, rx) = mpsc::channel(4);
+        let handle = spawn_sink_task(
+            config,
+            clickhouse,
+            checkpoints,
+            Arc::new(Metrics::default()),
+            rx,
+            true,
+            SinkAuthorConfig::fully_supported(String::new()),
+            backend_role(cell.clone(), replay_notify.clone()),
+        );
+
+        tx.send(SinkMessage::Batch(routed_batch(1, sample_checkpoint())))
+            .await
+            .expect("queue failing batch");
+        let (barrier_tx, barrier_rx) = tokio::sync::oneshot::channel();
+        tx.send(SinkMessage::FlushBarrier(barrier_tx))
+            .await
+            .expect("queue barrier behind failed flush");
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while cell.status() != crate::tee::BackendSinkStatus::Unreachable
+            && Instant::now() < deadline
+        {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            cell.status(),
+            crate::tee::BackendSinkStatus::Unreachable,
+            "the first flush must place the backend in unreachable"
+        );
+        mock_state
+            .fail_always_by_table
+            .lock()
+            .expect("mock fail_always mutex poisoned")
+            .remove("raw_events");
+
+        timeout(Duration::from_secs(3), barrier_rx)
+            .await
+            .expect("barrier recovery timeout")
+            .expect("barrier sender dropped");
+        assert_eq!(
+            cell.status(),
+            crate::tee::BackendSinkStatus::CatchingUp,
+            "an empty ordered barrier must complete recovery after retry drained"
+        );
+        assert!(
+            timeout(Duration::from_millis(200), replay_notify.notified())
+                .await
+                .is_ok(),
+            "barrier recovery must wake the catch-up supervisor"
+        );
+
+        drop(tx);
+        timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("sink exits")
+            .expect("sink task does not panic");
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2387,7 +3241,6 @@ mod tests {
                 cell: Arc::new(BackendSinkCell::new("team-ch")),
                 resolver,
                 replay_notify: Arc::new(Notify::new()),
-                replay_floor: Arc::new(Mutex::new(None)),
                 redactor: test_redactor(),
                 redactions: redactions.clone(),
             },
@@ -2509,48 +3362,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn recovery_captures_the_replay_floor_before_post_recovery_flushes() {
+    async fn durable_drain_enters_catch_up_and_notifies_supervisor() {
         let cell = Arc::new(BackendSinkCell::new("team-ch"));
-        cell.set_status(crate::tee::BackendSinkStatus::Lagging);
+        cell.set_status_for_test(crate::tee::BackendSinkStatus::Lagging);
         let replay_notify = Arc::new(Notify::new());
-        let replay_floor: ReplayFloor = Arc::new(Mutex::new(None));
         let role = SinkRole::Backend {
-            cell,
+            cell: cell.clone(),
             resolver: Arc::new(Mutex::new(crate::tee::RouteResolver::new(Arc::new(
                 moraine_config::AppConfig::default(),
             )))),
             replay_notify: replay_notify.clone(),
-            replay_floor: replay_floor.clone(),
             redactor: test_redactor(),
             redactions: test_redaction_audit(),
         };
 
-        let checkpoint = sample_checkpoint(); // offset 100
-        let key = checkpoint_key(&checkpoint.source_name, &checkpoint.source_file);
-        let checkpoints = Arc::new(RwLock::new(HashMap::from([(
-            key.clone(),
-            checkpoint.clone(),
-        )])));
+        note_flush_outcome(&role, true, true);
 
-        note_flush_outcome(&role, &checkpoints, true, true).await;
-
-        // A live batch flushed after recovery jumps the map past the outage
-        // gap; the floor captured at the transition must not move with it.
-        {
-            let mut state = checkpoints.write().await;
-            let entry = state.get_mut(&key).expect("checkpoint present");
-            entry.last_offset = 900;
-        }
-
-        let floor = replay_floor
-            .lock()
-            .expect("replay floor mutex poisoned")
-            .take()
-            .expect("recovery must capture a replay floor");
         assert_eq!(
-            floor.get(&key).map(|cp| cp.last_offset),
-            Some(100),
-            "the floor reflects what the backend had flushed at recovery"
+            cell.status(),
+            crate::tee::BackendSinkStatus::CatchingUp,
+            "durable drain must pause live admission until replay's barrier"
         );
         assert!(
             timeout(Duration::from_millis(100), replay_notify.notified())

--- a/crates/moraine-ingest-core/src/sqlite_poll/nac.rs
+++ b/crates/moraine-ingest-core/src/sqlite_poll/nac.rs
@@ -1978,7 +1978,9 @@ mod tests {
         )
         .await
         .expect("scan with local project excluded");
-        let SinkMessage::Batch(first_batch) = sink_rx.recv().await.expect("first NAC batch");
+        let SinkMessage::Batch(first_batch) = sink_rx.recv().await.expect("first NAC batch") else {
+            panic!("NAC processor emitted a sink control message")
+        };
         assert_eq!(first_batch.raw_rows.len(), 6);
         let checkpoint = first_batch.checkpoint.expect("first checkpoint");
         checkpoints
@@ -1997,7 +1999,10 @@ mod tests {
         )
         .await
         .expect("replay after exclusion changes");
-        let SinkMessage::Batch(replayed_batch) = sink_rx.recv().await.expect("replayed NAC batch");
+        let SinkMessage::Batch(replayed_batch) = sink_rx.recv().await.expect("replayed NAC batch")
+        else {
+            panic!("NAC processor emitted a sink control message")
+        };
         assert_eq!(
             replayed_batch.raw_rows.len(),
             19,
@@ -2061,7 +2066,10 @@ mod tests {
         )
         .await
         .expect("initial valid scan");
-        let SinkMessage::Batch(initial_batch) = sink_rx.recv().await.expect("initial NAC batch");
+        let SinkMessage::Batch(initial_batch) = sink_rx.recv().await.expect("initial NAC batch")
+        else {
+            panic!("NAC processor emitted a sink control message")
+        };
         let checkpoint = initial_batch.checkpoint.expect("initial checkpoint");
         let committed_inode = checkpoint.source_inode;
         let committed_generation = checkpoint.source_generation;
@@ -2077,7 +2085,10 @@ mod tests {
         process_nac_sqlite_db(&config, &work, checkpoints, &poll_state, sink_tx, &metrics)
             .await
             .expect("failed replacement is reported as a batch");
-        let SinkMessage::Batch(failed_batch) = sink_rx.recv().await.expect("failed NAC batch");
+        let SinkMessage::Batch(failed_batch) = sink_rx.recv().await.expect("failed NAC batch")
+        else {
+            panic!("NAC processor emitted a sink control message")
+        };
         assert_eq!(failed_batch.error_rows.len(), 1);
         assert_eq!(
             failed_batch.error_rows[0]["source_generation"],
@@ -2141,7 +2152,10 @@ mod tests {
         )
         .await
         .expect("oversized scan reports an ingest error");
-        let SinkMessage::Batch(batch) = sink_rx.recv().await.expect("oversized failure batch");
+        let SinkMessage::Batch(batch) = sink_rx.recv().await.expect("oversized failure batch")
+        else {
+            panic!("NAC processor emitted a sink control message")
+        };
         assert!(batch.raw_rows.is_empty());
         assert!(batch.event_rows.is_empty());
         assert!(batch.tool_rows.is_empty());

--- a/crates/moraine-ingest-core/src/tee.rs
+++ b/crates/moraine-ingest-core/src/tee.rs
@@ -756,8 +756,18 @@ fn forward_to_backend(handle: &BackendHandle, batch: &RowBatch) {
 /// non-default backend — skew disables the sink loudly instead), checkpoint
 /// load from the backend's own database, sink task spawn, then catch-up
 /// replay passes re-armed on every recovery.
-fn spawn_backend_supervisor(
+fn build_named_backend_clickhouse_client(
     mut backend_cfg: ClickHouseConfig,
+) -> anyhow::Result<ClickHouseClient> {
+    // A replay barrier may only acknowledge after every earlier row is
+    // inserted. Preserve async batching, but never allow a named mirror
+    // backend to acknowledge an async insert before ClickHouse flushes it.
+    backend_cfg.wait_for_async_insert = true;
+    ClickHouseClient::new(backend_cfg)
+}
+
+fn spawn_backend_supervisor(
+    backend_cfg: ClickHouseConfig,
     cell: Arc<BackendSinkCell>,
     replay_tx: mpsc::Sender<SinkMessage>,
     backend_rx: mpsc::Receiver<SinkMessage>,
@@ -766,11 +776,7 @@ fn spawn_backend_supervisor(
     tokio::spawn(async move {
         let name = cell.name().to_string();
         let allow_newer_server = backend_cfg.allow_newer_server;
-        // A replay barrier may only acknowledge after every earlier row is
-        // inserted. Preserve async batching, but never allow a named mirror
-        // backend to acknowledge an async insert before ClickHouse flushes it.
-        backend_cfg.wait_for_async_insert = true;
-        let client = match ClickHouseClient::new(backend_cfg) {
+        let client = match build_named_backend_clickhouse_client(backend_cfg) {
             Ok(client) => client,
             Err(exc) => {
                 cell.mark_unreachable();
@@ -1720,6 +1726,104 @@ mod tests {
         );
         assert_ne!(cell.status(), BackendSinkStatus::Ok);
         handle.abort();
+    }
+
+    #[derive(Clone, Default)]
+    struct DurabilityRequestState {
+        params: Arc<Mutex<Vec<HashMap<String, String>>>>,
+    }
+
+    async fn durability_request_handler(
+        State(state): State<DurabilityRequestState>,
+        Query(params): Query<HashMap<String, String>>,
+    ) -> (StatusCode, String) {
+        state
+            .params
+            .lock()
+            .expect("durability request mutex poisoned")
+            .push(params);
+        (StatusCode::OK, String::new())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn named_backend_forces_wait_for_async_insert_without_changing_default_policy() {
+        let state = DurabilityRequestState::default();
+        let app = Router::new()
+            .route("/", post(durability_request_handler))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind durability request listener");
+        let addr = listener.local_addr().expect("durability request addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let mut config = backend_cfg_for(format!("http://{addr}"));
+        config.async_insert = true;
+        config.wait_for_async_insert = false;
+        let named_client = build_named_backend_clickhouse_client(config.clone())
+            .expect("construct named backend client");
+        let default_client =
+            crate::build_ingest_clickhouse_client(config).expect("construct default ingest client");
+
+        named_client
+            .request_text(
+                "INSERT INTO named_probe FORMAT JSONEachRow",
+                Some(b"{}\n".to_vec()),
+                None,
+                true,
+                Some("JSONEachRow"),
+            )
+            .await
+            .expect("named backend request");
+        default_client
+            .request_text(
+                "INSERT INTO default_probe FORMAT JSONEachRow",
+                Some(b"{}\n".to_vec()),
+                None,
+                true,
+                Some("JSONEachRow"),
+            )
+            .await
+            .expect("default backend request");
+
+        let requests = state
+            .params
+            .lock()
+            .expect("durability request mutex poisoned");
+        let params_for = |needle: &str| {
+            requests
+                .iter()
+                .find(|params| {
+                    params
+                        .get("query")
+                        .is_some_and(|query| query.contains(needle))
+                })
+                .unwrap_or_else(|| panic!("missing request for {needle}"))
+        };
+        let named_params = params_for("named_probe");
+        let default_params = params_for("default_probe");
+
+        assert_eq!(
+            named_params.get("async_insert").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            named_params
+                .get("wait_for_async_insert")
+                .map(String::as_str),
+            Some("1"),
+            "named backend must override wait_for_async_insert=false for barrier durability"
+        );
+        assert_eq!(
+            default_params.get("async_insert").map(String::as_str),
+            Some("1")
+        );
+        assert!(
+            !default_params.contains_key("wait_for_async_insert"),
+            "the default backend must retain wait_for_async_insert=false"
+        );
     }
 
     #[derive(Clone, Default)]

--- a/crates/moraine-ingest-core/src/tee.rs
+++ b/crates/moraine-ingest-core/src/tee.rs
@@ -23,7 +23,6 @@ use moraine_clickhouse::{enforce_remote_schema_policy, ClickHouseClient};
 use moraine_config::{AppConfig, ClickHouseConfig, IngestSource, DEFAULT_BACKEND_NAME};
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::{mpsc, Notify, RwLock};
@@ -38,6 +37,10 @@ const HANDSHAKE_RETRY: Duration = Duration::from_secs(30);
 pub(crate) enum BackendSinkStatus {
     /// Constructed but the schema handshake has not completed yet.
     Connecting,
+    /// The sink is available, but replay has not yet established a durable
+    /// contiguous checkpoint. Live rows remain admissible without checkpoint
+    /// authority.
+    CatchingUp,
     Ok,
     /// Mirror queue overflowed; live forwarding is paused until the sink
     /// drains, then catch-up replay recovers the dropped span.
@@ -54,6 +57,7 @@ impl BackendSinkStatus {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Connecting => "connecting",
+            Self::CatchingUp => "catching_up",
             Self::Ok => "ok",
             Self::Lagging => "lagging",
             Self::Unreachable => "unreachable",
@@ -66,23 +70,28 @@ impl BackendSinkStatus {
 /// Shared per-backend state: status transitions are driven by the router
 /// (overflow), the backend's sink task (flush outcomes), and its supervisor
 /// (handshake); the default sink's heartbeat reads it.
+struct BackendSinkState {
+    status: BackendSinkStatus,
+    /// Advances for every routed batch that replay must recover. Comparing
+    /// this epoch under the same lock as admission closes the promotion race.
+    drop_epoch: u64,
+    dropped_batches: u64,
+}
+
 pub(crate) struct BackendSinkCell {
     name: String,
-    status: Mutex<BackendSinkStatus>,
-    /// Sink task running post-handshake; the router only forwards to live sinks.
-    live: AtomicBool,
-    /// Routed batches that were not mirrored (overflow or non-ok status).
-    /// Catch-up replay recovers the data; the count is diagnostic.
-    dropped_batches: AtomicU64,
+    state: Mutex<BackendSinkState>,
 }
 
 impl BackendSinkCell {
     pub(crate) fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
-            status: Mutex::new(BackendSinkStatus::Connecting),
-            live: AtomicBool::new(false),
-            dropped_batches: AtomicU64::new(0),
+            state: Mutex::new(BackendSinkState {
+                status: BackendSinkStatus::Connecting,
+                drop_epoch: 0,
+                dropped_batches: 0,
+            }),
         }
     }
 
@@ -91,78 +100,176 @@ impl BackendSinkCell {
     }
 
     pub(crate) fn status(&self) -> BackendSinkStatus {
-        *self.status.lock().expect("backend status mutex poisoned")
+        self.state
+            .lock()
+            .expect("backend status mutex poisoned")
+            .status
     }
 
-    pub(crate) fn set_status(&self, status: BackendSinkStatus) {
-        *self.status.lock().expect("backend status mutex poisoned") = status;
+    fn mark_unreachable(&self) {
+        let mut state = self.state.lock().expect("backend status mutex poisoned");
+        if !matches!(
+            state.status,
+            BackendSinkStatus::DisabledSkew | BackendSinkStatus::DisabledMissingIdentityAuthor
+        ) {
+            state.status = BackendSinkStatus::Unreachable;
+        }
     }
 
-    fn is_live(&self) -> bool {
-        self.live.load(Ordering::Relaxed)
+    fn disable_skew(&self) {
+        self.state
+            .lock()
+            .expect("backend status mutex poisoned")
+            .status = BackendSinkStatus::DisabledSkew;
     }
 
-    fn mark_live(&self) {
-        self.live.store(true, Ordering::Relaxed);
+    fn disable_missing_identity_author(&self) {
+        self.state
+            .lock()
+            .expect("backend status mutex poisoned")
+            .status = BackendSinkStatus::DisabledMissingIdentityAuthor;
     }
 
-    fn record_drop(&self) {
-        self.dropped_batches.fetch_add(1, Ordering::Relaxed);
+    #[cfg(test)]
+    pub(crate) fn set_status_for_test(&self, status: BackendSinkStatus) {
+        self.state
+            .lock()
+            .expect("backend status mutex poisoned")
+            .status = status;
     }
 
     pub(crate) fn dropped_batches(&self) -> u64 {
-        self.dropped_batches.load(Ordering::Relaxed)
+        self.state
+            .lock()
+            .expect("backend status mutex poisoned")
+            .dropped_batches
     }
 
-    /// Router-side: queue overflowed. Returns true on the Ok -> Lagging
-    /// transition so the caller can warn once instead of once per batch.
-    fn mark_overflow(&self) -> bool {
-        let mut status = self.status.lock().expect("backend status mutex poisoned");
-        if *status == BackendSinkStatus::Ok {
-            *status = BackendSinkStatus::Lagging;
-            return true;
-        }
-        false
+    /// Router-side admission, queueing, overflow demotion, and drop accounting
+    /// are one critical section. Catch-up promotion takes the same lock, so a
+    /// racing batch is either admitted after `Ok` or advances the replay epoch.
+    fn try_forward(
+        &self,
+        tx: &mpsc::Sender<SinkMessage>,
+        batch: &RowBatch,
+    ) -> BackendForwardOutcome {
+        let mut state = self.state.lock().expect("backend status mutex poisoned");
+        let persist_checkpoint = match state.status {
+            BackendSinkStatus::Ok => true,
+            BackendSinkStatus::CatchingUp => false,
+            _ => {
+                state.drop_epoch = state.drop_epoch.saturating_add(1);
+                state.dropped_batches = state.dropped_batches.saturating_add(1);
+                return BackendForwardOutcome::DroppedWhilePaused;
+            }
+        };
+        let permit = match tx.try_reserve() {
+            Ok(permit) => permit,
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                state.drop_epoch = state.drop_epoch.saturating_add(1);
+                state.dropped_batches = state.dropped_batches.saturating_add(1);
+                if state.status == BackendSinkStatus::Ok {
+                    state.status = BackendSinkStatus::Lagging;
+                }
+                return BackendForwardOutcome::Overflowed;
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                state.drop_epoch = state.drop_epoch.saturating_add(1);
+                state.dropped_batches = state.dropped_batches.saturating_add(1);
+                state.status = BackendSinkStatus::Unreachable;
+                return BackendForwardOutcome::Closed;
+            }
+        };
+        let epoch = state.drop_epoch;
+        drop(state);
+        permit.send(SinkMessage::BackendBatch {
+            batch: batch.clone(),
+            epoch,
+            persist_checkpoint,
+        });
+        BackendForwardOutcome::Queued
     }
 
     /// Sink-side: a flush failed. Returns true on the transition to
     /// Unreachable so the caller can warn once per outage.
     pub(crate) fn mark_flush_failure(&self) -> bool {
-        let mut status = self.status.lock().expect("backend status mutex poisoned");
-        match *status {
-            BackendSinkStatus::Ok | BackendSinkStatus::Lagging => {
-                *status = BackendSinkStatus::Unreachable;
+        let mut state = self.state.lock().expect("backend status mutex poisoned");
+        match state.status {
+            BackendSinkStatus::Ok | BackendSinkStatus::Lagging | BackendSinkStatus::CatchingUp => {
+                state.status = BackendSinkStatus::Unreachable;
                 true
             }
             _ => false,
         }
     }
 
-    /// Sink-side: a flush succeeded with an empty queue. Returns true on the
-    /// transition back to Ok so the caller can schedule catch-up replay.
+    /// Sink-side: a flush succeeded with an empty queue. Recovery enters
+    /// catch-up; only the supervisor's durability barrier may promote to Ok.
     pub(crate) fn mark_recovered(&self) -> bool {
-        let mut status = self.status.lock().expect("backend status mutex poisoned");
-        match *status {
+        let mut state = self.state.lock().expect("backend status mutex poisoned");
+        match state.status {
             BackendSinkStatus::Lagging | BackendSinkStatus::Unreachable => {
-                *status = BackendSinkStatus::Ok;
+                state.status = BackendSinkStatus::CatchingUp;
                 true
             }
             _ => false,
         }
     }
+
+    /// Sink-side: an admitted live batch was rejected before insert. Invalidate
+    /// every queued live checkpoint from the same admission epoch. Returning
+    /// true means an `Ok` backend re-entered catch-up and needs a wake-up.
+    pub(crate) fn invalidate_checkpoint_authority(&self, epoch: Option<u64>) -> bool {
+        let mut state = self.state.lock().expect("backend status mutex poisoned");
+        if epoch.is_some_and(|epoch| state.drop_epoch != epoch) {
+            return false;
+        }
+        state.drop_epoch = state.drop_epoch.saturating_add(1);
+        state.dropped_batches = state.dropped_batches.saturating_add(1);
+        if state.status == BackendSinkStatus::Ok {
+            state.status = BackendSinkStatus::CatchingUp;
+            return true;
+        }
+        false
+    }
+
+    pub(crate) fn can_persist_backend_checkpoint(&self, epoch: u64) -> bool {
+        let state = self.state.lock().expect("backend status mutex poisoned");
+        state.status == BackendSinkStatus::Ok && state.drop_epoch == epoch
+    }
+
+    fn begin_catch_up(&self) -> u64 {
+        let mut state = self.state.lock().expect("backend status mutex poisoned");
+        state.status = BackendSinkStatus::CatchingUp;
+        state.drop_epoch
+    }
+
+    fn catch_up_epoch(&self) -> Option<u64> {
+        let state = self.state.lock().expect("backend status mutex poisoned");
+        (state.status == BackendSinkStatus::CatchingUp).then_some(state.drop_epoch)
+    }
+
+    fn try_mark_caught_up(&self, expected_epoch: u64) -> bool {
+        let mut state = self.state.lock().expect("backend status mutex poisoned");
+        if state.status == BackendSinkStatus::CatchingUp && state.drop_epoch == expected_epoch {
+            state.status = BackendSinkStatus::Ok;
+            return true;
+        }
+        false
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackendForwardOutcome {
+    Queued,
+    DroppedWhilePaused,
+    Overflowed,
+    Closed,
 }
 
 /// Backend status cells keyed by backend name, shared with the default
 /// sink's heartbeat. `BTreeMap` keeps the heartbeat JSON deterministic.
 pub(crate) type StatusRegistry = Arc<Mutex<BTreeMap<String, Arc<BackendSinkCell>>>>;
-
-/// Checkpoint floor for the next catch-up replay pass, written by the
-/// backend's sink task at the recovery transition and taken by its
-/// supervisor when the pass is scheduled. Replay must never resume from the
-/// live-updating checkpoint map: live batches carry the default pipeline's
-/// offsets, and adopting one for a file the pass has not covered yet would
-/// silently skip the very span the pass exists to recover.
-pub(crate) type ReplayFloor = Arc<Mutex<Option<HashMap<String, Checkpoint>>>>;
 
 /// JSON-encoded `{backend: status}` map for the heartbeat's `backend_sinks`
 /// column; `None` when no backend sinks exist (so default-only installs
@@ -434,7 +541,14 @@ pub(crate) fn spawn_tee_router(
             ensure_backend(&name, &context, &mut handles);
         }
 
-        while let Some(SinkMessage::Batch(mut batch)) = rx.recv().await {
+        while let Some(message) = rx.recv().await {
+            let mut batch = match message {
+                SinkMessage::Batch(batch) => batch,
+                SinkMessage::BackendBatch { .. } | SinkMessage::FlushBarrier(_) => {
+                    error!("processor channel received a backend-only sink message");
+                    continue;
+                }
+            };
             redact_default_batch_if_enabled(&context.config, &context.redaction, &mut batch);
 
             let targets = {
@@ -583,7 +697,7 @@ fn ensure_backend<'a>(
             .insert(name.to_string(), cell.clone());
 
         if context.config.identity.author.is_empty() {
-            cell.set_status(BackendSinkStatus::DisabledMissingIdentityAuthor);
+            cell.disable_missing_identity_author();
             warn!(
                 backend = name,
                 "mirror sink disabled: [identity].author is required for non-default backends"
@@ -620,33 +734,20 @@ fn forward_to_backend(handle: &BackendHandle, batch: &RowBatch) {
         return;
     };
 
-    if !cell.is_live() || cell.status() != BackendSinkStatus::Ok {
-        // Not accepting (connecting / lagging / unreachable / disabled):
-        // drop the mirror copy. Replay recovers it from the source file.
-        cell.record_drop();
-        return;
-    }
-
-    match tx.try_send(SinkMessage::Batch(batch.clone())) {
-        Ok(()) => {}
-        Err(mpsc::error::TrySendError::Full(_)) => {
-            cell.record_drop();
-            if cell.mark_overflow() {
-                warn!(
-                    backend = cell.name(),
-                    "mirror queue full; backend marked lagging and live mirroring paused \
-                     (catch-up replay will recover the gap once it drains)"
-                );
-            }
+    match cell.try_forward(tx, batch) {
+        BackendForwardOutcome::Queued | BackendForwardOutcome::DroppedWhilePaused => {}
+        BackendForwardOutcome::Overflowed => {
+            warn!(
+                backend = cell.name(),
+                "mirror queue full; replay epoch invalidated and live mirroring paused \
+                 until catch-up closes the dropped gap"
+            );
         }
-        Err(mpsc::error::TrySendError::Closed(_)) => {
-            cell.record_drop();
-            if cell.mark_flush_failure() {
-                warn!(
-                    backend = cell.name(),
-                    "mirror sink channel closed unexpectedly; backend marked unreachable"
-                );
-            }
+        BackendForwardOutcome::Closed => {
+            warn!(
+                backend = cell.name(),
+                "mirror sink channel closed unexpectedly; backend marked unreachable"
+            );
         }
     }
 }
@@ -656,7 +757,7 @@ fn forward_to_backend(handle: &BackendHandle, batch: &RowBatch) {
 /// load from the backend's own database, sink task spawn, then catch-up
 /// replay passes re-armed on every recovery.
 fn spawn_backend_supervisor(
-    backend_cfg: ClickHouseConfig,
+    mut backend_cfg: ClickHouseConfig,
     cell: Arc<BackendSinkCell>,
     replay_tx: mpsc::Sender<SinkMessage>,
     backend_rx: mpsc::Receiver<SinkMessage>,
@@ -665,10 +766,14 @@ fn spawn_backend_supervisor(
     tokio::spawn(async move {
         let name = cell.name().to_string();
         let allow_newer_server = backend_cfg.allow_newer_server;
+        // A replay barrier may only acknowledge after every earlier row is
+        // inserted. Preserve async batching, but never allow a named mirror
+        // backend to acknowledge an async insert before ClickHouse flushes it.
+        backend_cfg.wait_for_async_insert = true;
         let client = match ClickHouseClient::new(backend_cfg) {
             Ok(client) => client,
             Err(exc) => {
-                cell.set_status(BackendSinkStatus::Unreachable);
+                cell.mark_unreachable();
                 error!(backend = %name, "failed to construct clickhouse client: {exc}");
                 return;
             }
@@ -681,14 +786,14 @@ fn spawn_backend_supervisor(
                         Ok(()) => break,
                         Err(exc) => {
                             // Terminal until restart; the default sink is unaffected.
-                            cell.set_status(BackendSinkStatus::DisabledSkew);
+                            cell.disable_skew();
                             error!(backend = %name, "backend sink disabled (schema skew): {exc}");
                             return;
                         }
                     }
                 }
                 Err(exc) => {
-                    cell.set_status(BackendSinkStatus::Unreachable);
+                    cell.mark_unreachable();
                     warn!(
                         backend = %name,
                         "schema handshake failed; retrying in {}s: {exc}",
@@ -710,7 +815,7 @@ fn spawn_backend_supervisor(
             match crate::load_checkpoints(&client, true, Some(&host)).await {
                 Ok(map) => break map,
                 Err(exc) => {
-                    cell.set_status(BackendSinkStatus::Unreachable);
+                    cell.mark_unreachable();
                     warn!(
                         backend = %name,
                         "failed to load backend checkpoints; retrying in {}s: {exc}",
@@ -720,16 +825,10 @@ fn spawn_backend_supervisor(
                 }
             }
         };
-        // The durable checkpoints, snapshotted before the sink can advance
-        // them, are the first replay pass's floor: the pass must resume
-        // from state the backend has actually flushed, never from the live
-        // map (see `ReplayFloor`).
-        let mut floor = Arc::new(RwLock::new(durable.clone()));
         let checkpoints = Arc::new(RwLock::new(durable));
 
         let metrics = Arc::new(Metrics::default());
         let replay_notify = Arc::new(Notify::new());
-        let replay_floor: ReplayFloor = Arc::new(Mutex::new(None));
         spawn_sink_task(
             context.config.as_ref().clone(),
             client,
@@ -742,72 +841,87 @@ fn spawn_backend_supervisor(
                 cell: cell.clone(),
                 resolver: context.resolver.clone(),
                 replay_notify: replay_notify.clone(),
-                replay_floor: replay_floor.clone(),
                 redactor: context.redaction.redactor.clone(),
                 redactions: context.redaction.audit.clone(),
             },
         );
 
-        // Go live before replaying: every batch the router forwards from
-        // here on covers file state newer than the snapshot floor above, so
-        // the pass and live mirroring overlap rather than gap — the pass
-        // closes everything between the floor and "now" (duplicate spans
-        // collapse via event-UID ReplacingMergeTree, like the rest of the
-        // pipeline).
-        cell.set_status(BackendSinkStatus::Ok);
-        cell.mark_live();
-        info!(backend = %name, "backend sink live; starting catch-up replay");
+        // Live rows may drain as checkpoint-suppressed deltas while replay and
+        // an ordered sink barrier establish a durable contiguous checkpoint.
+        // This prevents a newer live checkpoint from surviving a crash ahead
+        // of a dropped span without requiring a replay-length quiet window.
+        cell.begin_catch_up();
+        info!(backend = %name, "backend sink ready; starting catch-up replay");
 
         let mut reported_lost = HashSet::<String>::new();
         loop {
-            run_replay_pass(
+            let Some(epoch) = cell.catch_up_epoch() else {
+                replay_notify.notified().await;
+                continue;
+            };
+
+            let replay_complete = run_replay_pass(
                 &context.config,
                 context.sources.as_slice(),
-                &floor,
+                &checkpoints,
                 &replay_tx,
                 &metrics,
                 &name,
                 &mut reported_lost,
             )
             .await;
-            // Re-arm on the next lagging/unreachable -> ok recovery. The
-            // notify holds a permit, so a recovery that fires mid-pass
-            // immediately schedules another pass for the span it missed.
-            replay_notify.notified().await;
-            // Adopt the floor the sink captured at the recovery transition
-            // (by now the live map may already carry post-recovery
-            // checkpoints that jump the dropped span). A missing capture
-            // keeps the previous, lower floor — which only ever means
-            // re-reading more, never skipping.
-            if let Some(captured) = replay_floor
-                .lock()
-                .expect("replay floor mutex poisoned")
-                .take()
-            {
-                floor = Arc::new(RwLock::new(captured));
+
+            if !replay_complete {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
             }
-            info!(backend = %name, "backend recovered; replaying to catch up");
+
+            let (barrier_tx, barrier_rx) = tokio::sync::oneshot::channel();
+            if replay_tx
+                .send(SinkMessage::FlushBarrier(barrier_tx))
+                .await
+                .is_err()
+            {
+                cell.mark_flush_failure();
+                error!(backend = %name, "mirror sink closed before replay durability barrier");
+                return;
+            }
+            if barrier_rx.await.is_err() {
+                cell.mark_flush_failure();
+                error!(backend = %name, "mirror sink closed before replay durability barrier");
+                return;
+            }
+
+            if cell.try_mark_caught_up(epoch) {
+                info!(
+                    backend = %name,
+                    "backend replay reached a durable fixed point; live mirroring enabled"
+                );
+                continue;
+            }
+
+            // A routed batch was dropped while this pass was running, or the
+            // sink experienced another outage. Re-read from the now-durable
+            // checkpoint map; replay-stable event IDs make the overlap safe.
+            tokio::task::yield_now().await;
         }
     })
 }
 
-/// One targeted catch-up pass: re-enqueue every tracked file against a
-/// floor snapshot of the backend's own checkpoints (never the live map the
-/// sink advances — see `ReplayFloor`). `process_file` early-exits for
-/// caught-up files (a stat + offset compare), so a pass over a converged
-/// tree is cheap; files the backend has never seen are read in full,
-/// filtered at the sink, and checkpointed so the next pass's floor skips
-/// them.
+/// One targeted catch-up pass. Live deltas may share the sink while this runs,
+/// but only replay messages persist checkpoints. An ordered sink barrier makes
+/// every replay checkpoint update durable before promotion.
 #[allow(clippy::too_many_arguments)]
 async fn run_replay_pass(
     config: &AppConfig,
     sources: &[IngestSource],
-    floor: &Arc<RwLock<HashMap<String, Checkpoint>>>,
+    checkpoints: &Arc<RwLock<HashMap<String, Checkpoint>>>,
     tx: &mpsc::Sender<SinkMessage>,
     metrics: &Arc<Metrics>,
     backend: &str,
     reported_lost: &mut HashSet<String>,
-) {
+) -> bool {
+    let mut complete = true;
     for source in sources {
         let files = match enumerate_tracked_files(&source.glob, source.format) {
             Ok(files) => files,
@@ -817,6 +931,7 @@ async fn run_replay_pass(
                     source = %source.name,
                     "replay enumerate failed: {exc}"
                 );
+                complete = false;
                 continue;
             }
         };
@@ -828,7 +943,7 @@ async fn run_replay_pass(
         // trip this warning.
         {
             let enumerated: HashSet<&str> = files.iter().map(String::as_str).collect();
-            let map = floor.read().await;
+            let map = checkpoints.read().await;
             for cp in map.values() {
                 if cp.source_name == source.name
                     && !enumerated.contains(cp.source_file.as_str())
@@ -845,8 +960,8 @@ async fn run_replay_pass(
             }
         }
 
-        // Replay reads against this backend's own floor, not the live
-        // pipeline's, so it gets a fresh volatile map: every file scans.
+        // Each pass gets a fresh volatile poll map. Durable offsets/cursors
+        // still come from the backend checkpoint map.
         let poll_state = crate::sqlite_poll::VolatilePollMap::new();
         for path in files {
             let work = WorkItem {
@@ -861,13 +976,14 @@ async fn run_replay_pass(
             if let Err(exc) = process_file(
                 config,
                 &work,
-                floor.clone(),
+                checkpoints.clone(),
                 &poll_state,
                 tx.clone(),
                 metrics,
             )
             .await
             {
+                complete = false;
                 warn!(
                     backend,
                     source = %work.source_name,
@@ -877,6 +993,7 @@ async fn run_replay_pass(
             }
         }
     }
+    complete
 }
 
 #[cfg(test)]
@@ -894,7 +1011,7 @@ mod tests {
     use serde_json::json;
     use std::fs;
     use std::path::PathBuf;
-    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
     use tokio::time::timeout;
 
@@ -1166,29 +1283,28 @@ mod tests {
         let cell = BackendSinkCell::new("team-ch");
         assert_eq!(cell.status(), BackendSinkStatus::Connecting);
 
-        cell.set_status(BackendSinkStatus::Ok);
-        assert!(
-            cell.mark_overflow(),
-            "first overflow transitions to lagging"
-        );
-        assert!(!cell.mark_overflow(), "subsequent overflows are silent");
-        assert_eq!(cell.status(), BackendSinkStatus::Lagging);
+        let epoch = cell.begin_catch_up();
+        assert_eq!(cell.status(), BackendSinkStatus::CatchingUp);
+        assert!(cell.try_mark_caught_up(epoch));
+        assert_eq!(cell.status(), BackendSinkStatus::Ok);
 
         assert!(cell.mark_flush_failure());
         assert!(!cell.mark_flush_failure());
         assert_eq!(cell.status(), BackendSinkStatus::Unreachable);
 
         assert!(cell.mark_recovered());
-        assert!(!cell.mark_recovered(), "recovery from ok is a no-op");
-        assert_eq!(cell.status(), BackendSinkStatus::Ok);
+        assert!(
+            !cell.mark_recovered(),
+            "recovery from catching up is a no-op"
+        );
+        assert_eq!(cell.status(), BackendSinkStatus::CatchingUp);
     }
 
     #[test]
     fn disabled_skew_is_terminal() {
         let cell = BackendSinkCell::new("team-ch");
-        cell.set_status(BackendSinkStatus::DisabledSkew);
+        cell.set_status_for_test(BackendSinkStatus::DisabledSkew);
 
-        assert!(!cell.mark_overflow());
         assert!(!cell.mark_flush_failure());
         assert!(!cell.mark_recovered());
         assert_eq!(cell.status(), BackendSinkStatus::DisabledSkew);
@@ -1197,9 +1313,8 @@ mod tests {
     #[test]
     fn disabled_missing_identity_author_is_terminal() {
         let cell = BackendSinkCell::new("team-ch");
-        cell.set_status(BackendSinkStatus::DisabledMissingIdentityAuthor);
+        cell.set_status_for_test(BackendSinkStatus::DisabledMissingIdentityAuthor);
 
-        assert!(!cell.mark_overflow());
         assert!(!cell.mark_flush_failure());
         assert!(!cell.mark_recovered());
         assert_eq!(
@@ -1215,11 +1330,11 @@ mod tests {
         assert_eq!(backend_sinks_json(&registry), None);
 
         let lagging = Arc::new(BackendSinkCell::new("b-lagging"));
-        lagging.set_status(BackendSinkStatus::Lagging);
+        lagging.set_status_for_test(BackendSinkStatus::Lagging);
         let disabled = Arc::new(BackendSinkCell::new("c-disabled"));
-        disabled.set_status(BackendSinkStatus::DisabledMissingIdentityAuthor);
+        disabled.set_status_for_test(BackendSinkStatus::DisabledMissingIdentityAuthor);
         let ok = Arc::new(BackendSinkCell::new("a-ok"));
-        ok.set_status(BackendSinkStatus::Ok);
+        ok.set_status_for_test(BackendSinkStatus::Ok);
         {
             let mut cells = registry.lock().expect("registry mutex poisoned");
             cells.insert("b-lagging".to_string(), lagging);
@@ -1239,8 +1354,7 @@ mod tests {
     async fn forward_never_blocks_and_marks_overflow_as_lagging() {
         let (tx, mut backend_rx) = mpsc::channel::<SinkMessage>(1);
         let cell = Arc::new(BackendSinkCell::new("team-ch"));
-        cell.set_status(BackendSinkStatus::Ok);
-        cell.mark_live();
+        cell.set_status_for_test(BackendSinkStatus::Ok);
         let handle = BackendHandle::Active {
             tx,
             cell: cell.clone(),
@@ -1258,6 +1372,166 @@ mod tests {
             backend_rx.try_recv().is_err(),
             "overflowed batches are dropped, not queued"
         );
+
+        assert!(cell.mark_recovered());
+        assert_eq!(cell.status(), BackendSinkStatus::CatchingUp);
+        forward_to_backend(&handle, &batch);
+        assert!(
+            matches!(
+                backend_rx.try_recv(),
+                Ok(SinkMessage::BackendBatch {
+                    persist_checkpoint: false,
+                    ..
+                })
+            ),
+            "catch-up admits live rows without letting them advance checkpoints"
+        );
+        assert_eq!(cell.dropped_batches(), 2);
+    }
+
+    #[tokio::test]
+    async fn catch_up_admits_deltas_but_overflow_invalidates_promotion() {
+        let (tx, mut backend_rx) = mpsc::channel::<SinkMessage>(1);
+        let cell = Arc::new(BackendSinkCell::new("team-ch"));
+        let handle = BackendHandle::Active {
+            tx,
+            cell: cell.clone(),
+        };
+        let batch = mixed_session_batch();
+
+        let first_epoch = cell.begin_catch_up();
+        forward_to_backend(&handle, &batch);
+        assert!(matches!(
+            backend_rx.try_recv(),
+            Ok(SinkMessage::BackendBatch {
+                persist_checkpoint: false,
+                ..
+            })
+        ));
+        assert!(
+            cell.try_mark_caught_up(first_epoch),
+            "accepted catch-up deltas must not require a replay-length quiet window"
+        );
+
+        cell.mark_flush_failure();
+        assert!(cell.mark_recovered());
+        let overflow_epoch = cell.catch_up_epoch().expect("catch-up epoch");
+        forward_to_backend(&handle, &batch); // fills the bounded delta path
+        forward_to_backend(&handle, &batch); // actual drop invalidates this pass
+        assert!(
+            !cell.try_mark_caught_up(overflow_epoch),
+            "a catch-up delta overflow must reject promotion"
+        );
+        assert_eq!(cell.dropped_batches(), 1);
+        assert!(matches!(
+            backend_rx.try_recv(),
+            Ok(SinkMessage::BackendBatch {
+                persist_checkpoint: false,
+                ..
+            })
+        ));
+
+        let second_epoch = cell.catch_up_epoch().expect("still catching up");
+        assert!(cell.try_mark_caught_up(second_epoch));
+        forward_to_backend(&handle, &batch);
+        assert!(
+            matches!(
+                backend_rx.try_recv(),
+                Ok(SinkMessage::BackendBatch {
+                    persist_checkpoint: true,
+                    ..
+                })
+            ),
+            "a router arriving after atomic promotion must enter the live queue"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn continuous_in_capacity_deltas_do_not_block_catch_up_promotion() {
+        let (tx, mut backend_rx) = mpsc::channel::<SinkMessage>(8);
+        let cell = Arc::new(BackendSinkCell::new("team-ch"));
+        let epoch = cell.begin_catch_up();
+        let accepted = Arc::new(AtomicUsize::new(0));
+
+        let consumer_accepted = accepted.clone();
+        let consumer = tokio::spawn(async move {
+            while let Some(message) = backend_rx.recv().await {
+                match message {
+                    SinkMessage::BackendBatch {
+                        batch,
+                        persist_checkpoint: false,
+                        ..
+                    } => {
+                        assert!(
+                            batch.checkpoint.is_some(),
+                            "delta keeps the end-of-scan boundary for sink finalization"
+                        );
+                        consumer_accepted.fetch_add(1, Ordering::Relaxed);
+                    }
+                    SinkMessage::Batch(_)
+                    | SinkMessage::BackendBatch {
+                        persist_checkpoint: true,
+                        ..
+                    } => {}
+                    SinkMessage::FlushBarrier(barrier) => {
+                        let _ = barrier.send(());
+                    }
+                }
+            }
+        });
+
+        let producer_cell = cell.clone();
+        let producer_tx = tx.clone();
+        let producer = tokio::spawn(async move {
+            let mut batch = mixed_session_batch();
+            batch.checkpoint = Some(Checkpoint {
+                source_name: "source-a".to_string(),
+                source_file: "/tmp/source-a.jsonl".to_string(),
+                source_inode: 1,
+                source_generation: 1,
+                last_offset: 100,
+                last_line_no: 1,
+                status: "active".to_string(),
+                ..Default::default()
+            });
+            while producer_cell.status() == BackendSinkStatus::CatchingUp {
+                assert_eq!(
+                    producer_cell.try_forward(&producer_tx, &batch),
+                    BackendForwardOutcome::Queued,
+                    "in-capacity live traffic must stay on the bounded delta path"
+                );
+                tokio::task::yield_now().await;
+            }
+        });
+
+        timeout(Duration::from_secs(2), async {
+            while accepted.load(Ordering::Relaxed) < 20 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("continuous delta admission made progress");
+
+        let (barrier_tx, barrier_rx) = tokio::sync::oneshot::channel();
+        tx.send(SinkMessage::FlushBarrier(barrier_tx))
+            .await
+            .expect("queue replay barrier");
+        barrier_rx.await.expect("barrier sender dropped");
+        assert!(
+            cell.try_mark_caught_up(epoch),
+            "accepted deltas do not invalidate fixed-point promotion"
+        );
+        timeout(Duration::from_secs(2), producer)
+            .await
+            .expect("producer observes promotion")
+            .expect("producer does not panic");
+        assert_eq!(cell.dropped_batches(), 0);
+
+        drop(tx);
+        timeout(Duration::from_secs(2), consumer)
+            .await
+            .expect("consumer exits")
+            .expect("consumer does not panic");
     }
 
     #[tokio::test]
@@ -1283,7 +1557,7 @@ mod tests {
     #[test]
     fn forward_disabled_backend_is_noop_without_drop_accounting() {
         let cell = Arc::new(BackendSinkCell::new("team-ch"));
-        cell.set_status(BackendSinkStatus::DisabledMissingIdentityAuthor);
+        cell.set_status_for_test(BackendSinkStatus::DisabledMissingIdentityAuthor);
         let handle = BackendHandle::Disabled { cell: cell.clone() };
 
         forward_to_backend(&handle, &mixed_session_batch());
@@ -1320,7 +1594,10 @@ mod tests {
             cell.status(),
             BackendSinkStatus::DisabledMissingIdentityAuthor
         );
-        assert!(!cell.is_live());
+        assert_eq!(
+            cell.status(),
+            BackendSinkStatus::DisabledMissingIdentityAuthor
+        );
     }
 
     async fn wait_for_status(
@@ -1441,7 +1718,7 @@ mod tests {
             .await,
             "connection-refused handshake must surface as unreachable"
         );
-        assert!(!cell.is_live());
+        assert_ne!(cell.status(), BackendSinkStatus::Ok);
         handle.abort();
     }
 
@@ -1519,7 +1796,7 @@ mod tests {
             .await,
             "server-ahead skew with allow_newer_server=false must disable the sink"
         );
-        assert!(!cell.is_live());
+        assert_ne!(cell.status(), BackendSinkStatus::Ok);
         assert!(
             state
                 .write_statements
@@ -1596,7 +1873,10 @@ mod tests {
         let SinkMessage::Batch(batch) = timeout(Duration::from_millis(200), rx.recv())
             .await
             .expect("replay batch within timeout")
-            .expect("replay batch present");
+            .expect("replay batch present")
+        else {
+            panic!("replay processor emitted a sink control message")
+        };
         assert_eq!(batch.raw_rows.len(), 2);
         let checkpoint = batch.checkpoint.clone().expect("replay checkpoint");
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,7 +129,7 @@ projects to additional servers, see
 | `timeout_seconds` | `30.0` | Per-request ClickHouse HTTP timeout. |
 | `request_compression` | `none` | Compression for non-empty HTTP request bodies. Supported values are `none` and `gzip`. |
 | `async_insert` | `true` | Enables ClickHouse async insert mode on writes. |
-| `wait_for_async_insert` | `true` | Waits for async insert completion before advancing checkpoints, so write failures are visible. |
+| `wait_for_async_insert` | `true` | Waits for async insert completion before advancing checkpoints, so write failures are visible. Named mirror ingestion always enforces this setting even if configured as `false`; other clients retain the configured value. |
 | `allow_newer_server` | `false` | Allows a non-default backend whose migration ledger is ahead of this Moraine build. The default backend is migrated by Moraine itself, so this is only useful on `[backends.<name>]`. |
 
 ### Environment-backed ClickHouse values
@@ -277,7 +277,7 @@ window effectively empty (the working directory rides the records
 themselves, or is recovered from the session header), so in practice it
 only affects traces that carry no working directory at all.
 
-Per-backend mirror status — `connecting`, `ok`, `lagging`, `unreachable`,
+Per-backend mirror status — `connecting`, `catching_up`, `ok`, `lagging`, `unreachable`,
 `disabled_skew`, or `disabled_missing_identity_author` — is written to ingest
 heartbeats as a `backend_sinks` map and surfaced through the monitor's
 `/api/v1/health`. This uses a column added by migration 017; until
@@ -285,6 +285,14 @@ heartbeats as a `backend_sinks` map and surfaced through the monitor's
 field rather than failing heartbeats. `disabled_missing_identity_author` means
 `[identity].author` is empty; set it and restart ingest before mirroring to
 team backends.
+
+`catching_up` means the remote sink is reachable and retained source files are
+replaying. New live rows may drain during this phase, but their checkpoints are
+withheld until replay establishes contiguous coverage. Moraine switches to `ok`
+only after an ordered durability barrier confirms earlier replay batches were
+durably handled — inserted or recorded by the existing explicit oversized-row
+quarantine — with their checkpoints committed, and no routed batch was dropped
+across the promotion boundary.
 
 ### Schema version handshake
 


### PR DESCRIPTION
## Description

**What.** Makes named-backend mirror catch-up checkpoint-safe across backpressure, sink failure, and restart.

**Why.** A live mirror batch could previously persist a checkpoint beyond an older replay gap, so a crash in that window could make the missing span unreachable on the next restart.

The mirror now enters an explicit `catching_up` phase. Live routed batches still use the existing bounded backend queue, but they retain their scan boundary without receiving checkpoint authority until replay establishes contiguous coverage. Queue admission, drop accounting, and promotion share one mutex-protected epoch, so an actual overflow invalidates the promotion attempt without blocking default ingest.

Replay finishes through an ordered durability barrier. The barrier acknowledges after earlier accepted replay writes and authorized checkpoints are durable; rejected chunks revoke promotion authority, while replay and live normalization state remain isolated. Named mirror-ingest clients also force `wait_for_async_insert=true` so the barrier cannot acknowledge a server-queued insert as durable.

This is intentionally limited to the checkpoint-overrun and recovery invariant. It adds no migration, config schema, dependency, deployment, startup-discovery, or replay-performance change.

## Usage

No configuration change is required. During initial replay or recovery, named mirrors may now report:

```text
catching_up
```

The mirror changes to `ok` only after a clean replay barrier and an unchanged admission epoch. Default-only ingest behavior is unchanged.

## Bug Evidence

`backend_delta_cannot_advance_checkpoint_across_restart_gap` reproduces the failure boundary directly: with durable coverage at offset 50 and a live delta ending at 100, the live batch cannot persist 100 before replay closes the older gap. A simulated restart therefore resumes from 50 and replay can advance safely to 100.

Additional regressions cover retrying barriers, rejected chunks, stale queued checkpoint authority, replay/live identity interleaving, continuous in-capacity traffic, deterministic queue overflow, and empty-barrier recovery from `unreachable`.

## Operational Impact

- Named mirrors expose the additional `catching_up` heartbeat state.
- Named mirror-ingest clients override `wait_for_async_insert` to `true`; the configured value still applies to the default backend.
- Recovery still depends on retained source files. Files deleted before catch-up cannot be reconstructed by this patch.
- Moraine's existing explicit oversized-row quarantine remains a non-retryable exception: a barrier can confirm that a batch was durably handled by insertion or recorded quarantine.
- Team mode remains experimental. This advances only the backpressure, partial-backend failure, restart, and catch-up portion of #383; it does not address the epic's authorization, deletion, or production-graduation gates.

## Changelog

- Prevents named-backend checkpoints from advancing beyond unresolved replay gaps.
- Adds retry-safe mirror catch-up and recovery barriers without blocking local ingest.
- Documents the `catching_up` status and named-backend async-insert durability override.

## Validation

Against current upstream `main` at `5292b66`, `cargo fmt --all -- --check`, `bash scripts/ci/clippy-strict-baseline.sh`, `cargo test -p moraine-ingest-core --locked`, and `cargo test --workspace --locked -- --test-threads=1` passed. The ingest-core library ran 218 tests, including the checkpoint-overrun/restart regressions.

Owned sandbox `sb-e0f94e` passed formatting, all 218 ingest-core library tests, the strict Clippy baseline, and `bash scripts/ci/e2e-stack.sh`. The E2E run exercised migrations, named-backend routing, MCP search/open, backend termination, embedded fallback, and all-down recovery. The sandbox was torn down.

The sandbox-only full-package run has one pre-existing path-sensitive golden mismatch: its checkout is mounted at `/repo`, which is also the committed Codex fixture's synthetic cwd, so project metadata differs there. The same golden and complete package pass on the host.

A seven-persona delegated review completed with one documentation finding: the durability wording did not mention the existing oversized-row quarantine. The wording was corrected and the correctness follow-up found no remaining issue. No other correctness, completeness, security, scope, idiom, elegance, or YAGNI findings remain.

## References

- Follows up the crash/checkpoint-overrun limitation documented in #379.
- Advances, but does not close, the multi-writer correctness and failure-injection work tracked in #383.
