### PR TITLE
chore(release): cut v0.7.3

### DIFF
--- a/.github/workflows/release-moraine.yml
+++ b/.github/workflows/release-moraine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (for example v0.7.2)"
+        description: "Tag to release (for example v0.7.3)"
         required: true
         type: string
       target:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "moraine"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "glob",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-ingest-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "moraine-config",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-mcp-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1321,11 +1321,11 @@ dependencies = [
 
 [[package]]
 name = "moraine-monitor"
-version = "0.7.2"
+version = "0.7.3"
 
 [[package]]
 name = "moraine-monitor-core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/moraine-ingest/Cargo.toml
+++ b/apps/moraine-ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Moraine ingest service binary"
 

--- a/apps/moraine-mcp/Cargo.toml
+++ b/apps/moraine-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Moraine MCP stdio entry and unified backend daemon"
 

--- a/apps/moraine-monitor/Cargo.toml
+++ b/apps/moraine-monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Deprecated alias for the unified Moraine backend"
 

--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Unified runtime control plane for Moraine services"
 

--- a/bindings/python/moraine_conversations/Cargo.lock
+++ b/bindings/python/moraine_conversations/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-clickhouse"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "flate2",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-config"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "glob",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "moraine-conversations"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/moraine-clickhouse/Cargo.toml
+++ b/crates/moraine-clickhouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-clickhouse"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Shared Moraine ClickHouse client and query helpers"
 

--- a/crates/moraine-config/Cargo.toml
+++ b/crates/moraine-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-config"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Shared Moraine configuration schema and loaders"
 

--- a/crates/moraine-conversations/Cargo.toml
+++ b/crates/moraine-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-conversations"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "High-level read/query APIs for Moraine conversations"
 

--- a/crates/moraine-ingest-core/Cargo.toml
+++ b/crates/moraine-ingest-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-ingest-core"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Core ingestion pipeline internals for Moraine"
 

--- a/crates/moraine-mcp-core/Cargo.toml
+++ b/crates/moraine-mcp-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-mcp-core"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "MCP protocol and tool routing core for Moraine"
 

--- a/crates/moraine-monitor-core/Cargo.toml
+++ b/crates/moraine-monitor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moraine-monitor-core"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Analytics and query logic for Moraine monitor service"
 

--- a/plugins/hermes-moraine/plugin.yaml
+++ b/plugins/hermes-moraine/plugin.yaml
@@ -1,6 +1,6 @@
 manifest_version: 1
 name: moraine
-version: "0.7.2"
+version: "0.7.3"
 description: "Hermes integration for Moraine MCP session search, realtime agent awareness, sanitized bug reports, and setup diagnostics."
 author: "Moraine maintainers"
 provides_tools:

--- a/plugins/moraine/.claude-plugin/plugin.json
+++ b/plugins/moraine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "displayName": "Moraine",
   "description": "Claude Code plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {

--- a/plugins/moraine/.codex-plugin/plugin.json
+++ b/plugins/moraine/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Codex plugin for Moraine MCP session search, realtime agent awareness, and sanitized bug reports.",
   "author": {
     "name": "Moraine maintainers",

--- a/plugins/prime-agent-moraine/package.json
+++ b/plugins/prime-agent-moraine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moraine-prime-agent",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Prime Agent integration for Moraine session search and realtime agent awareness.",
   "keywords": ["pi-package", "moraine", "mcp", "agent-memory"],
   "license": "Apache-2.0",

--- a/plugins/prime-agent-moraine/skills/moraine/pyproject.toml
+++ b/plugins/prime-agent-moraine/skills/moraine/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prime-agent-skill-moraine"
-version = "0.7.2"
+version = "0.7.3"
 description = "Moraine MCP integration for Prime Agent."
 requires-python = ">=3.10"
 dependencies = ["mcp>=1,<2"]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ install directory precedence:
 
 examples:
   scripts/install.sh
-  MORAINE_INSTALL_VERSION=v0.7.2 scripts/install.sh
+  MORAINE_INSTALL_VERSION=v0.7.3 scripts/install.sh
   MORAINE_INSTALL_ASSET_BASE_URL=http://127.0.0.1:8080 \
     MORAINE_INSTALL_VERSION=ci-e2e scripts/install.sh
   MORAINE_INSTALL_DIR="$HOME/bin" MORAINE_INSTALL_SKIP_CLICKHOUSE=1 scripts/install.sh


### PR DESCRIPTION
## Description

**What.** Bumps all release-managed Moraine packages, plugins, lockfiles, workflow examples, and install examples from 0.7.2 to 0.7.3.

**Why.** This prepares the merged `main` commit for the annotated `v0.7.3` tag and the tag-triggered GitHub/PyPI publishing workflow.

Moraine 0.7.3 adds end-to-end Prime Agent and independent OMP setup, exact cancellation for abandoned ClickHouse queries, and fixes reported after v0.7.2 for migration 031, Codex labels and token attribution, plugin launch from home workspaces, and named-mirror checkpoint recovery.

## Usage

No release metadata action is required from users until the tag is published. After publication, upgrade with:

```bash
moraine down
uv tool upgrade moraine-cli
moraine up && moraine status
```

## Changelog

- Adds first-class Prime Agent root/RLM-child ingestion and managed runtime setup.
- Adds independent OMP detection, ingest ownership, and native MCP setup.
- Cancels exact abandoned ClickHouse query work and removes former default elapsed statement deadlines.
- Makes migration 031 retry-safe and fixes Codex session labels, model attribution, uv-tool plugin launch from home workspaces, and named-mirror catch-up checkpoints.

## Validation

`git diff --check` and `cargo fmt --all -- --check` passed. `cargo test --workspace --locked` passed 1,115 tests across 28 suites with 6 ignored. `python3 -m unittest plugins/moraine-dev/skills/release/scripts/tests/test_bump_version.py` passed both release-script tests.

Sandbox `sb-a4ed33` passed `bash scripts/ci/e2e-stack.sh` with the sandbox-built binaries and returned a healthy Monitor API response; it was torn down. A fresh host-session-mounted `agent-smoke-e2e` run passed the complete public MCP retrieval workflow on Opus 4.7 and Sonnet 4.6 and tore down sandbox `sb-1e597a`. The default three-model smoke was attempted twice; Opus and Sonnet passed, while Haiku 4.5 declined to invoke its registered MCP tools and reported a harness-access failure rather than a server response failure.

## Operational Impact

Merging this PR does not publish artifacts. Pushing annotated tag `v0.7.3` to the merged commit will trigger `.github/workflows/release-moraine.yml`, build four platform bundles and checksums, create the GitHub release, and publish `moraine-cli==0.7.3` to PyPI through trusted publishing.
