### PR TITLE
fix(setup): verify MCP backend health

### DIFF
--- a/apps/moraine/Cargo.toml
+++ b/apps/moraine/Cargo.toml
@@ -6,7 +6,7 @@ description = "Unified runtime control plane for Moraine services"
 
 [dependencies]
 anyhow = "1.0"
-tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "time", "process", "signal", "io-util"] }
+tokio = { version = "1.40", features = ["rt-multi-thread", "macros", "time", "process", "signal", "io-util", "net"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }

--- a/apps/moraine/src/commands.rs
+++ b/apps/moraine/src/commands.rs
@@ -184,7 +184,7 @@ pub(crate) async fn dispatch(
                 }
             }
         }
-        CliCommand::Setup(args) => setup::handle(&output, cli.config.clone(), args),
+        CliCommand::Setup(args) => setup::handle(&output, cli.config.clone(), args).await,
         CliCommand::Run(run) => run_service(cli.config.clone(), run).await,
     }
 }

--- a/apps/moraine/src/commands/setup.rs
+++ b/apps/moraine/src/commands/setup.rs
@@ -10,9 +10,11 @@ use std::io::{ErrorKind, IsTerminal, Write};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, Stdio};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::cli::{SetupArgs, SetupMcpTarget};
+use crate::mcp_health::{probe_mcp_backend, McpHealthSnapshot};
+use crate::paths::load_cfg;
 use crate::render::CliOutput;
 use toml_edit::{ArrayOfTables, DocumentMut, Item, Table};
 
@@ -23,16 +25,19 @@ use harnesses::{ManagedFileWrite, McpConfigFormat, McpConfigWrite};
 const DEFAULT_CONFIG_TEMPLATE: &str = include_str!("../../../../config/moraine.toml");
 const HOST_WIDE_ACCESS_WARNING: &str =
     "Selected harness integrations get host-wide Moraine session history access visible to your user.";
+const SETUP_MCP_HEALTH_TIMEOUT: Duration = Duration::from_secs(2);
 
-pub(super) fn handle(
+pub(super) async fn handle(
     output: &CliOutput,
     raw_config: Option<PathBuf>,
     args: SetupArgs,
 ) -> Result<ExitCode> {
     let target = resolve_setup_config_target(raw_config)?;
+    let config_path = target.path.clone();
     let interactive = can_prompt(output);
     let mut runner = RealCommandRunner;
-    let report = run_setup(output, &args, target, interactive, &mut runner)?;
+    let mut report = run_setup(output, &args, target, interactive, &mut runner)?;
+    record_setup_mcp_health(&mut report, &args, &config_path).await;
     render_report(output, &report)?;
 
     if report.success {
@@ -40,6 +45,33 @@ pub(super) fn handle(
     } else {
         Ok(ExitCode::from(1))
     }
+}
+
+async fn record_setup_mcp_health(report: &mut SetupReport, args: &SetupArgs, config_path: &Path) {
+    if args.dry_run
+        || args.skip_mcp
+        || !report
+            .mcp_targets
+            .iter()
+            .any(|target| target.status == SetupStatus::Ok)
+    {
+        return;
+    }
+
+    let health = match load_cfg(Some(config_path.to_path_buf())) {
+        Ok((_, cfg)) => {
+            probe_mcp_backend(
+                &cfg.mcp.central_socket_path,
+                &cfg.mcp.protocol_version,
+                SETUP_MCP_HEALTH_TIMEOUT,
+            )
+            .await
+        }
+        Err(_) => McpHealthSnapshot::unhealthy(
+            "load configured runtime: Moraine config could not be loaded",
+        ),
+    };
+    report.record_mcp_health(health);
 }
 
 fn can_prompt(output: &CliOutput) -> bool {
@@ -242,6 +274,7 @@ fn run_setup_with_paths(
         success,
         config,
         mcp_targets,
+        mcp_health: None,
     })
 }
 
@@ -2527,6 +2560,15 @@ struct SetupReport {
     success: bool,
     config: ConfigReport,
     mcp_targets: Vec<McpTargetReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mcp_health: Option<McpHealthSnapshot>,
+}
+
+impl SetupReport {
+    fn record_mcp_health(&mut self, health: McpHealthSnapshot) {
+        self.success &= health.healthy;
+        self.mcp_health = Some(health);
+    }
 }
 
 fn report_for_json(report: &SetupReport, verbose: bool) -> SetupReport {
@@ -2772,6 +2814,30 @@ fn render_report(output: &CliOutput, report: &SetupReport) -> Result<()> {
     }
     if !detail_lines.is_empty() {
         output.section("Integration Details", &detail_lines);
+    }
+    if let Some(health) = &report.mcp_health {
+        let status = if health.healthy {
+            SetupStatus::Ok
+        } else {
+            SetupStatus::Error
+        };
+        let mut lines = vec![format!(
+            "{} MCP initialize + ping {}",
+            status_mark(status, output.unicode),
+            if health.healthy {
+                "healthy"
+            } else {
+                "unhealthy"
+            }
+        )];
+        if let (Some(protocol), Some(server)) = (&health.protocol_version, &health.server_version) {
+            lines.push(format!("protocol: {protocol}  |  server: {server}"));
+        }
+        if let Some(error) = &health.error {
+            lines.push(format!("diagnostic: {error}"));
+            lines.push("remediation: run `moraine up`, then rerun `moraine setup`".to_string());
+        }
+        output.section("MCP Backend", &lines);
     }
 
     Ok(())
@@ -6269,6 +6335,7 @@ watch_root = "~/.codex/sessions"
                     stderr: "/sensitive/path".to_string(),
                 }],
             }],
+            mcp_health: None,
         };
 
         let redacted = report_for_json(&report, false);
@@ -6280,5 +6347,47 @@ watch_root = "~/.codex/sessions"
         let result = &verbose.mcp_targets[0].command_results[0];
         assert_eq!(result.stdout, "account@example.test");
         assert_eq!(result.stderr, "/sensitive/path");
+    }
+
+    #[tokio::test]
+    async fn unhealthy_mcp_probe_marks_setup_unsuccessful() {
+        let dir = temp_path("setup-mcp-health");
+        fs::create_dir_all(&dir).expect("create setup health directory");
+        let config_path = dir.join("moraine.toml");
+        fs::write(
+            &config_path,
+            format!(
+                "[mcp]\ncentral_socket_path = \"{}\"\n",
+                dir.join("missing.sock").display()
+            ),
+        )
+        .expect("write setup health config");
+        let args = SetupArgs {
+            yes: true,
+            dry_run: false,
+            skip_config: true,
+            skip_mcp: false,
+            repair_config: false,
+            mcp_targets: vec![SetupMcpTarget::Codex],
+        };
+        let mut target = McpTargetReport::error(SetupMcpTarget::Codex, "placeholder");
+        target.status = SetupStatus::Ok;
+        target.error = None;
+        let mut report = SetupReport {
+            success: true,
+            config: ConfigReport::skipped(&config_path, "skipped by --skip-config"),
+            mcp_targets: vec![target],
+            mcp_health: None,
+        };
+
+        record_setup_mcp_health(&mut report, &args, &config_path).await;
+
+        assert!(!report.success);
+        let health = report.mcp_health.expect("MCP health report");
+        assert!(!health.healthy);
+        let error = health.error.expect("MCP health error");
+        assert!(error.starts_with("connect: MCP socket"), "{error}");
+        assert!(!error.contains(dir.to_str().expect("UTF-8 test path")));
+        let _ = fs::remove_dir_all(dir);
     }
 }

--- a/apps/moraine/src/commands/status.rs
+++ b/apps/moraine/src/commands/status.rs
@@ -2,6 +2,7 @@ use crate::managed_clickhouse::{
     active_clickhouse_source, managed_clickhouse_bin, managed_clickhouse_checksum_state,
     managed_clickhouse_version,
 };
+use crate::mcp_health::probe_mcp_backend;
 use crate::paths::RuntimePaths;
 use crate::process::{
     backend_endpoint_status, backend_http_connect_host, legacy_service_running_read_only,
@@ -21,6 +22,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const STATUS_API_TIMEOUT: Duration = Duration::from_secs(2);
 const STATUS_API_MAX_RESPONSE_BYTES: usize = 256 * 1024;
+const STATUS_MCP_TIMEOUT: Duration = Duration::from_secs(2);
 fn unix_now_ms() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -448,6 +450,23 @@ pub(super) async fn cmd_status(
     cfg: &AppConfig,
     repository: &dyn ConversationRepository,
 ) -> Result<StatusSnapshot> {
+    collect_status(paths, cfg, repository, true).await
+}
+
+pub(super) async fn cmd_status_for_up(
+    paths: &RuntimePaths,
+    cfg: &AppConfig,
+    repository: &dyn ConversationRepository,
+) -> Result<StatusSnapshot> {
+    collect_status(paths, cfg, repository, false).await
+}
+
+async fn collect_status(
+    paths: &RuntimePaths,
+    cfg: &AppConfig,
+    repository: &dyn ConversationRepository,
+    probe_mcp: bool,
+) -> Result<StatusSnapshot> {
     let backend_endpoints = backend_endpoint_status(cfg);
     let services = vec![
         managed_runtime_status(
@@ -496,10 +515,23 @@ pub(super) async fn cmd_status(
     let monitor_url = backend_endpoints
         .http_listening
         .then(|| monitor_runtime_url(cfg));
+    let mcp_health = if probe_mcp {
+        Some(
+            probe_mcp_backend(
+                &cfg.mcp.central_socket_path,
+                &cfg.mcp.protocol_version,
+                STATUS_MCP_TIMEOUT,
+            )
+            .await,
+        )
+    } else {
+        None
+    };
 
     Ok(StatusSnapshot {
         services,
         monitor_url,
+        mcp_health,
         data_source,
         managed_clickhouse_installed: managed_server.exists(),
         managed_clickhouse_path: managed_server.display().to_string(),
@@ -1044,5 +1076,26 @@ mod tests {
         assert_eq!(status(None, false, false), ServiceRuntimeState::Stopped);
         assert_eq!(status(Some(200), true, false), ServiceRuntimeState::Partial);
         assert_eq!(status(None, false, true), ServiceRuntimeState::Partial);
+    }
+    #[tokio::test]
+    async fn up_status_collection_does_not_probe_or_serialize_mcp_health() {
+        let mut cfg = test_config(0);
+        let root =
+            std::env::temp_dir().join(format!("moraine-up-status-unit-{}", std::process::id()));
+        cfg.runtime.root_dir = root.display().to_string();
+        cfg.runtime.logs_dir = root.join("logs").display().to_string();
+        cfg.runtime.pids_dir = root.join("run").display().to_string();
+        cfg.runtime.service_bin_dir = root.join("services").display().to_string();
+        cfg.runtime.managed_clickhouse_dir = root.join("managed").display().to_string();
+        cfg.mcp.central_socket_path = root.join("must-not-probe.sock").display().to_string();
+        let paths = crate::paths::runtime_paths(&cfg);
+
+        let snapshot = cmd_status_for_up(&paths, &cfg, &test_repository())
+            .await
+            .expect("collect status for up");
+
+        assert!(snapshot.mcp_health.is_none());
+        let json = serde_json::to_value(snapshot).expect("serialize up status");
+        assert!(json.get("mcp_health").is_none());
     }
 }

--- a/apps/moraine/src/commands/up.rs
+++ b/apps/moraine/src/commands/up.rs
@@ -25,7 +25,7 @@ use crate::render::{render_up, CliOutput, MigrationOutcome, StatusSnapshot, UpSn
 use crate::service::Service;
 
 use super::{
-    conversation_repository, doctor_is_healthy, migrate_database_for_up, status::cmd_status,
+    conversation_repository, doctor_is_healthy, migrate_database_for_up, status::cmd_status_for_up,
     writer_barrier_required, WRITER_BARRIER_SERVICES,
 };
 
@@ -494,7 +494,7 @@ async fn start_selected_services<W: Write>(
     let status_owner = QueryOwner::new(query_runtime, QueryWorkload::Administrative)?;
     let status_started = Instant::now();
     let status = drive_status_progress(
-        status_owner.scope(cmd_status(paths, cfg, &repository)),
+        status_owner.scope(cmd_status_for_up(paths, cfg, &repository)),
         status_started,
         progress,
     )

--- a/apps/moraine/src/main.rs
+++ b/apps/moraine/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod commands;
 mod managed_clickhouse;
+mod mcp_health;
 mod paths;
 mod process;
 mod progress;

--- a/apps/moraine/src/mcp_health.rs
+++ b/apps/moraine/src/mcp_health.rs
@@ -1,0 +1,395 @@
+use serde_json::{json, Value};
+use std::time::Duration;
+
+const MAX_MCP_RESPONSE_BYTES: u64 = 64 * 1024;
+const MAX_MCP_VERSION_BYTES: usize = 128;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct McpHealthSnapshot {
+    pub(crate) healthy: bool,
+    pub(crate) protocol_version: Option<String>,
+    pub(crate) server_version: Option<String>,
+    pub(crate) error: Option<String>,
+}
+
+impl McpHealthSnapshot {
+    fn healthy(protocol_version: String, server_version: String) -> Self {
+        Self {
+            healthy: true,
+            protocol_version: Some(protocol_version),
+            server_version: Some(server_version),
+            error: None,
+        }
+    }
+
+    pub(crate) fn unhealthy(error: impl Into<String>) -> Self {
+        Self {
+            healthy: false,
+            protocol_version: None,
+            server_version: None,
+            error: Some(error.into()),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn io_diagnostic(action: &str, error: &std::io::Error) -> String {
+    let detail = match error.kind() {
+        std::io::ErrorKind::NotFound => "MCP socket is absent",
+        std::io::ErrorKind::ConnectionRefused => "MCP socket refused the connection",
+        std::io::ErrorKind::PermissionDenied => "MCP socket permission was denied",
+        std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock => {
+            "MCP backend did not respond before the timeout"
+        }
+        std::io::ErrorKind::BrokenPipe
+        | std::io::ErrorKind::ConnectionAborted
+        | std::io::ErrorKind::ConnectionReset
+        | std::io::ErrorKind::UnexpectedEof => "MCP backend closed the connection",
+        _ => "MCP socket I/O failed",
+    };
+    format!("{action}: {detail}")
+}
+
+#[cfg(unix)]
+async fn write_message<W>(writer: &mut W, message: &Value, action: &str) -> Result<(), String>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    use tokio::io::AsyncWriteExt;
+
+    let mut encoded = serde_json::to_vec(message)
+        .map_err(|_| format!("{action}: failed to encode MCP request"))?;
+    encoded.push(b'\n');
+    writer
+        .write_all(&encoded)
+        .await
+        .map_err(|error| io_diagnostic(action, &error))?;
+    writer
+        .flush()
+        .await
+        .map_err(|error| io_diagnostic(action, &error))
+}
+
+#[cfg(unix)]
+async fn read_response<R>(reader: &mut R, expected_id: i64, action: &str) -> Result<Value, String>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+{
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt};
+
+    let mut body = Vec::new();
+    let bytes_read = reader
+        .take(MAX_MCP_RESPONSE_BYTES + 1)
+        .read_until(b'\n', &mut body)
+        .await
+        .map_err(|error| io_diagnostic(action, &error))?;
+    if bytes_read == 0 {
+        return Err(format!("{action}: MCP backend closed the connection"));
+    }
+    if bytes_read as u64 > MAX_MCP_RESPONSE_BYTES || body.last() != Some(&b'\n') {
+        return Err(format!("{action}: MCP response exceeded the size limit"));
+    }
+
+    let response: Value =
+        serde_json::from_slice(&body).map_err(|_| format!("{action}: invalid JSON response"))?;
+    if response.get("jsonrpc").and_then(Value::as_str) != Some("2.0") {
+        return Err(format!("{action}: invalid JSON-RPC version"));
+    }
+    if response.get("id") != Some(&json!(expected_id)) {
+        return Err(format!("{action}: response id did not match the request"));
+    }
+    if response.get("error").is_some_and(|error| !error.is_null()) {
+        return Err(format!("{action}: MCP backend returned a JSON-RPC error"));
+    }
+    Ok(response)
+}
+
+#[cfg(unix)]
+fn validated_version(value: Option<&Value>, field: &str) -> Result<String, String> {
+    let value = value
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| format!("initialize handshake: missing {field}"))?;
+    if value.len() > MAX_MCP_VERSION_BYTES || !value.bytes().all(|byte| byte.is_ascii_graphic()) {
+        return Err(format!("initialize handshake: invalid {field}"));
+    }
+    Ok(value.to_string())
+}
+
+#[cfg(unix)]
+async fn probe_mcp_backend_inner(
+    socket_path: &str,
+    protocol_version: &str,
+) -> Result<McpHealthSnapshot, String> {
+    use tokio::io::BufReader;
+    use tokio::net::UnixStream;
+
+    let stream = UnixStream::connect(socket_path)
+        .await
+        .map_err(|error| io_diagnostic("connect", &error))?;
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+
+    write_message(
+        &mut write_half,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": protocol_version,
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "moraine-cli-health",
+                    "version": moraine_config::BUILD_VERSION
+                }
+            }
+        }),
+        "initialize handshake",
+    )
+    .await?;
+    let initialize = read_response(&mut reader, 1, "initialize handshake").await?;
+    let result = initialize
+        .get("result")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "initialize handshake: missing result".to_string())?;
+    let negotiated_protocol = validated_version(result.get("protocolVersion"), "protocol version")?;
+    let server_info = result
+        .get("serverInfo")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "initialize handshake: missing server info".to_string())?;
+    if server_info.get("name").and_then(Value::as_str) != Some("moraine-mcp") {
+        return Err("initialize handshake: unexpected MCP server identity".to_string());
+    }
+    let server_version = validated_version(server_info.get("version"), "server version")?;
+
+    write_message(
+        &mut write_half,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+            "params": {}
+        }),
+        "initialize notification",
+    )
+    .await?;
+    write_message(
+        &mut write_half,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "ping",
+            "params": {}
+        }),
+        "MCP ping",
+    )
+    .await?;
+    let ping = read_response(&mut reader, 2, "MCP ping").await?;
+    if !ping.get("result").is_some_and(Value::is_object) {
+        return Err("MCP ping: missing result".to_string());
+    }
+
+    Ok(McpHealthSnapshot::healthy(
+        negotiated_protocol,
+        server_version,
+    ))
+}
+
+#[cfg(unix)]
+pub(crate) async fn probe_mcp_backend(
+    socket_path: &str,
+    protocol_version: &str,
+    timeout: Duration,
+) -> McpHealthSnapshot {
+    match tokio::time::timeout(
+        timeout,
+        probe_mcp_backend_inner(socket_path, protocol_version),
+    )
+    .await
+    {
+        Ok(Ok(health)) => health,
+        Ok(Err(error)) => McpHealthSnapshot::unhealthy(error),
+        Err(_) => McpHealthSnapshot::unhealthy("MCP health check timed out"),
+    }
+}
+
+#[cfg(not(unix))]
+pub(crate) async fn probe_mcp_backend(
+    _socket_path: &str,
+    _protocol_version: &str,
+    _timeout: Duration,
+) -> McpHealthSnapshot {
+    McpHealthSnapshot::unhealthy("MCP backend health checks require a Unix socket")
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixListener;
+    use std::path::PathBuf;
+    use std::thread;
+    use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+    fn socket_path(label: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        PathBuf::from("/tmp").join(format!("mh-{label}-{}-{stamp}.sock", std::process::id()))
+    }
+
+    #[tokio::test]
+    async fn initialize_and_ping_prove_backend_health() {
+        let path = socket_path("healthy");
+        let listener = UnixListener::bind(&path).expect("bind MCP fixture");
+        let worker = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept probe");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(1)))
+                .expect("set fixture timeout");
+            let mut reader = BufReader::new(stream.try_clone().expect("clone fixture stream"));
+            let mut methods = Vec::new();
+            for response in [
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {"tools": {"listChanged": false}},
+                        "serverInfo": {"name": "moraine-mcp", "version": "test-version"}
+                    }
+                }),
+                json!({"jsonrpc": "2.0", "id": 2, "result": {}}),
+            ] {
+                let mut line = String::new();
+                reader.read_line(&mut line).expect("read MCP request");
+                let request: Value = serde_json::from_str(&line).expect("decode MCP request");
+                methods.push(
+                    request["method"]
+                        .as_str()
+                        .expect("request method")
+                        .to_string(),
+                );
+                if request["method"] == "notifications/initialized" {
+                    line.clear();
+                    reader
+                        .read_line(&mut line)
+                        .expect("read ping after notification");
+                    let ping: Value = serde_json::from_str(&line).expect("decode ping");
+                    methods.push(ping["method"].as_str().expect("ping method").to_string());
+                }
+                serde_json::to_writer(&mut stream, &response).expect("encode MCP response");
+                stream.write_all(b"\n").expect("write MCP response");
+                stream.flush().expect("flush MCP response");
+            }
+            methods
+        });
+
+        let health = probe_mcp_backend(
+            path.to_str().expect("UTF-8 socket path"),
+            "2025-03-26",
+            Duration::from_secs(1),
+        )
+        .await;
+        assert_eq!(
+            health,
+            McpHealthSnapshot {
+                healthy: true,
+                protocol_version: Some("2025-03-26".to_string()),
+                server_version: Some("test-version".to_string()),
+                error: None,
+            }
+        );
+        assert_eq!(
+            worker.join().expect("MCP fixture worker"),
+            ["initialize", "notifications/initialized", "ping"]
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn total_probe_deadline_rejects_drip_fed_response() {
+        let path = socket_path("deadline");
+        let listener = UnixListener::bind(&path).expect("bind MCP fixture");
+        let worker = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept probe");
+            let mut request = String::new();
+            BufReader::new(stream.try_clone().expect("clone fixture stream"))
+                .read_line(&mut request)
+                .expect("read initialize request");
+            for byte in br#"{"jsonrpc":"2.0","id":1,"result":{}}\n"# {
+                if stream.write_all(std::slice::from_ref(byte)).is_err() {
+                    break;
+                }
+                let _ = stream.flush();
+                thread::sleep(Duration::from_millis(30));
+            }
+        });
+
+        let started = Instant::now();
+        let health = probe_mcp_backend(
+            path.to_str().expect("UTF-8 socket path"),
+            "2025-03-26",
+            Duration::from_millis(100),
+        )
+        .await;
+        assert_eq!(health.error.as_deref(), Some("MCP health check timed out"));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        worker.join().expect("MCP fixture worker");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn rejects_control_characters_in_reported_versions() {
+        let path = socket_path("controls");
+        let listener = UnixListener::bind(&path).expect("bind MCP fixture");
+        let worker = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept probe");
+            let mut request = String::new();
+            BufReader::new(stream.try_clone().expect("clone fixture stream"))
+                .read_line(&mut request)
+                .expect("read initialize request");
+            serde_json::to_writer(
+                &mut stream,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "protocolVersion": "2025-03-26",
+                        "serverInfo": {"name": "moraine-mcp", "version": "forged\nline"}
+                    }
+                }),
+            )
+            .expect("encode MCP response");
+            stream.write_all(b"\n").expect("write MCP response");
+        });
+
+        let health = probe_mcp_backend(
+            path.to_str().expect("UTF-8 socket path"),
+            "2025-03-26",
+            Duration::from_secs(1),
+        )
+        .await;
+        assert_eq!(
+            health.error.as_deref(),
+            Some("initialize handshake: invalid server version")
+        );
+        worker.join().expect("MCP fixture worker");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn diagnostics_do_not_expose_socket_paths() {
+        let missing = socket_path("missing");
+        let health = probe_mcp_backend(
+            missing.to_str().expect("UTF-8 socket path"),
+            "2025-03-26",
+            Duration::from_millis(100),
+        )
+        .await;
+        let error = health.error.expect("health error");
+        assert!(error.contains("socket is absent"), "{error}");
+        assert!(!error.contains(missing.to_str().expect("UTF-8 socket path")));
+    }
+}

--- a/apps/moraine/src/render.rs
+++ b/apps/moraine/src/render.rs
@@ -9,6 +9,7 @@ use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table, 
 use std::io::IsTerminal;
 
 use crate::cli::{Cli, OutputFormat};
+use crate::mcp_health::McpHealthSnapshot;
 use crate::process::{StartOutcome, StartState};
 use crate::service::Service;
 
@@ -92,6 +93,8 @@ pub(crate) enum HeartbeatSnapshot {
 pub(crate) struct StatusSnapshot {
     pub(crate) services: Vec<ServiceRuntimeStatus>,
     pub(crate) monitor_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) mcp_health: Option<McpHealthSnapshot>,
     pub(crate) data_source: StatusDataSource,
     pub(crate) managed_clickhouse_installed: bool,
     pub(crate) managed_clickhouse_path: String,
@@ -476,6 +479,25 @@ pub(crate) fn render_status(output: &CliOutput, snapshot: &StatusSnapshot) -> Re
         output.table("Services", &["", "state", "endpoint", "pid"], &service_rows);
     } else {
         output.table("Services", &["", "state", "endpoint"], &service_rows);
+    }
+
+    if let Some(health) = &snapshot.mcp_health {
+        let mut mcp_lines = vec![format!(
+            "{} MCP initialize + ping {}",
+            stoplight(health.healthy),
+            health_label(health.healthy)
+        )];
+        if let (Some(protocol), Some(server)) = (&health.protocol_version, &health.server_version) {
+            mcp_lines.push(format!("protocol: {protocol}  |  server: {server}"));
+        }
+        if let Some(error) = &health.error {
+            mcp_lines.push(format!("diagnostic: {error}"));
+            mcp_lines.push(
+                "remediation: run `moraine up`; if the check still fails, inspect `moraine logs backend`"
+                    .to_string(),
+            );
+        }
+        output.section("MCP", &mcp_lines);
     }
 
     // -- Database Health (concise) --

--- a/apps/moraine/tests/status_cli.rs
+++ b/apps/moraine/tests/status_cli.rs
@@ -1,6 +1,6 @@
 use std::fs;
 #[cfg(unix)]
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 #[cfg(unix)]
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
@@ -151,6 +151,121 @@ fn backend_row(status: &Value) -> &Value {
         .iter()
         .find(|service| service["service"] == "backend")
         .expect("backend service row")
+}
+
+#[cfg(unix)]
+fn spawn_mcp_endpoint(socket_path: &Path) -> thread::JoinHandle<Vec<Value>> {
+    use std::os::unix::net::UnixListener;
+
+    let listener = UnixListener::bind(socket_path).expect("bind MCP endpoint");
+    listener
+        .set_nonblocking(true)
+        .expect("set MCP endpoint nonblocking");
+    thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let mut accepted = Vec::new();
+        while accepted.len() < 2 && Instant::now() < deadline {
+            match listener.accept() {
+                Ok((stream, _)) => accepted.push(stream),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("accept MCP connection: {error}"),
+            }
+        }
+        assert_eq!(accepted.len(), 2, "liveness and health connections");
+        drop(accepted.remove(0));
+        let mut stream = accepted.remove(0);
+        stream
+            .set_nonblocking(false)
+            .expect("set MCP fixture blocking mode");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(3)))
+            .expect("set MCP read timeout");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone MCP stream"));
+        let mut requests = Vec::new();
+
+        let mut initialize_line = String::new();
+        reader
+            .read_line(&mut initialize_line)
+            .expect("read initialize request");
+        requests.push(
+            serde_json::from_str::<Value>(&initialize_line).expect("decode initialize request"),
+        );
+        let initialize_response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {"tools": {"listChanged": false}},
+                "serverInfo": {"name": "moraine-mcp", "version": "fixture-version"}
+            }
+        });
+        serde_json::to_writer(&mut stream, &initialize_response)
+            .expect("encode initialize response");
+        stream.write_all(b"\n").expect("write initialize response");
+        stream.flush().expect("flush initialize response");
+
+        for expected_method in ["notifications/initialized", "ping"] {
+            let mut line = String::new();
+            reader.read_line(&mut line).expect("read MCP request");
+            let request: Value = serde_json::from_str(&line).expect("decode MCP request");
+            assert_eq!(request["method"], expected_method);
+            requests.push(request);
+        }
+        let ping_response = serde_json::json!({"jsonrpc": "2.0", "id": 2, "result": {}});
+        serde_json::to_writer(&mut stream, &ping_response).expect("encode ping response");
+        stream.write_all(b"\n").expect("write ping response");
+        stream.flush().expect("flush ping response");
+        requests
+    })
+}
+
+#[cfg(unix)]
+#[test]
+fn status_reports_mcp_initialize_and_ping_health() {
+    for plain in [false, true] {
+        let root = temp_dir();
+        let worker = spawn_mcp_endpoint(&root.join("backend.sock"));
+        let config = write_config(&root, 0);
+        let output = if plain {
+            run_plain_status(&config)
+        } else {
+            run_status(&config)
+        };
+        assert!(
+            output.status.success(),
+            "status failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if plain {
+            let rendered = String::from_utf8_lossy(&output.stdout);
+            assert!(
+                rendered.contains("MCP initialize + ping healthy"),
+                "{rendered}"
+            );
+            assert!(
+                rendered.contains("protocol: 2025-03-26  |  server: fixture-version"),
+                "{rendered}"
+            );
+        } else {
+            let status: Value = serde_json::from_slice(&output.stdout).expect("status JSON output");
+            assert_eq!(status["mcp_health"]["healthy"], true, "{status}");
+            assert_eq!(status["mcp_health"]["protocol_version"], "2025-03-26");
+            assert_eq!(status["mcp_health"]["server_version"], "fixture-version");
+            assert_eq!(status["mcp_health"]["error"], Value::Null);
+        }
+
+        let requests = worker.join().expect("MCP endpoint worker");
+        assert_eq!(requests[0]["method"], "initialize");
+        assert_eq!(
+            requests[0]["params"]["clientInfo"]["name"],
+            "moraine-cli-health"
+        );
+        assert_eq!(requests[1]["method"], "notifications/initialized");
+        assert_eq!(requests[2]["method"], "ping");
+        let _ = fs::remove_dir_all(root);
+    }
 }
 
 #[test]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -81,6 +81,10 @@ automatically falls back to a direct database read when the backend is
 unreachable. Human output labels the source as `daemon API` or `direct DB`;
 JSON output adds the compatible top-level `data_source` field with
 `daemon_api` or `direct_db`.
+It also connects directly to the backend MCP socket, completes an `initialize`
+handshake, sends the MCP `ping` health check, and reports the result as
+`mcp_health` in JSON output. This checks Moraine's shared MCP service without
+starting Codex, Claude Code, or another harness.
 
 For a local ClickHouse process started by `moraine up`, Moraine keeps a small
 supervisor running after startup. If ClickHouse exits unexpectedly, the
@@ -160,6 +164,12 @@ described in [Agent MCP Search → NAC](agent-mcp-search/install.md#nac).
 These user-scoped integrations can search the host-wide Moraine history visible
 to your user, so enable them only in trusted harness environments.
 Qwen registration does not enable Qwen's MCP trust option.
+After at least one integration is configured, setup runs the same backend MCP
+`initialize` and `ping` check. An unhealthy or stopped backend makes setup exit
+nonzero while leaving the per-target result as configured, so plugin installation
+is distinguishable from MCP service health. Run `moraine up` and rerun setup; no
+harness session is launched by this check. Dry runs and manual-only targets do
+not contact the backend.
 
 The same Codex marketplace also contains the contributor-only `moraine-dev`
 plugin for Moraine maintainers; end users should install `moraine@moraine`.


### PR DESCRIPTION
## Description

**What.** Adds a backend-only MCP initialize and ping health check to `moraine status` and post-integration `moraine setup`.

**Why.** Setup previously treated successful plugin-manager commands and config writes as proof that Moraine MCP was usable, even when the backend could not complete an MCP handshake.

The CLI now connects directly to the configured shared MCP Unix socket, completes `initialize`, sends `notifications/initialized`, and verifies `ping`. The entire exchange, including connect, is bounded by one two-second deadline. Responses are size-bounded, server identity is checked, reported versions are terminal-safe, and failures expose only sanitized diagnostics.

`moraine status` reports the result as `mcp_health`. Setup runs the same probe once after at least one non-manual integration succeeds, keeps per-target plugin status separate, and exits nonzero when backend MCP is unhealthy. Dry runs, `--skip-mcp`, manual-only targets, and `moraine up` do not add a probe.

Closes #656.

## Bug Evidence

Before this change, a target moved to `SetupStatus::Ok` after its commands and managed writes succeeded. There was no connection to the configured backend MCP socket and no MCP protocol exchange, so setup could report a configured integration while clients saw `Failed to connect`.

The new status integration fixture observes the exact request sequence:

```text
initialize -> notifications/initialized -> ping
```

In a fresh isolated sandbox, status and Claude Code-targeted setup both reported a healthy backend with protocol `2024-11-05` and server version `0.7.3`. After `moraine down`, the same setup command retained the configured target result, reported `connect: MCP socket is absent`, and exited 1.

## Usage

Start Moraine, configure the desired integrations, then inspect backend MCP health without launching a harness session:

```bash
moraine up
moraine setup --yes --mcp-target codex --mcp-target claude-code
moraine status
```

JSON output includes:

```json
{
  "mcp_health": {
    "healthy": true,
    "protocol_version": "2024-11-05",
    "server_version": "0.7.3",
    "error": null
  }
}
```

## Changelog

- Verify the shared backend MCP service with an initialize handshake and ping in `moraine status`.
- Make post-integration `moraine setup` fail clearly when backend MCP is unavailable, without launching a full harness.
- Document the new status/setup behavior and remediation.

## Operational Impact

No configuration or migration changes. Healthy setup requires the shared backend started by `moraine up`. A failed probe adds at most the configured two-second health deadline and returns a sanitized remediation message.

## Validation

`cargo fmt --all -- --check` passed. `cargo test -p moraine --bin moraine --locked` passed 242 tests, and `cargo test -p moraine --test status_cli --locked` passed 7 tests. `python3 docs/development/test-architecture/package_isolation.py` compiled all 10 workspace packages successfully, and `make docs-build` completed with no issues.

`cargo clippy -p moraine --all-targets --locked -- -D warnings -A clippy::collapsible_if` passed. The unsuppressed strict command remains blocked by the pre-existing `collapsible_if` in `apps/moraine/src/commands/setup/prime_agent.rs:334`, outside this PR.

A fresh `moraine-sandbox` stack verified healthy JSON output from both status and setup, then verified stopped-backend setup returned exit 1 with a sanitized diagnostic. Both owned sandboxes were torn down. No Codex, Claude Code, or other harness session was launched.
