### PR TITLE
feat(setup): configure OMP independently

### DIFF
--- a/apps/moraine/src/cli.rs
+++ b/apps/moraine/src/cli.rs
@@ -233,6 +233,7 @@ pub(crate) enum SetupMcpTarget {
     OpenCode,
     Cursor,
     PiCodingAgent,
+    Omp,
 }
 
 #[derive(Debug, Args)]
@@ -378,6 +379,8 @@ mod tests {
             "--mcp-target",
             "pi-coding-agent",
             "--mcp-target",
+            "omp",
+            "--mcp-target",
             "claude-code",
             "--mcp-target",
             "hermes",
@@ -399,6 +402,7 @@ mod tests {
                         SetupMcpTarget::OpenCode,
                         SetupMcpTarget::Cursor,
                         SetupMcpTarget::PiCodingAgent,
+                        SetupMcpTarget::Omp,
                         SetupMcpTarget::ClaudeCode,
                         SetupMcpTarget::Hermes,
                         SetupMcpTarget::QwenCode,

--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -2899,8 +2899,12 @@ impl SetupMcpTarget {
         let Ok(paths) = harnesses::SetupPathContext::from_env() else {
             return false;
         };
+        self.has_default_probe_path(&paths)
+    }
+
+    fn has_default_probe_path(self, paths: &harnesses::SetupPathContext) -> bool {
         harnesses::spec(self)
-            .default_probe_paths(&paths)
+            .default_probe_paths(paths)
             .iter()
             .any(|path| path.exists())
     }
@@ -3724,7 +3728,7 @@ watch_root = "~/archive"
     }
 
     #[test]
-    fn ingest_selection_adds_omp_source_to_existing_pi_config() {
+    fn omp_ingest_selection_adds_omp_source_without_changing_pi() {
         let mut document = r#"
 [ingest]
 
@@ -3742,11 +3746,11 @@ format = "jsonl"
         let update = apply_ingest_selections_to_document(
             &mut document,
             &[SetupTargetSelection {
-                target: SetupMcpTarget::PiCodingAgent,
+                target: SetupMcpTarget::Omp,
                 mode: SetupSelectionMode::IngestOnly,
             }],
         )
-        .expect("apply pi ingest selection");
+        .expect("apply OMP ingest selection");
 
         assert_eq!(
             update,
@@ -4956,6 +4960,24 @@ host = "127.42.0.9"
     }
 
     #[test]
+    fn omp_detection_accepts_executable_or_agent_directory_without_pi() {
+        let runner = FakeRunner::default().with_existing("omp");
+        assert!(runner.command_exists("omp"));
+        assert!(!runner.command_exists("pi"));
+        assert!(SetupMcpTarget::Omp.is_available_for_setup(&runner));
+
+        let home = temp_path("omp-detection-home");
+        fs::create_dir_all(home.join(".omp").join("agent")).expect("create OMP agent dir");
+        let paths = harnesses::SetupPathContext::with_home(Some(home.clone()));
+        let no_executables = FakeRunner::default();
+        assert!(SetupMcpTarget::Omp.has_default_probe_path(&paths));
+        assert!(!SetupMcpTarget::PiCodingAgent.has_default_probe_path(&paths));
+        assert!(!no_executables.command_exists("omp"));
+        assert!(!no_executables.command_exists("pi"));
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
     fn qwen_setup_detects_cli_and_builds_exact_registration_commands() {
         assert!(SetupMcpTarget::QwenCode
             .is_available_for_setup(&FakeRunner::default().with_existing("qwen")));
@@ -5459,6 +5481,189 @@ host = "127.42.0.9"
         );
         assert_eq!(value["mcpServers"]["moraine"]["lifecycle"], "eager");
         let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn omp_plan_merges_custom_config_independently_and_is_repeatable() {
+        let home = temp_path("omp-home");
+        let omp_dir = home.join(".omp").join("agent");
+        let pi_dir = home.join(".pi").join("agent");
+        fs::create_dir_all(&omp_dir).expect("create OMP dir");
+        fs::create_dir_all(&pi_dir).expect("create Pi dir");
+        fs::write(
+            omp_dir.join("mcp.json"),
+            r#"{"mcpServers":{"other":{"command":"other-server"}},"theme":"dark"}"#,
+        )
+        .expect("write OMP config");
+        fs::write(pi_dir.join("mcp.json"), "pi sentinel").expect("write Pi sentinel");
+
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/custom-moraine.toml"),
+            source: ConfigTargetSource::Cli,
+        };
+        for _ in 0..2 {
+            let plan =
+                McpPlan::for_target_with_home(SetupMcpTarget::Omp, &target, Some(home.clone()));
+            assert_eq!(plan.action, McpAction::WriteConfig);
+            assert!(plan.commands().is_empty());
+            let mut runner = FakeRunner::default();
+            let report = execute_mcp_plan(plan, &mut runner).expect("execute OMP plan");
+            assert_eq!(report.status, SetupStatus::Ok);
+            assert!(runner.ran.is_empty());
+        }
+
+        let path = omp_dir.join("mcp.json");
+        let first = fs::read(&path).expect("read repeated OMP config");
+        let value: Value = serde_json::from_slice(&first).expect("OMP config JSON");
+        assert_eq!(value["theme"], "dark");
+        assert_eq!(value["mcpServers"]["other"]["command"], "other-server");
+        assert_eq!(value["mcpServers"]["moraine"]["command"], "moraine");
+        assert_eq!(
+            value["mcpServers"]["moraine"]["args"],
+            serde_json::json!(["run", "mcp", "--config", "/tmp/custom-moraine.toml"])
+        );
+        assert_eq!(
+            fs::read_to_string(pi_dir.join("mcp.json")).expect("read Pi sentinel"),
+            "pi sentinel"
+        );
+
+        let repeat_plan =
+            McpPlan::for_target_with_home(SetupMcpTarget::Omp, &target, Some(home.clone()));
+        let repeat_write = &repeat_plan.config_writes[0];
+        apply_mcp_config_write(repeat_write).expect("repeat OMP merge");
+        assert_eq!(fs::read(&path).expect("read stable OMP config"), first);
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn combined_pi_and_omp_setup_is_order_independent_and_repeatable() {
+        let home = temp_path("pi-omp-combined-home");
+        let pi_path = home.join(".pi").join("agent").join("mcp.json");
+        let omp_path = home.join(".omp").join("agent").join("mcp.json");
+        fs::create_dir_all(pi_path.parent().expect("Pi config parent")).expect("create Pi dir");
+        fs::create_dir_all(omp_path.parent().expect("OMP config parent")).expect("create OMP dir");
+        fs::write(
+            &pi_path,
+            r#"{"mcpServers":{"pi-only":{"command":"pi-server"}}}"#,
+        )
+        .expect("write Pi config");
+        fs::write(
+            &omp_path,
+            r#"{"mcpServers":{"omp-only":{"command":"omp-server"}}}"#,
+        )
+        .expect("write OMP config");
+
+        let config_target = ConfigTarget {
+            path: PathBuf::from("/tmp/custom-combined.toml"),
+            source: ConfigTargetSource::Cli,
+        };
+        let paths = harnesses::SetupPathContext::with_home(Some(home.clone()));
+        let pi_command = CommandSpec::new("pi", ["install", "npm:pi-mcp-extension"]);
+        let orders = [
+            vec![SetupMcpTarget::PiCodingAgent, SetupMcpTarget::Omp],
+            vec![SetupMcpTarget::Omp, SetupMcpTarget::PiCodingAgent],
+        ];
+        let mut stable_contents = None;
+
+        for targets in orders {
+            let args = SetupArgs {
+                yes: true,
+                dry_run: false,
+                skip_config: true,
+                skip_mcp: false,
+                repair_config: false,
+                mcp_targets: targets.clone(),
+            };
+            let mut runner = FakeRunner::default().with_existing("pi").with_response(
+                pi_command.clone(),
+                true,
+                "",
+            );
+            let report = run_setup_with_paths(
+                &plain_output(),
+                &args,
+                config_target.clone(),
+                false,
+                &mut runner,
+                &paths,
+            )
+            .expect("run combined Pi/OMP setup");
+            assert!(report.success);
+            assert_eq!(
+                report
+                    .mcp_targets
+                    .iter()
+                    .map(|target| target.target)
+                    .collect::<Vec<_>>(),
+                targets
+            );
+            assert_eq!(runner.ran, vec![pi_command.clone()]);
+
+            let contents = (
+                fs::read(&pi_path).expect("read Pi config"),
+                fs::read(&omp_path).expect("read OMP config"),
+            );
+            if let Some(expected) = &stable_contents {
+                assert_eq!(&contents, expected);
+            } else {
+                stable_contents = Some(contents);
+            }
+        }
+
+        let pi: Value = serde_json::from_slice(&fs::read(&pi_path).expect("read Pi JSON"))
+            .expect("parse Pi JSON");
+        let omp: Value = serde_json::from_slice(&fs::read(&omp_path).expect("read OMP JSON"))
+            .expect("parse OMP JSON");
+        assert_eq!(pi["mcpServers"]["pi-only"]["command"], "pi-server");
+        assert_eq!(omp["mcpServers"]["omp-only"]["command"], "omp-server");
+        for config in [&pi, &omp] {
+            assert_eq!(config["mcpServers"]["moraine"]["command"], "moraine");
+            assert_eq!(
+                config["mcpServers"]["moraine"]["args"],
+                serde_json::json!(["run", "mcp", "--config", "/tmp/custom-combined.toml"])
+            );
+        }
+
+        let omp_before_pi_only = fs::read(&omp_path).expect("read OMP before Pi-only setup");
+        let pi_plan = McpPlan::for_target_with_home(
+            SetupMcpTarget::PiCodingAgent,
+            &config_target,
+            Some(home.clone()),
+        );
+        let mut pi_runner =
+            FakeRunner::default()
+                .with_existing("pi")
+                .with_response(pi_command.clone(), true, "");
+        execute_mcp_plan(pi_plan, &mut pi_runner).expect("execute Pi-only plan");
+        assert_eq!(
+            fs::read(&omp_path).expect("read OMP after Pi-only setup"),
+            omp_before_pi_only
+        );
+        let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn omp_dry_run_reports_only_omp_changes_without_side_effects() {
+        let home = temp_path("omp-dry-run");
+        let target = ConfigTarget {
+            path: PathBuf::from("/tmp/config.toml"),
+            source: ConfigTargetSource::HomeDefault,
+        };
+        let plan = McpPlan::for_target_with_home(SetupMcpTarget::Omp, &target, Some(home.clone()));
+        let report = McpTargetReport::planned(plan);
+        assert_eq!(report.target, SetupMcpTarget::Omp);
+        assert_eq!(report.status, SetupStatus::Planned);
+        assert!(report.commands.is_empty());
+        assert_eq!(report.config_files.len(), 1);
+        assert_eq!(
+            report.config_files[0].path,
+            home.join(".omp")
+                .join("agent")
+                .join("mcp.json")
+                .display()
+                .to_string()
+        );
+        assert!(!home.exists());
     }
 
     #[test]

--- a/apps/moraine/src/commands/setup/harnesses.rs
+++ b/apps/moraine/src/commands/setup/harnesses.rs
@@ -240,6 +240,7 @@ enum ProbePaths {
     Cursor,
     Nac,
     Pi,
+    Omp,
 }
 
 impl ProbePaths {
@@ -259,6 +260,7 @@ impl ProbePaths {
             ],
             ProbePaths::Nac => vec![home.join(".config").join("nac")],
             ProbePaths::Pi => vec![home.join(".pi").join("agent")],
+            ProbePaths::Omp => vec![home.join(".omp").join("agent")],
         }
     }
 }
@@ -404,25 +406,24 @@ const CURSOR_INGEST: [DefaultIngestSource; 2] = [
     },
 ];
 
-const PI_INGEST: [DefaultIngestSource; 2] = [
-    DefaultIngestSource {
-        name: "pi",
-        harness: "pi-coding-agent",
-        glob: "~/.pi/agent/sessions/**/*.jsonl",
-        watch_root: "~/.pi/agent/sessions",
-        format: Some("jsonl"),
-    },
-    DefaultIngestSource {
-        name: "omp",
-        harness: "pi-coding-agent",
-        glob: "~/.omp/agent/sessions/**/*.jsonl",
-        watch_root: "~/.omp/agent/sessions",
-        format: Some("jsonl"),
-    },
-];
+const PI_INGEST: [DefaultIngestSource; 1] = [DefaultIngestSource {
+    name: "pi",
+    harness: "pi-coding-agent",
+    glob: "~/.pi/agent/sessions/**/*.jsonl",
+    watch_root: "~/.pi/agent/sessions",
+    format: Some("jsonl"),
+}];
+
+const OMP_INGEST: [DefaultIngestSource; 1] = [DefaultIngestSource {
+    name: "omp",
+    harness: "pi-coding-agent",
+    glob: "~/.omp/agent/sessions/**/*.jsonl",
+    watch_root: "~/.omp/agent/sessions",
+    format: Some("jsonl"),
+}];
 
 const NAC_INGEST: [DefaultIngestSource; 0] = [];
-const SPECS: [HarnessSpec; 10] = [
+const SPECS: [HarnessSpec; 11] = [
     HarnessSpec {
         target: SetupMcpTarget::ClaudeCode,
         label: "Claude Code",
@@ -502,6 +503,14 @@ const SPECS: [HarnessSpec; 10] = [
         programs: &["pi"],
         probe_paths: ProbePaths::Pi,
         ingest_sources: &PI_INGEST,
+    },
+    HarnessSpec {
+        target: SetupMcpTarget::Omp,
+        label: "OMP",
+        setup_kind: "MCP config",
+        programs: &["omp"],
+        probe_paths: ProbePaths::Omp,
+        ingest_sources: &OMP_INGEST,
     },
 ];
 
@@ -877,6 +886,12 @@ pub(super) fn mcp_plan(
             }
             plan
         }
+        SetupMcpTarget::Omp => McpPlan::write_config(
+            target,
+            home.as_ref()
+                .map(|home| McpConfigWrite::omp(home, config_target)),
+            omp_snippet(config_target),
+        ),
     })
 }
 
@@ -978,6 +993,15 @@ impl McpConfigWrite {
         }
     }
 
+    pub(super) fn omp(home: &Path, config_target: &ConfigTarget) -> Self {
+        Self {
+            path: home.join(".omp").join("agent").join("mcp.json"),
+            kind: McpConfigKind::Omp,
+            command: mcp_run_args(config_target),
+            nac_write: None,
+        }
+    }
+
     pub(super) fn opencode(home: &Path, config_target: &ConfigTarget) -> Self {
         Self {
             path: home.join(".config").join("opencode").join("opencode.json"),
@@ -1038,7 +1062,7 @@ impl McpConfigWrite {
                 let servers = object_entry_mut(root, "mcpServers")?;
                 servers.insert("moraine".to_string(), self.server_value());
             }
-            McpConfigKind::Pi => {
+            McpConfigKind::Pi | McpConfigKind::Omp => {
                 let servers = object_entry_mut(root, "mcpServers")?;
                 servers.insert("moraine".to_string(), self.server_value());
             }
@@ -1060,7 +1084,7 @@ impl McpConfigWrite {
                 "command": "moraine",
                 "args": self.command.clone(),
             }),
-            McpConfigKind::Pi => serde_json::json!({
+            McpConfigKind::Pi | McpConfigKind::Omp => serde_json::json!({
                 "transport": "stdio",
                 "command": "moraine",
                 "args": self.command.clone(),
@@ -1087,6 +1111,7 @@ impl McpConfigWrite {
 enum McpConfigKind {
     Cursor,
     Pi,
+    Omp,
     OpenCode,
     Nac,
 }
@@ -1096,6 +1121,7 @@ impl McpConfigKind {
         match self {
             McpConfigKind::Cursor => "Cursor",
             McpConfigKind::Pi => "Pi",
+            McpConfigKind::Omp => "OMP",
             McpConfigKind::OpenCode => "OpenCode",
             McpConfigKind::Nac => "NAC",
         }
@@ -1103,7 +1129,7 @@ impl McpConfigKind {
 
     fn format(self) -> McpConfigFormat {
         match self {
-            McpConfigKind::Cursor | McpConfigKind::Pi => McpConfigFormat::Json,
+            McpConfigKind::Cursor | McpConfigKind::Pi | McpConfigKind::Omp => McpConfigFormat::Json,
             McpConfigKind::OpenCode => McpConfigFormat::Jsonc,
             McpConfigKind::Nac => McpConfigFormat::Toml,
         }
@@ -1326,6 +1352,12 @@ fn pi_snippet(config_target: &ConfigTarget) -> String {
     )
 }
 
+fn omp_snippet(config_target: &ConfigTarget) -> String {
+    snippet(
+        "Add this server to ~/.omp/agent/mcp.json; OMP loads this file natively",
+        Value::Object(McpConfigWrite::omp(Path::new("~"), config_target).snippet_root()),
+    )
+}
 fn snippet(intro: &str, value: Value) -> String {
     format!(
         "{intro}:\n{}",
@@ -1358,6 +1390,36 @@ mod tests {
         assert!(ProbePaths::Cursor
             .paths(home)
             .contains(&home.join(".config").join("Cursor")));
+    }
+
+    #[test]
+    fn pi_and_omp_have_independent_detection_and_ingest_ownership() {
+        let home = Path::new("/home/example");
+        assert_eq!(
+            ProbePaths::Pi.paths(home),
+            vec![home.join(".pi").join("agent")]
+        );
+        assert_eq!(
+            ProbePaths::Omp.paths(home),
+            vec![home.join(".omp").join("agent")]
+        );
+
+        let paths = SetupPathContext::with_home(Some(home.to_path_buf()));
+        let pi = default_ingest_sources(SetupMcpTarget::PiCodingAgent, &paths, true)
+            .expect("resolve Pi sources");
+        let omp =
+            default_ingest_sources(SetupMcpTarget::Omp, &paths, true).expect("resolve OMP sources");
+        assert_eq!(pi.len(), 1);
+        assert_eq!(pi[0].name, "pi");
+        assert_eq!(omp.len(), 1);
+        assert_eq!(omp[0].name, "omp");
+        assert_eq!(omp[0].harness, "pi-coding-agent");
+        assert_eq!(omp[0].format.as_deref(), Some("jsonl"));
+        assert_eq!(
+            spec(SetupMcpTarget::PiCodingAgent).program_candidates(),
+            &["pi"]
+        );
+        assert_eq!(spec(SetupMcpTarget::Omp).program_candidates(), &["omp"]);
     }
 
     #[test]

--- a/docs/agent-mcp-search/install.md
+++ b/docs/agent-mcp-search/install.md
@@ -578,6 +578,32 @@ With the extension's default prefix, Pi exposes Moraine tools as
 `mcp_moraine_list_sessions`, and `mcp_moraine_file_attention`. Use `/mcp` inside
 Pi to inspect server status.
 
+## OMP (Oh My Pi)
+
+OMP has native MCP support and keeps its own agent state.
+`moraine setup --mcp-target omp` creates or updates
+`~/.omp/agent/mcp.json`; no MCP extension is required. Existing servers and
+unrelated settings in that file are preserved. OMP setup is independent from
+Pi: it detects `omp` or `~/.omp/agent`, owns only the `omp` ingest source, and
+does not read or write `~/.pi/agent/mcp.json`.
+
+Do not install `pi-mcp-extension` for this integration. That Pi extension reads
+Pi's global MCP config rather than OMP's, while current OMP releases load
+`~/.omp/agent/mcp.json` directly.
+
+To preview the OMP config change without writing files, run:
+
+```bash
+moraine setup --mcp-target omp --dry-run
+```
+
+For manual setup, use the same JSON shape shown above at OMP's global config
+path:
+
+```bash
+$EDITOR ~/.omp/agent/mcp.json
+```
+
 ## Generic MCP Clients
 
 Most MCP clients that support local stdio servers can use this shape:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -132,13 +132,13 @@ rerunning setup after installing a new harness CLI. Direct targets do not change
 ingest source selections:
 
 ```bash
-moraine setup --yes --mcp-target claude-code --mcp-target codex --mcp-target hermes --mcp-target kiro-cli --mcp-target kimi-cli --mcp-target qwen-code --mcp-target nac --mcp-target opencode --mcp-target cursor --mcp-target pi-coding-agent
+moraine setup --yes --mcp-target claude-code --mcp-target codex --mcp-target hermes --mcp-target kiro-cli --mcp-target kimi-cli --mcp-target qwen-code --mcp-target nac --mcp-target opencode --mcp-target cursor --mcp-target pi-coding-agent --mcp-target omp
 ```
 
 Preview targeted MCP/plugin changes without touching host agent config:
 
 ```bash
-moraine setup --dry-run --mcp-target claude-code --mcp-target codex --mcp-target hermes --mcp-target kiro-cli --mcp-target kimi-cli --mcp-target qwen-code --mcp-target nac --mcp-target opencode --mcp-target cursor --mcp-target pi-coding-agent
+moraine setup --dry-run --mcp-target claude-code --mcp-target codex --mcp-target hermes --mcp-target kiro-cli --mcp-target kimi-cli --mcp-target qwen-code --mcp-target nac --mcp-target opencode --mcp-target cursor --mcp-target pi-coding-agent --mcp-target omp
 ```
 
 The Claude Code, Codex, and Hermes plugins bundle Moraine search, realtime, and
@@ -149,7 +149,7 @@ managed search and realtime guidance under `$KIRO_HOME/steering` when
 ingest source at the matching `sessions/cli` directory. It also registers MCP
 directly or writes global MCP config for supported harnesses such as Qwen Code,
 Kimi CLI, NAC, OpenCode,
-Cursor, and Pi Coding Agent. For NAC, setup merges `[mcp_servers.moraine]` into the config at
+Cursor, Pi Coding Agent, and OMP. For NAC, setup merges `[mcp_servers.moraine]` into the config at
 `NAC_HOME`, then `XDG_CONFIG_HOME/nac`, then `~/.config/nac`, without replacing
 model, storage, sandbox, or unrelated MCP settings. It adds a `nac_sqlite`
 source only for the default store or an absolute `storage.store_path`; relative


### PR DESCRIPTION
## Description

**What.** Adds OMP as an independent `moraine setup` target with its own detection, ingest ownership, and MCP configuration.

**Why.** OMP sessions were ingestible, but OMP-only installations could not be detected or configured without going through the Pi target.

- Adds `--mcp-target omp` and detects either `omp` or `~/.omp/agent`.
- Moves the existing `omp` ingest source from Pi setup ownership to OMP while retaining the `pi-coding-agent` harness and normalizer.
- Merges Moraine into `~/.omp/agent/mcp.json` without replacing unrelated settings or servers.
- Keeps Pi and OMP config writes independent and propagates explicit Moraine config paths to both launchers.
- Uses OMP's native MCP support instead of installing `pi-mcp-extension`, which reads Pi's global MCP config and would violate Pi/OMP isolation.

Closes #642.

## Usage

Configure OMP non-interactively:

```bash
moraine setup --yes --mcp-target omp
```

Preview the OMP-only change without writing files or running external commands:

```bash
moraine setup --dry-run --mcp-target omp
```

Pi and OMP can be selected together when both should be configured:

```bash
moraine setup --yes --mcp-target pi-coding-agent --mcp-target omp
```

## Changelog

- Adds independent OMP detection, ingest-source selection, and native MCP configuration to `moraine setup`.
- Documents OMP's native MCP config and Pi/OMP isolation behavior.

## Validation

Ran `cargo test -p moraine --locked commands::setup`; all 101 focused setup tests passed. Ran `cargo test -p moraine --bin moraine --locked`; all 222 binary tests passed. Ran `cargo clippy -p moraine --bin moraine --locked --no-deps -- -D warnings`, the repository pre-commit formatting and strict Clippy baseline, and `make docs-build`; all completed successfully.

Exercised `target/debug/moraine --output json setup --mcp-target omp --dry-run`; it reported only `~/.omp/agent/mcp.json` as `would_update` and no external command. Also loaded installed OMP v17.2.7's native MCP provider against isolated, distinct Pi and OMP config files; it returned the Moraine and OMP-only entries from `~/.omp/agent/mcp.json` and did not load the Pi-only entry.
